### PR TITLE
test: cover verify/attest flows for first-3 examples

### DIFF
--- a/cmd/cub-gen/attest_command_test.go
+++ b/cmd/cub-gen/attest_command_test.go
@@ -48,6 +48,42 @@ func TestAttestFromStdin(t *testing.T) {
 	}
 }
 
+func TestAttestFromStdinFirstThreeTargets(t *testing.T) {
+	setupAliases(t)
+
+	targets := []string{"helm", "score", "spring"}
+	for _, target := range targets {
+		t.Run(target, func(t *testing.T) {
+			bundleJSON, err := generateBundleJSONForTarget(target)
+			if err != nil {
+				t.Fatalf("generate bundle for target %q: %v", target, err)
+			}
+
+			out, stderr, err := runWithCapturedIOAndStdin([]string{"attest", "--in", "-", "--verifier", "ci-bot"}, bundleJSON)
+			if err != nil {
+				t.Fatalf("attest returned error: %v\nstderr=%s", err, stderr)
+			}
+			if strings.TrimSpace(stderr) != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("unmarshal attest output: %v\noutput=%s", err, out)
+			}
+			if got["status"] != "verified" {
+				t.Fatalf("unexpected status for target %q: %v", target, got["status"])
+			}
+			if got["verifier"] != "ci-bot" {
+				t.Fatalf("unexpected verifier for target %q: %v", target, got["verifier"])
+			}
+			if v, ok := got["attestation_digest"].(string); !ok || !strings.HasPrefix(v, "sha256:") {
+				t.Fatalf("unexpected attestation_digest for target %q: %v", target, got["attestation_digest"])
+			}
+		})
+	}
+}
+
 func TestAttestFromFileToFile(t *testing.T) {
 	setupAliases(t)
 

--- a/cmd/cub-gen/verify_command_test.go
+++ b/cmd/cub-gen/verify_command_test.go
@@ -62,6 +62,39 @@ func TestVerifyFromStdinJSONOutput(t *testing.T) {
 	}
 }
 
+func TestVerifyFromStdinJSONOutputFirstThreeTargets(t *testing.T) {
+	setupAliases(t)
+
+	targets := []string{"helm", "score", "spring"}
+	for _, target := range targets {
+		t.Run(target, func(t *testing.T) {
+			bundleJSON, err := generateBundleJSONForTarget(target)
+			if err != nil {
+				t.Fatalf("generate bundle for target %q: %v", target, err)
+			}
+
+			out, stderr, err := runWithCapturedIOAndStdin([]string{"verify", "--json", "--in", "-"}, bundleJSON)
+			if err != nil {
+				t.Fatalf("verify stdin returned error: %v\nstderr=%s", err, stderr)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("unmarshal verify output: %v\noutput=%s", err, out)
+			}
+			if valid, ok := got["valid"].(bool); !ok || !valid {
+				t.Fatalf("expected valid=true for target %q, got %v", target, got["valid"])
+			}
+			if got["digest_algorithm"] != "sha256" {
+				t.Fatalf("unexpected digest_algorithm for target %q: %v", target, got["digest_algorithm"])
+			}
+		})
+	}
+}
+
 func TestVerifyDetectsTamper(t *testing.T) {
 	setupAliases(t)
 
@@ -95,7 +128,11 @@ func TestVerifyDetectsTamper(t *testing.T) {
 }
 
 func generateBundleJSON() (string, error) {
-	importOut, stderr, err := runWithCapturedIO([]string{"gitops", "import", "--space", "platform", "--json", "helm", "render-target"})
+	return generateBundleJSONForTarget("helm")
+}
+
+func generateBundleJSONForTarget(target string) (string, error) {
+	importOut, stderr, err := runWithCapturedIO([]string{"gitops", "import", "--space", "platform", "--json", target, "render-target"})
 	if err != nil {
 		return "", err
 	}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -37,6 +37,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Run at least one command per example for changed behavior.
 - For bridge changes, validate import -> publish pipeline output.
 - Automated path-mode smoke for Helm/Score/Spring in `cmd/cub-gen/examples_smoke_test.go`.
+- Publish/verify/attest command tests include Helm/Score/Spring bundle flows.
 
 ## Required commands
 

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -16,6 +16,12 @@
   - error mode coverage
 - `cmd/cub-gen/examples_smoke_test.go`
   - path-mode discover/import for Helm, Score, Spring (`./examples/...` without alias config)
+- `cmd/cub-gen/publish_command_test.go`
+  - direct publish mode validated for Helm, Score, Spring
+- `cmd/cub-gen/verify_command_test.go`
+  - verify JSON path validated for Helm, Score, Spring bundles
+- `cmd/cub-gen/attest_command_test.go`
+  - attest path validated for Helm, Score, Spring bundles
 
 ### Internal logic tests
 


### PR DESCRIPTION
## Summary
- add table-driven verify JSON tests for Helm/Score/Spring bundles
- add table-driven attest tests for Helm/Score/Spring bundles
- update test inventory/testing docs to reflect first-three bridge-flow coverage

## Proof
- go test ./...
- go test ./cmd/cub-gen -run '^(TestVerifyFromStdinJSONOutputFirstThreeTargets|TestAttestFromStdinFirstThreeTargets)$' -count=1 -v