### PR TITLE
test: lock discover parity for score and spring

### DIFF
--- a/cmd/cub-gen/gitops_parity_test.go
+++ b/cmd/cub-gen/gitops_parity_test.go
@@ -32,6 +32,52 @@ func TestGitOpsParityGoldenDiscover(t *testing.T) {
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gitops-discover.golden.json"), got)
 }
 
+func TestGitOpsParityGoldenDiscoverScore(t *testing.T) {
+	aliases := setupAliases(t)
+
+	out, stderr, err := runWithCapturedIO([]string{"gitops", "discover", "--space", "platform", "--json", "score"})
+	if err != nil {
+		t.Fatalf("run score discover returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %s", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal score discover json: %v\noutput=%s", err, out)
+	}
+	normalizeDiscover(got)
+
+	got["target_path_expected_suffix"] = filepath.ToSlash(filepath.Join("examples", "scoredev-paas"))
+	got["alias_path_suffix"] = trimToSuffix(filepath.ToSlash(aliases["score"]), filepath.ToSlash(filepath.Join("examples", "scoredev-paas")))
+
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gitops-discover-score.golden.json"), got)
+}
+
+func TestGitOpsParityGoldenDiscoverSpring(t *testing.T) {
+	aliases := setupAliases(t)
+
+	out, stderr, err := runWithCapturedIO([]string{"gitops", "discover", "--space", "platform", "--json", "spring"})
+	if err != nil {
+		t.Fatalf("run spring discover returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %s", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal spring discover json: %v\noutput=%s", err, out)
+	}
+	normalizeDiscover(got)
+
+	got["target_path_expected_suffix"] = filepath.ToSlash(filepath.Join("examples", "springboot-paas"))
+	got["alias_path_suffix"] = trimToSuffix(filepath.ToSlash(aliases["spring"]), filepath.ToSlash(filepath.Join("examples", "springboot-paas")))
+
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gitops-discover-spring.golden.json"), got)
+}
+
 func TestGitOpsParityGoldenImport(t *testing.T) {
 	setupAliases(t)
 

--- a/cmd/cub-gen/testdata/parity/gitops-discover-score.golden.json
+++ b/cmd/cub-gen/testdata/parity/gitops-discover-score.golden.json
@@ -1,0 +1,39 @@
+{
+  "alias_path_suffix": "examples/scoredev-paas",
+  "detections": [
+    {
+      "confidence": 0.96,
+      "id": "gen_5813cd3820138512",
+      "inputs": [
+        "score.yaml"
+      ],
+      "kind": "score",
+      "name": "scoredev-paas",
+      "profile": "scoredev-paas",
+      "root": ""
+    }
+  ],
+  "discover_file": "\u003cdiscover_file\u003e",
+  "discover_unit_slug": "\u003cdiscover_unit_slug\u003e",
+  "discovered_at": "\u003ctimestamp\u003e",
+  "ref": "HEAD",
+  "resources": [
+    {
+      "generator_id": "gen_5813cd3820138512",
+      "generator_kind": "score",
+      "generator_profile": "scoredev-paas",
+      "inputs": [
+        "score.yaml"
+      ],
+      "resource_body": "kind: Application\nmetadata:\n  name: scoredev-paas\nspec:\n  root: \n",
+      "resource_kind": "Application",
+      "resource_name": "scoredev-paas",
+      "resource_type": "argoproj.io/v1alpha1/Application",
+      "root": ""
+    }
+  ],
+  "space": "platform",
+  "target_path": "\u003ctarget_path\u003e",
+  "target_path_expected_suffix": "examples/scoredev-paas",
+  "target_slug": "score"
+}

--- a/cmd/cub-gen/testdata/parity/gitops-discover-spring.golden.json
+++ b/cmd/cub-gen/testdata/parity/gitops-discover-spring.golden.json
@@ -1,0 +1,43 @@
+{
+  "alias_path_suffix": "examples/springboot-paas",
+  "detections": [
+    {
+      "confidence": 0.93,
+      "id": "gen_73ed79c3c8b65360",
+      "inputs": [
+        "pom.xml",
+        "src/main/resources/application-prod.yaml",
+        "src/main/resources/application.yaml"
+      ],
+      "kind": "springboot",
+      "name": "springboot-paas",
+      "profile": "springboot-paas",
+      "root": ""
+    }
+  ],
+  "discover_file": "\u003cdiscover_file\u003e",
+  "discover_unit_slug": "\u003cdiscover_unit_slug\u003e",
+  "discovered_at": "\u003ctimestamp\u003e",
+  "ref": "HEAD",
+  "resources": [
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "generator_kind": "springboot",
+      "generator_profile": "springboot-paas",
+      "inputs": [
+        "pom.xml",
+        "src/main/resources/application-prod.yaml",
+        "src/main/resources/application.yaml"
+      ],
+      "resource_body": "kind: Kustomization\nmetadata:\n  name: springboot-paas\nspec:\n  root: \n",
+      "resource_kind": "Kustomization",
+      "resource_name": "springboot-paas",
+      "resource_type": "kustomize.toolkit.fluxcd.io/v1/Kustomization",
+      "root": ""
+    }
+  ],
+  "space": "platform",
+  "target_path": "\u003ctarget_path\u003e",
+  "target_path_expected_suffix": "examples/springboot-paas",
+  "target_slug": "spring"
+}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -28,6 +28,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Golden files under `cmd/cub-gen/testdata/parity/`.
 - Includes command help/usage goldens to lock human-facing CLI contract.
 - Helm example is covered across discover/import/cleanup parity paths.
+- Score and Spring Boot discover/import JSON contracts are golden-locked.
 - Score import JSON contract is golden-locked (`gitops-import-score.golden.json`).
 - Spring Boot import JSON contract is golden-locked (`gitops-import-spring.golden.json`).
 

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -5,7 +5,9 @@
 ### CLI parity tests
 
 - `cmd/cub-gen/gitops_parity_test.go`
-  - golden discover JSON
+  - golden discover JSON (Helm)
+  - golden discover JSON (Score)
+  - golden discover JSON (Spring Boot)
   - golden import JSON (Helm)
   - golden import JSON (Score)
   - golden import JSON (Spring Boot)
@@ -22,6 +24,8 @@
 ## Golden artifacts
 
 - `cmd/cub-gen/testdata/parity/gitops-discover.golden.json`
+- `cmd/cub-gen/testdata/parity/gitops-discover-score.golden.json`
+- `cmd/cub-gen/testdata/parity/gitops-discover-spring.golden.json`
 - `cmd/cub-gen/testdata/parity/gitops-import.golden.json`
 - `cmd/cub-gen/testdata/parity/gitops-import-score.golden.json`
 - `cmd/cub-gen/testdata/parity/gitops-import-spring.golden.json`


### PR DESCRIPTION
## Summary\n- add discover JSON parity tests for score and spring targets\n- add new golden contracts for discover outputs\n- update testing docs/inventory to reflect full first-3 discover/import coverage\n\n## Proof\n- go test ./...\n- go test ./cmd/cub-gen -run '^TestGitOpsParity' -count=1 -v