### PR TITLE
test: add v0.2 generator capability contract coverage

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -17,6 +17,7 @@ Implemented in this preview slice:
    - `gitops-discover-backstage.golden.json`
    - `gitops-import-backstage.golden.json`
 5. Extended path-mode smoke and bridge smoke tests to include Backstage.
+6. Added generator capability contract tests across all supported families.
 
 ## v0.2 preview invariants
 
@@ -30,5 +31,5 @@ Implemented in this preview slice:
 1. Add one app-config-only generator family (e.g. config-provider style DRY source).
 2. Add one ops/workflow-style generator family.
 3. Define a stable extension surface for adding generator families without large switch edits.
-4. Add parity tests for generator-family capability metadata.
+4. Keep generator-family capability metadata contract tests updated as families are added.
 5. Keep bridge artifacts (`publish/verify/attest`) symmetric across all supported families.

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -3,6 +3,7 @@ package importer
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -108,6 +109,58 @@ func TestImportRepoExamples(t *testing.T) {
 			}
 			if len(plan.Patches) == 0 {
 				t.Fatalf("expected at least one inverse patch; got %+v", plan)
+			}
+		})
+	}
+}
+
+func TestImportRepoGeneratorCapabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		repoDir              string
+		expectedCapabilities []string
+	}{
+		{
+			name:                 "helm-paas",
+			repoDir:              "helm-paas",
+			expectedCapabilities: []string{"render-manifests", "values-overrides", "inverse-values-patch"},
+		},
+		{
+			name:                 "scoredev-paas",
+			repoDir:              "scoredev-paas",
+			expectedCapabilities: []string{"render-manifests", "workload-spec", "inverse-score-patch"},
+		},
+		{
+			name:                 "springboot-paas",
+			repoDir:              "springboot-paas",
+			expectedCapabilities: []string{"render-app-config", "profile-overrides", "inverse-app-config-patch"},
+		},
+		{
+			name:                 "backstage-idp",
+			repoDir:              "backstage-idp",
+			expectedCapabilities: []string{"catalog-metadata", "render-manifests", "inverse-catalog-patch"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := filepath.Join("..", "..", "examples", tt.repoDir)
+			result, err := ImportRepo(repo, "main", "platform")
+			if err != nil {
+				t.Fatalf("ImportRepo returned error: %v", err)
+			}
+			if len(result.GeneratorContracts) != 1 {
+				t.Fatalf("expected 1 generator contract, got %d", len(result.GeneratorContracts))
+			}
+
+			got := result.GeneratorContracts[0].Capabilities
+			if !reflect.DeepEqual(got, tt.expectedCapabilities) {
+				t.Fatalf("expected capabilities %+v, got %+v", tt.expectedCapabilities, got)
 			}
 		})
 	}

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -32,7 +32,7 @@
 ### Internal logic tests
 
 - `internal/detect/detect_test.go`
-- `internal/importer/importer_test.go`
+- `internal/importer/importer_test.go` (includes generator capability contract assertions)
 - `internal/gitops/flow_test.go`
 
 ## Golden artifacts


### PR DESCRIPTION
## Summary
- add deterministic capability contract assertions across Helm/Score/Spring/Backstage
- update v0.2 roadmap snapshot to mark capability contract coverage implemented
- update test inventory reference

## Proof
- go test ./...
- make ci