### PR TITLE
v0.2: add attest command for verified bundles

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -34,6 +34,7 @@ Contract lock means:
 | Optional bridge command | N/A | `publish` (top-level) | deferred/parity-safe | Added outside `gitops` contract so v0.1 parity surface remains stable |
 | Bridge digest fields | N/A | `digest_algorithm` + `bundle_digest` | matched (local contract) | Deterministic bundle verification handle for attestation pipelines |
 | Optional verify command | N/A | `verify` (top-level) | matched (local contract) | Verifies schema + digest integrity; non-zero exit on mismatch |
+| Optional attest command | N/A | `attest` (top-level) | matched (local contract) | Emits attestation envelope only from valid verified bundles |
 
 ## Flow parity
 
@@ -75,6 +76,8 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/verify.stdout.golden.txt`
   - `cmd/cub-gen/testdata/parity/verify.json.golden.json`
   - `cmd/cub-gen/testdata/parity/verify-tampered.stderr.golden.txt`
+  - `cmd/cub-gen/testdata/parity/attest.json.golden.json`
+  - `cmd/cub-gen/testdata/parity/attest-tampered.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-discover.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-help.stdout.golden.txt`

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ Verify a bundle (file or stdin):
 ./cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas | ./cub-gen verify --in -
 ```
 
+Emit an attestation record from a verified bundle:
+
+```bash
+./cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas \
+  | ./cub-gen attest --in - --verifier ci-bot \
+  | jq '{schema_version,status,verifier,bundle_digest,attestation_digest}'
+```
+
 ## Plain-English collaboration story
 
 A practical app-team/platform-team path in a Spring Boot repo:

--- a/cmd/cub-gen/attest_command_test.go
+++ b/cmd/cub-gen/attest_command_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAttestFromStdin(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"attest", "--in", "-", "--verifier", "ci-bot"}, bundleJSON)
+	if err != nil {
+		t.Fatalf("attest returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal attest output: %v\noutput=%s", err, out)
+	}
+	if got["schema_version"] != "cub.confighub.io/attestation/v1" {
+		t.Fatalf("unexpected schema_version: %v", got["schema_version"])
+	}
+	if got["source"] != "cub-gen" {
+		t.Fatalf("unexpected source: %v", got["source"])
+	}
+	if got["status"] != "verified" {
+		t.Fatalf("unexpected status: %v", got["status"])
+	}
+	if got["verifier"] != "ci-bot" {
+		t.Fatalf("unexpected verifier: %v", got["verifier"])
+	}
+	if got["digest_algorithm"] != "sha256" {
+		t.Fatalf("unexpected digest_algorithm: %v", got["digest_algorithm"])
+	}
+	if v, ok := got["attestation_digest"].(string); !ok || !strings.HasPrefix(v, "sha256:") {
+		t.Fatalf("unexpected attestation_digest: %v", got["attestation_digest"])
+	}
+}
+
+func TestAttestFromFileToFile(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+	inPath := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(inPath, []byte(bundleJSON), 0o644); err != nil {
+		t.Fatalf("write input bundle: %v", err)
+	}
+	outPath := filepath.Join(t.TempDir(), "attestation.json")
+
+	_, stderr, err := runWithCapturedIO([]string{"attest", "--in", inPath, "--out", outPath})
+	if err != nil {
+		t.Fatalf("attest file->file returned error: %v\nstderr=%s", err, stderr)
+	}
+
+	b, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read attestation output: %v", err)
+	}
+	if !strings.Contains(string(b), "\"schema_version\": \"cub.confighub.io/attestation/v1\"") {
+		t.Fatalf("unexpected attestation payload: %s", string(b))
+	}
+}
+
+func TestAttestDetectsTamperedBundle(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	var bundle map[string]any
+	if err := json.Unmarshal([]byte(bundleJSON), &bundle); err != nil {
+		t.Fatalf("unmarshal bundle: %v", err)
+	}
+	bundle["space"] = "tampered"
+	tamperedBytes, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal tampered bundle: %v", err)
+	}
+
+	_, _, err = runWithCapturedIOAndStdin([]string{"attest", "--in", "-"}, string(tamperedBytes))
+	if err == nil {
+		t.Fatal("expected attest to fail for tampered bundle")
+	}
+	if !strings.Contains(err.Error(), "bundle digest mismatch") {
+		t.Fatalf("expected digest mismatch error, got %q", err.Error())
+	}
+}

--- a/cmd/cub-gen/attest_parity_test.go
+++ b/cmd/cub-gen/attest_parity_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAttestGoldenJSON(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"attest", "--in", "-", "--verifier", "ci-bot"}, bundleJSON)
+	if err != nil {
+		t.Fatalf("attest returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal attest output: %v\noutput=%s", err, out)
+	}
+	replaceString(got, "generated_at", "<timestamp>")
+	replaceString(got, "bundle_digest", "<bundle_digest>")
+	replaceString(got, "attestation_digest", "<attestation_digest>")
+	replaceString(got, "change_id", "<change_id>")
+	assertGoldenJSON(t, "testdata/parity/attest.json.golden.json", got)
+}
+
+func TestAttestGoldenTamperedError(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	var bundle map[string]any
+	if err := json.Unmarshal([]byte(bundleJSON), &bundle); err != nil {
+		t.Fatalf("unmarshal bundle: %v", err)
+	}
+	bundle["space"] = "tampered"
+	tamperedBytes, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal tampered bundle: %v", err)
+	}
+
+	_, _, err = runWithCapturedIOAndStdin([]string{"attest", "--in", "-"}, string(tamperedBytes))
+	if err == nil {
+		t.Fatal("expected attest to fail for tampered bundle")
+	}
+	normalizedErr := normalizeVerifyError(err.Error()) + "\n"
+	assertGoldenText(t, "testdata/parity/attest-tampered.stderr.golden.txt", normalizedErr)
+}

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/confighub/cub-gen/internal/attest"
 	"github.com/confighub/cub-gen/internal/detect"
 	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
 	"github.com/confighub/cub-gen/internal/importer"
@@ -40,6 +41,8 @@ func run(args []string) error {
 		return runPublish(args[1:])
 	case "verify":
 		return runVerify(args[1:])
+	case "attest":
+		return runAttest(args[1:])
 	case "gitops":
 		return runGitOps(args[1:])
 	default:
@@ -220,6 +223,59 @@ func runVerify(args []string) error {
 
 	fmt.Printf("Bundle verification OK: %s\n", bundle.BundleDigest)
 	return nil
+}
+
+func runAttest(args []string) error {
+	fs := flag.NewFlagSet("attest", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	in := fs.String("in", "-", "Bundle JSON input path, or '-' for stdin")
+	out := fs.String("out", "-", "Attestation JSON output path, or '-' for stdout")
+	verifier := fs.String("verifier", "cub-gen", "Verifier identity label")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: cub-gen attest [flags]")
+	}
+
+	var inputBytes []byte
+	var err error
+	if *in == "-" {
+		inputBytes, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+	} else {
+		inputBytes, err = os.ReadFile(*in)
+		if err != nil {
+			return fmt.Errorf("read input file: %w", err)
+		}
+	}
+
+	var bundle publish.ChangeBundle
+	if err := json.Unmarshal(inputBytes, &bundle); err != nil {
+		return fmt.Errorf("parse bundle json: %w", err)
+	}
+	rec, err := attest.Build(bundle, *verifier)
+	if err != nil {
+		return err
+	}
+
+	if *out == "-" {
+		return writeJSON(os.Stdout, rec, *pretty)
+	}
+	f, err := os.Create(*out)
+	if err != nil {
+		return fmt.Errorf("create output file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	return writeJSON(f, rec, *pretty)
 }
 
 func runGitOps(args []string) error {
@@ -408,6 +464,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen publish [--in FILE|-] [--out FILE|-] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen publish [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen verify [--in FILE|-] [--json] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "GitOps parity examples:")
@@ -417,6 +474,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen gitops import --space my-space --json ./examples/helm-paas local-renderer | cub-gen publish --in -")
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas")
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas | cub-gen verify --in -")
+	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas | cub-gen attest --in - --verifier ci-bot")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Note: gitops commands are local-only prototypes that mirror cub gitops stages.")
 }

--- a/cmd/cub-gen/testdata/parity/attest-tampered.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/attest-tampered.stderr.golden.txt
@@ -1,0 +1,1 @@
+bundle digest mismatch: expected <bundle_digest>, got <bundle_digest>

--- a/cmd/cub-gen/testdata/parity/attest.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/attest.json.golden.json
@@ -1,0 +1,14 @@
+{
+  "attestation_digest": "\u003cattestation_digest\u003e",
+  "bundle_digest": "\u003cbundle_digest\u003e",
+  "change_id": "\u003cchange_id\u003e",
+  "digest_algorithm": "sha256",
+  "generated_at": "\u003ctimestamp\u003e",
+  "render_target_slug": "render-target",
+  "schema_version": "cub.confighub.io/attestation/v1",
+  "source": "cub-gen",
+  "space": "platform",
+  "status": "verified",
+  "target_slug": "helm",
+  "verifier": "ci-bot"
+}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -13,6 +13,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - `go test ./...`
 - Core detection/import/flow logic tests in `internal/...`.
 - Bridge bundle tests in `internal/publish/...`.
+- Attestation model tests in `internal/attest/...`.
 
 ### Tier 2: parity/golden
 
@@ -20,6 +21,8 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Bridge publish golden lock in `cmd/cub-gen/publish_parity_test.go`.
 - Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
 - Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.
+- Attest command behavior tests in `cmd/cub-gen/attest_command_test.go`.
+- Attest command golden locks in `cmd/cub-gen/attest_parity_test.go`.
 - Golden files under `cmd/cub-gen/testdata/parity/`.
 - Includes command help/usage goldens to lock human-facing CLI contract.
 - Helm example is covered across discover/import/cleanup parity paths.

--- a/internal/attest/attest.go
+++ b/internal/attest/attest.go
@@ -1,0 +1,76 @@
+package attest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"time"
+
+	"github.com/confighub/cub-gen/internal/publish"
+)
+
+const (
+	attestationSchema = "cub.confighub.io/attestation/v1"
+	attestationSource = "cub-gen"
+	digestAlgorithm   = "sha256"
+)
+
+// Record is an attestation envelope for a verified change bundle.
+type Record struct {
+	SchemaVersion     string `json:"schema_version"`
+	Source            string `json:"source"`
+	GeneratedAt       string `json:"generated_at"`
+	Status            string `json:"status"`
+	Verifier          string `json:"verifier"`
+	DigestAlgorithm   string `json:"digest_algorithm"`
+	BundleDigest      string `json:"bundle_digest"`
+	ChangeID          string `json:"change_id,omitempty"`
+	Space             string `json:"space,omitempty"`
+	TargetSlug        string `json:"target_slug,omitempty"`
+	RenderTargetSlug  string `json:"render_target_slug,omitempty"`
+	AttestationDigest string `json:"attestation_digest"`
+}
+
+// BuildAt verifies a bundle and emits an attestation record.
+func BuildAt(bundle publish.ChangeBundle, at time.Time, verifier string) (Record, error) {
+	if err := publish.VerifyBundle(bundle); err != nil {
+		return Record{}, err
+	}
+	if verifier == "" {
+		verifier = attestationSource
+	}
+
+	rec := Record{
+		SchemaVersion:    attestationSchema,
+		Source:           attestationSource,
+		GeneratedAt:      at.UTC().Format(time.RFC3339),
+		Status:           "verified",
+		Verifier:         verifier,
+		DigestAlgorithm:  digestAlgorithm,
+		BundleDigest:     bundle.BundleDigest,
+		ChangeID:         bundle.ChangeID,
+		Space:            bundle.Space,
+		TargetSlug:       bundle.TargetSlug,
+		RenderTargetSlug: bundle.RenderTargetSlug,
+	}
+	rec.AttestationDigest = computeAttestationDigest(rec)
+	return rec, nil
+}
+
+// Build uses current UTC time for record generation.
+func Build(bundle publish.ChangeBundle, verifier string) (Record, error) {
+	return BuildAt(bundle, time.Now().UTC(), verifier)
+}
+
+func computeAttestationDigest(rec Record) string {
+	input := rec
+	input.AttestationDigest = ""
+	input.DigestAlgorithm = ""
+
+	b, err := json.Marshal(input)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return digestAlgorithm + ":" + hex.EncodeToString(sum[:])
+}

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -1,0 +1,62 @@
+package attest
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
+	"github.com/confighub/cub-gen/internal/publish"
+)
+
+func TestBuildAt(t *testing.T) {
+	repo := filepath.Join("..", "..", "examples", "helm-paas")
+	imported, err := gitopsflow.Import(repo, repo, "HEAD", "platform", "")
+	if err != nil {
+		t.Fatalf("Import returned error: %v", err)
+	}
+	bundle := publish.BuildBundleAt(imported, time.Date(2026, 3, 6, 0, 0, 0, 0, time.UTC))
+
+	rec, err := BuildAt(bundle, time.Date(2026, 3, 6, 1, 0, 0, 0, time.UTC), "ci-bot")
+	if err != nil {
+		t.Fatalf("BuildAt returned error: %v", err)
+	}
+
+	if rec.SchemaVersion != attestationSchema {
+		t.Fatalf("unexpected schema_version: %q", rec.SchemaVersion)
+	}
+	if rec.Source != attestationSource {
+		t.Fatalf("unexpected source: %q", rec.Source)
+	}
+	if rec.Verifier != "ci-bot" {
+		t.Fatalf("unexpected verifier: %q", rec.Verifier)
+	}
+	if rec.Status != "verified" {
+		t.Fatalf("unexpected status: %q", rec.Status)
+	}
+	if rec.DigestAlgorithm != "sha256" {
+		t.Fatalf("unexpected digest_algorithm: %q", rec.DigestAlgorithm)
+	}
+	if !strings.HasPrefix(rec.BundleDigest, "sha256:") {
+		t.Fatalf("expected bundle digest sha256 prefix, got %q", rec.BundleDigest)
+	}
+	if !strings.HasPrefix(rec.AttestationDigest, "sha256:") {
+		t.Fatalf("expected attestation digest sha256 prefix, got %q", rec.AttestationDigest)
+	}
+
+	again, err := BuildAt(bundle, time.Date(2026, 3, 6, 1, 0, 0, 0, time.UTC), "ci-bot")
+	if err != nil {
+		t.Fatalf("BuildAt second run error: %v", err)
+	}
+	if rec.AttestationDigest != again.AttestationDigest {
+		t.Fatalf("expected deterministic attestation digest, got %q and %q", rec.AttestationDigest, again.AttestationDigest)
+	}
+}
+
+func TestBuildAtRejectsInvalidBundle(t *testing.T) {
+	bundle := publish.ChangeBundle{}
+	if _, err := BuildAt(bundle, time.Date(2026, 3, 6, 0, 0, 0, 0, time.UTC), ""); err == nil {
+		t.Fatal("expected BuildAt to fail for invalid bundle")
+	}
+}


### PR DESCRIPTION
## Summary
- add top-level `cub-gen attest` command
- attest consumes a verified change bundle and emits an attestation record:
  - `schema_version`, `status`, `verifier`
  - `bundle_digest`, `attestation_digest`
- add internal attestation package (`internal/attest`)
- add command tests and parity goldens for attest success + tampered error
- update README/PARITY/testing docs

## Commands
- `cub-gen attest --in <bundle.json|-> --out <file|-> --verifier <name>`

## Proof
- `go test ./...`
- `go test ./cmd/cub-gen -run '^TestGitOpsParity|^TestPublishGoldenFromImport|^TestVerifyGolden|^TestVerify|^TestAttestGolden|^TestAttest' -count=1 -v`
- `go run ./cmd/cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas | go run ./cmd/cub-gen verify --in -`
- `go run ./cmd/cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas | go run ./cmd/cub-gen attest --in - --verifier ci-bot`
