### PR TITLE
docs: refresh v0.1 roadmap status/proof snapshot

### DIFF
--- a/docs/roadmap-v0.1-first-3-examples.md
+++ b/docs/roadmap-v0.1-first-3-examples.md
@@ -51,11 +51,13 @@ They want opinionated app kits (DRY) while still preserving auditable runtime in
 2. First three examples (Helm, Score, Spring Boot) are golden-locked for discover/import JSON outputs.
 3. Top-level and subcommand help/usage output is golden-locked.
 4. Path-mode smoke tests prove direct `./examples/...` usage without alias config.
-5. Local bridge path is available and tested:
+5. Local bridge path is available and tested across Helm/Score/Spring:
    - `publish` (bundle generation)
    - `verify` (bundle integrity)
    - `attest` (attestation record)
    - `verify-attestation` (attestation integrity + optional bundle linkage)
+6. Path-mode bridge smoke tests prove `publish -> verify -> attest -> verify-attestation` without alias config.
+7. Deterministic proof commands are centralized in Make targets (`test-contracts`, `test-examples`, `update-goldens`).
 
 Milestone: [v0.1 - first 3 examples](https://github.com/confighub/cub-gen/milestone/1)
 
@@ -113,7 +115,7 @@ Required commands:
 1. `go test ./...`
 2. `go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v`
 3. `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v`
-3. Example command for changed path (`discover` or `import`).
+4. `make update-goldens` (only when intentional CLI contract changes occur)
 
 ## Non-goals in v0.1
 


### PR DESCRIPTION
## Summary
- update roadmap status snapshot to include first-3 bridge coverage and path-mode bridge smoke
- document deterministic make-based proof commands now in use
- fix duplicate numbering in required commands

## Proof
- go test ./...