### PR TITLE
test: add linked verify-attestation goldens for score/spring

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -96,6 +96,8 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/attest.json.golden.json`
   - `cmd/cub-gen/testdata/parity/attest-tampered.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/verify-attestation.json.golden.json`
+  - `cmd/cub-gen/testdata/parity/verify-attestation-linked-score.json.golden.json`
+  - `cmd/cub-gen/testdata/parity/verify-attestation-linked-spring.json.golden.json`
   - `cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt`
 - Error-mode tests:
   - `cmd/cub-gen/command_surface_parity_test.go`

--- a/cmd/cub-gen/testdata/parity/verify-attestation-linked-score.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-linked-score.json.golden.json
@@ -1,0 +1,7 @@
+{
+  "attestation_digest": "\u003cattestation_digest\u003e",
+  "bundle_digest": "\u003cbundle_digest\u003e",
+  "change_id": "\u003cchange_id\u003e",
+  "linked_bundle_check": true,
+  "valid": true
+}

--- a/cmd/cub-gen/testdata/parity/verify-attestation-linked-spring.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-linked-spring.json.golden.json
@@ -1,0 +1,7 @@
+{
+  "attestation_digest": "\u003cattestation_digest\u003e",
+  "bundle_digest": "\u003cbundle_digest\u003e",
+  "change_id": "\u003cchange_id\u003e",
+  "linked_bundle_check": true,
+  "valid": true
+}

--- a/cmd/cub-gen/verify_attestation_parity_test.go
+++ b/cmd/cub-gen/verify_attestation_parity_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -55,4 +57,48 @@ func TestVerifyAttestationGoldenTamperedError(t *testing.T) {
 		t.Fatal("expected verify-attestation to fail")
 	}
 	assertGoldenText(t, "testdata/parity/verify-attestation-tampered.stderr.golden.txt", err.Error()+"\n")
+}
+
+func TestVerifyAttestationGoldenLinkedScoreJSON(t *testing.T) {
+	assertVerifyAttestationLinkedGolden(t, "score", "testdata/parity/verify-attestation-linked-score.json.golden.json")
+}
+
+func TestVerifyAttestationGoldenLinkedSpringJSON(t *testing.T) {
+	assertVerifyAttestationLinkedGolden(t, "spring", "testdata/parity/verify-attestation-linked-spring.json.golden.json")
+}
+
+func assertVerifyAttestationLinkedGolden(t *testing.T, target, goldenPath string) {
+	t.Helper()
+	setupAliases(t)
+
+	attJSON, bundleJSON, err := generateAttestationJSONForTarget("ci-bot", target)
+	if err != nil {
+		t.Fatalf("generate attestation for target %q: %v", target, err)
+	}
+
+	attPath := filepath.Join(t.TempDir(), "attestation.json")
+	bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(attPath, []byte(attJSON), 0o644); err != nil {
+		t.Fatalf("write attestation file: %v", err)
+	}
+	if err := os.WriteFile(bundlePath, []byte(bundleJSON), 0o644); err != nil {
+		t.Fatalf("write bundle file: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{"verify-attestation", "--json", "--in", attPath, "--bundle", bundlePath})
+	if err != nil {
+		t.Fatalf("verify-attestation linked --json returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal verify-attestation linked json: %v\noutput=%s", err, out)
+	}
+	replaceString(got, "attestation_digest", "<attestation_digest>")
+	replaceString(got, "bundle_digest", "<bundle_digest>")
+	replaceString(got, "change_id", "<change_id>")
+	assertGoldenJSON(t, goldenPath, got)
 }

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -24,7 +24,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Attest command behavior tests in `cmd/cub-gen/attest_command_test.go`.
 - Attest command golden locks in `cmd/cub-gen/attest_parity_test.go`.
 - Verify-attestation behavior tests in `cmd/cub-gen/verify_attestation_command_test.go`.
-- Verify-attestation golden locks in `cmd/cub-gen/verify_attestation_parity_test.go`.
+- Verify-attestation golden locks in `cmd/cub-gen/verify_attestation_parity_test.go` (including linked score/spring JSON contracts).
 - Golden files under `cmd/cub-gen/testdata/parity/`.
 - Includes command help/usage goldens to lock human-facing CLI contract.
 - Helm example is covered across discover/import/cleanup parity paths.

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -47,6 +47,9 @@
 - `cmd/cub-gen/testdata/parity/publish-from-import.golden.json`
 - `cmd/cub-gen/testdata/parity/publish-direct-score.golden.json`
 - `cmd/cub-gen/testdata/parity/publish-direct-spring.golden.json`
+- `cmd/cub-gen/testdata/parity/verify-attestation.json.golden.json`
+- `cmd/cub-gen/testdata/parity/verify-attestation-linked-score.json.golden.json`
+- `cmd/cub-gen/testdata/parity/verify-attestation-linked-spring.json.golden.json`
 
 ## Mandatory validation commands
 


### PR DESCRIPTION
## Summary
- add parity tests for linked verify-attestation JSON output on score/spring
- add new golden contracts for linked score/spring verify-attestation paths
- update parity/testing docs and test inventory references

## Proof
- go test ./...
- make test-contracts