### PR TITLE
test: add path-mode smoke tests for first-3 examples

### DIFF
--- a/cmd/cub-gen/examples_smoke_test.go
+++ b/cmd/cub-gen/examples_smoke_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExamplesPathModeDiscoverAndImport(t *testing.T) {
+	tests := []struct {
+		name            string
+		repoSuffix      string
+		expectedProfile string
+		expectedKind    string
+	}{
+		{
+			name:            "helm",
+			repoSuffix:      filepath.Join("examples", "helm-paas"),
+			expectedProfile: "helm-paas",
+			expectedKind:    "helm",
+		},
+		{
+			name:            "score",
+			repoSuffix:      filepath.Join("examples", "scoredev-paas"),
+			expectedProfile: "scoredev-paas",
+			expectedKind:    "score",
+		},
+		{
+			name:            "spring",
+			repoSuffix:      filepath.Join("examples", "springboot-paas"),
+			expectedProfile: "springboot-paas",
+			expectedKind:    "springboot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoPath, err := filepath.Abs(filepath.Join("..", "..", tt.repoSuffix))
+			if err != nil {
+				t.Fatalf("resolve repo path: %v", err)
+			}
+
+			discoverOut, discoverErr, err := runWithCapturedIO([]string{"gitops", "discover", "--space", "platform", "--json", repoPath})
+			if err != nil {
+				t.Fatalf("discover returned error: %v\nstderr=%s", err, discoverErr)
+			}
+			if strings.TrimSpace(discoverErr) != "" {
+				t.Fatalf("expected empty discover stderr, got: %q", discoverErr)
+			}
+
+			var discover map[string]any
+			if err := json.Unmarshal([]byte(discoverOut), &discover); err != nil {
+				t.Fatalf("unmarshal discover output: %v\noutput=%s", err, discoverOut)
+			}
+			assertFirstGeneratorRecord(t, discover, tt.expectedProfile, tt.expectedKind)
+
+			importOut, importErr, err := runWithCapturedIO([]string{"gitops", "import", "--space", "platform", "--json", repoPath, repoPath})
+			if err != nil {
+				t.Fatalf("import returned error: %v\nstderr=%s", err, importErr)
+			}
+			if strings.TrimSpace(importErr) != "" {
+				t.Fatalf("expected empty import stderr, got: %q", importErr)
+			}
+
+			var imp map[string]any
+			if err := json.Unmarshal([]byte(importOut), &imp); err != nil {
+				t.Fatalf("unmarshal import output: %v\noutput=%s", err, importOut)
+			}
+			assertFirstGeneratorRecord(t, imp, tt.expectedProfile, tt.expectedKind)
+		})
+	}
+}
+
+func assertFirstGeneratorRecord(t *testing.T, payload map[string]any, expectedProfile, expectedKind string) {
+	t.Helper()
+
+	var records []any
+	if discoveredAny, ok := payload["discovered"]; ok {
+		if arr, ok := discoveredAny.([]any); ok && len(arr) > 0 {
+			records = arr
+		}
+	}
+	if len(records) == 0 {
+		if resourcesAny, ok := payload["resources"]; ok {
+			if arr, ok := resourcesAny.([]any); ok && len(arr) > 0 {
+				records = arr
+			}
+		}
+	}
+	if len(records) == 0 {
+		t.Fatalf("missing discovered/resources records in payload: %+v", payload)
+	}
+
+	first, ok := records[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected first record object, got: %#v", records[0])
+	}
+
+	if got := first["generator_profile"]; got != expectedProfile {
+		t.Fatalf("expected generator_profile=%q, got %v", expectedProfile, got)
+	}
+	if got := first["generator_kind"]; got != expectedKind {
+		t.Fatalf("expected generator_kind=%q, got %v", expectedKind, got)
+	}
+}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -36,6 +36,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 
 - Run at least one command per example for changed behavior.
 - For bridge changes, validate import -> publish pipeline output.
+- Automated path-mode smoke for Helm/Score/Spring in `cmd/cub-gen/examples_smoke_test.go`.
 
 ## Required commands
 

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -14,6 +14,8 @@
   - golden cleanup JSON
   - golden discover/import table output
   - error mode coverage
+- `cmd/cub-gen/examples_smoke_test.go`
+  - path-mode discover/import for Helm, Score, Spring (`./examples/...` without alias config)
 
 ### Internal logic tests
 


### PR DESCRIPTION
## Summary\n- add direct path-mode smoke tests for Helm, Score, and Spring examples\n- validate discover/import contracts without alias config\n- update testing docs/inventory for automated Tier 3 example proof\n\n## Proof\n- go test ./...\n- go test ./cmd/cub-gen -run '^TestGitOpsParity' -count=1 -v