### PR TITLE
test: add score/spring direct publish golden contracts

### DIFF
--- a/cmd/cub-gen/publish_parity_test.go
+++ b/cmd/cub-gen/publish_parity_test.go
@@ -37,6 +37,35 @@ func TestPublishGoldenFromImport(t *testing.T) {
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "publish-from-import.golden.json"), got)
 }
 
+func TestPublishGoldenDirectScore(t *testing.T) {
+	assertPublishDirectGolden(t, "score", filepath.Join("testdata", "parity", "publish-direct-score.golden.json"))
+}
+
+func TestPublishGoldenDirectSpring(t *testing.T) {
+	assertPublishDirectGolden(t, "spring", filepath.Join("testdata", "parity", "publish-direct-spring.golden.json"))
+}
+
+func assertPublishDirectGolden(t *testing.T, target, golden string) {
+	t.Helper()
+	setupAliases(t)
+
+	out, stderr, err := runWithCapturedIO([]string{"publish", "--space", "platform", target, "render-target"})
+	if err != nil {
+		t.Fatalf("run direct publish returned error: %v\nstderr=%s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal direct publish json: %v\noutput=%s", err, out)
+	}
+	normalizePublish(got)
+
+	assertGoldenJSON(t, golden, got)
+}
+
 func normalizePublish(m map[string]any) {
 	replaceString(m, "generated_at", "<timestamp>")
 	replaceString(m, "change_id", "<change_id>")

--- a/cmd/cub-gen/testdata/parity/publish-direct-score.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-score.golden.json
@@ -1,0 +1,257 @@
+{
+  "bundle_digest": "\u003cbundle_digest\u003e",
+  "change_id": "\u003cchange_id\u003e",
+  "contracts": [
+    {
+      "capabilities": [
+        "render-manifests",
+        "workload-spec",
+        "inverse-score-patch"
+      ],
+      "deterministic": true,
+      "generator_id": "gen_5813cd3820138512",
+      "inputs": [
+        {
+          "name": "input_01",
+          "required": true,
+          "schema_ref": "https://docs.score.dev/schemas/score-v1b1.json"
+        }
+      ],
+      "kind": "score",
+      "name": "scoredev-paas",
+      "output_format": "kubernetes/yaml",
+      "profile": "scoredev-paas",
+      "schema_version": "cub.confighub.io/generator-contract/v1",
+      "source_path": "",
+      "source_ref": "HEAD",
+      "source_repo": "\u003ctarget_path\u003e",
+      "transport": "oci+git",
+      "version": "0.1.0"
+    }
+  ],
+  "digest_algorithm": "sha256",
+  "discovered": [
+    {
+      "generator_id": "gen_5813cd3820138512",
+      "generator_kind": "score",
+      "generator_profile": "scoredev-paas",
+      "inputs": [
+        "score.yaml"
+      ],
+      "resource_body": "kind: Application\nmetadata:\n  name: scoredev-paas\nspec:\n  root: \n",
+      "resource_kind": "Application",
+      "resource_name": "scoredev-paas",
+      "resource_type": "argoproj.io/v1alpha1/Application",
+      "root": ""
+    }
+  ],
+  "dry_inputs": [
+    {
+      "generator_id": "gen_5813cd3820138512",
+      "owner": "app-team",
+      "path": "score.yaml",
+      "profile": "scoredev-paas",
+      "required": true,
+      "role": "score-spec"
+    }
+  ],
+  "dry_units": [
+    {
+      "id": "dry_9a0407a761eadbab",
+      "kind": "dry-unit",
+      "layer": "dry",
+      "name": "scoredev-paas-dry"
+    }
+  ],
+  "generated_at": "\u003ctimestamp\u003e",
+  "generator_units": [
+    {
+      "id": "gen_9670efa074cb2d03",
+      "kind": "generator-unit",
+      "layer": "generator",
+      "name": "scoredev-paas-generator"
+    }
+  ],
+  "inverse_transform_plans": [
+    {
+      "change_id": "\u003cchange_id\u003e",
+      "created_at": "\u003ctimestamp\u003e",
+      "patches": [
+        {
+          "confidence": 0.9,
+          "dry_path": "containers.main.variables.LOG_LEVEL",
+          "editable_by": "app-team",
+          "op": "replace",
+          "reason": "Score variable maps to a single Kubernetes env var.",
+          "requires_review": false,
+          "wet_path": "Deployment/spec/template/spec/containers[name=main]/env[name=LOG_LEVEL]/value"
+        }
+      ],
+      "plan_id": "\u003cplan_id\u003e",
+      "schema_version": "cub.confighub.io/inverse-transform-plan/v1",
+      "source_kind": "score",
+      "source_ref": "",
+      "status": "draft",
+      "target_unit_id": "dry_9a0407a761eadbab"
+    }
+  ],
+  "links": [
+    {
+      "dry_unit_id": "dry_9a0407a761eadbab",
+      "generator_unit_id": "gen_9670efa074cb2d03",
+      "wet_unit_id": "wet_3b630d8a9fb3502c"
+    }
+  ],
+  "provenance": [
+    {
+      "change_id": "\u003cchange_id\u003e",
+      "field_origin_map": [
+        {
+          "confidence": 0.94,
+          "dry_path": "containers.main.image",
+          "source_path": "score.yaml",
+          "transform": "score-to-k8s",
+          "wet_path": "Deployment/spec/template/spec/containers[name=main]/image"
+        },
+        {
+          "confidence": 0.9,
+          "dry_path": "containers.main.variables.LOG_LEVEL",
+          "source_path": "score.yaml",
+          "transform": "score-to-k8s",
+          "wet_path": "Deployment/spec/template/spec/containers[name=main]/env[name=LOG_LEVEL]/value"
+        },
+        {
+          "confidence": 0.91,
+          "dry_path": "service.ports.web.port",
+          "source_path": "score.yaml",
+          "transform": "score-to-k8s",
+          "wet_path": "Service/spec/ports[name=web]/port"
+        }
+      ],
+      "generator_id": "gen_5813cd3820138512",
+      "generator_name": "scoredev-paas",
+      "generator_profile": "scoredev-paas",
+      "input_digest": "sha256:d6046ef3f99c2542355019a1cc5932bd10e494ed8144d6e304625d93d5decd79",
+      "inverse_edit_pointers": [
+        {
+          "confidence": 0.94,
+          "dry_path": "containers.main.image",
+          "edit_hint": "Edit the Score container image in score.yaml.",
+          "owner": "app-team",
+          "wet_path": "Deployment/spec/template/spec/containers[name=main]/image"
+        },
+        {
+          "confidence": 0.9,
+          "dry_path": "containers.main.variables.LOG_LEVEL",
+          "edit_hint": "Edit LOG_LEVEL under containers.main.variables in score.yaml.",
+          "owner": "app-team",
+          "wet_path": "Deployment/spec/template/spec/containers[name=main]/env[name=LOG_LEVEL]/value"
+        },
+        {
+          "confidence": 0.91,
+          "dry_path": "service.ports.web.port",
+          "edit_hint": "Edit web service port in score.yaml.",
+          "owner": "app-team",
+          "wet_path": "Service/spec/ports[name=web]/port"
+        }
+      ],
+      "outputs": [
+        {
+          "digest": "\u003cdigest\u003e",
+          "role": "rendered-manifests",
+          "uri": "oci://example.local/platform/scoredev-paas:latest"
+        }
+      ],
+      "provenance_id": "\u003cprovenance_id\u003e",
+      "rendered_at": "\u003ctimestamp\u003e",
+      "rendered_object_lineage": [
+        {
+          "kind": "Application",
+          "name": "scoredev-paas",
+          "namespace": "apps",
+          "source_dry_path": "metadata.name",
+          "source_path": "score.yaml"
+        },
+        {
+          "kind": "Deployment",
+          "name": "scoredev-paas",
+          "namespace": "apps",
+          "source_dry_path": "containers.main.image",
+          "source_path": "score.yaml"
+        },
+        {
+          "kind": "Service",
+          "name": "scoredev-paas",
+          "namespace": "apps",
+          "source_dry_path": "service.ports.web.port",
+          "source_path": "score.yaml"
+        }
+      ],
+      "schema_version": "cub.confighub.io/provenance/v1",
+      "sources": [
+        {
+          "path": "score.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "ref": "HEAD",
+  "render_target_slug": "render-target",
+  "schema_version": "cub.confighub.io/change-bundle/v1",
+  "source": "cub-gen",
+  "space": "platform",
+  "summary": {
+    "contracts": 1,
+    "discovered_resources": 1,
+    "dry_inputs": 1,
+    "dry_units": 1,
+    "generator_profiles": [
+      "scoredev-paas"
+    ],
+    "generator_units": 1,
+    "inverse_transform_plans": 1,
+    "links": 1,
+    "provenance_records": 1,
+    "wet_manifest_targets": 3,
+    "wet_units": 1
+  },
+  "target_path": "\u003ctarget_path\u003e",
+  "target_slug": "score",
+  "wet_manifest_targets": [
+    {
+      "generator_id": "gen_5813cd3820138512",
+      "kind": "Application",
+      "name": "scoredev-paas",
+      "namespace": "apps",
+      "owner": "platform-runtime"
+    },
+    {
+      "generator_id": "gen_5813cd3820138512",
+      "kind": "Deployment",
+      "name": "scoredev-paas",
+      "namespace": "apps",
+      "owner": "platform-runtime",
+      "source_dry_path": "containers.main.image"
+    },
+    {
+      "generator_id": "gen_5813cd3820138512",
+      "kind": "Service",
+      "name": "scoredev-paas",
+      "namespace": "apps",
+      "owner": "platform-runtime",
+      "source_dry_path": "service.ports.web.port"
+    }
+  ],
+  "wet_units": [
+    {
+      "id": "wet_3b630d8a9fb3502c",
+      "kind": "wet-unit",
+      "layer": "wet",
+      "name": "scoredev-paas-wet"
+    }
+  ]
+}

--- a/cmd/cub-gen/testdata/parity/publish-direct-spring.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-spring.golden.json
@@ -1,0 +1,329 @@
+{
+  "bundle_digest": "\u003cbundle_digest\u003e",
+  "change_id": "\u003cchange_id\u003e",
+  "contracts": [
+    {
+      "capabilities": [
+        "render-app-config",
+        "profile-overrides",
+        "inverse-app-config-patch"
+      ],
+      "deterministic": true,
+      "generator_id": "gen_73ed79c3c8b65360",
+      "inputs": [
+        {
+          "name": "input_01",
+          "required": true,
+          "schema_ref": "https://maven.apache.org/xsd/maven-4.0.0.xsd"
+        },
+        {
+          "name": "input_02",
+          "required": true,
+          "schema_ref": "https://json.schemastore.org/spring-configuration-metadata"
+        },
+        {
+          "name": "input_03",
+          "required": true,
+          "schema_ref": "https://json.schemastore.org/spring-configuration-metadata"
+        }
+      ],
+      "kind": "springboot",
+      "name": "springboot-paas",
+      "output_format": "kubernetes/yaml",
+      "profile": "springboot-paas",
+      "schema_version": "cub.confighub.io/generator-contract/v1",
+      "source_path": "",
+      "source_ref": "HEAD",
+      "source_repo": "\u003ctarget_path\u003e",
+      "transport": "oci+git",
+      "version": "0.1.0"
+    }
+  ],
+  "digest_algorithm": "sha256",
+  "discovered": [
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "generator_kind": "springboot",
+      "generator_profile": "springboot-paas",
+      "inputs": [
+        "pom.xml",
+        "src/main/resources/application-prod.yaml",
+        "src/main/resources/application.yaml"
+      ],
+      "resource_body": "kind: Kustomization\nmetadata:\n  name: springboot-paas\nspec:\n  root: \n",
+      "resource_kind": "Kustomization",
+      "resource_name": "springboot-paas",
+      "resource_type": "kustomize.toolkit.fluxcd.io/v1/Kustomization",
+      "root": ""
+    }
+  ],
+  "dry_inputs": [
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "owner": "app-team",
+      "path": "src/main/resources/application.yaml",
+      "profile": "springboot-paas",
+      "required": true,
+      "role": "app-config-base"
+    },
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "owner": "app-team",
+      "path": "src/main/resources/application-prod.yaml",
+      "profile": "springboot-paas",
+      "required": true,
+      "role": "app-config-profile"
+    },
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "owner": "platform-engineer",
+      "path": "pom.xml",
+      "profile": "springboot-paas",
+      "required": true,
+      "role": "build-config"
+    }
+  ],
+  "dry_units": [
+    {
+      "id": "dry_5b90287a647b6d00",
+      "kind": "dry-unit",
+      "layer": "dry",
+      "name": "springboot-paas-dry"
+    }
+  ],
+  "generated_at": "\u003ctimestamp\u003e",
+  "generator_units": [
+    {
+      "id": "gen_14fc080d57edc21b",
+      "kind": "generator-unit",
+      "layer": "generator",
+      "name": "springboot-paas-generator"
+    }
+  ],
+  "inverse_transform_plans": [
+    {
+      "change_id": "\u003cchange_id\u003e",
+      "created_at": "\u003ctimestamp\u003e",
+      "patches": [
+        {
+          "confidence": 0.88,
+          "dry_path": "spring.application.name",
+          "editable_by": "app-team",
+          "op": "replace",
+          "reason": "Application identity should be app-editable without platform escalation.",
+          "requires_review": false,
+          "wet_path": "Deployment/metadata/labels[app.kubernetes.io/name]"
+        },
+        {
+          "confidence": 0.91,
+          "dry_path": "server.port",
+          "editable_by": "app-team",
+          "op": "replace",
+          "reason": "Application listener port is an app-level configuration concern.",
+          "requires_review": false,
+          "wet_path": "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort"
+        },
+        {
+          "confidence": 0.78,
+          "dry_path": "spring.datasource.url",
+          "editable_by": "platform-engineer",
+          "op": "replace",
+          "reason": "Database connectivity impacts shared runtime dependencies.",
+          "requires_review": true,
+          "wet_path": "ConfigMap/data/application.yaml:spring.datasource.url"
+        }
+      ],
+      "plan_id": "\u003cplan_id\u003e",
+      "schema_version": "cub.confighub.io/inverse-transform-plan/v1",
+      "source_kind": "springboot",
+      "source_ref": "",
+      "status": "draft",
+      "target_unit_id": "dry_5b90287a647b6d00"
+    }
+  ],
+  "links": [
+    {
+      "dry_unit_id": "dry_5b90287a647b6d00",
+      "generator_unit_id": "gen_14fc080d57edc21b",
+      "wet_unit_id": "wet_24b4f9e96079fa9a"
+    }
+  ],
+  "provenance": [
+    {
+      "change_id": "\u003cchange_id\u003e",
+      "field_origin_map": [
+        {
+          "confidence": 0.89,
+          "dry_path": "spring.application.name",
+          "source_path": "src/main/resources/application.yaml",
+          "transform": "spring-config-to-manifest",
+          "wet_path": "Deployment/metadata/labels[app.kubernetes.io/name]"
+        },
+        {
+          "confidence": 0.92,
+          "dry_path": "server.port",
+          "source_path": "src/main/resources/application.yaml",
+          "transform": "spring-config-to-manifest",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort"
+        },
+        {
+          "confidence": 0.78,
+          "dry_path": "spring.datasource.url",
+          "source_path": "src/main/resources/application.yaml",
+          "transform": "spring-config-to-manifest",
+          "wet_path": "ConfigMap/data/application.yaml:spring.datasource.url"
+        },
+        {
+          "confidence": 0.88,
+          "dry_path": "server.port",
+          "source_path": "src/main/resources/application-prod.yaml",
+          "transform": "spring-profile-overlay",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort"
+        }
+      ],
+      "generator_id": "gen_73ed79c3c8b65360",
+      "generator_name": "springboot-paas",
+      "generator_profile": "springboot-paas",
+      "input_digest": "sha256:f996825a673f1865dee25269566b575fa5e6f97609f368e2c44742f7fa9758c6",
+      "inverse_edit_pointers": [
+        {
+          "confidence": 0.89,
+          "dry_path": "spring.application.name",
+          "edit_hint": "Edit spring.application.name in src/main/resources/application.yaml.",
+          "owner": "app-team",
+          "wet_path": "Deployment/metadata/labels[app.kubernetes.io/name]"
+        },
+        {
+          "confidence": 0.91,
+          "dry_path": "server.port",
+          "edit_hint": "Edit server.port in src/main/resources/application-prod.yaml for environment overrides; use src/main/resources/application.yaml for the default.",
+          "owner": "app-team",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort"
+        },
+        {
+          "confidence": 0.78,
+          "dry_path": "spring.datasource.url",
+          "edit_hint": "Edit spring.datasource.url in src/main/resources/application.yaml and coordinate with platform ownership rules.",
+          "owner": "platform-engineer",
+          "wet_path": "ConfigMap/data/application.yaml:spring.datasource.url"
+        }
+      ],
+      "outputs": [
+        {
+          "digest": "\u003cdigest\u003e",
+          "role": "rendered-manifests",
+          "uri": "oci://example.local/platform/springboot-paas:latest"
+        }
+      ],
+      "provenance_id": "\u003cprovenance_id\u003e",
+      "rendered_at": "\u003ctimestamp\u003e",
+      "rendered_object_lineage": [
+        {
+          "kind": "Kustomization",
+          "name": "springboot-paas",
+          "namespace": "apps",
+          "source_dry_path": "build",
+          "source_path": "pom.xml"
+        },
+        {
+          "kind": "Deployment",
+          "name": "springboot-paas",
+          "namespace": "apps",
+          "source_dry_path": "spring.application.name",
+          "source_path": "src/main/resources/application.yaml"
+        },
+        {
+          "kind": "ConfigMap",
+          "name": "springboot-paas-config",
+          "namespace": "apps",
+          "source_dry_path": "spring.datasource.url",
+          "source_path": "src/main/resources/application.yaml"
+        },
+        {
+          "kind": "Deployment",
+          "name": "springboot-paas",
+          "namespace": "apps",
+          "source_dry_path": "server.port",
+          "source_path": "src/main/resources/application-prod.yaml"
+        }
+      ],
+      "schema_version": "cub.confighub.io/provenance/v1",
+      "sources": [
+        {
+          "path": "pom.xml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "src/main/resources/application-prod.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "src/main/resources/application.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "ref": "HEAD",
+  "render_target_slug": "render-target",
+  "schema_version": "cub.confighub.io/change-bundle/v1",
+  "source": "cub-gen",
+  "space": "platform",
+  "summary": {
+    "contracts": 1,
+    "discovered_resources": 1,
+    "dry_inputs": 3,
+    "dry_units": 1,
+    "generator_profiles": [
+      "springboot-paas"
+    ],
+    "generator_units": 1,
+    "inverse_transform_plans": 1,
+    "links": 1,
+    "provenance_records": 1,
+    "wet_manifest_targets": 3,
+    "wet_units": 1
+  },
+  "target_path": "\u003ctarget_path\u003e",
+  "target_slug": "spring",
+  "wet_manifest_targets": [
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "kind": "Kustomization",
+      "name": "springboot-paas",
+      "namespace": "apps",
+      "owner": "platform-runtime"
+    },
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "kind": "Deployment",
+      "name": "springboot-paas",
+      "namespace": "apps",
+      "owner": "platform-runtime",
+      "source_dry_path": "server.port"
+    },
+    {
+      "generator_id": "gen_73ed79c3c8b65360",
+      "kind": "ConfigMap",
+      "name": "springboot-paas-config",
+      "namespace": "apps",
+      "owner": "platform-runtime",
+      "source_dry_path": "spring.datasource.url"
+    }
+  ],
+  "wet_units": [
+    {
+      "id": "wet_24b4f9e96079fa9a",
+      "kind": "wet-unit",
+      "layer": "wet",
+      "name": "springboot-paas-wet"
+    }
+  ]
+}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -18,7 +18,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 ### Tier 2: parity/golden
 
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
-- Bridge publish golden lock in `cmd/cub-gen/publish_parity_test.go`.
+- Bridge publish golden locks in `cmd/cub-gen/publish_parity_test.go` (import path + direct score/spring paths).
 - Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
 - Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.
 - Attest command behavior tests in `cmd/cub-gen/attest_command_test.go`.

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -40,6 +40,9 @@
 - `cmd/cub-gen/testdata/parity/gitops-cleanup.golden.json`
 - `cmd/cub-gen/testdata/parity/gitops-discover.table.golden.txt`
 - `cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt`
+- `cmd/cub-gen/testdata/parity/publish-from-import.golden.json`
+- `cmd/cub-gen/testdata/parity/publish-direct-score.golden.json`
+- `cmd/cub-gen/testdata/parity/publish-direct-spring.golden.json`
 
 ## Mandatory validation commands
 


### PR DESCRIPTION
## Summary
- add parity tests for direct publish on score and spring targets
- add direct publish golden artifacts for both targets
- update testing docs/inventory for expanded publish golden coverage

## Proof
- go test ./...
- make test-contracts