### PR TITLE
MVP-03: Spring Boot import ownership + parity contract

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -16,6 +16,7 @@ Contract lock means:
 - help/usage output for `gitops` and subcommands is golden-tested
 - unsupported behavior must fail explicitly (never silently degrade)
 - Helm import contract includes explicit DRY/WET surfaces (`dry_inputs`, `wet_manifest_targets`) and provenance lineage fields (`chart_path`, `values_paths`, `rendered_object_lineage`)
+- Spring Boot import contract includes explicit DRY ownership (`dry_inputs.owner`) and platform-owned WET targets (`wet_manifest_targets.owner`) with app-team inverse-edit hints
 
 ## Command contract parity
 
@@ -65,6 +66,7 @@ Contract lock means:
 - Command parity golden tests:
   - `cmd/cub-gen/testdata/parity/gitops-discover.golden.json`
   - `cmd/cub-gen/testdata/parity/gitops-import.golden.json`
+  - `cmd/cub-gen/testdata/parity/gitops-import-spring.golden.json`
   - `cmd/cub-gen/testdata/parity/gitops-cleanup.golden.json`
   - `cmd/cub-gen/testdata/parity/gitops-discover.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ For Helm repos, `gitops import --json` now emits explicit DRY and WET structures
 - provenance `values_paths`
 - provenance `rendered_object_lineage`
 
+## Spring Boot import contract (MVP-03)
+
+For Spring Boot repos, `gitops import --json` now emits app/platform ownership boundaries:
+
+- `dry_inputs` with explicit ownership:
+  - `app-config-base` / `app-config-profile` owned by `app-team`
+  - `build-config` owned by `platform-engineer`
+- `wet_manifest_targets` owned by `platform-runtime`
+- provenance + inverse-edit pointers include app-team edit paths (`spring.application.name`, `server.port`) and platform-owned edits (`spring.datasource.url`)
+
 ## Quality model (inherited from cub-scout, adapted)
 
 - Deterministic behavior: same input => same output

--- a/cmd/cub-gen/gitops_parity_test.go
+++ b/cmd/cub-gen/gitops_parity_test.go
@@ -52,6 +52,26 @@ func TestGitOpsParityGoldenImport(t *testing.T) {
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gitops-import.golden.json"), got)
 }
 
+func TestGitOpsParityGoldenImportSpring(t *testing.T) {
+	setupAliases(t)
+
+	out, stderr, err := runWithCapturedIO([]string{"gitops", "import", "--space", "platform", "--json", "spring", "render-target"})
+	if err != nil {
+		t.Fatalf("run spring import returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %s", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal spring import json: %v\noutput=%s", err, out)
+	}
+	normalizeImport(got)
+
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gitops-import-spring.golden.json"), got)
+}
+
 func TestGitOpsParityGoldenCleanup(t *testing.T) {
 	setupAliases(t)
 

--- a/cmd/cub-gen/testdata/parity/gitops-import-spring.golden.json
+++ b/cmd/cub-gen/testdata/parity/gitops-import-spring.golden.json
@@ -1,0 +1,310 @@
+{
+  "contracts": [
+    {
+      "capabilities": [
+        "render-app-config",
+        "profile-overrides",
+        "inverse-app-config-patch"
+      ],
+      "deterministic": true,
+      "generator_id": "gen_73ed79c3c8b65360",
+      "inputs": [
+        {
+          "name": "input_01",
+          "required": true,
+          "schema_ref": "https://maven.apache.org/xsd/maven-4.0.0.xsd"
+        },
+        {
+          "name": "input_02",
+          "required": true,
+          "schema_ref": "https://json.schemastore.org/spring-configuration-metadata"
+        },
+        {
+          "name": "input_03",
+          "required": true,
+          "schema_ref": "https://json.schemastore.org/spring-configuration-metadata"
+        }
+      ],
+      "kind": "springboot",
+      "name": "springboot-paas",
+      "output_format": "kubernetes/yaml",
+      "profile": "springboot-paas",
+      "schema_version": "cub.confighub.io/generator-contract/v1",
+      "source_path": "",
+      "source_ref": "HEAD",
+      "source_repo": "\u003ctarget_path\u003e",
+      "transport": "oci+git",
+      "version": "0.1.0"
+    }
+  ],
+  "discover_unit_slug": "\u003cdiscover_unit_slug\u003e",
+  "discovered": [
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "generator_kind": "springboot",
+      "generator_profile": "springboot-paas",
+      "inputs": [
+        "pom.xml",
+        "src/main/resources/application-prod.yaml",
+        "src/main/resources/application.yaml"
+      ],
+      "resource_body": "kind: Kustomization\nmetadata:\n  name: springboot-paas\nspec:\n  root: \n",
+      "resource_kind": "Kustomization",
+      "resource_name": "springboot-paas",
+      "resource_type": "kustomize.toolkit.fluxcd.io/v1/Kustomization",
+      "root": ""
+    }
+  ],
+  "dry_inputs": [
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "owner": "app-team",
+      "path": "src/main/resources/application.yaml",
+      "profile": "springboot-paas",
+      "required": true,
+      "role": "app-config-base"
+    },
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "owner": "app-team",
+      "path": "src/main/resources/application-prod.yaml",
+      "profile": "springboot-paas",
+      "required": true,
+      "role": "app-config-profile"
+    },
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "owner": "platform-engineer",
+      "path": "pom.xml",
+      "profile": "springboot-paas",
+      "required": true,
+      "role": "build-config"
+    }
+  ],
+  "dry_units": [
+    {
+      "id": "dry_5b90287a647b6d00",
+      "kind": "dry-unit",
+      "layer": "dry",
+      "name": "springboot-paas-dry"
+    }
+  ],
+  "generator_units": [
+    {
+      "id": "gen_14fc080d57edc21b",
+      "kind": "generator-unit",
+      "layer": "generator",
+      "name": "springboot-paas-generator"
+    }
+  ],
+  "imported_at": "\u003ctimestamp\u003e",
+  "inverse_transform_plans": [
+    {
+      "change_id": "\u003cchange_id\u003e",
+      "created_at": "\u003ctimestamp\u003e",
+      "patches": [
+        {
+          "confidence": 0.88,
+          "dry_path": "spring.application.name",
+          "editable_by": "app-team",
+          "op": "replace",
+          "reason": "Application identity should be app-editable without platform escalation.",
+          "requires_review": false,
+          "wet_path": "Deployment/metadata/labels[app.kubernetes.io/name]"
+        },
+        {
+          "confidence": 0.91,
+          "dry_path": "server.port",
+          "editable_by": "app-team",
+          "op": "replace",
+          "reason": "Application listener port is an app-level configuration concern.",
+          "requires_review": false,
+          "wet_path": "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort"
+        },
+        {
+          "confidence": 0.78,
+          "dry_path": "spring.datasource.url",
+          "editable_by": "platform-engineer",
+          "op": "replace",
+          "reason": "Database connectivity impacts shared runtime dependencies.",
+          "requires_review": true,
+          "wet_path": "ConfigMap/data/application.yaml:spring.datasource.url"
+        }
+      ],
+      "plan_id": "\u003cplan_id\u003e",
+      "schema_version": "cub.confighub.io/inverse-transform-plan/v1",
+      "source_kind": "springboot",
+      "source_ref": "",
+      "status": "draft",
+      "target_unit_id": "dry_5b90287a647b6d00"
+    }
+  ],
+  "links": [
+    {
+      "dry_unit_id": "dry_5b90287a647b6d00",
+      "generator_unit_id": "gen_14fc080d57edc21b",
+      "wet_unit_id": "wet_24b4f9e96079fa9a"
+    }
+  ],
+  "provenance": [
+    {
+      "change_id": "\u003cchange_id\u003e",
+      "field_origin_map": [
+        {
+          "confidence": 0.89,
+          "dry_path": "spring.application.name",
+          "source_path": "src/main/resources/application.yaml",
+          "transform": "spring-config-to-manifest",
+          "wet_path": "Deployment/metadata/labels[app.kubernetes.io/name]"
+        },
+        {
+          "confidence": 0.92,
+          "dry_path": "server.port",
+          "source_path": "src/main/resources/application.yaml",
+          "transform": "spring-config-to-manifest",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort"
+        },
+        {
+          "confidence": 0.78,
+          "dry_path": "spring.datasource.url",
+          "source_path": "src/main/resources/application.yaml",
+          "transform": "spring-config-to-manifest",
+          "wet_path": "ConfigMap/data/application.yaml:spring.datasource.url"
+        },
+        {
+          "confidence": 0.88,
+          "dry_path": "server.port",
+          "source_path": "src/main/resources/application-prod.yaml",
+          "transform": "spring-profile-overlay",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort"
+        }
+      ],
+      "generator_id": "gen_73ed79c3c8b65360",
+      "generator_name": "springboot-paas",
+      "generator_profile": "springboot-paas",
+      "input_digest": "sha256:f996825a673f1865dee25269566b575fa5e6f97609f368e2c44742f7fa9758c6",
+      "inverse_edit_pointers": [
+        {
+          "confidence": 0.89,
+          "dry_path": "spring.application.name",
+          "edit_hint": "Edit spring.application.name in src/main/resources/application.yaml.",
+          "owner": "app-team",
+          "wet_path": "Deployment/metadata/labels[app.kubernetes.io/name]"
+        },
+        {
+          "confidence": 0.91,
+          "dry_path": "server.port",
+          "edit_hint": "Edit server.port in src/main/resources/application-prod.yaml for environment overrides; use src/main/resources/application.yaml for the default.",
+          "owner": "app-team",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort"
+        },
+        {
+          "confidence": 0.78,
+          "dry_path": "spring.datasource.url",
+          "edit_hint": "Edit spring.datasource.url in src/main/resources/application.yaml and coordinate with platform ownership rules.",
+          "owner": "platform-engineer",
+          "wet_path": "ConfigMap/data/application.yaml:spring.datasource.url"
+        }
+      ],
+      "outputs": [
+        {
+          "digest": "\u003cdigest\u003e",
+          "role": "rendered-manifests",
+          "uri": "oci://example.local/platform/springboot-paas:latest"
+        }
+      ],
+      "provenance_id": "\u003cprovenance_id\u003e",
+      "rendered_at": "\u003ctimestamp\u003e",
+      "rendered_object_lineage": [
+        {
+          "kind": "Kustomization",
+          "name": "springboot-paas",
+          "namespace": "apps",
+          "source_dry_path": "build",
+          "source_path": "pom.xml"
+        },
+        {
+          "kind": "Deployment",
+          "name": "springboot-paas",
+          "namespace": "apps",
+          "source_dry_path": "spring.application.name",
+          "source_path": "src/main/resources/application.yaml"
+        },
+        {
+          "kind": "ConfigMap",
+          "name": "springboot-paas-config",
+          "namespace": "apps",
+          "source_dry_path": "spring.datasource.url",
+          "source_path": "src/main/resources/application.yaml"
+        },
+        {
+          "kind": "Deployment",
+          "name": "springboot-paas",
+          "namespace": "apps",
+          "source_dry_path": "server.port",
+          "source_path": "src/main/resources/application-prod.yaml"
+        }
+      ],
+      "schema_version": "cub.confighub.io/provenance/v1",
+      "sources": [
+        {
+          "path": "pom.xml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "src/main/resources/application-prod.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "src/main/resources/application.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "ref": "HEAD",
+  "render_target_slug": "render-target",
+  "space": "platform",
+  "target_path": "\u003ctarget_path\u003e",
+  "target_slug": "spring",
+  "wet_manifest_targets": [
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "kind": "Kustomization",
+      "name": "springboot-paas",
+      "namespace": "apps",
+      "owner": "platform-runtime"
+    },
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "kind": "Deployment",
+      "name": "springboot-paas",
+      "namespace": "apps",
+      "owner": "platform-runtime",
+      "source_dry_path": "server.port"
+    },
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "kind": "ConfigMap",
+      "name": "springboot-paas-config",
+      "namespace": "apps",
+      "owner": "platform-runtime",
+      "source_dry_path": "spring.datasource.url"
+    }
+  ],
+  "wet_units": [
+    {
+      "id": "wet_24b4f9e96079fa9a",
+      "kind": "wet-unit",
+      "layer": "wet",
+      "name": "springboot-paas-wet"
+    }
+  ]
+}

--- a/cmd/cub-gen/testdata/parity/gitops-import.golden.json
+++ b/cmd/cub-gen/testdata/parity/gitops-import.golden.json
@@ -58,6 +58,7 @@
   "dry_inputs": [
     {
       "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
       "path": "Chart.yaml",
       "profile": "helm-paas",
       "required": true,
@@ -65,6 +66,7 @@
     },
     {
       "generator_id": "gen_635643e45fbf3410",
+      "owner": "app-team",
       "path": "values-prod.yaml",
       "profile": "helm-paas",
       "required": true,
@@ -72,6 +74,7 @@
     },
     {
       "generator_id": "gen_635643e45fbf3410",
+      "owner": "app-team",
       "path": "values.yaml",
       "profile": "helm-paas",
       "required": true,
@@ -235,13 +238,15 @@
       "generator_id": "gen_635643e45fbf3410",
       "kind": "HelmRelease",
       "name": "helm-paas",
-      "namespace": "apps"
+      "namespace": "apps",
+      "owner": "platform-runtime"
     },
     {
       "generator_id": "gen_635643e45fbf3410",
       "kind": "Deployment",
       "name": "helm-paas",
       "namespace": "apps",
+      "owner": "platform-runtime",
       "source_dry_path": "values.image.tag"
     },
     {
@@ -249,6 +254,7 @@
       "kind": "Service",
       "name": "helm-paas",
       "namespace": "apps",
+      "owner": "platform-runtime",
       "source_dry_path": "values.service.port"
     }
   ],

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -19,6 +19,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Golden files under `cmd/cub-gen/testdata/parity/`.
 - Includes command help/usage goldens to lock human-facing CLI contract.
 - Helm example is covered across discover/import/cleanup parity paths.
+- Spring Boot import JSON contract is golden-locked (`gitops-import-spring.golden.json`).
 
 ### Tier 3: examples proof
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -233,15 +233,35 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 			Reason:         "Score variable maps to a single Kubernetes env var.",
 		}}
 	case model.GeneratorSpringBoot:
-		return []model.InversePatch{{
-			Operation:      "replace",
-			DryPath:        "spring.datasource.url",
-			WetPath:        "ConfigMap/data/application.yaml:spring.datasource.url",
-			EditableBy:     "platform-engineer",
-			Confidence:     0.78,
-			RequiresReview: true,
-			Reason:         "Database connectivity impacts shared runtime dependencies.",
-		}}
+		return []model.InversePatch{
+			{
+				Operation:      "replace",
+				DryPath:        "spring.application.name",
+				WetPath:        "Deployment/metadata/labels[app.kubernetes.io/name]",
+				EditableBy:     "app-team",
+				Confidence:     0.88,
+				RequiresReview: false,
+				Reason:         "Application identity should be app-editable without platform escalation.",
+			},
+			{
+				Operation:      "replace",
+				DryPath:        "server.port",
+				WetPath:        "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
+				EditableBy:     "app-team",
+				Confidence:     0.91,
+				RequiresReview: false,
+				Reason:         "Application listener port is an app-level configuration concern.",
+			},
+			{
+				Operation:      "replace",
+				DryPath:        "spring.datasource.url",
+				WetPath:        "ConfigMap/data/application.yaml:spring.datasource.url",
+				EditableBy:     "platform-engineer",
+				Confidence:     0.78,
+				RequiresReview: true,
+				Reason:         "Database connectivity impacts shared runtime dependencies.",
+			},
+		}
 	default:
 		return []model.InversePatch{}
 	}
@@ -285,15 +305,40 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 			},
 		}
 	case model.GeneratorSpringBoot:
-		return []model.FieldOrigin{
+		hints := springPathHintsFromInputs(g.Inputs)
+		origins := []model.FieldOrigin{
+			{
+				DryPath:    "spring.application.name",
+				WetPath:    "Deployment/metadata/labels[app.kubernetes.io/name]",
+				SourcePath: hints.BaseConfigPath,
+				Transform:  "spring-config-to-manifest",
+				Confidence: 0.89,
+			},
+			{
+				DryPath:    "server.port",
+				WetPath:    "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
+				SourcePath: hints.BaseConfigPath,
+				Transform:  "spring-config-to-manifest",
+				Confidence: 0.92,
+			},
 			{
 				DryPath:    "spring.datasource.url",
 				WetPath:    "ConfigMap/data/application.yaml:spring.datasource.url",
-				SourcePath: "src/main/resources/application.yaml",
+				SourcePath: hints.BaseConfigPath,
 				Transform:  "spring-config-to-manifest",
 				Confidence: 0.78,
 			},
 		}
+		if hints.ProfileConfigPath != "" {
+			origins = append(origins, model.FieldOrigin{
+				DryPath:    "server.port",
+				WetPath:    "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
+				SourcePath: hints.ProfileConfigPath,
+				Transform:  "spring-profile-overlay",
+				Confidence: 0.88,
+			})
+		}
+		return origins
 	default:
 		return []model.FieldOrigin{}
 	}
@@ -337,12 +382,27 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 			},
 		}
 	case model.GeneratorSpringBoot:
+		hints := springPathHintsFromInputs(g.Inputs)
 		return []model.InverseEditPointer{
+			{
+				WetPath:    "Deployment/metadata/labels[app.kubernetes.io/name]",
+				DryPath:    "spring.application.name",
+				Owner:      "app-team",
+				EditHint:   fmt.Sprintf("Edit spring.application.name in %s.", hints.BaseConfigPath),
+				Confidence: 0.89,
+			},
+			{
+				WetPath:    "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
+				DryPath:    "server.port",
+				Owner:      "app-team",
+				EditHint:   springServerPortEditHint(hints),
+				Confidence: 0.91,
+			},
 			{
 				WetPath:    "ConfigMap/data/application.yaml:spring.datasource.url",
 				DryPath:    "spring.datasource.url",
 				Owner:      "platform-engineer",
-				EditHint:   "Edit datasource URL in application.yaml profile hierarchy.",
+				EditHint:   fmt.Sprintf("Edit spring.datasource.url in %s and coordinate with platform ownership rules.", hints.BaseConfigPath),
 				Confidence: 0.78,
 			},
 		}
@@ -456,10 +516,12 @@ func firstScoreInputPath(inputs []string) string {
 func dryInputsForGenerator(g model.GeneratorDetection) []model.DryInputRef {
 	out := make([]model.DryInputRef, 0, len(g.Inputs))
 	for _, in := range g.Inputs {
+		role := classifyDryInputRole(g.Kind, in)
 		out = append(out, model.DryInputRef{
 			GeneratorID: g.ID,
 			Profile:     g.Profile,
-			Role:        classifyDryInputRole(g.Kind, in),
+			Role:        role,
+			Owner:       ownerForDryInput(g.Kind, role),
 			Path:        in,
 			Required:    true,
 		})
@@ -477,21 +539,22 @@ func wetManifestTargetsForGenerator(detection model.DetectionResult, g model.Gen
 	switch g.Kind {
 	case model.GeneratorHelm:
 		return []model.WetManifestTarget{
-			{GeneratorID: g.ID, Kind: "HelmRelease", Name: g.Name, Namespace: "apps"},
-			{GeneratorID: g.ID, Kind: "Deployment", Name: g.Name, Namespace: "apps", SourceDryPath: "values.image.tag"},
-			{GeneratorID: g.ID, Kind: "Service", Name: g.Name, Namespace: "apps", SourceDryPath: "values.service.port"},
+			{GeneratorID: g.ID, Kind: "HelmRelease", Name: g.Name, Owner: "platform-runtime", Namespace: "apps"},
+			{GeneratorID: g.ID, Kind: "Deployment", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "values.image.tag"},
+			{GeneratorID: g.ID, Kind: "Service", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "values.service.port"},
 		}
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
 		return []model.WetManifestTarget{
-			{GeneratorID: g.ID, Kind: "Application", Name: g.Name, Namespace: "apps"},
-			{GeneratorID: g.ID, Kind: "Deployment", Name: g.Name, Namespace: "apps", SourceDryPath: fmt.Sprintf("containers.%s.image", hints.ContainerName)},
-			{GeneratorID: g.ID, Kind: "Service", Name: g.Name, Namespace: "apps", SourceDryPath: fmt.Sprintf("service.ports.%s.port", hints.ServicePortName)},
+			{GeneratorID: g.ID, Kind: "Application", Name: g.Name, Owner: "platform-runtime", Namespace: "apps"},
+			{GeneratorID: g.ID, Kind: "Deployment", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: fmt.Sprintf("containers.%s.image", hints.ContainerName)},
+			{GeneratorID: g.ID, Kind: "Service", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: fmt.Sprintf("service.ports.%s.port", hints.ServicePortName)},
 		}
 	case model.GeneratorSpringBoot:
 		return []model.WetManifestTarget{
-			{GeneratorID: g.ID, Kind: "Kustomization", Name: g.Name, Namespace: "apps"},
-			{GeneratorID: g.ID, Kind: "ConfigMap", Name: g.Name + "-config", Namespace: "apps", SourceDryPath: "spring.datasource.url"},
+			{GeneratorID: g.ID, Kind: "Kustomization", Name: g.Name, Owner: "platform-runtime", Namespace: "apps"},
+			{GeneratorID: g.ID, Kind: "Deployment", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "server.port"},
+			{GeneratorID: g.ID, Kind: "ConfigMap", Name: g.Name + "-config", Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "spring.datasource.url"},
 		}
 	default:
 		return []model.WetManifestTarget{}
@@ -519,12 +582,34 @@ func classifyDryInputRole(kind model.GeneratorKind, in string) string {
 		if base == "pom.xml" || base == "build.gradle" || base == "build.gradle.kts" {
 			return "build-config"
 		}
-		if strings.HasPrefix(base, "application") && (strings.HasSuffix(base, ".yaml") || strings.HasSuffix(base, ".yml")) {
-			return "app-config"
+		if base == "application.yaml" || base == "application.yml" {
+			return "app-config-base"
+		}
+		if strings.HasPrefix(base, "application-") && (strings.HasSuffix(base, ".yaml") || strings.HasSuffix(base, ".yml")) {
+			return "app-config-profile"
 		}
 		return "spring-input"
 	default:
 		return "input"
+	}
+}
+
+func ownerForDryInput(kind model.GeneratorKind, role string) string {
+	switch kind {
+	case model.GeneratorHelm:
+		if role == "values" {
+			return "app-team"
+		}
+		return "platform-engineer"
+	case model.GeneratorScore:
+		return "app-team"
+	case model.GeneratorSpringBoot:
+		if strings.HasPrefix(role, "app-config") {
+			return "app-team"
+		}
+		return "platform-engineer"
+	default:
+		return "platform-engineer"
 	}
 }
 
@@ -584,13 +669,73 @@ func renderedLineageForGenerator(detection model.DetectionResult, g model.Genera
 			{Kind: "Service", Name: g.Name, Namespace: "apps", SourcePath: hints.SourcePath, SourceDryPath: fmt.Sprintf("service.ports.%s.port", hints.ServicePortName)},
 		}
 	case model.GeneratorSpringBoot:
-		return []model.RenderedObjectLineage{
-			{Kind: "Kustomization", Name: g.Name, Namespace: "apps", SourcePath: "kustomization.yaml", SourceDryPath: "resources"},
-			{Kind: "ConfigMap", Name: g.Name + "-config", Namespace: "apps", SourcePath: "src/main/resources/application.yaml", SourceDryPath: "spring.datasource.url"},
+		hints := springPathHintsFromInputs(g.Inputs)
+		lineage := []model.RenderedObjectLineage{
+			{Kind: "Kustomization", Name: g.Name, Namespace: "apps", SourcePath: hints.BuildConfigPath, SourceDryPath: "build"},
+			{Kind: "Deployment", Name: g.Name, Namespace: "apps", SourcePath: hints.BaseConfigPath, SourceDryPath: "spring.application.name"},
+			{Kind: "ConfigMap", Name: g.Name + "-config", Namespace: "apps", SourcePath: hints.BaseConfigPath, SourceDryPath: "spring.datasource.url"},
 		}
+		if hints.ProfileConfigPath != "" {
+			lineage = append(lineage, model.RenderedObjectLineage{
+				Kind: "Deployment", Name: g.Name, Namespace: "apps", SourcePath: hints.ProfileConfigPath, SourceDryPath: "server.port",
+			})
+		} else {
+			lineage = append(lineage, model.RenderedObjectLineage{
+				Kind: "Deployment", Name: g.Name, Namespace: "apps", SourcePath: hints.BaseConfigPath, SourceDryPath: "server.port",
+			})
+		}
+		return lineage
 	default:
 		return nil
 	}
+}
+
+type springHints struct {
+	BuildConfigPath   string
+	BaseConfigPath    string
+	ProfileConfigPath string
+}
+
+func springPathHintsFromInputs(inputs []string) springHints {
+	h := springHints{
+		BuildConfigPath: "pom.xml",
+		BaseConfigPath:  "src/main/resources/application.yaml",
+	}
+
+	for _, in := range inputs {
+		p := filepath.ToSlash(in)
+		base := strings.ToLower(filepath.Base(in))
+		switch base {
+		case "pom.xml", "build.gradle", "build.gradle.kts":
+			h.BuildConfigPath = p
+		case "application.yaml", "application.yml":
+			h.BaseConfigPath = p
+		}
+	}
+	for _, in := range inputs {
+		p := filepath.ToSlash(in)
+		base := strings.ToLower(filepath.Base(in))
+		if strings.HasPrefix(base, "application-") && (strings.HasSuffix(base, ".yaml") || strings.HasSuffix(base, ".yml")) {
+			if h.ProfileConfigPath == "" || p < h.ProfileConfigPath {
+				h.ProfileConfigPath = p
+			}
+		}
+	}
+	if h.BaseConfigPath == "" {
+		if h.ProfileConfigPath != "" {
+			h.BaseConfigPath = h.ProfileConfigPath
+		} else {
+			h.BaseConfigPath = "src/main/resources/application.yaml"
+		}
+	}
+	return h
+}
+
+func springServerPortEditHint(h springHints) string {
+	if h.ProfileConfigPath != "" {
+		return fmt.Sprintf("Edit server.port in %s for environment overrides; use %s for the default.", h.ProfileConfigPath, h.BaseConfigPath)
+	}
+	return fmt.Sprintf("Edit server.port in %s.", h.BaseConfigPath)
 }
 
 func inferInputSchema(kind model.GeneratorKind, inputPath string) string {

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -145,12 +145,76 @@ func TestImportRepoHelmDryWetContract(t *testing.T) {
 	if !dryInputHasRolePath(result.DryInputs, "values", "values-prod.yaml") {
 		t.Fatalf("expected values-prod.yaml dry input, got %+v", result.DryInputs)
 	}
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "chart", "platform-engineer", "Chart.yaml") {
+		t.Fatalf("expected chart owner to be platform-engineer, got %+v", result.DryInputs)
+	}
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "values", "app-team", "values.yaml") {
+		t.Fatalf("expected values.yaml owner to be app-team, got %+v", result.DryInputs)
+	}
 
 	if !wetTargetHasKind(result.WetManifestTargets, "HelmRelease") {
 		t.Fatalf("expected HelmRelease wet target, got %+v", result.WetManifestTargets)
 	}
 	if !wetTargetHasKind(result.WetManifestTargets, "Deployment") {
 		t.Fatalf("expected Deployment wet target, got %+v", result.WetManifestTargets)
+	}
+	if !wetTargetHasKindOwner(result.WetManifestTargets, "HelmRelease", "platform-runtime") {
+		t.Fatalf("expected HelmRelease owner to be platform-runtime, got %+v", result.WetManifestTargets)
+	}
+}
+
+func TestImportRepoSpringBootDryWetContract(t *testing.T) {
+	repo := filepath.Join("..", "..", "examples", "springboot-paas")
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+
+	if len(result.Provenance) != 1 {
+		t.Fatalf("expected single provenance record, got %d", len(result.Provenance))
+	}
+	prov := result.Provenance[0]
+	if !fieldOriginHasDryPath(prov.FieldOriginMap, "spring.application.name") {
+		t.Fatalf("expected spring.application.name field origin, got %+v", prov.FieldOriginMap)
+	}
+	if !fieldOriginHasDryPath(prov.FieldOriginMap, "server.port") {
+		t.Fatalf("expected server.port field origin, got %+v", prov.FieldOriginMap)
+	}
+	if !fieldOriginHasDryPath(prov.FieldOriginMap, "spring.datasource.url") {
+		t.Fatalf("expected spring.datasource.url field origin, got %+v", prov.FieldOriginMap)
+	}
+	if !inversePointerHasDryPath(prov.InverseEditPointers, "spring.application.name") {
+		t.Fatalf("expected spring.application.name inverse pointer, got %+v", prov.InverseEditPointers)
+	}
+	if !inversePointerHasDryPath(prov.InverseEditPointers, "server.port") {
+		t.Fatalf("expected server.port inverse pointer, got %+v", prov.InverseEditPointers)
+	}
+
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "app-config-base", "app-team", "src/main/resources/application.yaml") {
+		t.Fatalf("expected base app config owned by app-team, got %+v", result.DryInputs)
+	}
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "app-config-profile", "app-team", "src/main/resources/application-prod.yaml") {
+		t.Fatalf("expected profile app config owned by app-team, got %+v", result.DryInputs)
+	}
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "build-config", "platform-engineer", "pom.xml") {
+		t.Fatalf("expected build config owned by platform-engineer, got %+v", result.DryInputs)
+	}
+
+	if !wetTargetHasKindOwner(result.WetManifestTargets, "Kustomization", "platform-runtime") {
+		t.Fatalf("expected Kustomization owner to be platform-runtime, got %+v", result.WetManifestTargets)
+	}
+	if !wetTargetHasKindOwner(result.WetManifestTargets, "Deployment", "platform-runtime") {
+		t.Fatalf("expected Deployment owner to be platform-runtime, got %+v", result.WetManifestTargets)
+	}
+	if !wetTargetHasKindOwner(result.WetManifestTargets, "ConfigMap", "platform-runtime") {
+		t.Fatalf("expected ConfigMap owner to be platform-runtime, got %+v", result.WetManifestTargets)
+	}
+
+	if len(result.InversePlans) != 1 {
+		t.Fatalf("expected 1 inverse plan, got %d", len(result.InversePlans))
+	}
+	if len(result.InversePlans[0].Patches) < 2 {
+		t.Fatalf("expected at least 2 spring inverse patches, got %+v", result.InversePlans[0].Patches)
 	}
 }
 
@@ -325,9 +389,27 @@ func dryInputHasRolePath(v []model.DryInputRef, role, path string) bool {
 	return false
 }
 
+func dryInputHasRoleOwnerPath(v []model.DryInputRef, role, owner, path string) bool {
+	for _, item := range v {
+		if item.Role == role && item.Owner == owner && item.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
 func wetTargetHasKind(v []model.WetManifestTarget, kind string) bool {
 	for _, item := range v {
 		if item.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func wetTargetHasKindOwner(v []model.WetManifestTarget, kind, owner string) bool {
+	for _, item := range v {
+		if item.Kind == kind && item.Owner == owner {
 			return true
 		}
 	}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -143,6 +143,7 @@ type DryInputRef struct {
 	GeneratorID string `json:"generator_id"`
 	Profile     string `json:"profile"`
 	Role        string `json:"role"`
+	Owner       string `json:"owner"`
 	Path        string `json:"path"`
 	Required    bool   `json:"required"`
 }
@@ -151,6 +152,7 @@ type WetManifestTarget struct {
 	GeneratorID   string `json:"generator_id"`
 	Kind          string `json:"kind"`
 	Name          string `json:"name"`
+	Owner         string `json:"owner"`
 	Namespace     string `json:"namespace,omitempty"`
 	SourceDryPath string `json:"source_dry_path,omitempty"`
 }


### PR DESCRIPTION
## Summary
- implement Spring Boot DRY/WET ownership boundaries in import output
- add app-team inverse-edit hints for `spring.application.name` and `server.port`
- keep platform-owned edit path for `spring.datasource.url`
- add Spring Boot parity golden coverage (`gitops-import-spring.golden.json`)
- update README/PARITY/testing docs for MVP-03

## Acceptance mapping (Issue #4)
- detect Spring Boot roots and app config inputs: already present and preserved
- app-owned DRY vs platform-owned WET: `dry_inputs.owner` + `wet_manifest_targets.owner`
- inverse-edit hints for app teams: added in provenance and inverse plan
- parity + stable goldens: added Spring import golden + updated Helm golden for ownership fields

## Proof
- `go test ./...` (run twice consecutively)
- `go test ./cmd/cub-gen -run '^TestGitOpsParity' -count=1 -v`
- `go run ./cmd/cub-gen gitops discover --space platform ./examples/springboot-paas`

Closes #4
