### PR TITLE
refactor(v0.2): move dry input role ownership rules into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -34,6 +34,7 @@ Implemented in this preview slice:
 16. Extended publish parity goldens and verify-attestation linked goldens to include Ops workflow.
 17. Extended path-mode smoke and bridge smoke tests to include Ops workflow.
 18. Added a shared generator family registry (`internal/registry`) for cross-cutting metadata (profile/resource mapping/capabilities) to reduce multi-file switch edits.
+19. Extended the family registry to own DRY input role classification and role-owner mapping, removing importer-local switch logic for these semantics.
 
 ## v0.2 preview invariants
 
@@ -44,6 +45,6 @@ Implemented in this preview slice:
 
 ## Next slices toward v0.2
 
-1. Extend the family registry pattern to input-role ownership and richer family semantics.
+1. Extend the family registry pattern further to cover schema inference and additional family-level semantics.
 2. Keep generator-family capability metadata contract tests updated as families are added.
 3. Keep bridge artifacts (`publish/verify/attest`) symmetric across all supported families.

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -702,12 +702,12 @@ func firstScoreInputPath(inputs []string) string {
 func dryInputsForGenerator(g model.GeneratorDetection) []model.DryInputRef {
 	out := make([]model.DryInputRef, 0, len(g.Inputs))
 	for _, in := range g.Inputs {
-		role := classifyDryInputRole(g.Kind, in)
+		role := registry.InputRole(g.Kind, in)
 		out = append(out, model.DryInputRef{
 			GeneratorID: g.ID,
 			Profile:     g.Profile,
 			Role:        role,
-			Owner:       ownerForDryInput(g.Kind, role),
+			Owner:       registry.OwnerForRole(g.Kind, role),
 			Path:        in,
 			Required:    true,
 		})
@@ -759,93 +759,6 @@ func wetManifestTargetsForGenerator(detection model.DetectionResult, g model.Gen
 		}
 	default:
 		return []model.WetManifestTarget{}
-	}
-}
-
-func classifyDryInputRole(kind model.GeneratorKind, in string) string {
-	base := strings.ToLower(filepath.Base(in))
-	switch kind {
-	case model.GeneratorHelm:
-		switch {
-		case base == "chart.yaml":
-			return "chart"
-		case strings.HasPrefix(base, "values") && (strings.HasSuffix(base, ".yaml") || strings.HasSuffix(base, ".yml")):
-			return "values"
-		default:
-			return "helm-input"
-		}
-	case model.GeneratorScore:
-		if base == "score.yaml" || base == "score.yml" {
-			return "score-spec"
-		}
-		return "score-input"
-	case model.GeneratorSpringBoot:
-		if base == "pom.xml" || base == "build.gradle" || base == "build.gradle.kts" {
-			return "build-config"
-		}
-		if base == "application.yaml" || base == "application.yml" {
-			return "app-config-base"
-		}
-		if strings.HasPrefix(base, "application-") && (strings.HasSuffix(base, ".yaml") || strings.HasSuffix(base, ".yml")) {
-			return "app-config-profile"
-		}
-		return "spring-input"
-	case model.GeneratorBackstage:
-		if base == "catalog-info.yaml" || base == "catalog-info.yml" {
-			return "catalog-spec"
-		}
-		if base == "app-config.yaml" || base == "app-config.yml" {
-			return "app-config"
-		}
-		return "backstage-input"
-	case model.GeneratorAbly:
-		switch {
-		case base == "ably.yaml" || base == "ably.yml" || base == "ably.json":
-			return "provider-config-base"
-		case strings.HasPrefix(base, "ably-"):
-			return "provider-config-overlay"
-		default:
-			return "provider-config"
-		}
-	case model.GeneratorOpsFlow:
-		switch {
-		case base == "operations.yaml" || base == "operations.yml" || base == "workflow.yaml" || base == "workflow.yml":
-			return "operations-base"
-		case strings.HasPrefix(base, "operations-") || strings.HasPrefix(base, "workflow-"):
-			return "operations-overlay"
-		default:
-			return "operations-input"
-		}
-	default:
-		return "input"
-	}
-}
-
-func ownerForDryInput(kind model.GeneratorKind, role string) string {
-	switch kind {
-	case model.GeneratorHelm:
-		if role == "values" {
-			return "app-team"
-		}
-		return "platform-engineer"
-	case model.GeneratorScore:
-		return "app-team"
-	case model.GeneratorSpringBoot:
-		if strings.HasPrefix(role, "app-config") {
-			return "app-team"
-		}
-		return "platform-engineer"
-	case model.GeneratorBackstage:
-		if role == "app-config" {
-			return "app-team"
-		}
-		return "platform-engineer"
-	case model.GeneratorAbly:
-		return "app-team"
-	case model.GeneratorOpsFlow:
-		return "platform-engineer"
-	default:
-		return "platform-engineer"
 	}
 }
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,19 +1,32 @@
 package registry
 
 import (
+	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/confighub/cub-gen/internal/model"
 )
 
+type InputRoleRule struct {
+	Role           string
+	ExactBasenames []string
+	Prefixes       []string
+	Extensions     []string
+}
+
 // FamilySpec captures cross-cutting generator-family metadata used by multiple
 // command/runtime layers.
 type FamilySpec struct {
-	Kind         model.GeneratorKind
-	Profile      string
-	ResourceKind string
-	ResourceType string
-	Capabilities []string
+	Kind             model.GeneratorKind
+	Profile          string
+	ResourceKind     string
+	ResourceType     string
+	Capabilities     []string
+	InputRoleRules   []InputRoleRule
+	DefaultInputRole string
+	RoleOwners       map[string]string
+	DefaultOwner     string
 }
 
 var familySpecs = map[model.GeneratorKind]FamilySpec{
@@ -23,13 +36,23 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		ResourceKind: "HelmRelease",
 		ResourceType: "helm.toolkit.fluxcd.io/v2/HelmRelease",
 		Capabilities: []string{"render-manifests", "values-overrides", "inverse-values-patch"},
+		InputRoleRules: []InputRoleRule{
+			{Role: "chart", ExactBasenames: []string{"chart.yaml"}},
+			{Role: "values", Prefixes: []string{"values"}, Extensions: []string{".yaml", ".yml"}},
+		},
+		DefaultInputRole: "helm-input",
+		RoleOwners:       map[string]string{"values": "app-team"},
+		DefaultOwner:     "platform-engineer",
 	},
 	model.GeneratorScore: {
-		Kind:         model.GeneratorScore,
-		Profile:      "scoredev-paas",
-		ResourceKind: "Application",
-		ResourceType: "argoproj.io/v1alpha1/Application",
-		Capabilities: []string{"render-manifests", "workload-spec", "inverse-score-patch"},
+		Kind:             model.GeneratorScore,
+		Profile:          "scoredev-paas",
+		ResourceKind:     "Application",
+		ResourceType:     "argoproj.io/v1alpha1/Application",
+		Capabilities:     []string{"render-manifests", "workload-spec", "inverse-score-patch"},
+		InputRoleRules:   []InputRoleRule{{Role: "score-spec", ExactBasenames: []string{"score.yaml", "score.yml"}}},
+		DefaultInputRole: "score-input",
+		DefaultOwner:     "app-team",
 	},
 	model.GeneratorSpringBoot: {
 		Kind:         model.GeneratorSpringBoot,
@@ -37,6 +60,17 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		ResourceKind: "Kustomization",
 		ResourceType: "kustomize.toolkit.fluxcd.io/v1/Kustomization",
 		Capabilities: []string{"render-app-config", "profile-overrides", "inverse-app-config-patch"},
+		InputRoleRules: []InputRoleRule{
+			{Role: "build-config", ExactBasenames: []string{"pom.xml", "build.gradle", "build.gradle.kts"}},
+			{Role: "app-config-base", ExactBasenames: []string{"application.yaml", "application.yml"}},
+			{Role: "app-config-profile", Prefixes: []string{"application-"}, Extensions: []string{".yaml", ".yml"}},
+		},
+		DefaultInputRole: "spring-input",
+		RoleOwners: map[string]string{
+			"app-config-base":    "app-team",
+			"app-config-profile": "app-team",
+		},
+		DefaultOwner: "platform-engineer",
 	},
 	model.GeneratorBackstage: {
 		Kind:         model.GeneratorBackstage,
@@ -44,6 +78,13 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		ResourceKind: "Component",
 		ResourceType: "backstage.io/v1alpha1/Component",
 		Capabilities: []string{"catalog-metadata", "render-manifests", "inverse-catalog-patch"},
+		InputRoleRules: []InputRoleRule{
+			{Role: "catalog-spec", ExactBasenames: []string{"catalog-info.yaml", "catalog-info.yml"}},
+			{Role: "app-config", ExactBasenames: []string{"app-config.yaml", "app-config.yml"}},
+		},
+		DefaultInputRole: "backstage-input",
+		RoleOwners:       map[string]string{"app-config": "app-team"},
+		DefaultOwner:     "platform-engineer",
 	},
 	model.GeneratorAbly: {
 		Kind:         model.GeneratorAbly,
@@ -51,6 +92,12 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		ResourceKind: "ConfigMap",
 		ResourceType: "v1/ConfigMap",
 		Capabilities: []string{"app-config-only", "provider-config", "inverse-provider-config-patch"},
+		InputRoleRules: []InputRoleRule{
+			{Role: "provider-config-base", ExactBasenames: []string{"ably.yaml", "ably.yml", "ably.json"}},
+			{Role: "provider-config-overlay", Prefixes: []string{"ably-"}, Extensions: []string{".yaml", ".yml", ".json"}},
+		},
+		DefaultInputRole: "provider-config",
+		DefaultOwner:     "app-team",
 	},
 	model.GeneratorOpsFlow: {
 		Kind:         model.GeneratorOpsFlow,
@@ -58,6 +105,12 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		ResourceKind: "Workflow",
 		ResourceType: "argoproj.io/v1alpha1/Workflow",
 		Capabilities: []string{"workflow-plan", "governed-execution-intent", "inverse-workflow-patch"},
+		InputRoleRules: []InputRoleRule{
+			{Role: "operations-base", ExactBasenames: []string{"operations.yaml", "operations.yml", "workflow.yaml", "workflow.yml"}},
+			{Role: "operations-overlay", Prefixes: []string{"operations-", "workflow-"}, Extensions: []string{".yaml", ".yml"}},
+		},
+		DefaultInputRole: "operations-input",
+		DefaultOwner:     "platform-engineer",
 	},
 }
 
@@ -67,11 +120,15 @@ func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
 		return FamilySpec{}, false
 	}
 	return FamilySpec{
-		Kind:         spec.Kind,
-		Profile:      spec.Profile,
-		ResourceKind: spec.ResourceKind,
-		ResourceType: spec.ResourceType,
-		Capabilities: append([]string(nil), spec.Capabilities...),
+		Kind:             spec.Kind,
+		Profile:          spec.Profile,
+		ResourceKind:     spec.ResourceKind,
+		ResourceType:     spec.ResourceType,
+		Capabilities:     append([]string(nil), spec.Capabilities...),
+		InputRoleRules:   copyInputRoleRules(spec.InputRoleRules),
+		DefaultInputRole: spec.DefaultInputRole,
+		RoleOwners:       copyRoleOwners(spec.RoleOwners),
+		DefaultOwner:     spec.DefaultOwner,
 	}, true
 }
 
@@ -107,6 +164,38 @@ func Capabilities(kind model.GeneratorKind) []string {
 	return append([]string(nil), spec.Capabilities...)
 }
 
+func InputRole(kind model.GeneratorKind, inputPath string) string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return "input"
+	}
+	base := strings.ToLower(filepath.Base(inputPath))
+	ext := strings.ToLower(filepath.Ext(base))
+	for _, rule := range spec.InputRoleRules {
+		if matchesInputRule(rule, base, ext) {
+			return rule.Role
+		}
+	}
+	if spec.DefaultInputRole != "" {
+		return spec.DefaultInputRole
+	}
+	return "input"
+}
+
+func OwnerForRole(kind model.GeneratorKind, role string) string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return "platform-engineer"
+	}
+	if owner, ok := spec.RoleOwners[role]; ok {
+		return owner
+	}
+	if spec.DefaultOwner != "" {
+		return spec.DefaultOwner
+	}
+	return "platform-engineer"
+}
+
 func Kinds() []model.GeneratorKind {
 	out := make([]model.GeneratorKind, 0, len(familySpecs))
 	for kind := range familySpecs {
@@ -115,5 +204,52 @@ func Kinds() []model.GeneratorKind {
 	sort.Slice(out, func(i, j int) bool {
 		return out[i] < out[j]
 	})
+	return out
+}
+
+func matchesInputRule(rule InputRoleRule, base, ext string) bool {
+	for _, exact := range rule.ExactBasenames {
+		if base == strings.ToLower(exact) {
+			return true
+		}
+	}
+
+	for _, prefix := range rule.Prefixes {
+		if !strings.HasPrefix(base, strings.ToLower(prefix)) {
+			continue
+		}
+		if len(rule.Extensions) == 0 {
+			return true
+		}
+		for _, allowed := range rule.Extensions {
+			if ext == strings.ToLower(allowed) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func copyInputRoleRules(in []InputRoleRule) []InputRoleRule {
+	out := make([]InputRoleRule, 0, len(in))
+	for _, rule := range in {
+		out = append(out, InputRoleRule{
+			Role:           rule.Role,
+			ExactBasenames: append([]string(nil), rule.ExactBasenames...),
+			Prefixes:       append([]string(nil), rule.Prefixes...),
+			Extensions:     append([]string(nil), rule.Extensions...),
+		})
+	}
+	return out
+}
+
+func copyRoleOwners(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
 	return out
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -53,4 +53,45 @@ func TestRegistryFallbacks(t *testing.T) {
 	if got := Capabilities(unknown); !reflect.DeepEqual(got, []string{"render-manifests"}) {
 		t.Fatalf("expected capabilities fallback render-manifests, got %+v", got)
 	}
+	if got := InputRole(unknown, "any.yaml"); got != "input" {
+		t.Fatalf("expected input role fallback input, got %q", got)
+	}
+	if got := OwnerForRole(unknown, "any"); got != "platform-engineer" {
+		t.Fatalf("expected owner fallback platform-engineer, got %q", got)
+	}
+}
+
+func TestRegistryInputRoleAndOwnerClassification(t *testing.T) {
+	tests := []struct {
+		name          string
+		kind          model.GeneratorKind
+		path          string
+		expectedRole  string
+		expectedOwner string
+	}{
+		{name: "helm-chart", kind: model.GeneratorHelm, path: "Chart.yaml", expectedRole: "chart", expectedOwner: "platform-engineer"},
+		{name: "helm-values", kind: model.GeneratorHelm, path: "values-prod.yaml", expectedRole: "values", expectedOwner: "app-team"},
+		{name: "score-spec", kind: model.GeneratorScore, path: "score.yaml", expectedRole: "score-spec", expectedOwner: "app-team"},
+		{name: "spring-build", kind: model.GeneratorSpringBoot, path: "pom.xml", expectedRole: "build-config", expectedOwner: "platform-engineer"},
+		{name: "spring-profile", kind: model.GeneratorSpringBoot, path: "application-prod.yml", expectedRole: "app-config-profile", expectedOwner: "app-team"},
+		{name: "backstage-catalog", kind: model.GeneratorBackstage, path: "catalog-info.yaml", expectedRole: "catalog-spec", expectedOwner: "platform-engineer"},
+		{name: "backstage-app-config", kind: model.GeneratorBackstage, path: "app-config.yaml", expectedRole: "app-config", expectedOwner: "app-team"},
+		{name: "ably-base", kind: model.GeneratorAbly, path: "ably.yaml", expectedRole: "provider-config-base", expectedOwner: "app-team"},
+		{name: "ably-overlay", kind: model.GeneratorAbly, path: "ably-prod.json", expectedRole: "provider-config-overlay", expectedOwner: "app-team"},
+		{name: "ops-base", kind: model.GeneratorOpsFlow, path: "operations.yaml", expectedRole: "operations-base", expectedOwner: "platform-engineer"},
+		{name: "ops-overlay", kind: model.GeneratorOpsFlow, path: "workflow-prod.yml", expectedRole: "operations-overlay", expectedOwner: "platform-engineer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			role := InputRole(tt.kind, tt.path)
+			if role != tt.expectedRole {
+				t.Fatalf("expected role %q, got %q", tt.expectedRole, role)
+			}
+			owner := OwnerForRole(tt.kind, role)
+			if owner != tt.expectedOwner {
+				t.Fatalf("expected owner %q, got %q", tt.expectedOwner, owner)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- extend `internal/registry` with data-driven DRY input role rules and role-owner mapping per generator family
- refactor importer dry input assembly to consume registry methods (`InputRole`, `OwnerForRole`)
- add registry classification tests and update v0.2 roadmap progress

## Validation
- go test ./...
- make ci
