### PR TITLE
MVP-04: adoption-focused docs for Flux/Argo Git users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,98 @@
 # cub-gen
 
-`cub-gen` is a prototype for Git-native generator import based on `cub gitops`.
+`cub-gen` is a local-first prototype for deterministic DRY -> WET generator import, modeled on `cub gitops` command flow.
 
-## Current scope
+## What cub-gen does today
 
-- Detect generator source types in a repo (`helm`, `score.dev`, `springboot`)
-- Per `cub gitops` the flow stages are:
+- Detects generator-style app sources in Git repos (`helm`, `score.dev`, `springboot`).
+- Runs the same staged flow shape as `cub gitops`:
   - `gitops discover`
   - `gitops import`
   - `gitops cleanup`
-- Keep all behavior local for now
+- Emits provenance and inverse-edit guidance ("what rendered field came from which DRY field").
+- Stays local and pre-sync in v0.1 (no cluster deploys, no ConfigHub backend required).
 
-## Quick start
+## Where Flux/Argo/OCI fit
+
+`cub-gen` is the import/provenance step, not the reconciler.
+
+1. DRY app intent lives in Git (`Chart.yaml`, `score.yaml`, `application.yaml`, etc.).
+2. `cub-gen gitops import` classifies DRY inputs + WET targets and emits provenance/inverse map data.
+3. WET artifacts move through Git/OCI transport.
+4. Flux/Argo continue to reconcile WET -> LIVE.
+
+This means teams can add `cub-gen` to existing Flux/Argo repos today without changing runtime controllers.
+
+## Terminology (locked for v0.1)
+
+| Term | Meaning in cub-gen |
+|---|---|
+| DRY source | Human-editable app/platform intent (`values.yaml`, `score.yaml`, `application.yaml`) |
+| WET rendered units | Explicit rendered deployment-facing units/manifests |
+| Provenance | Record of DRY inputs, rendered outputs, field-origin map, inverse-edit pointers |
+| Inverse map | Guidance from changed WET field -> where to edit DRY safely |
+| Pre-sync | `cub-gen` stops before WET->LIVE; Flux/Argo own reconciliation |
+
+## Quickstart (copy/paste)
 
 ```bash
 go build ./cmd/cub-gen
+```
 
+### Helm example
+
+```bash
 ./cub-gen gitops discover --space platform ./examples/helm-paas
-./cub-gen gitops import --space platform ./examples/helm-paas ./examples/helm-paas
+./cub-gen gitops import --space platform --json ./examples/helm-paas ./examples/helm-paas | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets}'
 ./cub-gen gitops cleanup --space platform ./examples/helm-paas
 ```
 
-## Examples
+### score.dev example
 
-- `examples/helm-paas`
-- `examples/scoredev-paas`
-- `examples/springboot-paas`
+```bash
+./cub-gen gitops discover --space platform ./examples/scoredev-paas
+./cub-gen gitops import --space platform --json ./examples/scoredev-paas ./examples/scoredev-paas | jq '{profile: .discovered[0].generator_profile, field_origin_map: .provenance[0].field_origin_map, inverse_edit_pointers: .provenance[0].inverse_edit_pointers}'
+./cub-gen gitops cleanup --space platform ./examples/scoredev-paas
+```
 
-## Score.dev import contract (MVP-01)
+### Spring Boot example
 
-For score.dev repos, `gitops import --json` now emits:
+```bash
+./cub-gen gitops discover --space platform ./examples/springboot-paas
+./cub-gen gitops import --space platform --json ./examples/springboot-paas ./examples/springboot-paas | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets, inverse_edit_pointers: .provenance[0].inverse_edit_pointers}'
+./cub-gen gitops cleanup --space platform ./examples/springboot-paas
+```
+
+## Plain-English collaboration story
+
+A practical app-team/platform-team path in a Spring Boot repo:
+
+1. App team changes `server.port` in `application-prod.yaml` for a feature rollout.
+2. Platform team runs `cub-gen gitops import --json` and sees:
+   - app-owned DRY inputs (`app-config-base`, `app-config-profile`)
+   - platform-owned WET targets (`wet_manifest_targets.owner = platform-runtime`)
+   - inverse pointers showing app-editable fields (`spring.application.name`, `server.port`) vs platform-governed field (`spring.datasource.url`)
+3. Flux/Argo reconciliation path stays unchanged for deployment.
+4. Teams keep app velocity while preserving governance boundaries.
+
+## Contract highlights by example
+
+### score.dev (MVP-01)
 
 - `generator_profile: "scoredev-paas"`
-- provenance `field_origin_map` entries
-- provenance `inverse_edit_pointers` entries
+- provenance `field_origin_map`
+- provenance `inverse_edit_pointers`
 
-This makes app-level edits explicit: each important rendered field points back to a DRY score path and edit hint.
+### Helm (MVP-02)
 
-## Helm import contract (MVP-02)
+- top-level `dry_inputs` and `wet_manifest_targets`
+- provenance `chart_path`, `values_paths`, `rendered_object_lineage`
 
-For Helm repos, `gitops import --json` now emits explicit DRY and WET structures:
+### Spring Boot (MVP-03)
 
-- top-level `dry_inputs` (chart + values files)
-- top-level `wet_manifest_targets` (HelmRelease/Deployment/Service targets)
-- provenance `chart_path`
-- provenance `values_paths`
-- provenance `rendered_object_lineage`
-
-## Spring Boot import contract (MVP-03)
-
-For Spring Boot repos, `gitops import --json` now emits app/platform ownership boundaries:
-
-- `dry_inputs` with explicit ownership:
-  - `app-config-base` / `app-config-profile` owned by `app-team`
-  - `build-config` owned by `platform-engineer`
-- `wet_manifest_targets` owned by `platform-runtime`
-- provenance + inverse-edit pointers include app-team edit paths (`spring.application.name`, `server.port`) and platform-owned edits (`spring.datasource.url`)
+- `dry_inputs.owner` separates app-team vs platform-engineer edit ownership
+- `wet_manifest_targets.owner` marks platform runtime ownership
+- inverse-edit paths include app-team edits (`spring.application.name`, `server.port`) and platform-governed edits (`spring.datasource.url`)
 
 ## Quality model (inherited from cub-scout, adapted)
 


### PR DESCRIPTION
## Summary
- rewrite README for broad Git user adoption (Flux/Argo + AI tool users)
- add copy/paste quickstart flows for Helm, score.dev, and Spring Boot
- lock terminology in plain English (DRY, WET, provenance, inverse map, pre-sync)
- clarify architecture boundary: cub-gen pre-sync import/provenance vs Flux/Argo WET->LIVE reconcile via Git/OCI
- add one app-team + platform-team collaboration story

## Acceptance mapping (Issue #5)
- README quickstart for all three examples: done
- terminology consistency: done
- Flux/Argo/OCI fit + cub-gen pre-sync role: done
- plain-English collaboration story: done
- final proof run after docs update: done

## Proof
- `go test ./...` (run twice consecutively)
- `go run ./cmd/cub-gen gitops discover --space platform ./examples/helm-paas`

Closes #5
