### PR TITLE
v0.2: add parity goldens for verify

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -72,6 +72,9 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/gitops-import-spring.golden.json`
   - `cmd/cub-gen/testdata/parity/gitops-cleanup.golden.json`
   - `cmd/cub-gen/testdata/parity/publish-from-import.golden.json`
+  - `cmd/cub-gen/testdata/parity/verify.stdout.golden.txt`
+  - `cmd/cub-gen/testdata/parity/verify.json.golden.json`
+  - `cmd/cub-gen/testdata/parity/verify-tampered.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-discover.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-help.stdout.golden.txt`

--- a/cmd/cub-gen/testdata/parity/verify-tampered.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/verify-tampered.stderr.golden.txt
@@ -1,0 +1,1 @@
+bundle digest mismatch: expected <bundle_digest>, got <bundle_digest>

--- a/cmd/cub-gen/testdata/parity/verify.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify.json.golden.json
@@ -1,0 +1,6 @@
+{
+  "bundle_digest": "\u003cbundle_digest\u003e",
+  "change_id": "\u003cchange_id\u003e",
+  "digest_algorithm": "sha256",
+  "valid": true
+}

--- a/cmd/cub-gen/testdata/parity/verify.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/verify.stdout.golden.txt
@@ -1,0 +1,1 @@
+Bundle verification OK: <bundle_digest>

--- a/cmd/cub-gen/verify_parity_test.go
+++ b/cmd/cub-gen/verify_parity_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var sha256Re = regexp.MustCompile(`sha256:[a-f0-9]{64}`)
+
+func TestVerifyGoldenText(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"verify", "--in", "-"}, bundleJSON)
+	if err != nil {
+		t.Fatalf("verify returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	normalized := normalizeVerifyText(out)
+	assertGoldenText(t, "testdata/parity/verify.stdout.golden.txt", normalized)
+}
+
+func TestVerifyGoldenJSON(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"verify", "--json", "--in", "-"}, bundleJSON)
+	if err != nil {
+		t.Fatalf("verify --json returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal verify json: %v\noutput=%s", err, out)
+	}
+	replaceString(got, "bundle_digest", "<bundle_digest>")
+	replaceString(got, "change_id", "<change_id>")
+	assertGoldenJSON(t, "testdata/parity/verify.json.golden.json", got)
+}
+
+func TestVerifyGoldenTamperedError(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	var bundle map[string]any
+	if err := json.Unmarshal([]byte(bundleJSON), &bundle); err != nil {
+		t.Fatalf("unmarshal bundle: %v", err)
+	}
+	bundle["space"] = "tampered"
+	tamperedBytes, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal tampered bundle: %v", err)
+	}
+
+	_, _, err = runWithCapturedIOAndStdin([]string{"verify", "--in", "-"}, string(tamperedBytes))
+	if err == nil {
+		t.Fatal("expected verify to fail for tampered bundle")
+	}
+
+	normalizedErr := normalizeVerifyError(err.Error()) + "\n"
+	assertGoldenText(t, "testdata/parity/verify-tampered.stderr.golden.txt", normalizedErr)
+}
+
+func normalizeVerifyText(s string) string {
+	return sha256Re.ReplaceAllString(s, "<bundle_digest>")
+}
+
+func normalizeVerifyError(s string) string {
+	return sha256Re.ReplaceAllString(s, "<bundle_digest>")
+}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -19,6 +19,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
 - Bridge publish golden lock in `cmd/cub-gen/publish_parity_test.go`.
 - Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
+- Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.
 - Golden files under `cmd/cub-gen/testdata/parity/`.
 - Includes command help/usage goldens to lock human-facing CLI contract.
 - Helm example is covered across discover/import/cleanup parity paths.


### PR DESCRIPTION
## Summary
- add verify parity golden tests and fixtures
  - success text output
  - success JSON output
  - tampered bundle error output
- normalize volatile digest values before golden assertion
- update parity + testing docs to include verify golden lock

## Proof
- `go test ./...`
- `go test ./cmd/cub-gen -run '^TestGitOpsParity|^TestPublishGoldenFromImport|^TestVerifyGolden|^TestVerify' -count=1 -v`
