### PR TITLE
test: lock top-level command help and error surface

### DIFF
--- a/cmd/cub-gen/command_surface_parity_test.go
+++ b/cmd/cub-gen/command_surface_parity_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTopLevelCommandGoldenHelp(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		stdoutGolden string
+		stderrGolden string
+	}{
+		{
+			name:         "top-help",
+			args:         []string{"--help"},
+			stdoutGolden: filepath.Join("testdata", "parity", "top-help.stdout.golden.txt"),
+		},
+		{
+			name:         "publish-help",
+			args:         []string{"publish", "--help"},
+			stderrGolden: filepath.Join("testdata", "parity", "publish-help.stderr.golden.txt"),
+		},
+		{
+			name:         "verify-help",
+			args:         []string{"verify", "--help"},
+			stderrGolden: filepath.Join("testdata", "parity", "verify-help.stderr.golden.txt"),
+		},
+		{
+			name:         "attest-help",
+			args:         []string{"attest", "--help"},
+			stderrGolden: filepath.Join("testdata", "parity", "attest-help.stderr.golden.txt"),
+		},
+		{
+			name:         "verify-attestation-help",
+			args:         []string{"verify-attestation", "--help"},
+			stderrGolden: filepath.Join("testdata", "parity", "verify-attestation-help.stderr.golden.txt"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, err := runWithCapturedIO(tt.args)
+			if err != nil {
+				t.Fatalf("run help returned error: %v", err)
+			}
+
+			if tt.stdoutGolden == "" {
+				if strings.TrimSpace(stdout) != "" {
+					t.Fatalf("expected empty stdout, got: %q", stdout)
+				}
+			} else {
+				assertGoldenText(t, tt.stdoutGolden, stdout)
+			}
+
+			if tt.stderrGolden == "" {
+				if strings.TrimSpace(stderr) != "" {
+					t.Fatalf("expected empty stderr, got: %q", stderr)
+				}
+			} else {
+				assertGoldenText(t, tt.stderrGolden, stderr)
+			}
+		})
+	}
+}
+
+func TestTopLevelCommandErrorModes(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		sub  string
+	}{
+		{
+			name: "publish-extra-arg",
+			args: []string{"publish", "one"},
+			sub:  "usage: cub-gen publish",
+		},
+		{
+			name: "verify-extra-arg",
+			args: []string{"verify", "extra"},
+			sub:  "usage: cub-gen verify",
+		},
+		{
+			name: "attest-extra-arg",
+			args: []string{"attest", "extra"},
+			sub:  "usage: cub-gen attest",
+		},
+		{
+			name: "verify-attestation-extra-arg",
+			args: []string{"verify-attestation", "extra"},
+			sub:  "usage: cub-gen verify-attestation",
+		},
+		{
+			name: "verify-attestation-invalid-json",
+			args: []string{"verify-attestation", "--in", "/dev/null"},
+			sub:  "parse attestation json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := runWithCapturedIO(tt.args)
+			if err == nil {
+				t.Fatalf("expected error for args %v", tt.args)
+			}
+			if !strings.Contains(err.Error(), tt.sub) {
+				t.Fatalf("expected error containing %q, got %q", tt.sub, err.Error())
+			}
+		})
+	}
+}

--- a/cmd/cub-gen/testdata/parity/attest-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/attest-help.stderr.golden.txt
@@ -1,0 +1,9 @@
+Usage of attest:
+  -in string
+    	Bundle JSON input path, or '-' for stdin (default "-")
+  -out string
+    	Attestation JSON output path, or '-' for stdout (default "-")
+  -pretty
+    	Pretty-print JSON output (default true)
+  -verifier string
+    	Verifier identity label (default "cub-gen")

--- a/cmd/cub-gen/testdata/parity/publish-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/publish-help.stderr.golden.txt
@@ -1,0 +1,13 @@
+Usage of publish:
+  -in string
+    	ImportFlow JSON input path, or '-' for stdin (default "-")
+  -out string
+    	Bundle JSON output path, or '-' for stdout (default "-")
+  -pretty
+    	Pretty-print JSON output (default true)
+  -ref string
+    	Git ref label to include in output (direct mode) (default "HEAD")
+  -space string
+    	ConfigHub space label (direct mode) (default "default")
+  -where-resource string
+    	Additional resource filter expression (direct mode)

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -1,0 +1,23 @@
+cub-gen: prototype generator importer for agentic GitOps
+
+Usage:
+  cub-gen detect [--repo PATH] [--ref REF] [--pretty]
+  cub-gen import [--repo PATH] [--ref REF] [--space SPACE] [--out FILE|-] [--pretty]
+  cub-gen publish [--in FILE|-] [--out FILE|-] [--pretty]
+  cub-gen publish [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--pretty] <target-slug> <render-target-slug>
+  cub-gen verify [--in FILE|-] [--json] [--pretty]
+  cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]
+  cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]
+  cub-gen gitops <discover|import|cleanup> [flags]
+
+GitOps parity examples:
+  cub-gen gitops discover --space my-space ./examples/helm-paas
+  cub-gen gitops import --space my-space ./examples/helm-paas local-renderer
+  cub-gen gitops cleanup --space my-space ./examples/helm-paas
+  cub-gen gitops import --space my-space --json ./examples/helm-paas local-renderer | cub-gen publish --in -
+  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas
+  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas | cub-gen verify --in -
+  cub-gen publish --space my-space ./examples/helm-paas ./examples/helm-paas | cub-gen attest --in - --verifier ci-bot
+  cub-gen verify-attestation --in attestation.json --bundle bundle.json
+
+Note: gitops commands are local-only prototypes that mirror cub gitops stages.

--- a/cmd/cub-gen/testdata/parity/verify-attestation-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-help.stderr.golden.txt
@@ -1,0 +1,9 @@
+Usage of verify-attestation:
+  -bundle string
+    	Optional bundle JSON input path to verify digest linkage
+  -in string
+    	Attestation JSON input path, or '-' for stdin (default "-")
+  -json
+    	Output JSON
+  -pretty
+    	Pretty-print JSON output (default true)

--- a/cmd/cub-gen/testdata/parity/verify-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/verify-help.stderr.golden.txt
@@ -1,0 +1,7 @@
+Usage of verify:
+  -in string
+    	Bundle JSON input path, or '-' for stdin (default "-")
+  -json
+    	Output JSON
+  -pretty
+    	Pretty-print JSON output (default true)


### PR DESCRIPTION
## Summary\n- add parity tests for top-level and subcommand help output\n- add usage/error-mode tests for malformed invocations\n- lock help text in golden files under cmd/cub-gen/testdata/parity\n\n## Proof\n- go test ./...