### PR TITLE
v0.2: add local publish bridge command

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -31,6 +31,7 @@ Contract lock means:
 | `--wait` on import | controls async wait | accepted no-op | partial | Kept for CLI compatibility |
 | `--json` output mode | structured output | structured output | matched | Golden-tested |
 | Default/table output mode | human-oriented command output | human-oriented command output | matched | Golden-tested for discover + import |
+| Optional bridge command | N/A | `publish` (top-level) | deferred/parity-safe | Added outside `gitops` contract so v0.1 parity surface remains stable |
 
 ## Flow parity
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ go build ./cmd/cub-gen
 ./cub-gen gitops cleanup --space platform ./examples/springboot-paas
 ```
 
+### Optional bridge artifact (local, no backend)
+
+Generate a ConfigHub-ready change bundle from import output:
+
+```bash
+./cub-gen gitops import --space platform --json ./examples/helm-paas ./examples/helm-paas \
+  | ./cub-gen publish --in - --out - \
+  | jq '{schema_version,source,change_id,summary}'
+```
+
+This emits a deterministic `change-bundle` JSON envelope you can upload later,
+without coupling the core flow to a running ConfigHub backend.
+
 ## Plain-English collaboration story
 
 A practical app-team/platform-team path in a Spring Boot repo:

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/confighub/cub-gen/internal/detect"
 	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
 	"github.com/confighub/cub-gen/internal/importer"
+	"github.com/confighub/cub-gen/internal/publish"
 )
 
 func main() {
@@ -35,6 +36,8 @@ func run(args []string) error {
 		return runDetect(args[1:])
 	case "import":
 		return runLegacyImport(args[1:])
+	case "publish":
+		return runPublish(args[1:])
 	case "gitops":
 		return runGitOps(args[1:])
 	default:
@@ -99,6 +102,56 @@ func runLegacyImport(args []string) error {
 	}()
 
 	return writeJSON(f, result, *pretty)
+}
+
+func runPublish(args []string) error {
+	fs := flag.NewFlagSet("publish", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	in := fs.String("in", "-", "ImportFlow JSON input path, or '-' for stdin")
+	out := fs.String("out", "-", "Bundle JSON output path, or '-' for stdout")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: cub-gen publish [flags]")
+	}
+
+	var inputBytes []byte
+	var err error
+	if *in == "-" {
+		inputBytes, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+	} else {
+		inputBytes, err = os.ReadFile(*in)
+		if err != nil {
+			return fmt.Errorf("read input file: %w", err)
+		}
+	}
+
+	var imported gitopsflow.ImportFlowResult
+	if err := json.Unmarshal(inputBytes, &imported); err != nil {
+		return fmt.Errorf("parse import flow json: %w", err)
+	}
+
+	bundle := publish.BuildBundle(imported)
+	if *out == "-" {
+		return writeJSON(os.Stdout, bundle, *pretty)
+	}
+
+	f, err := os.Create(*out)
+	if err != nil {
+		return fmt.Errorf("create output file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	return writeJSON(f, bundle, *pretty)
 }
 
 func runGitOps(args []string) error {
@@ -284,12 +337,14 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  cub-gen detect [--repo PATH] [--ref REF] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen import [--repo PATH] [--ref REF] [--space SPACE] [--out FILE|-] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen publish [--in FILE|-] [--out FILE|-] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "GitOps parity examples:")
 	fmt.Fprintln(out, "  cub-gen gitops discover --space my-space ./examples/helm-paas")
 	fmt.Fprintln(out, "  cub-gen gitops import --space my-space ./examples/helm-paas local-renderer")
 	fmt.Fprintln(out, "  cub-gen gitops cleanup --space my-space ./examples/helm-paas")
+	fmt.Fprintln(out, "  cub-gen gitops import --space my-space --json ./examples/helm-paas local-renderer | cub-gen publish --in -")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Note: gitops commands are local-only prototypes that mirror cub gitops stages.")
 }

--- a/cmd/cub-gen/publish_command_test.go
+++ b/cmd/cub-gen/publish_command_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPublishFromImportFile(t *testing.T) {
+	setupAliases(t)
+
+	importOut, importErr, err := runWithCapturedIO([]string{"gitops", "import", "--space", "platform", "--json", "helm", "render-target"})
+	if err != nil {
+		t.Fatalf("gitops import returned error: %v\nstderr=%s", err, importErr)
+	}
+	if importErr != "" {
+		t.Fatalf("expected empty stderr from import, got %q", importErr)
+	}
+
+	inPath := filepath.Join(t.TempDir(), "import.json")
+	if err := os.WriteFile(inPath, []byte(importOut), 0o644); err != nil {
+		t.Fatalf("write import json: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{"publish", "--in", inPath})
+	if err != nil {
+		t.Fatalf("publish returned error: %v\nstderr=%s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr from publish, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal publish output: %v\noutput=%s", err, out)
+	}
+	if got["schema_version"] != "cub.confighub.io/change-bundle/v1" {
+		t.Fatalf("unexpected schema_version: %v", got["schema_version"])
+	}
+	if got["source"] != "cub-gen" {
+		t.Fatalf("unexpected source: %v", got["source"])
+	}
+	if got["change_id"] == "" {
+		t.Fatalf("expected non-empty change_id: %v", got["change_id"])
+	}
+
+	summary, ok := got["summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected summary object, got: %T", got["summary"])
+	}
+	if summary["discovered_resources"] != float64(1) {
+		t.Fatalf("expected discovered_resources=1, got %v", summary["discovered_resources"])
+	}
+}
+
+func TestPublishRejectsInvalidJSON(t *testing.T) {
+	inPath := filepath.Join(t.TempDir(), "invalid.json")
+	if err := os.WriteFile(inPath, []byte("not-json"), 0o644); err != nil {
+		t.Fatalf("write invalid input: %v", err)
+	}
+
+	_, _, err := runWithCapturedIO([]string{"publish", "--in", inPath})
+	if err == nil {
+		t.Fatal("expected publish to fail on invalid json")
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "parse import flow json") {
+		t.Fatalf("expected parse import flow json error, got %q", got)
+	}
+}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -12,6 +12,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 
 - `go test ./...`
 - Core detection/import/flow logic tests in `internal/...`.
+- Bridge bundle tests in `internal/publish/...`.
 
 ### Tier 2: parity/golden
 
@@ -24,6 +25,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 ### Tier 3: examples proof
 
 - Run at least one command per example for changed behavior.
+- For bridge changes, validate import -> publish pipeline output.
 
 ## Required commands
 

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -1,0 +1,123 @@
+package publish
+
+import (
+	"sort"
+	"time"
+
+	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
+	"github.com/confighub/cub-gen/internal/model"
+)
+
+const (
+	changeBundleSchema = "cub.confighub.io/change-bundle/v1"
+	changeBundleSource = "cub-gen"
+)
+
+// Summary captures high-signal counts for bridge ingestion and audit logs.
+type Summary struct {
+	DiscoveredResources int      `json:"discovered_resources"`
+	DryUnits            int      `json:"dry_units"`
+	WetUnits            int      `json:"wet_units"`
+	GeneratorUnits      int      `json:"generator_units"`
+	Links               int      `json:"links"`
+	Contracts           int      `json:"contracts"`
+	ProvenanceRecords   int      `json:"provenance_records"`
+	InversePlans        int      `json:"inverse_transform_plans"`
+	DryInputs           int      `json:"dry_inputs"`
+	WetManifestTargets  int      `json:"wet_manifest_targets"`
+	GeneratorProfiles   []string `json:"generator_profiles"`
+}
+
+// ChangeBundle is a local bridge artifact that can be uploaded to ConfigHub
+// later without changing cub-gen's local-first behavior.
+type ChangeBundle struct {
+	SchemaVersion      string                          `json:"schema_version"`
+	Source             string                          `json:"source"`
+	GeneratedAt        string                          `json:"generated_at"`
+	Space              string                          `json:"space"`
+	TargetSlug         string                          `json:"target_slug"`
+	TargetPath         string                          `json:"target_path"`
+	RenderTargetSlug   string                          `json:"render_target_slug"`
+	Ref                string                          `json:"ref"`
+	ChangeID           string                          `json:"change_id,omitempty"`
+	Summary            Summary                         `json:"summary"`
+	Discovered         []gitopsflow.DiscoveredResource `json:"discovered"`
+	DryUnits           []model.UnitRef                 `json:"dry_units"`
+	WetUnits           []model.UnitRef                 `json:"wet_units"`
+	GeneratorUnits     []model.UnitRef                 `json:"generator_units"`
+	Links              []model.UnitLink                `json:"links"`
+	Contracts          []model.GeneratorContract       `json:"contracts"`
+	Provenance         []model.ProvenanceRecord        `json:"provenance"`
+	InversePlans       []model.InverseTransformPlan    `json:"inverse_transform_plans"`
+	DryInputs          []model.DryInputRef             `json:"dry_inputs"`
+	WetManifestTargets []model.WetManifestTarget       `json:"wet_manifest_targets"`
+}
+
+// BuildBundleAt builds a deterministic bridge artifact from import output.
+func BuildBundleAt(imported gitopsflow.ImportFlowResult, at time.Time) ChangeBundle {
+	profilesSet := map[string]struct{}{}
+	for _, item := range imported.Discovered {
+		if item.GeneratorProfile != "" {
+			profilesSet[item.GeneratorProfile] = struct{}{}
+		}
+	}
+	profiles := make([]string, 0, len(profilesSet))
+	for p := range profilesSet {
+		profiles = append(profiles, p)
+	}
+	sort.Strings(profiles)
+
+	return ChangeBundle{
+		SchemaVersion:    changeBundleSchema,
+		Source:           changeBundleSource,
+		GeneratedAt:      at.UTC().Format(time.RFC3339),
+		Space:            imported.Space,
+		TargetSlug:       imported.TargetSlug,
+		TargetPath:       imported.TargetPath,
+		RenderTargetSlug: imported.RenderTargetSlug,
+		Ref:              imported.Ref,
+		ChangeID:         extractChangeID(imported),
+		Summary: Summary{
+			DiscoveredResources: len(imported.Discovered),
+			DryUnits:            len(imported.DryUnits),
+			WetUnits:            len(imported.WetUnits),
+			GeneratorUnits:      len(imported.GeneratorUnits),
+			Links:               len(imported.Links),
+			Contracts:           len(imported.Contracts),
+			ProvenanceRecords:   len(imported.Provenance),
+			InversePlans:        len(imported.InversePlans),
+			DryInputs:           len(imported.DryInputs),
+			WetManifestTargets:  len(imported.WetManifestTargets),
+			GeneratorProfiles:   profiles,
+		},
+		Discovered:         imported.Discovered,
+		DryUnits:           imported.DryUnits,
+		WetUnits:           imported.WetUnits,
+		GeneratorUnits:     imported.GeneratorUnits,
+		Links:              imported.Links,
+		Contracts:          imported.Contracts,
+		Provenance:         imported.Provenance,
+		InversePlans:       imported.InversePlans,
+		DryInputs:          imported.DryInputs,
+		WetManifestTargets: imported.WetManifestTargets,
+	}
+}
+
+// BuildBundle uses current UTC time for bundle generation.
+func BuildBundle(imported gitopsflow.ImportFlowResult) ChangeBundle {
+	return BuildBundleAt(imported, time.Now().UTC())
+}
+
+func extractChangeID(imported gitopsflow.ImportFlowResult) string {
+	for _, p := range imported.Provenance {
+		if p.ChangeID != "" {
+			return p.ChangeID
+		}
+	}
+	for _, p := range imported.InversePlans {
+		if p.ChangeID != "" {
+			return p.ChangeID
+		}
+	}
+	return ""
+}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -1,0 +1,60 @@
+package publish
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
+	"github.com/confighub/cub-gen/internal/model"
+)
+
+func TestBuildBundleAtFromHelmImport(t *testing.T) {
+	repo := filepath.Join("..", "..", "examples", "helm-paas")
+	imported, err := gitopsflow.Import(repo, repo, "HEAD", "platform", "")
+	if err != nil {
+		t.Fatalf("Import returned error: %v", err)
+	}
+
+	at := time.Date(2026, 3, 6, 0, 0, 0, 0, time.UTC)
+	bundle := BuildBundleAt(imported, at)
+
+	if bundle.SchemaVersion != changeBundleSchema {
+		t.Fatalf("unexpected schema version: %q", bundle.SchemaVersion)
+	}
+	if bundle.Source != changeBundleSource {
+		t.Fatalf("unexpected source: %q", bundle.Source)
+	}
+	if bundle.GeneratedAt != "2026-03-06T00:00:00Z" {
+		t.Fatalf("unexpected generated_at: %q", bundle.GeneratedAt)
+	}
+	if bundle.Space != "platform" {
+		t.Fatalf("expected space=platform, got %q", bundle.Space)
+	}
+	if bundle.ChangeID == "" {
+		t.Fatal("expected non-empty change_id")
+	}
+	if bundle.Summary.DiscoveredResources != len(imported.Discovered) {
+		t.Fatalf("summary discovered mismatch: %d vs %d", bundle.Summary.DiscoveredResources, len(imported.Discovered))
+	}
+	if bundle.Summary.DryInputs != len(imported.DryInputs) {
+		t.Fatalf("summary dry_inputs mismatch: %d vs %d", bundle.Summary.DryInputs, len(imported.DryInputs))
+	}
+	if len(bundle.Summary.GeneratorProfiles) != 1 || bundle.Summary.GeneratorProfiles[0] != "helm-paas" {
+		t.Fatalf("unexpected generator profiles: %+v", bundle.Summary.GeneratorProfiles)
+	}
+}
+
+func TestBuildBundleAtChangeIDFallbackToInversePlans(t *testing.T) {
+	imported := gitopsflow.ImportFlowResult{
+		Provenance: nil,
+		InversePlans: []model.InverseTransformPlan{{
+			ChangeID: "chg_fallback",
+		}},
+	}
+
+	bundle := BuildBundleAt(imported, time.Date(2026, 3, 6, 0, 0, 0, 0, time.UTC))
+	if bundle.ChangeID != "chg_fallback" {
+		t.Fatalf("expected fallback change id chg_fallback, got %q", bundle.ChangeID)
+	}
+}


### PR DESCRIPTION
## Summary
- add new top-level `cub-gen publish` command to convert `gitops import --json` output into a deterministic bridge artifact (`change-bundle`)
- keep v0.1 parity stable by adding this as a top-level command (no change to `gitops discover|import|cleanup` contract)
- add `internal/publish` package and tests
- add CLI tests for `publish`
- update README/PARITY/testing docs with bridge usage

## Why
This provides the first optional ConfigHub bridge path while preserving local-first behavior and no backend dependency.

## Usage
```bash
cub-gen gitops import --space platform --json ./examples/helm-paas ./examples/helm-paas \
  | cub-gen publish --in - --out -
```

## Proof
- `go test ./...` (run twice consecutively)
- `go test ./cmd/cub-gen -run '^TestGitOpsParity' -count=1 -v`
- `go run ./cmd/cub-gen gitops import --space platform --json ./examples/helm-paas ./examples/helm-paas | go run ./cmd/cub-gen publish --in - --out - | jq -e '.schema_version == "cub.confighub.io/change-bundle/v1" and .source == "cub-gen"'`
