### PR TITLE
test: add helm linked verify-attestation golden contract

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -97,6 +97,7 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/attest.json.golden.json`
   - `cmd/cub-gen/testdata/parity/attest-tampered.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/verify-attestation.json.golden.json`
+  - `cmd/cub-gen/testdata/parity/verify-attestation-linked-helm.json.golden.json`
   - `cmd/cub-gen/testdata/parity/verify-attestation-linked-score.json.golden.json`
   - `cmd/cub-gen/testdata/parity/verify-attestation-linked-spring.json.golden.json`
   - `cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt`

--- a/cmd/cub-gen/testdata/parity/verify-attestation-linked-helm.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-linked-helm.json.golden.json
@@ -1,0 +1,7 @@
+{
+  "attestation_digest": "\u003cattestation_digest\u003e",
+  "bundle_digest": "\u003cbundle_digest\u003e",
+  "change_id": "\u003cchange_id\u003e",
+  "linked_bundle_check": true,
+  "valid": true
+}

--- a/cmd/cub-gen/verify_attestation_parity_test.go
+++ b/cmd/cub-gen/verify_attestation_parity_test.go
@@ -59,6 +59,10 @@ func TestVerifyAttestationGoldenTamperedError(t *testing.T) {
 	assertGoldenText(t, "testdata/parity/verify-attestation-tampered.stderr.golden.txt", err.Error()+"\n")
 }
 
+func TestVerifyAttestationGoldenLinkedHelmJSON(t *testing.T) {
+	assertVerifyAttestationLinkedGolden(t, "helm", "testdata/parity/verify-attestation-linked-helm.json.golden.json")
+}
+
 func TestVerifyAttestationGoldenLinkedScoreJSON(t *testing.T) {
 	assertVerifyAttestationLinkedGolden(t, "score", "testdata/parity/verify-attestation-linked-score.json.golden.json")
 }

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -24,7 +24,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Attest command behavior tests in `cmd/cub-gen/attest_command_test.go`.
 - Attest command golden locks in `cmd/cub-gen/attest_parity_test.go`.
 - Verify-attestation behavior tests in `cmd/cub-gen/verify_attestation_command_test.go`.
-- Verify-attestation golden locks in `cmd/cub-gen/verify_attestation_parity_test.go` (including linked score/spring JSON contracts).
+- Verify-attestation golden locks in `cmd/cub-gen/verify_attestation_parity_test.go` (including linked helm/score/spring JSON contracts).
 - Golden files under `cmd/cub-gen/testdata/parity/`.
 - Includes command help/usage goldens to lock human-facing CLI contract.
 - Helm example is covered across discover/import/cleanup parity paths.

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -49,6 +49,7 @@
 - `cmd/cub-gen/testdata/parity/publish-direct-score.golden.json`
 - `cmd/cub-gen/testdata/parity/publish-direct-spring.golden.json`
 - `cmd/cub-gen/testdata/parity/verify-attestation.json.golden.json`
+- `cmd/cub-gen/testdata/parity/verify-attestation-linked-helm.json.golden.json`
 - `cmd/cub-gen/testdata/parity/verify-attestation-linked-score.json.golden.json`
 - `cmd/cub-gen/testdata/parity/verify-attestation-linked-spring.json.golden.json`
 


### PR DESCRIPTION
## Summary
- add linked verify-attestation parity test for helm target
- add helm linked verify-attestation golden artifact
- update parity/testing docs and inventory references

## Proof
- go test ./...
- make test-contracts