### PR TITLE
v0.2: lock publish output with golden tests

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -69,6 +69,7 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/gitops-import.golden.json`
   - `cmd/cub-gen/testdata/parity/gitops-import-spring.golden.json`
   - `cmd/cub-gen/testdata/parity/gitops-cleanup.golden.json`
+  - `cmd/cub-gen/testdata/parity/publish-from-import.golden.json`
   - `cmd/cub-gen/testdata/parity/gitops-discover.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-help.stdout.golden.txt`

--- a/cmd/cub-gen/publish_parity_test.go
+++ b/cmd/cub-gen/publish_parity_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPublishGoldenFromImport(t *testing.T) {
+	setupAliases(t)
+
+	importOut, stderr, err := runWithCapturedIO([]string{"gitops", "import", "--space", "platform", "--json", "helm", "render-target"})
+	if err != nil {
+		t.Fatalf("run import returned error: %v\nstderr=%s", err, stderr)
+	}
+
+	inPath := filepath.Join(t.TempDir(), "import.json")
+	if writeErr := os.WriteFile(inPath, []byte(importOut), 0o644); writeErr != nil {
+		t.Fatalf("write import input: %v", writeErr)
+	}
+
+	out, pubStderr, err := runWithCapturedIO([]string{"publish", "--in", inPath})
+	if err != nil {
+		t.Fatalf("run publish returned error: %v\nstderr=%s", err, pubStderr)
+	}
+	if pubStderr != "" {
+		t.Fatalf("expected empty stderr, got %q", pubStderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal publish json: %v\noutput=%s", err, out)
+	}
+	normalizePublish(got)
+
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "publish-from-import.golden.json"), got)
+}
+
+func normalizePublish(m map[string]any) {
+	replaceString(m, "generated_at", "<timestamp>")
+	replaceString(m, "change_id", "<change_id>")
+	replaceString(m, "target_path", "<target_path>")
+
+	for _, item := range asSlice(m["contracts"]) {
+		replaceString(item, "source_repo", "<target_path>")
+	}
+	for _, item := range asSlice(m["provenance"]) {
+		replaceString(item, "provenance_id", "<provenance_id>")
+		replaceString(item, "change_id", "<change_id>")
+		replaceString(item, "rendered_at", "<timestamp>")
+		for _, source := range asSlice(item["sources"]) {
+			replaceString(source, "uri", "<source_uri>")
+		}
+		for _, output := range asSlice(item["outputs"]) {
+			replaceString(output, "digest", "<digest>")
+		}
+	}
+	for _, item := range asSlice(m["inverse_transform_plans"]) {
+		replaceString(item, "plan_id", "<plan_id>")
+		replaceString(item, "change_id", "<change_id>")
+		replaceString(item, "created_at", "<timestamp>")
+	}
+}

--- a/cmd/cub-gen/testdata/parity/publish-from-import.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import.golden.json
@@ -1,0 +1,286 @@
+{
+  "change_id": "\u003cchange_id\u003e",
+  "contracts": [
+    {
+      "capabilities": [
+        "render-manifests",
+        "values-overrides",
+        "inverse-values-patch"
+      ],
+      "deterministic": true,
+      "generator_id": "gen_635643e45fbf3410",
+      "inputs": [
+        {
+          "name": "input_01",
+          "required": true,
+          "schema_ref": "https://json.schemastore.org/chart"
+        },
+        {
+          "name": "input_02",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_03",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        }
+      ],
+      "kind": "helm",
+      "name": "helm-paas",
+      "output_format": "kubernetes/yaml",
+      "profile": "helm-paas",
+      "schema_version": "cub.confighub.io/generator-contract/v1",
+      "source_path": "",
+      "source_ref": "HEAD",
+      "source_repo": "\u003ctarget_path\u003e",
+      "transport": "oci+git",
+      "version": "0.1.0"
+    }
+  ],
+  "discovered": [
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "generator_kind": "helm",
+      "generator_profile": "helm-paas",
+      "inputs": [
+        "Chart.yaml",
+        "values-prod.yaml",
+        "values.yaml"
+      ],
+      "resource_body": "kind: HelmRelease\nmetadata:\n  name: helm-paas\nspec:\n  root: \n",
+      "resource_kind": "HelmRelease",
+      "resource_name": "helm-paas",
+      "resource_type": "helm.toolkit.fluxcd.io/v2/HelmRelease",
+      "root": ""
+    }
+  ],
+  "dry_inputs": [
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
+      "path": "Chart.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "chart"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "app-team",
+      "path": "values-prod.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "values"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "app-team",
+      "path": "values.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "values"
+    }
+  ],
+  "dry_units": [
+    {
+      "id": "dry_55f23c7293f5bf86",
+      "kind": "dry-unit",
+      "layer": "dry",
+      "name": "helm-paas-dry"
+    }
+  ],
+  "generated_at": "\u003ctimestamp\u003e",
+  "generator_units": [
+    {
+      "id": "gen_70b4d2ade0642f1c",
+      "kind": "generator-unit",
+      "layer": "generator",
+      "name": "helm-paas-generator"
+    }
+  ],
+  "inverse_transform_plans": [
+    {
+      "change_id": "\u003cchange_id\u003e",
+      "created_at": "\u003ctimestamp\u003e",
+      "patches": [
+        {
+          "confidence": 0.86,
+          "dry_path": "values.image.tag",
+          "editable_by": "app-team",
+          "op": "replace",
+          "reason": "Container image tag maps cleanly to helm values.",
+          "requires_review": false,
+          "wet_path": "Deployment/spec/template/spec/containers[0]/image"
+        }
+      ],
+      "plan_id": "\u003cplan_id\u003e",
+      "schema_version": "cub.confighub.io/inverse-transform-plan/v1",
+      "source_kind": "helm",
+      "source_ref": "",
+      "status": "draft",
+      "target_unit_id": "dry_55f23c7293f5bf86"
+    }
+  ],
+  "links": [
+    {
+      "dry_unit_id": "dry_55f23c7293f5bf86",
+      "generator_unit_id": "gen_70b4d2ade0642f1c",
+      "wet_unit_id": "wet_b4595877225309fc"
+    }
+  ],
+  "provenance": [
+    {
+      "change_id": "\u003cchange_id\u003e",
+      "chart_path": "Chart.yaml",
+      "field_origin_map": [
+        {
+          "confidence": 0.86,
+          "dry_path": "values.image.tag",
+          "source_path": "values.yaml",
+          "transform": "helm-template",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/image"
+        }
+      ],
+      "generator_id": "gen_635643e45fbf3410",
+      "generator_name": "helm-paas",
+      "generator_profile": "helm-paas",
+      "input_digest": "sha256:0ceaab864fc2c01e0d45011864aa2f8bbe3e1f9a6f2a4bc81b1d4d667dbd6ba9",
+      "inverse_edit_pointers": [
+        {
+          "confidence": 0.86,
+          "dry_path": "values.image.tag",
+          "edit_hint": "Edit chart values file and keep chart template unchanged.",
+          "owner": "app-team",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/image"
+        }
+      ],
+      "outputs": [
+        {
+          "digest": "\u003cdigest\u003e",
+          "role": "rendered-manifests",
+          "uri": "oci://example.local/platform/helm-paas:latest"
+        }
+      ],
+      "provenance_id": "\u003cprovenance_id\u003e",
+      "rendered_at": "\u003ctimestamp\u003e",
+      "rendered_object_lineage": [
+        {
+          "kind": "HelmRelease",
+          "name": "helm-paas",
+          "namespace": "apps",
+          "source_dry_path": "Chart.yaml",
+          "source_path": "Chart.yaml"
+        },
+        {
+          "kind": "Deployment",
+          "name": "helm-paas",
+          "namespace": "apps",
+          "source_dry_path": "values.image.tag",
+          "source_path": "values-prod.yaml"
+        },
+        {
+          "kind": "Service",
+          "name": "helm-paas",
+          "namespace": "apps",
+          "source_dry_path": "values.service.port",
+          "source_path": "values-prod.yaml"
+        },
+        {
+          "kind": "Deployment",
+          "name": "helm-paas",
+          "namespace": "apps",
+          "source_dry_path": "values.image.tag",
+          "source_path": "values.yaml"
+        },
+        {
+          "kind": "Service",
+          "name": "helm-paas",
+          "namespace": "apps",
+          "source_dry_path": "values.service.port",
+          "source_path": "values.yaml"
+        }
+      ],
+      "schema_version": "cub.confighub.io/provenance/v1",
+      "sources": [
+        {
+          "path": "Chart.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "values-prod.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "values.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        }
+      ],
+      "values_paths": [
+        "values-prod.yaml",
+        "values.yaml"
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "ref": "HEAD",
+  "render_target_slug": "render-target",
+  "schema_version": "cub.confighub.io/change-bundle/v1",
+  "source": "cub-gen",
+  "space": "platform",
+  "summary": {
+    "contracts": 1,
+    "discovered_resources": 1,
+    "dry_inputs": 3,
+    "dry_units": 1,
+    "generator_profiles": [
+      "helm-paas"
+    ],
+    "generator_units": 1,
+    "inverse_transform_plans": 1,
+    "links": 1,
+    "provenance_records": 1,
+    "wet_manifest_targets": 3,
+    "wet_units": 1
+  },
+  "target_path": "\u003ctarget_path\u003e",
+  "target_slug": "helm",
+  "wet_manifest_targets": [
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "kind": "HelmRelease",
+      "name": "helm-paas",
+      "namespace": "apps",
+      "owner": "platform-runtime"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "kind": "Deployment",
+      "name": "helm-paas",
+      "namespace": "apps",
+      "owner": "platform-runtime",
+      "source_dry_path": "values.image.tag"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "kind": "Service",
+      "name": "helm-paas",
+      "namespace": "apps",
+      "owner": "platform-runtime",
+      "source_dry_path": "values.service.port"
+    }
+  ],
+  "wet_units": [
+    {
+      "id": "wet_b4595877225309fc",
+      "kind": "wet-unit",
+      "layer": "wet",
+      "name": "helm-paas-wet"
+    }
+  ]
+}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -17,6 +17,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 ### Tier 2: parity/golden
 
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
+- Bridge publish golden lock in `cmd/cub-gen/publish_parity_test.go`.
 - Golden files under `cmd/cub-gen/testdata/parity/`.
 - Includes command help/usage goldens to lock human-facing CLI contract.
 - Helm example is covered across discover/import/cleanup parity paths.


### PR DESCRIPTION
## Summary
- add `TestPublishGoldenFromImport` to lock publish output contract
- add `publish-from-import.golden.json` fixture
- update parity and testing docs to reference publish contract lock

## Proof
- `go test ./...`
- `go test ./cmd/cub-gen -run '^TestGitOpsParity|^TestPublishGoldenFromImport$' -count=1 -v`
