### PR TITLE
v0.2: add deterministic digest to published bundles

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -32,6 +32,7 @@ Contract lock means:
 | `--json` output mode | structured output | structured output | matched | Golden-tested |
 | Default/table output mode | human-oriented command output | human-oriented command output | matched | Golden-tested for discover + import |
 | Optional bridge command | N/A | `publish` (top-level) | deferred/parity-safe | Added outside `gitops` contract so v0.1 parity surface remains stable |
+| Bridge digest fields | N/A | `digest_algorithm` + `bundle_digest` | matched (local contract) | Deterministic bundle verification handle for attestation pipelines |
 
 ## Flow parity
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Or run direct mode (import + bundle in one command):
 ./cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas
 ```
 
+Bundle output includes:
+
+- `digest_algorithm` (currently `sha256`)
+- `bundle_digest` (deterministic digest over bundle content excluding digest fields)
+
+This gives you a simple verification handle for attestation pipelines.
+
 ## Plain-English collaboration story
 
 A practical app-team/platform-team path in a Spring Boot repo:

--- a/cmd/cub-gen/publish_command_test.go
+++ b/cmd/cub-gen/publish_command_test.go
@@ -43,6 +43,12 @@ func TestPublishFromImportFile(t *testing.T) {
 	if got["source"] != "cub-gen" {
 		t.Fatalf("unexpected source: %v", got["source"])
 	}
+	if got["digest_algorithm"] != "sha256" {
+		t.Fatalf("unexpected digest_algorithm: %v", got["digest_algorithm"])
+	}
+	if v, ok := got["bundle_digest"].(string); !ok || !strings.HasPrefix(v, "sha256:") {
+		t.Fatalf("unexpected bundle_digest: %v", got["bundle_digest"])
+	}
 	if got["change_id"] == "" {
 		t.Fatalf("expected non-empty change_id: %v", got["change_id"])
 	}

--- a/cmd/cub-gen/publish_parity_test.go
+++ b/cmd/cub-gen/publish_parity_test.go
@@ -40,6 +40,7 @@ func TestPublishGoldenFromImport(t *testing.T) {
 func normalizePublish(m map[string]any) {
 	replaceString(m, "generated_at", "<timestamp>")
 	replaceString(m, "change_id", "<change_id>")
+	replaceString(m, "bundle_digest", "<bundle_digest>")
 	replaceString(m, "target_path", "<target_path>")
 
 	for _, item := range asSlice(m["contracts"]) {

--- a/cmd/cub-gen/testdata/parity/publish-from-import.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import.golden.json
@@ -1,4 +1,5 @@
 {
+  "bundle_digest": "\u003cbundle_digest\u003e",
   "change_id": "\u003cchange_id\u003e",
   "contracts": [
     {
@@ -38,6 +39,7 @@
       "version": "0.1.0"
     }
   ],
+  "digest_algorithm": "sha256",
   "discovered": [
     {
       "generator_id": "gen_635643e45fbf3410",

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -1,6 +1,9 @@
 package publish
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"sort"
 	"time"
 
@@ -11,6 +14,7 @@ import (
 const (
 	changeBundleSchema = "cub.confighub.io/change-bundle/v1"
 	changeBundleSource = "cub-gen"
+	digestAlgorithm    = "sha256"
 )
 
 // Summary captures high-signal counts for bridge ingestion and audit logs.
@@ -34,6 +38,8 @@ type ChangeBundle struct {
 	SchemaVersion      string                          `json:"schema_version"`
 	Source             string                          `json:"source"`
 	GeneratedAt        string                          `json:"generated_at"`
+	DigestAlgorithm    string                          `json:"digest_algorithm"`
+	BundleDigest       string                          `json:"bundle_digest"`
 	Space              string                          `json:"space"`
 	TargetSlug         string                          `json:"target_slug"`
 	TargetPath         string                          `json:"target_path"`
@@ -67,10 +73,11 @@ func BuildBundleAt(imported gitopsflow.ImportFlowResult, at time.Time) ChangeBun
 	}
 	sort.Strings(profiles)
 
-	return ChangeBundle{
+	bundle := ChangeBundle{
 		SchemaVersion:    changeBundleSchema,
 		Source:           changeBundleSource,
 		GeneratedAt:      at.UTC().Format(time.RFC3339),
+		DigestAlgorithm:  digestAlgorithm,
 		Space:            imported.Space,
 		TargetSlug:       imported.TargetSlug,
 		TargetPath:       imported.TargetPath,
@@ -101,6 +108,8 @@ func BuildBundleAt(imported gitopsflow.ImportFlowResult, at time.Time) ChangeBun
 		DryInputs:          imported.DryInputs,
 		WetManifestTargets: imported.WetManifestTargets,
 	}
+	bundle.BundleDigest = computeBundleDigest(bundle)
+	return bundle
 }
 
 // BuildBundle uses current UTC time for bundle generation.
@@ -120,4 +129,18 @@ func extractChangeID(imported gitopsflow.ImportFlowResult) string {
 		}
 	}
 	return ""
+}
+
+func computeBundleDigest(bundle ChangeBundle) string {
+	// Digest excludes digest fields so re-hashing published output is stable.
+	digestInput := bundle
+	digestInput.BundleDigest = ""
+	digestInput.DigestAlgorithm = ""
+
+	b, err := json.Marshal(digestInput)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return digestAlgorithm + ":" + hex.EncodeToString(sum[:])
 }

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -2,6 +2,7 @@ package publish
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +29,12 @@ func TestBuildBundleAtFromHelmImport(t *testing.T) {
 	if bundle.GeneratedAt != "2026-03-06T00:00:00Z" {
 		t.Fatalf("unexpected generated_at: %q", bundle.GeneratedAt)
 	}
+	if bundle.DigestAlgorithm != "sha256" {
+		t.Fatalf("unexpected digest_algorithm: %q", bundle.DigestAlgorithm)
+	}
+	if !strings.HasPrefix(bundle.BundleDigest, "sha256:") {
+		t.Fatalf("expected bundle_digest with sha256 prefix, got %q", bundle.BundleDigest)
+	}
 	if bundle.Space != "platform" {
 		t.Fatalf("expected space=platform, got %q", bundle.Space)
 	}
@@ -42,6 +49,11 @@ func TestBuildBundleAtFromHelmImport(t *testing.T) {
 	}
 	if len(bundle.Summary.GeneratorProfiles) != 1 || bundle.Summary.GeneratorProfiles[0] != "helm-paas" {
 		t.Fatalf("unexpected generator profiles: %+v", bundle.Summary.GeneratorProfiles)
+	}
+
+	again := BuildBundleAt(imported, at)
+	if bundle.BundleDigest != again.BundleDigest {
+		t.Fatalf("expected deterministic bundle_digest, got %q and %q", bundle.BundleDigest, again.BundleDigest)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add attestation-ready digest fields to change bundles:
  - `digest_algorithm` (`sha256`)
  - `bundle_digest` (`sha256:<hex>`)
- compute digest deterministically over bundle content excluding digest fields
- add test coverage for digest presence and determinism
- update publish golden fixture + normalization
- update README and PARITY docs

## Why
This gives every published bundle a stable verification handle for downstream attestation and policy pipelines.

## Proof
- `go test ./...`
- `go test ./cmd/cub-gen -run '^TestGitOpsParity|^TestPublishGoldenFromImport$' -count=1 -v`
- `go run ./cmd/cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas | jq '{digest_algorithm,bundle_digest,change_id}'`
