### PR TITLE
chore: add deterministic example-proof target and docs wiring

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-request.md
+++ b/.github/ISSUE_TEMPLATE/change-request.md
@@ -28,7 +28,7 @@ assignees: []
 |---|---|---|---|
 | Unit | Yes | `go test ./...` | deterministic logic result |
 | Parity/Golden | If output contract changes | `go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v` | stable CLI contract |
-| Example proof | If user-visible behavior changes | `go run ./cmd/cub-gen ...` | docs/example aligned |
+| Example proof | If user-visible behavior changes | `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v` | docs/example aligned |
 
 ## Graceful Degradation
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,13 +20,14 @@
 |---|---|---|---|
 | Unit | Yes | `go test ./...` | Core logic output is stable |
 | Parity/Golden | If CLI/JSON/table output changed | `go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v` | Contract output is stable |
-| Example proof | If user-visible flow changed | `go run ./cmd/cub-gen ...` | Docs/example output matches implementation |
+| Example proof | If user-visible flow changed | `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v` | Docs/example output matches implementation |
 
 ## Commands Run
 
 - [ ] `go build ./cmd/cub-gen`
 - [ ] `go test ./...`
 - [ ] `go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v`
+- [ ] `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v` (if user-visible flow changed)
 - Additional commands:
 
 ## Graceful Degradation / Error Behavior

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts ci
+.PHONY: build test test-parity test-contracts test-examples ci
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)
 
@@ -13,4 +13,7 @@ test-contracts:
 
 test-parity: test-contracts
 
-ci: build test test-contracts
+test-examples:
+	go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$$' -count=1 -v
+
+ci: build test test-contracts test-examples

--- a/README.md
+++ b/README.md
@@ -170,4 +170,5 @@ See:
 ```bash
 go test ./...
 go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v
+go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v
 ```

--- a/docs/roadmap-v0.1-first-3-examples.md
+++ b/docs/roadmap-v0.1-first-3-examples.md
@@ -112,6 +112,7 @@ Required commands:
 
 1. `go test ./...`
 2. `go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v`
+3. `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v`
 3. Example command for changed path (`discover` or `import`).
 
 ## Non-goals in v0.1

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -46,6 +46,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 go build ./cmd/cub-gen
 go test ./...
 go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v
+go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v
 ```
 
 ## Rules

--- a/docs/workflows/proof-first-delivery.md
+++ b/docs/workflows/proof-first-delivery.md
@@ -21,7 +21,7 @@ This is the inherited delivery model from cub-scout, trimmed for cub-gen scope.
 |---|---|---|---|
 | Unit | Yes | `go test ./...` | deterministic logic/output |
 | Parity/Golden | For CLI behavior | `go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v` | stable command contract |
-| Example proof | For user-visible changes | `go run ./cmd/cub-gen ...` | docs/example matches behavior |
+| Example proof | For user-visible changes | `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v` | docs/example matches behavior |
 
 ## Completion rule
 

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -52,4 +52,5 @@
 go build ./cmd/cub-gen
 go test ./...
 go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v
+go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v
 ```


### PR DESCRIPTION
## Summary
- add Makefile test-examples target and include it in make ci
- wire deterministic example-proof command through README/docs/templates/roadmap
- replace generic go-run example proof guidance with stable test command

## Proof
- make ci
- go test ./...