### PR TITLE
v0.2: add verify-attestation command

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -35,6 +35,7 @@ Contract lock means:
 | Bridge digest fields | N/A | `digest_algorithm` + `bundle_digest` | matched (local contract) | Deterministic bundle verification handle for attestation pipelines |
 | Optional verify command | N/A | `verify` (top-level) | matched (local contract) | Verifies schema + digest integrity; non-zero exit on mismatch |
 | Optional attest command | N/A | `attest` (top-level) | matched (local contract) | Emits attestation envelope only from valid verified bundles |
+| Optional verify-attestation command | N/A | `verify-attestation` (top-level) | matched (local contract) | Verifies attestation integrity and optional bundle linkage |
 
 ## Flow parity
 
@@ -78,6 +79,8 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/verify-tampered.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/attest.json.golden.json`
   - `cmd/cub-gen/testdata/parity/attest-tampered.stderr.golden.txt`
+  - `cmd/cub-gen/testdata/parity/verify-attestation.json.golden.json`
+  - `cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-discover.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/gitops-help.stdout.golden.txt`

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Emit an attestation record from a verified bundle:
   | jq '{schema_version,status,verifier,bundle_digest,attestation_digest}'
 ```
 
+Verify an attestation (optionally linked against a bundle file):
+
+```bash
+./cub-gen verify-attestation --in attestation.json --bundle bundle.json
+```
+
 ## Plain-English collaboration story
 
 A practical app-team/platform-team path in a Spring Boot repo:

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/confighub/cub-gen/internal/attest"
 	"github.com/confighub/cub-gen/internal/detect"
@@ -43,6 +44,8 @@ func run(args []string) error {
 		return runVerify(args[1:])
 	case "attest":
 		return runAttest(args[1:])
+	case "verify-attestation":
+		return runVerifyAttestation(args[1:])
 	case "gitops":
 		return runGitOps(args[1:])
 	default:
@@ -278,6 +281,80 @@ func runAttest(args []string) error {
 	return writeJSON(f, rec, *pretty)
 }
 
+func runVerifyAttestation(args []string) error {
+	fs := flag.NewFlagSet("verify-attestation", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	in := fs.String("in", "-", "Attestation JSON input path, or '-' for stdin")
+	bundlePath := fs.String("bundle", "", "Optional bundle JSON input path to verify digest linkage")
+	jsonOut := fs.Bool("json", false, "Output JSON")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: cub-gen verify-attestation [flags]")
+	}
+
+	var recBytes []byte
+	var err error
+	if *in == "-" {
+		recBytes, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+	} else {
+		recBytes, err = os.ReadFile(*in)
+		if err != nil {
+			return fmt.Errorf("read input file: %w", err)
+		}
+	}
+
+	var rec attest.Record
+	if err := json.Unmarshal(recBytes, &rec); err != nil {
+		return fmt.Errorf("parse attestation json: %w", err)
+	}
+
+	linked := false
+	if strings.TrimSpace(*bundlePath) == "" {
+		if err := attest.VerifyRecord(rec); err != nil {
+			return err
+		}
+	} else {
+		bundleBytes, err := os.ReadFile(*bundlePath)
+		if err != nil {
+			return fmt.Errorf("read bundle file: %w", err)
+		}
+		var bundle publish.ChangeBundle
+		if err := json.Unmarshal(bundleBytes, &bundle); err != nil {
+			return fmt.Errorf("parse bundle json: %w", err)
+		}
+		if err := attest.VerifyRecordAgainstBundle(rec, bundle); err != nil {
+			return err
+		}
+		linked = true
+	}
+
+	if *jsonOut {
+		return writeJSON(os.Stdout, map[string]any{
+			"valid":               true,
+			"linked_bundle_check": linked,
+			"attestation_digest":  rec.AttestationDigest,
+			"bundle_digest":       rec.BundleDigest,
+			"change_id":           rec.ChangeID,
+		}, *pretty)
+	}
+
+	if linked {
+		fmt.Printf("Attestation verification OK (linked): %s\n", rec.AttestationDigest)
+		return nil
+	}
+	fmt.Printf("Attestation verification OK: %s\n", rec.AttestationDigest)
+	return nil
+}
+
 func runGitOps(args []string) error {
 	if len(args) == 0 {
 		printGitOpsUsage(os.Stderr)
@@ -465,6 +542,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen publish [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen verify [--in FILE|-] [--json] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "GitOps parity examples:")
@@ -475,6 +553,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas")
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas | cub-gen verify --in -")
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas | cub-gen attest --in - --verifier ci-bot")
+	fmt.Fprintln(out, "  cub-gen verify-attestation --in attestation.json --bundle bundle.json")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Note: gitops commands are local-only prototypes that mirror cub gitops stages.")
 }

--- a/cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt
@@ -1,0 +1,1 @@
+unsupported status "tampered"

--- a/cmd/cub-gen/testdata/parity/verify-attestation.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation.json.golden.json
@@ -1,0 +1,7 @@
+{
+  "attestation_digest": "\u003cattestation_digest\u003e",
+  "bundle_digest": "\u003cbundle_digest\u003e",
+  "change_id": "\u003cchange_id\u003e",
+  "linked_bundle_check": false,
+  "valid": true
+}

--- a/cmd/cub-gen/verify_attestation_command_test.go
+++ b/cmd/cub-gen/verify_attestation_command_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerifyAttestationFromStdin(t *testing.T) {
+	setupAliases(t)
+
+	attJSON, _, err := generateAttestationJSON("ci-bot")
+	if err != nil {
+		t.Fatalf("generate attestation: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"verify-attestation", "--in", "-"}, attJSON)
+	if err != nil {
+		t.Fatalf("verify-attestation returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(out, "Attestation verification OK:") {
+		t.Fatalf("expected success output, got %q", out)
+	}
+}
+
+func TestVerifyAttestationAgainstBundleFile(t *testing.T) {
+	setupAliases(t)
+
+	attJSON, bundleJSON, err := generateAttestationJSON("ci-bot")
+	if err != nil {
+		t.Fatalf("generate attestation: %v", err)
+	}
+
+	attPath := filepath.Join(t.TempDir(), "attestation.json")
+	bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(attPath, []byte(attJSON), 0o644); err != nil {
+		t.Fatalf("write attestation file: %v", err)
+	}
+	if err := os.WriteFile(bundlePath, []byte(bundleJSON), 0o644); err != nil {
+		t.Fatalf("write bundle file: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{"verify-attestation", "--in", attPath, "--bundle", bundlePath})
+	if err != nil {
+		t.Fatalf("verify-attestation linked returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(out, "Attestation verification OK (linked):") {
+		t.Fatalf("expected linked success output, got %q", out)
+	}
+}
+
+func TestVerifyAttestationJSONOutput(t *testing.T) {
+	setupAliases(t)
+
+	attJSON, _, err := generateAttestationJSON("ci-bot")
+	if err != nil {
+		t.Fatalf("generate attestation: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"verify-attestation", "--json", "--in", "-"}, attJSON)
+	if err != nil {
+		t.Fatalf("verify-attestation --json returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal verify-attestation json: %v\noutput=%s", err, out)
+	}
+	if valid, ok := got["valid"].(bool); !ok || !valid {
+		t.Fatalf("expected valid=true, got %v", got["valid"])
+	}
+	if linked, ok := got["linked_bundle_check"].(bool); !ok || linked {
+		t.Fatalf("expected linked_bundle_check=false, got %v", got["linked_bundle_check"])
+	}
+}
+
+func TestVerifyAttestationDetectsTamper(t *testing.T) {
+	setupAliases(t)
+
+	attJSON, _, err := generateAttestationJSON("ci-bot")
+	if err != nil {
+		t.Fatalf("generate attestation: %v", err)
+	}
+
+	var rec map[string]any
+	if err := json.Unmarshal([]byte(attJSON), &rec); err != nil {
+		t.Fatalf("unmarshal attestation: %v", err)
+	}
+	rec["status"] = "tampered"
+	tamperedBytes, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal tampered attestation: %v", err)
+	}
+
+	_, _, err = runWithCapturedIOAndStdin([]string{"verify-attestation", "--in", "-"}, string(tamperedBytes))
+	if err == nil {
+		t.Fatal("expected verify-attestation to fail for tampered attestation")
+	}
+	if !strings.Contains(err.Error(), "unsupported status") {
+		t.Fatalf("expected unsupported status error, got %q", err.Error())
+	}
+}
+
+func TestVerifyAttestationDetectsBundleLinkMismatch(t *testing.T) {
+	setupAliases(t)
+
+	attJSON, bundleJSON, err := generateAttestationJSON("ci-bot")
+	if err != nil {
+		t.Fatalf("generate attestation: %v", err)
+	}
+
+	var bundle map[string]any
+	if err := json.Unmarshal([]byte(bundleJSON), &bundle); err != nil {
+		t.Fatalf("unmarshal bundle: %v", err)
+	}
+	bundle["space"] = "tampered"
+	tamperedBundleBytes, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal tampered bundle: %v", err)
+	}
+
+	attPath := filepath.Join(t.TempDir(), "attestation.json")
+	bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(attPath, []byte(attJSON), 0o644); err != nil {
+		t.Fatalf("write attestation file: %v", err)
+	}
+	if err := os.WriteFile(bundlePath, tamperedBundleBytes, 0o644); err != nil {
+		t.Fatalf("write tampered bundle file: %v", err)
+	}
+
+	_, _, err = runWithCapturedIO([]string{"verify-attestation", "--in", attPath, "--bundle", bundlePath})
+	if err == nil {
+		t.Fatal("expected verify-attestation to fail for bundle mismatch")
+	}
+	if !strings.Contains(err.Error(), "bundle digest mismatch") {
+		t.Fatalf("expected bundle digest mismatch error, got %q", err.Error())
+	}
+}
+
+func generateAttestationJSON(verifier string) (string, string, error) {
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		return "", "", err
+	}
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"attest", "--in", "-", "--verifier", verifier}, bundleJSON)
+	if err != nil {
+		return "", "", err
+	}
+	if strings.TrimSpace(stderr) != "" {
+		return "", "", fmt.Errorf("unexpected stderr from attest: %s", stderr)
+	}
+	return out, bundleJSON, nil
+}

--- a/cmd/cub-gen/verify_attestation_parity_test.go
+++ b/cmd/cub-gen/verify_attestation_parity_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestVerifyAttestationGoldenJSON(t *testing.T) {
+	setupAliases(t)
+
+	attJSON, _, err := generateAttestationJSON("ci-bot")
+	if err != nil {
+		t.Fatalf("generate attestation: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"verify-attestation", "--json", "--in", "-"}, attJSON)
+	if err != nil {
+		t.Fatalf("verify-attestation --json returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal verify-attestation json: %v\noutput=%s", err, out)
+	}
+	replaceString(got, "attestation_digest", "<attestation_digest>")
+	replaceString(got, "bundle_digest", "<bundle_digest>")
+	replaceString(got, "change_id", "<change_id>")
+	assertGoldenJSON(t, "testdata/parity/verify-attestation.json.golden.json", got)
+}
+
+func TestVerifyAttestationGoldenTamperedError(t *testing.T) {
+	setupAliases(t)
+
+	attJSON, _, err := generateAttestationJSON("ci-bot")
+	if err != nil {
+		t.Fatalf("generate attestation: %v", err)
+	}
+
+	var rec map[string]any
+	if err := json.Unmarshal([]byte(attJSON), &rec); err != nil {
+		t.Fatalf("unmarshal attestation: %v", err)
+	}
+	rec["status"] = "tampered"
+	tamperedBytes, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal tampered attestation: %v", err)
+	}
+
+	_, _, err = runWithCapturedIOAndStdin([]string{"verify-attestation", "--in", "-"}, string(tamperedBytes))
+	if err == nil {
+		t.Fatal("expected verify-attestation to fail")
+	}
+	assertGoldenText(t, "testdata/parity/verify-attestation-tampered.stderr.golden.txt", err.Error()+"\n")
+}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -23,6 +23,8 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.
 - Attest command behavior tests in `cmd/cub-gen/attest_command_test.go`.
 - Attest command golden locks in `cmd/cub-gen/attest_parity_test.go`.
+- Verify-attestation behavior tests in `cmd/cub-gen/verify_attestation_command_test.go`.
+- Verify-attestation golden locks in `cmd/cub-gen/verify_attestation_parity_test.go`.
 - Golden files under `cmd/cub-gen/testdata/parity/`.
 - Includes command help/usage goldens to lock human-facing CLI contract.
 - Helm example is covered across discover/import/cleanup parity paths.

--- a/internal/attest/attest.go
+++ b/internal/attest/attest.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/confighub/cub-gen/internal/publish"
@@ -73,4 +75,55 @@ func computeAttestationDigest(rec Record) string {
 	}
 	sum := sha256.Sum256(b)
 	return digestAlgorithm + ":" + hex.EncodeToString(sum[:])
+}
+
+// VerifyRecord validates attestation schema and digest integrity.
+func VerifyRecord(rec Record) error {
+	if rec.SchemaVersion != attestationSchema {
+		return fmt.Errorf("unsupported schema_version %q", rec.SchemaVersion)
+	}
+	if rec.Source != attestationSource {
+		return fmt.Errorf("unsupported source %q", rec.Source)
+	}
+	if rec.Status != "verified" {
+		return fmt.Errorf("unsupported status %q", rec.Status)
+	}
+	if rec.DigestAlgorithm == "" {
+		return fmt.Errorf("missing digest_algorithm")
+	}
+	if rec.DigestAlgorithm != digestAlgorithm {
+		return fmt.Errorf("unsupported digest_algorithm %q", rec.DigestAlgorithm)
+	}
+	if rec.BundleDigest == "" {
+		return fmt.Errorf("missing bundle_digest")
+	}
+	if !strings.HasPrefix(rec.BundleDigest, digestAlgorithm+":") {
+		return fmt.Errorf("bundle_digest must use %s prefix", digestAlgorithm)
+	}
+	if rec.AttestationDigest == "" {
+		return fmt.Errorf("missing attestation_digest")
+	}
+	expected := computeAttestationDigest(rec)
+	if rec.AttestationDigest != expected {
+		return fmt.Errorf("attestation digest mismatch: expected %s, got %s", expected, rec.AttestationDigest)
+	}
+	return nil
+}
+
+// VerifyRecordAgainstBundle validates both attestation and bundle integrity and
+// then checks their digest linkage.
+func VerifyRecordAgainstBundle(rec Record, bundle publish.ChangeBundle) error {
+	if err := VerifyRecord(rec); err != nil {
+		return err
+	}
+	if err := publish.VerifyBundle(bundle); err != nil {
+		return err
+	}
+	if rec.BundleDigest != bundle.BundleDigest {
+		return fmt.Errorf("bundle digest link mismatch: attestation=%s bundle=%s", rec.BundleDigest, bundle.BundleDigest)
+	}
+	if rec.ChangeID != "" && bundle.ChangeID != "" && rec.ChangeID != bundle.ChangeID {
+		return fmt.Errorf("change_id link mismatch: attestation=%s bundle=%s", rec.ChangeID, bundle.ChangeID)
+	}
+	return nil
 }

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -60,3 +60,55 @@ func TestBuildAtRejectsInvalidBundle(t *testing.T) {
 		t.Fatal("expected BuildAt to fail for invalid bundle")
 	}
 }
+
+func TestVerifyRecord(t *testing.T) {
+	repo := filepath.Join("..", "..", "examples", "helm-paas")
+	imported, err := gitopsflow.Import(repo, repo, "HEAD", "platform", "")
+	if err != nil {
+		t.Fatalf("Import returned error: %v", err)
+	}
+	bundle := publish.BuildBundleAt(imported, time.Date(2026, 3, 6, 0, 0, 0, 0, time.UTC))
+	rec, err := BuildAt(bundle, time.Date(2026, 3, 6, 1, 0, 0, 0, time.UTC), "ci-bot")
+	if err != nil {
+		t.Fatalf("BuildAt returned error: %v", err)
+	}
+
+	if err := VerifyRecord(rec); err != nil {
+		t.Fatalf("VerifyRecord returned error for valid record: %v", err)
+	}
+
+	tampered := rec
+	tampered.Status = "tampered"
+	if err := VerifyRecord(tampered); err == nil {
+		t.Fatal("expected VerifyRecord to fail for tampered status")
+	}
+
+	missingDigest := rec
+	missingDigest.AttestationDigest = ""
+	if err := VerifyRecord(missingDigest); err == nil || !strings.Contains(err.Error(), "missing attestation_digest") {
+		t.Fatalf("expected missing attestation digest error, got %v", err)
+	}
+}
+
+func TestVerifyRecordAgainstBundle(t *testing.T) {
+	repo := filepath.Join("..", "..", "examples", "helm-paas")
+	imported, err := gitopsflow.Import(repo, repo, "HEAD", "platform", "")
+	if err != nil {
+		t.Fatalf("Import returned error: %v", err)
+	}
+	bundle := publish.BuildBundleAt(imported, time.Date(2026, 3, 6, 0, 0, 0, 0, time.UTC))
+	rec, err := BuildAt(bundle, time.Date(2026, 3, 6, 1, 0, 0, 0, time.UTC), "ci-bot")
+	if err != nil {
+		t.Fatalf("BuildAt returned error: %v", err)
+	}
+
+	if err := VerifyRecordAgainstBundle(rec, bundle); err != nil {
+		t.Fatalf("VerifyRecordAgainstBundle returned error for valid link: %v", err)
+	}
+
+	// Use a different generated_at to produce a different valid bundle digest.
+	mismatched := publish.BuildBundleAt(imported, time.Date(2026, 3, 6, 2, 0, 0, 0, time.UTC))
+	if err := VerifyRecordAgainstBundle(rec, mismatched); err == nil || !strings.Contains(err.Error(), "bundle digest link mismatch") {
+		t.Fatalf("expected bundle digest link mismatch, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add top-level `cub-gen verify-attestation` command
- verify modes:
  - attestation integrity only
  - optional bundle linkage check via `--bundle`
- add internal attestation verification functions:
  - `VerifyRecord`
  - `VerifyRecordAgainstBundle`
- add behavior tests + parity golden tests for verify-attestation
- update README/PARITY/testing docs

## Commands
- `cub-gen verify-attestation --in <attestation.json|-> [--bundle <bundle.json>] [--json]`

## Proof
- `go test ./...`
- `go test ./cmd/cub-gen -run '^TestGitOpsParity|^TestPublishGoldenFromImport|^TestVerifyGolden|^TestVerify|^TestAttestGolden|^TestAttest|^TestVerifyAttestationGolden|^TestVerifyAttestation' -count=1 -v`
- `go run ./cmd/cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas > /tmp/cub-gen-bundle.json`
- `go run ./cmd/cub-gen attest --in /tmp/cub-gen-bundle.json --out /tmp/cub-gen-attestation.json --verifier ci-bot`
- `go run ./cmd/cub-gen verify-attestation --in /tmp/cub-gen-attestation.json --bundle /tmp/cub-gen-bundle.json`
