### PR TITLE
test: cover verify-attestation flows for first-3 examples

### DIFF
--- a/cmd/cub-gen/verify_attestation_command_test.go
+++ b/cmd/cub-gen/verify_attestation_command_test.go
@@ -86,6 +86,81 @@ func TestVerifyAttestationJSONOutput(t *testing.T) {
 	}
 }
 
+func TestVerifyAttestationJSONOutputFirstThreeTargets(t *testing.T) {
+	setupAliases(t)
+
+	targets := []string{"helm", "score", "spring"}
+	for _, target := range targets {
+		t.Run(target, func(t *testing.T) {
+			attJSON, _, err := generateAttestationJSONForTarget("ci-bot", target)
+			if err != nil {
+				t.Fatalf("generate attestation for target %q: %v", target, err)
+			}
+
+			out, stderr, err := runWithCapturedIOAndStdin([]string{"verify-attestation", "--json", "--in", "-"}, attJSON)
+			if err != nil {
+				t.Fatalf("verify-attestation --json returned error: %v\nstderr=%s", err, stderr)
+			}
+			if strings.TrimSpace(stderr) != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("unmarshal verify-attestation json: %v\noutput=%s", err, out)
+			}
+			if valid, ok := got["valid"].(bool); !ok || !valid {
+				t.Fatalf("expected valid=true for target %q, got %v", target, got["valid"])
+			}
+			if linked, ok := got["linked_bundle_check"].(bool); !ok || linked {
+				t.Fatalf("expected linked_bundle_check=false for target %q, got %v", target, got["linked_bundle_check"])
+			}
+		})
+	}
+}
+
+func TestVerifyAttestationLinkedJSONOutputFirstThreeTargets(t *testing.T) {
+	setupAliases(t)
+
+	targets := []string{"helm", "score", "spring"}
+	for _, target := range targets {
+		t.Run(target, func(t *testing.T) {
+			attJSON, bundleJSON, err := generateAttestationJSONForTarget("ci-bot", target)
+			if err != nil {
+				t.Fatalf("generate attestation for target %q: %v", target, err)
+			}
+
+			attPath := filepath.Join(t.TempDir(), "attestation.json")
+			bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+			if err := os.WriteFile(attPath, []byte(attJSON), 0o644); err != nil {
+				t.Fatalf("write attestation file: %v", err)
+			}
+			if err := os.WriteFile(bundlePath, []byte(bundleJSON), 0o644); err != nil {
+				t.Fatalf("write bundle file: %v", err)
+			}
+
+			out, stderr, err := runWithCapturedIO([]string{"verify-attestation", "--json", "--in", attPath, "--bundle", bundlePath})
+			if err != nil {
+				t.Fatalf("verify-attestation --json linked returned error: %v\nstderr=%s", err, stderr)
+			}
+			if strings.TrimSpace(stderr) != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("unmarshal verify-attestation linked json: %v\noutput=%s", err, out)
+			}
+			if valid, ok := got["valid"].(bool); !ok || !valid {
+				t.Fatalf("expected valid=true for target %q, got %v", target, got["valid"])
+			}
+			if linked, ok := got["linked_bundle_check"].(bool); !ok || !linked {
+				t.Fatalf("expected linked_bundle_check=true for target %q, got %v", target, got["linked_bundle_check"])
+			}
+		})
+	}
+}
+
 func TestVerifyAttestationDetectsTamper(t *testing.T) {
 	setupAliases(t)
 
@@ -150,7 +225,11 @@ func TestVerifyAttestationDetectsBundleLinkMismatch(t *testing.T) {
 }
 
 func generateAttestationJSON(verifier string) (string, string, error) {
-	bundleJSON, err := generateBundleJSON()
+	return generateAttestationJSONForTarget(verifier, "helm")
+}
+
+func generateAttestationJSONForTarget(verifier, target string) (string, string, error) {
+	bundleJSON, err := generateBundleJSONForTarget(target)
 	if err != nil {
 		return "", "", err
 	}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -39,6 +39,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Automated path-mode smoke for Helm/Score/Spring in `cmd/cub-gen/examples_smoke_test.go`.
 - Automated path-mode bridge smoke (`publish -> verify -> attest -> verify-attestation`) for Helm/Score/Spring in `cmd/cub-gen/examples_bridge_smoke_test.go`.
 - Publish/verify/attest command tests include Helm/Score/Spring bundle flows.
+- Verify-attestation command tests include Helm/Score/Spring attestation flows (with and without linked bundle checks).
 
 ## Required commands
 

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -24,6 +24,8 @@
   - verify JSON path validated for Helm, Score, Spring bundles
 - `cmd/cub-gen/attest_command_test.go`
   - attest path validated for Helm, Score, Spring bundles
+- `cmd/cub-gen/verify_attestation_command_test.go`
+  - verify-attestation JSON and linked-bundle JSON paths validated for Helm, Score, Spring attestation records
 
 ### Internal logic tests
 


### PR DESCRIPTION
## Summary
- add Helm/Score/Spring table-driven tests for verify-attestation JSON mode
- add Helm/Score/Spring table-driven tests for linked bundle JSON mode
- update testing docs/inventory for verify-attestation first-three coverage

## Proof
- go test ./...
- go test ./cmd/cub-gen -run '^(TestVerifyAttestationJSONOutputFirstThreeTargets|TestVerifyAttestationLinkedJSONOutputFirstThreeTargets)$' -count=1 -v