### PR TITLE
v0.2: test publish stdin pipeline behavior

### DIFF
--- a/cmd/cub-gen/publish_command_test.go
+++ b/cmd/cub-gen/publish_command_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,4 +69,97 @@ func TestPublishRejectsInvalidJSON(t *testing.T) {
 	if got := err.Error(); got == "" || !strings.Contains(got, "parse import flow json") {
 		t.Fatalf("expected parse import flow json error, got %q", got)
 	}
+}
+
+func TestPublishFromStdin(t *testing.T) {
+	setupAliases(t)
+
+	importOut, importErr, err := runWithCapturedIO([]string{"gitops", "import", "--space", "platform", "--json", "helm", "render-target"})
+	if err != nil {
+		t.Fatalf("gitops import returned error: %v\nstderr=%s", err, importErr)
+	}
+	if importErr != "" {
+		t.Fatalf("expected empty stderr from import, got %q", importErr)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"publish", "--in", "-"}, importOut)
+	if err != nil {
+		t.Fatalf("publish stdin returned error: %v\nstderr=%s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr from publish stdin, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal publish stdin output: %v\noutput=%s", err, out)
+	}
+	if got["schema_version"] != "cub.confighub.io/change-bundle/v1" {
+		t.Fatalf("unexpected schema_version: %v", got["schema_version"])
+	}
+}
+
+func runWithCapturedIOAndStdin(args []string, stdin string) (stdout, stderr string, err error) {
+	oldOut := os.Stdout
+	oldErr := os.Stderr
+	oldIn := os.Stdin
+
+	outR, outW, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		return "", "", pipeErr
+	}
+	errR, errW, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		_ = outR.Close()
+		_ = outW.Close()
+		return "", "", pipeErr
+	}
+	inR, inW, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		_ = outR.Close()
+		_ = outW.Close()
+		_ = errR.Close()
+		_ = errW.Close()
+		return "", "", pipeErr
+	}
+
+	if _, writeErr := inW.Write([]byte(stdin)); writeErr != nil {
+		_ = outR.Close()
+		_ = outW.Close()
+		_ = errR.Close()
+		_ = errW.Close()
+		_ = inR.Close()
+		_ = inW.Close()
+		return "", "", writeErr
+	}
+	_ = inW.Close()
+
+	os.Stdout = outW
+	os.Stderr = errW
+	os.Stdin = inR
+
+	defer func() {
+		os.Stdout = oldOut
+		os.Stderr = oldErr
+		os.Stdin = oldIn
+	}()
+
+	err = run(args)
+
+	_ = outW.Close()
+	_ = errW.Close()
+	_ = inR.Close()
+
+	outBytes, outReadErr := io.ReadAll(outR)
+	errBytes, errReadErr := io.ReadAll(errR)
+	_ = outR.Close()
+	_ = errR.Close()
+	if outReadErr != nil {
+		return "", "", outReadErr
+	}
+	if errReadErr != nil {
+		return "", "", errReadErr
+	}
+
+	return string(outBytes), string(errBytes), err
 }


### PR DESCRIPTION
## Summary
- add explicit stdin-path contract test for `publish --in -`
- validate the exact shell pipeline usage path (`gitops import --json | publish --in -`) remains safe

## Proof
- `go test ./cmd/cub-gen -run '^TestPublish' -count=1 -v`
- `go test ./...`
