### PR TITLE
refactor(v0.2): move family schema inference into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -35,6 +35,7 @@ Implemented in this preview slice:
 17. Extended path-mode smoke and bridge smoke tests to include Ops workflow.
 18. Added a shared generator family registry (`internal/registry`) for cross-cutting metadata (profile/resource mapping/capabilities) to reduce multi-file switch edits.
 19. Extended the family registry to own DRY input role classification and role-owner mapping, removing importer-local switch logic for these semantics.
+20. Extended the family registry to own family-aware input schema resolution, removing importer-local schema switch logic.
 
 ## v0.2 preview invariants
 
@@ -45,6 +46,6 @@ Implemented in this preview slice:
 
 ## Next slices toward v0.2
 
-1. Extend the family registry pattern further to cover schema inference and additional family-level semantics.
+1. Extend the family registry pattern further to cover additional family-level semantics (for example wet-target defaults and hint strategies).
 2. Keep generator-family capability metadata contract tests updated as families are added.
 3. Keep bridge artifacts (`publish/verify/attest`) symmetric across all supported families.

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -1002,44 +1002,7 @@ func opsWorkflowScheduleEditHint(h opsWorkflowHints) string {
 }
 
 func inferInputSchema(kind model.GeneratorKind, inputPath string) string {
-	ext := strings.ToLower(filepath.Ext(inputPath))
-	switch {
-	case ext == ".yaml" || ext == ".yml":
-		if kind == model.GeneratorHelm && strings.Contains(strings.ToLower(filepath.Base(inputPath)), "chart") {
-			return "https://json.schemastore.org/chart"
-		}
-		if kind == model.GeneratorScore {
-			return "https://docs.score.dev/schemas/score-v1b1.json"
-		}
-		if kind == model.GeneratorSpringBoot {
-			return "https://json.schemastore.org/spring-configuration-metadata"
-		}
-		if kind == model.GeneratorBackstage {
-			base := strings.ToLower(filepath.Base(inputPath))
-			if base == "catalog-info.yaml" || base == "catalog-info.yml" {
-				return "https://json.schemastore.org/backstage-catalog-info"
-			}
-			if base == "app-config.yaml" || base == "app-config.yml" {
-				return "https://json.schemastore.org/backstage-app-config"
-			}
-		}
-		if kind == model.GeneratorAbly {
-			return "https://schema.confighub.dev/generators/ably-config-v1"
-		}
-		if kind == model.GeneratorOpsFlow {
-			return "https://schema.confighub.dev/generators/ops-workflow-v1"
-		}
-		return "https://json-schema.org/draft/2020-12/schema"
-	case ext == ".json":
-		if kind == model.GeneratorAbly {
-			return "https://schema.confighub.dev/generators/ably-config-v1"
-		}
-		return "https://json-schema.org/draft/2020-12/schema"
-	case ext == ".xml":
-		return "https://maven.apache.org/xsd/maven-4.0.0.xsd"
-	default:
-		return "https://json-schema.org/draft/2020-12/schema"
-	}
+	return registry.SchemaRef(kind, inputPath)
 }
 
 func sanitizeName(name string) string {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -164,6 +164,53 @@ func Capabilities(kind model.GeneratorKind) []string {
 	return append([]string(nil), spec.Capabilities...)
 }
 
+func SchemaRef(kind model.GeneratorKind, inputPath string) string {
+	base := strings.ToLower(filepath.Base(inputPath))
+	ext := strings.ToLower(filepath.Ext(base))
+	role := InputRole(kind, inputPath)
+
+	switch ext {
+	case ".xml":
+		return "https://maven.apache.org/xsd/maven-4.0.0.xsd"
+	case ".yaml", ".yml":
+		switch kind {
+		case model.GeneratorHelm:
+			if role == "chart" {
+				return "https://json.schemastore.org/chart"
+			}
+		case model.GeneratorScore:
+			if role == "score-spec" {
+				return "https://docs.score.dev/schemas/score-v1b1.json"
+			}
+		case model.GeneratorSpringBoot:
+			if role == "app-config-base" || role == "app-config-profile" {
+				return "https://json.schemastore.org/spring-configuration-metadata"
+			}
+		case model.GeneratorBackstage:
+			if role == "catalog-spec" {
+				return "https://json.schemastore.org/backstage-catalog-info"
+			}
+			if role == "app-config" {
+				return "https://json.schemastore.org/backstage-app-config"
+			}
+		case model.GeneratorAbly:
+			if strings.HasPrefix(role, "provider-config") {
+				return "https://schema.confighub.dev/generators/ably-config-v1"
+			}
+		case model.GeneratorOpsFlow:
+			if strings.HasPrefix(role, "operations-") {
+				return "https://schema.confighub.dev/generators/ops-workflow-v1"
+			}
+		}
+	case ".json":
+		if kind == model.GeneratorAbly && strings.HasPrefix(role, "provider-config") {
+			return "https://schema.confighub.dev/generators/ably-config-v1"
+		}
+	}
+
+	return "https://json-schema.org/draft/2020-12/schema"
+}
+
 func InputRole(kind model.GeneratorKind, inputPath string) string {
 	spec, ok := Spec(kind)
 	if !ok {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -95,3 +95,31 @@ func TestRegistryInputRoleAndOwnerClassification(t *testing.T) {
 		})
 	}
 }
+
+func TestRegistrySchemaRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     model.GeneratorKind
+		path     string
+		expected string
+	}{
+		{name: "helm-chart", kind: model.GeneratorHelm, path: "Chart.yaml", expected: "https://json.schemastore.org/chart"},
+		{name: "score", kind: model.GeneratorScore, path: "score.yaml", expected: "https://docs.score.dev/schemas/score-v1b1.json"},
+		{name: "spring-app", kind: model.GeneratorSpringBoot, path: "application.yaml", expected: "https://json.schemastore.org/spring-configuration-metadata"},
+		{name: "backstage-catalog", kind: model.GeneratorBackstage, path: "catalog-info.yaml", expected: "https://json.schemastore.org/backstage-catalog-info"},
+		{name: "backstage-app-config", kind: model.GeneratorBackstage, path: "app-config.yaml", expected: "https://json.schemastore.org/backstage-app-config"},
+		{name: "ably-yaml", kind: model.GeneratorAbly, path: "ably.yaml", expected: "https://schema.confighub.dev/generators/ably-config-v1"},
+		{name: "ably-json", kind: model.GeneratorAbly, path: "ably-prod.json", expected: "https://schema.confighub.dev/generators/ably-config-v1"},
+		{name: "ops", kind: model.GeneratorOpsFlow, path: "operations.yaml", expected: "https://schema.confighub.dev/generators/ops-workflow-v1"},
+		{name: "xml-maven", kind: model.GeneratorSpringBoot, path: "pom.xml", expected: "https://maven.apache.org/xsd/maven-4.0.0.xsd"},
+		{name: "default", kind: model.GeneratorSpringBoot, path: "README.md", expected: "https://json-schema.org/draft/2020-12/schema"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SchemaRef(tt.kind, tt.path); got != tt.expected {
+				t.Fatalf("expected schema %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- extend `internal/registry` with family-aware `SchemaRef` resolution
- refactor importer schema inference to consume registry (`registry.SchemaRef`)
- add registry schema tests and update v0.2 roadmap status

## Validation
- go test ./...
- make ci
