### PR TITLE
refactor(v0.2): add shared generator family registry metadata

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -33,6 +33,7 @@ Implemented in this preview slice:
    - `gitops-import-ops.golden.json`
 16. Extended publish parity goldens and verify-attestation linked goldens to include Ops workflow.
 17. Extended path-mode smoke and bridge smoke tests to include Ops workflow.
+18. Added a shared generator family registry (`internal/registry`) for cross-cutting metadata (profile/resource mapping/capabilities) to reduce multi-file switch edits.
 
 ## v0.2 preview invariants
 
@@ -43,6 +44,6 @@ Implemented in this preview slice:
 
 ## Next slices toward v0.2
 
-1. Define a stable extension surface for adding generator families without large switch edits.
+1. Extend the family registry pattern to input-role ownership and richer family semantics.
 2. Keep generator-family capability metadata contract tests updated as families are added.
 3. Keep bridge artifacts (`publish/verify/attest`) symmetric across all supported families.

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/confighub/cub-gen/internal/model"
+	"github.com/confighub/cub-gen/internal/registry"
 )
 
 // ScanRepo scans a local repository path and returns deterministic generator detections.
@@ -544,20 +545,5 @@ func unique(v []string) []string {
 }
 
 func profileForKind(kind model.GeneratorKind) string {
-	switch kind {
-	case model.GeneratorHelm:
-		return "helm-paas"
-	case model.GeneratorScore:
-		return "scoredev-paas"
-	case model.GeneratorSpringBoot:
-		return "springboot-paas"
-	case model.GeneratorBackstage:
-		return "backstage-idp"
-	case model.GeneratorAbly:
-		return "ably-config"
-	case model.GeneratorOpsFlow:
-		return "ops-workflow"
-	default:
-		return "generator"
-	}
+	return registry.Profile(kind)
 }

--- a/internal/gitops/flow.go
+++ b/internal/gitops/flow.go
@@ -14,6 +14,7 @@ import (
 	"github.com/confighub/cub-gen/internal/detect"
 	"github.com/confighub/cub-gen/internal/importer"
 	"github.com/confighub/cub-gen/internal/model"
+	"github.com/confighub/cub-gen/internal/registry"
 )
 
 const (
@@ -785,39 +786,9 @@ func matchesLike(value, pattern string) bool {
 }
 
 func mappedResourceKind(kind model.GeneratorKind) string {
-	switch kind {
-	case model.GeneratorHelm:
-		return "HelmRelease"
-	case model.GeneratorScore:
-		return "Application"
-	case model.GeneratorSpringBoot:
-		return "Kustomization"
-	case model.GeneratorBackstage:
-		return "Component"
-	case model.GeneratorAbly:
-		return "ConfigMap"
-	case model.GeneratorOpsFlow:
-		return "Workflow"
-	default:
-		return "Resource"
-	}
+	return registry.ResourceKind(kind)
 }
 
 func mappedResourceType(kind model.GeneratorKind) string {
-	switch kind {
-	case model.GeneratorHelm:
-		return "helm.toolkit.fluxcd.io/v2/HelmRelease"
-	case model.GeneratorScore:
-		return "argoproj.io/v1alpha1/Application"
-	case model.GeneratorSpringBoot:
-		return "kustomize.toolkit.fluxcd.io/v1/Kustomization"
-	case model.GeneratorBackstage:
-		return "backstage.io/v1alpha1/Component"
-	case model.GeneratorAbly:
-		return "v1/ConfigMap"
-	case model.GeneratorOpsFlow:
-		return "argoproj.io/v1alpha1/Workflow"
-	default:
-		return "v1/Resource"
-	}
+	return registry.ResourceType(kind)
 }

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/confighub/cub-gen/internal/detect"
 	"github.com/confighub/cub-gen/internal/model"
+	"github.com/confighub/cub-gen/internal/registry"
 )
 
 const (
@@ -197,22 +198,7 @@ func stableChangeID(detection model.DetectionResult, space string) string {
 }
 
 func capabilitiesForKind(kind model.GeneratorKind) []string {
-	switch kind {
-	case model.GeneratorHelm:
-		return []string{"render-manifests", "values-overrides", "inverse-values-patch"}
-	case model.GeneratorScore:
-		return []string{"render-manifests", "workload-spec", "inverse-score-patch"}
-	case model.GeneratorSpringBoot:
-		return []string{"render-app-config", "profile-overrides", "inverse-app-config-patch"}
-	case model.GeneratorBackstage:
-		return []string{"catalog-metadata", "render-manifests", "inverse-catalog-patch"}
-	case model.GeneratorAbly:
-		return []string{"app-config-only", "provider-config", "inverse-provider-config-patch"}
-	case model.GeneratorOpsFlow:
-		return []string{"workflow-plan", "governed-execution-intent", "inverse-workflow-patch"}
-	default:
-		return []string{"render-manifests"}
-	}
+	return registry.Capabilities(kind)
 }
 
 func defaultPatchesForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.InversePatch {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,119 @@
+package registry
+
+import (
+	"sort"
+
+	"github.com/confighub/cub-gen/internal/model"
+)
+
+// FamilySpec captures cross-cutting generator-family metadata used by multiple
+// command/runtime layers.
+type FamilySpec struct {
+	Kind         model.GeneratorKind
+	Profile      string
+	ResourceKind string
+	ResourceType string
+	Capabilities []string
+}
+
+var familySpecs = map[model.GeneratorKind]FamilySpec{
+	model.GeneratorHelm: {
+		Kind:         model.GeneratorHelm,
+		Profile:      "helm-paas",
+		ResourceKind: "HelmRelease",
+		ResourceType: "helm.toolkit.fluxcd.io/v2/HelmRelease",
+		Capabilities: []string{"render-manifests", "values-overrides", "inverse-values-patch"},
+	},
+	model.GeneratorScore: {
+		Kind:         model.GeneratorScore,
+		Profile:      "scoredev-paas",
+		ResourceKind: "Application",
+		ResourceType: "argoproj.io/v1alpha1/Application",
+		Capabilities: []string{"render-manifests", "workload-spec", "inverse-score-patch"},
+	},
+	model.GeneratorSpringBoot: {
+		Kind:         model.GeneratorSpringBoot,
+		Profile:      "springboot-paas",
+		ResourceKind: "Kustomization",
+		ResourceType: "kustomize.toolkit.fluxcd.io/v1/Kustomization",
+		Capabilities: []string{"render-app-config", "profile-overrides", "inverse-app-config-patch"},
+	},
+	model.GeneratorBackstage: {
+		Kind:         model.GeneratorBackstage,
+		Profile:      "backstage-idp",
+		ResourceKind: "Component",
+		ResourceType: "backstage.io/v1alpha1/Component",
+		Capabilities: []string{"catalog-metadata", "render-manifests", "inverse-catalog-patch"},
+	},
+	model.GeneratorAbly: {
+		Kind:         model.GeneratorAbly,
+		Profile:      "ably-config",
+		ResourceKind: "ConfigMap",
+		ResourceType: "v1/ConfigMap",
+		Capabilities: []string{"app-config-only", "provider-config", "inverse-provider-config-patch"},
+	},
+	model.GeneratorOpsFlow: {
+		Kind:         model.GeneratorOpsFlow,
+		Profile:      "ops-workflow",
+		ResourceKind: "Workflow",
+		ResourceType: "argoproj.io/v1alpha1/Workflow",
+		Capabilities: []string{"workflow-plan", "governed-execution-intent", "inverse-workflow-patch"},
+	},
+}
+
+func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
+	spec, ok := familySpecs[kind]
+	if !ok {
+		return FamilySpec{}, false
+	}
+	return FamilySpec{
+		Kind:         spec.Kind,
+		Profile:      spec.Profile,
+		ResourceKind: spec.ResourceKind,
+		ResourceType: spec.ResourceType,
+		Capabilities: append([]string(nil), spec.Capabilities...),
+	}, true
+}
+
+func Profile(kind model.GeneratorKind) string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return "generator"
+	}
+	return spec.Profile
+}
+
+func ResourceKind(kind model.GeneratorKind) string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return "Resource"
+	}
+	return spec.ResourceKind
+}
+
+func ResourceType(kind model.GeneratorKind) string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return "v1/Resource"
+	}
+	return spec.ResourceType
+}
+
+func Capabilities(kind model.GeneratorKind) []string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return []string{"render-manifests"}
+	}
+	return append([]string(nil), spec.Capabilities...)
+}
+
+func Kinds() []model.GeneratorKind {
+	out := make([]model.GeneratorKind, 0, len(familySpecs))
+	for kind := range familySpecs {
+		out = append(out, kind)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i] < out[j]
+	})
+	return out
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,56 @@
+package registry
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/confighub/cub-gen/internal/model"
+)
+
+func TestRegistryHasSpecForAllKinds(t *testing.T) {
+	expected := []model.GeneratorKind{
+		model.GeneratorAbly,
+		model.GeneratorBackstage,
+		model.GeneratorHelm,
+		model.GeneratorOpsFlow,
+		model.GeneratorScore,
+		model.GeneratorSpringBoot,
+	}
+
+	if got := Kinds(); !reflect.DeepEqual(got, expected) {
+		t.Fatalf("expected kinds %+v, got %+v", expected, got)
+	}
+
+	for _, kind := range expected {
+		spec, ok := Spec(kind)
+		if !ok {
+			t.Fatalf("expected spec for kind %q", kind)
+		}
+		if spec.Profile == "" {
+			t.Fatalf("expected non-empty profile for kind %q", kind)
+		}
+		if spec.ResourceKind == "" || spec.ResourceType == "" {
+			t.Fatalf("expected resource mapping for kind %q, got %+v", kind, spec)
+		}
+		if len(spec.Capabilities) == 0 {
+			t.Fatalf("expected capabilities for kind %q", kind)
+		}
+	}
+}
+
+func TestRegistryFallbacks(t *testing.T) {
+	unknown := model.GeneratorKind("unknown")
+
+	if got := Profile(unknown); got != "generator" {
+		t.Fatalf("expected profile fallback generator, got %q", got)
+	}
+	if got := ResourceKind(unknown); got != "Resource" {
+		t.Fatalf("expected resource kind fallback Resource, got %q", got)
+	}
+	if got := ResourceType(unknown); got != "v1/Resource" {
+		t.Fatalf("expected resource type fallback v1/Resource, got %q", got)
+	}
+	if got := Capabilities(unknown); !reflect.DeepEqual(got, []string{"render-manifests"}) {
+		t.Fatalf("expected capabilities fallback render-manifests, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared internal generator family registry (profile/resource/capabilities metadata)
- refactor detect/import/flow paths to use registry lookups instead of repeated switch logic
- add registry unit tests and update v0.2 roadmap status

## Validation
- make ci
- go test ./...
