### PR TITLE
v0.2: add verify command for published bundles

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -33,6 +33,7 @@ Contract lock means:
 | Default/table output mode | human-oriented command output | human-oriented command output | matched | Golden-tested for discover + import |
 | Optional bridge command | N/A | `publish` (top-level) | deferred/parity-safe | Added outside `gitops` contract so v0.1 parity surface remains stable |
 | Bridge digest fields | N/A | `digest_algorithm` + `bundle_digest` | matched (local contract) | Deterministic bundle verification handle for attestation pipelines |
+| Optional verify command | N/A | `verify` (top-level) | matched (local contract) | Verifies schema + digest integrity; non-zero exit on mismatch |
 
 ## Flow parity
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Bundle output includes:
 
 This gives you a simple verification handle for attestation pipelines.
 
+Verify a bundle (file or stdin):
+
+```bash
+./cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas | ./cub-gen verify --in -
+```
+
 ## Plain-English collaboration story
 
 A practical app-team/platform-team path in a Spring Boot repo:

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -38,6 +38,8 @@ func run(args []string) error {
 		return runLegacyImport(args[1:])
 	case "publish":
 		return runPublish(args[1:])
+	case "verify":
+		return runVerify(args[1:])
 	case "gitops":
 		return runGitOps(args[1:])
 	default:
@@ -167,6 +169,57 @@ func runPublish(args []string) error {
 		_ = f.Close()
 	}()
 	return writeJSON(f, bundle, *pretty)
+}
+
+func runVerify(args []string) error {
+	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	in := fs.String("in", "-", "Bundle JSON input path, or '-' for stdin")
+	jsonOut := fs.Bool("json", false, "Output JSON")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: cub-gen verify [flags]")
+	}
+
+	var inputBytes []byte
+	var err error
+	if *in == "-" {
+		inputBytes, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+	} else {
+		inputBytes, err = os.ReadFile(*in)
+		if err != nil {
+			return fmt.Errorf("read input file: %w", err)
+		}
+	}
+
+	var bundle publish.ChangeBundle
+	if err := json.Unmarshal(inputBytes, &bundle); err != nil {
+		return fmt.Errorf("parse bundle json: %w", err)
+	}
+	if err := publish.VerifyBundle(bundle); err != nil {
+		return err
+	}
+
+	if *jsonOut {
+		return writeJSON(os.Stdout, map[string]any{
+			"valid":            true,
+			"digest_algorithm": bundle.DigestAlgorithm,
+			"bundle_digest":    bundle.BundleDigest,
+			"change_id":        bundle.ChangeID,
+		}, *pretty)
+	}
+
+	fmt.Printf("Bundle verification OK: %s\n", bundle.BundleDigest)
+	return nil
 }
 
 func runGitOps(args []string) error {
@@ -354,6 +407,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen import [--repo PATH] [--ref REF] [--space SPACE] [--out FILE|-] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen publish [--in FILE|-] [--out FILE|-] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen publish [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--pretty] <target-slug> <render-target-slug>")
+	fmt.Fprintln(out, "  cub-gen verify [--in FILE|-] [--json] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "GitOps parity examples:")
@@ -362,6 +416,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen gitops cleanup --space my-space ./examples/helm-paas")
 	fmt.Fprintln(out, "  cub-gen gitops import --space my-space --json ./examples/helm-paas local-renderer | cub-gen publish --in -")
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas")
+	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas | cub-gen verify --in -")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Note: gitops commands are local-only prototypes that mirror cub gitops stages.")
 }

--- a/cmd/cub-gen/verify_command_test.go
+++ b/cmd/cub-gen/verify_command_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerifyFromFile(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	inPath := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(inPath, []byte(bundleJSON), 0o644); err != nil {
+		t.Fatalf("write bundle json: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{"verify", "--in", inPath})
+	if err != nil {
+		t.Fatalf("verify returned error: %v\nstderr=%s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(out, "Bundle verification OK:") {
+		t.Fatalf("expected verification OK output, got %q", out)
+	}
+}
+
+func TestVerifyFromStdinJSONOutput(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"verify", "--json", "--in", "-"}, bundleJSON)
+	if err != nil {
+		t.Fatalf("verify stdin returned error: %v\nstderr=%s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal verify output: %v\noutput=%s", err, out)
+	}
+	if valid, ok := got["valid"].(bool); !ok || !valid {
+		t.Fatalf("expected valid=true, got %v", got["valid"])
+	}
+	if got["digest_algorithm"] != "sha256" {
+		t.Fatalf("unexpected digest_algorithm: %v", got["digest_algorithm"])
+	}
+}
+
+func TestVerifyDetectsTamper(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	var bundle map[string]any
+	if err := json.Unmarshal([]byte(bundleJSON), &bundle); err != nil {
+		t.Fatalf("unmarshal bundle: %v", err)
+	}
+	bundle["space"] = "tampered"
+	tamperedBytes, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal tampered bundle: %v", err)
+	}
+
+	inPath := filepath.Join(t.TempDir(), "tampered.json")
+	if err := os.WriteFile(inPath, tamperedBytes, 0o644); err != nil {
+		t.Fatalf("write tampered bundle: %v", err)
+	}
+
+	_, _, err = runWithCapturedIO([]string{"verify", "--in", inPath})
+	if err == nil {
+		t.Fatal("expected verify to fail for tampered bundle")
+	}
+	if !strings.Contains(err.Error(), "bundle digest mismatch") {
+		t.Fatalf("expected digest mismatch error, got %q", err.Error())
+	}
+}
+
+func generateBundleJSON() (string, error) {
+	importOut, stderr, err := runWithCapturedIO([]string{"gitops", "import", "--space", "platform", "--json", "helm", "render-target"})
+	if err != nil {
+		return "", err
+	}
+	if stderr != "" {
+		return "", fmt.Errorf("unexpected stderr from import: %s", stderr)
+	}
+
+	out, pubStderr, err := runWithCapturedIOAndStdin([]string{"publish", "--in", "-"}, importOut)
+	if err != nil {
+		return "", err
+	}
+	if pubStderr != "" {
+		return "", fmt.Errorf("unexpected stderr from publish: %s", pubStderr)
+	}
+	return out, nil
+}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -18,6 +18,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
 - Bridge publish golden lock in `cmd/cub-gen/publish_parity_test.go`.
+- Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
 - Golden files under `cmd/cub-gen/testdata/parity/`.
 - Includes command help/usage goldens to lock human-facing CLI contract.
 - Helm example is covered across discover/import/cleanup parity paths.

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"time"
 
@@ -143,4 +144,25 @@ func computeBundleDigest(bundle ChangeBundle) string {
 	}
 	sum := sha256.Sum256(b)
 	return digestAlgorithm + ":" + hex.EncodeToString(sum[:])
+}
+
+// VerifyBundle validates bundle schema and digest integrity.
+func VerifyBundle(bundle ChangeBundle) error {
+	if bundle.SchemaVersion != changeBundleSchema {
+		return fmt.Errorf("unsupported schema_version %q", bundle.SchemaVersion)
+	}
+	if bundle.DigestAlgorithm == "" {
+		return fmt.Errorf("missing digest_algorithm")
+	}
+	if bundle.DigestAlgorithm != digestAlgorithm {
+		return fmt.Errorf("unsupported digest_algorithm %q", bundle.DigestAlgorithm)
+	}
+	if bundle.BundleDigest == "" {
+		return fmt.Errorf("missing bundle_digest")
+	}
+	expected := computeBundleDigest(bundle)
+	if bundle.BundleDigest != expected {
+		return fmt.Errorf("bundle digest mismatch: expected %s, got %s", expected, bundle.BundleDigest)
+	}
+	return nil
 }

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -70,3 +70,34 @@ func TestBuildBundleAtChangeIDFallbackToInversePlans(t *testing.T) {
 		t.Fatalf("expected fallback change id chg_fallback, got %q", bundle.ChangeID)
 	}
 }
+
+func TestVerifyBundle(t *testing.T) {
+	repo := filepath.Join("..", "..", "examples", "helm-paas")
+	imported, err := gitopsflow.Import(repo, repo, "HEAD", "platform", "")
+	if err != nil {
+		t.Fatalf("Import returned error: %v", err)
+	}
+	bundle := BuildBundleAt(imported, time.Date(2026, 3, 6, 0, 0, 0, 0, time.UTC))
+
+	if err := VerifyBundle(bundle); err != nil {
+		t.Fatalf("VerifyBundle returned error for valid bundle: %v", err)
+	}
+
+	tampered := bundle
+	tampered.Space = "tampered"
+	if err := VerifyBundle(tampered); err == nil {
+		t.Fatal("expected VerifyBundle to fail on tampered bundle")
+	}
+
+	missingDigest := bundle
+	missingDigest.BundleDigest = ""
+	if err := VerifyBundle(missingDigest); err == nil || !strings.Contains(err.Error(), "missing bundle_digest") {
+		t.Fatalf("expected missing bundle_digest error, got %v", err)
+	}
+
+	unsupported := bundle
+	unsupported.DigestAlgorithm = "sha512"
+	if err := VerifyBundle(unsupported); err == nil || !strings.Contains(err.Error(), "unsupported digest_algorithm") {
+		t.Fatalf("expected unsupported digest_algorithm error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add top-level `cub-gen verify` command
- verifies change bundle integrity:
  - schema version
  - digest algorithm support
  - presence of `bundle_digest`
  - recomputed digest equality
- support file and stdin input (`--in`)
- return non-zero on verification failure
- add tests for valid bundle, stdin/json mode, and tamper detection
- update docs/parity/testing notes

## Proof
- `go test ./...`
- `go test ./cmd/cub-gen -run '^TestGitOpsParity|^TestPublishGoldenFromImport|^TestVerify' -count=1 -v`
- `go run ./cmd/cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas | go run ./cmd/cub-gen verify --in -`
