### PR TITLE
refactor(v0.2): derive gitops supported kind help from registry

### DIFF
--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -15,6 +15,7 @@ import (
 	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
 	"github.com/confighub/cub-gen/internal/importer"
 	"github.com/confighub/cub-gen/internal/publish"
+	"github.com/confighub/cub-gen/internal/registry"
 )
 
 func main() {
@@ -574,6 +575,10 @@ func printUsage(out io.Writer) {
 }
 
 func printGitOpsUsage(out io.Writer) {
+	resourceKinds := registry.SupportedResourceKinds()
+	kindEq := renderKindEqualsClause(resourceKinds)
+	kindIn := quoteKindsWithDelimiter(resourceKinds, ",")
+
 	fmt.Fprintln(out, "cub-gen gitops: local parity commands for cub gitops pattern")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Usage:")
@@ -582,8 +587,8 @@ func printGitOpsUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen gitops cleanup [--space SPACE] [--json] <target-slug>")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Supported where-resource clauses:")
-	fmt.Fprintln(out, "  kind = 'HelmRelease' | kind = 'Application' | kind = 'Kustomization' | kind = 'Component' | kind = 'ConfigMap' | kind = 'Workflow'")
-	fmt.Fprintln(out, "  kind IN ('HelmRelease','Application','Component','ConfigMap','Workflow')")
+	fmt.Fprintf(out, "  kind = %s\n", kindEq)
+	fmt.Fprintf(out, "  kind IN (%s)\n", kindIn)
 	fmt.Fprintln(out, "  name = 'checkout-api' | resource_name LIKE '<contains-api>' | root LIKE '<contains-prod>'")
 	fmt.Fprintln(out, "  combine clauses with AND")
 	fmt.Fprintln(out)
@@ -597,4 +602,20 @@ func printGitOpsUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen gitops cleanup --space my-space ./examples/springboot-paas")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Tip: <target-slug> is a local repo path in this prototype.")
+}
+
+func quoteKindsWithDelimiter(kinds []string, delimiter string) string {
+	quoted := make([]string, 0, len(kinds))
+	for _, kind := range kinds {
+		quoted = append(quoted, fmt.Sprintf("'%s'", kind))
+	}
+	return strings.Join(quoted, delimiter)
+}
+
+func renderKindEqualsClause(kinds []string) string {
+	parts := make([]string, 0, len(kinds))
+	for _, kind := range kinds {
+		parts = append(parts, fmt.Sprintf("kind = '%s'", kind))
+	}
+	return strings.Join(parts, " | ")
 }

--- a/cmd/cub-gen/testdata/parity/gitops-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/gitops-help.stdout.golden.txt
@@ -6,8 +6,8 @@ Usage:
   cub-gen gitops cleanup [--space SPACE] [--json] <target-slug>
 
 Supported where-resource clauses:
-  kind = 'HelmRelease' | kind = 'Application' | kind = 'Kustomization' | kind = 'Component' | kind = 'ConfigMap' | kind = 'Workflow'
-  kind IN ('HelmRelease','Application','Component','ConfigMap','Workflow')
+  kind = kind = 'Application' | kind = 'Component' | kind = 'ConfigMap' | kind = 'HelmRelease' | kind = 'Kustomization' | kind = 'Workflow'
+  kind IN ('Application','Component','ConfigMap','HelmRelease','Kustomization','Workflow')
   name = 'checkout-api' | resource_name LIKE '<contains-api>' | root LIKE '<contains-prod>'
   combine clauses with AND
 

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -36,6 +36,7 @@ Implemented in this preview slice:
 18. Added a shared generator family registry (`internal/registry`) for cross-cutting metadata (profile/resource mapping/capabilities) to reduce multi-file switch edits.
 19. Extended the family registry to own DRY input role classification and role-owner mapping, removing importer-local switch logic for these semantics.
 20. Extended the family registry to own family-aware input schema resolution, removing importer-local schema switch logic.
+21. Updated `gitops` help to derive supported resource kinds from the family registry, avoiding manual help-text edits when families are added.
 
 ## v0.2 preview invariants
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -254,6 +254,21 @@ func Kinds() []model.GeneratorKind {
 	return out
 }
 
+func SupportedResourceKinds() []string {
+	kinds := make([]string, 0, len(familySpecs))
+	seen := map[string]struct{}{}
+	for _, kind := range Kinds() {
+		mapped := ResourceKind(kind)
+		if _, ok := seen[mapped]; ok {
+			continue
+		}
+		seen[mapped] = struct{}{}
+		kinds = append(kinds, mapped)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
 func matchesInputRule(rule InputRoleRule, base, ext string) bool {
 	for _, exact := range rule.ExactBasenames {
 		if base == strings.ToLower(exact) {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -36,6 +36,18 @@ func TestRegistryHasSpecForAllKinds(t *testing.T) {
 			t.Fatalf("expected capabilities for kind %q", kind)
 		}
 	}
+
+	expectedResourceKinds := []string{
+		"Application",
+		"Component",
+		"ConfigMap",
+		"HelmRelease",
+		"Kustomization",
+		"Workflow",
+	}
+	if got := SupportedResourceKinds(); !reflect.DeepEqual(got, expectedResourceKinds) {
+		t.Fatalf("expected supported resource kinds %+v, got %+v", expectedResourceKinds, got)
+	}
 }
 
 func TestRegistryFallbacks(t *testing.T) {


### PR DESCRIPTION
## Summary
- add registry helper for supported resource kinds
- make `cub-gen gitops --help` build kind clause text from registry metadata
- add registry coverage and refresh parity golden for gitops help
- update v0.2 roadmap status

## Validation
- make update-goldens
- go test ./...
- make ci
