### PR TITLE
refactor(v0.2): move wet target templates into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -37,6 +37,7 @@ Implemented in this preview slice:
 19. Extended the family registry to own DRY input role classification and role-owner mapping, removing importer-local switch logic for these semantics.
 20. Extended the family registry to own family-aware input schema resolution, removing importer-local schema switch logic.
 21. Updated `gitops` help to derive supported resource kinds from the family registry, avoiding manual help-text edits when families are added.
+22. Extended the family registry to own wet-manifest target templates, removing importer-local wet target switch logic.
 
 ## v0.2 preview invariants
 
@@ -47,6 +48,6 @@ Implemented in this preview slice:
 
 ## Next slices toward v0.2
 
-1. Extend the family registry pattern further to cover additional family-level semantics (for example wet-target defaults and hint strategies).
+1. Extend the family registry pattern further to cover additional family-level semantics (for example hint strategies and provenance-field templates).
 2. Keep generator-family capability metadata contract tests updated as families are added.
 3. Keep bridge artifacts (`publish/verify/attest`) symmetric across all supported families.

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -722,44 +722,46 @@ func dryInputsForGenerator(g model.GeneratorDetection) []model.DryInputRef {
 }
 
 func wetManifestTargetsForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.WetManifestTarget {
-	switch g.Kind {
-	case model.GeneratorHelm:
-		return []model.WetManifestTarget{
-			{GeneratorID: g.ID, Kind: "HelmRelease", Name: g.Name, Owner: "platform-runtime", Namespace: "apps"},
-			{GeneratorID: g.ID, Kind: "Deployment", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "values.image.tag"},
-			{GeneratorID: g.ID, Kind: "Service", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "values.service.port"},
-		}
-	case model.GeneratorScore:
-		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
-		return []model.WetManifestTarget{
-			{GeneratorID: g.ID, Kind: "Application", Name: g.Name, Owner: "platform-runtime", Namespace: "apps"},
-			{GeneratorID: g.ID, Kind: "Deployment", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: fmt.Sprintf("containers.%s.image", hints.ContainerName)},
-			{GeneratorID: g.ID, Kind: "Service", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: fmt.Sprintf("service.ports.%s.port", hints.ServicePortName)},
-		}
-	case model.GeneratorSpringBoot:
-		return []model.WetManifestTarget{
-			{GeneratorID: g.ID, Kind: "Kustomization", Name: g.Name, Owner: "platform-runtime", Namespace: "apps"},
-			{GeneratorID: g.ID, Kind: "Deployment", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "server.port"},
-			{GeneratorID: g.ID, Kind: "ConfigMap", Name: g.Name + "-config", Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "spring.datasource.url"},
-		}
-	case model.GeneratorBackstage:
-		return []model.WetManifestTarget{
-			{GeneratorID: g.ID, Kind: "Application", Name: g.Name, Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "metadata.name"},
-			{GeneratorID: g.ID, Kind: "ConfigMap", Name: g.Name + "-catalog", Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "spec.lifecycle"},
-		}
-	case model.GeneratorAbly:
-		return []model.WetManifestTarget{
-			{GeneratorID: g.ID, Kind: "ConfigMap", Name: g.Name + "-ably", Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "app.environment"},
-			{GeneratorID: g.ID, Kind: "Secret", Name: g.Name + "-ably-credentials", Owner: "platform-runtime", Namespace: "apps", SourceDryPath: "credentials.api_key_ref"},
-		}
-	case model.GeneratorOpsFlow:
-		return []model.WetManifestTarget{
-			{GeneratorID: g.ID, Kind: "Workflow", Name: g.Name + "-workflow", Owner: "platform-runtime", Namespace: "ops", SourceDryPath: "actions.deploy.image_tag"},
-			{GeneratorID: g.ID, Kind: "Job", Name: g.Name + "-dry-run", Owner: "platform-runtime", Namespace: "ops", SourceDryPath: "triggers.schedule"},
-		}
-	default:
+	templates := registry.WetTargetTemplates(g.Kind)
+	if len(templates) == 0 {
 		return []model.WetManifestTarget{}
 	}
+
+	vars := map[string]string{"name": g.Name}
+	if g.Kind == model.GeneratorScore {
+		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
+		vars["container"] = hints.ContainerName
+		vars["service_port"] = hints.ServicePortName
+	}
+
+	out := make([]model.WetManifestTarget, 0, len(templates))
+	for _, t := range templates {
+		out = append(out, model.WetManifestTarget{
+			GeneratorID:   g.ID,
+			Kind:          t.Kind,
+			Name:          renderTargetTemplate(t.NameTemplate, vars),
+			Owner:         t.Owner,
+			Namespace:     t.Namespace,
+			SourceDryPath: renderTargetTemplate(t.SourceDryPathTemplate, vars),
+		})
+	}
+	return out
+}
+
+func renderTargetTemplate(template string, vars map[string]string) string {
+	if template == "" || len(vars) == 0 {
+		return template
+	}
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := template
+	for _, k := range keys {
+		out = strings.ReplaceAll(out, "{{"+k+"}}", vars[k])
+	}
+	return out
 }
 
 func chartPathForGenerator(g model.GeneratorDetection) string {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -15,6 +15,14 @@ type InputRoleRule struct {
 	Extensions     []string
 }
 
+type WetTargetTemplate struct {
+	Kind                  string
+	NameTemplate          string
+	Owner                 string
+	Namespace             string
+	SourceDryPathTemplate string
+}
+
 // FamilySpec captures cross-cutting generator-family metadata used by multiple
 // command/runtime layers.
 type FamilySpec struct {
@@ -27,6 +35,7 @@ type FamilySpec struct {
 	DefaultInputRole string
 	RoleOwners       map[string]string
 	DefaultOwner     string
+	WetTargets       []WetTargetTemplate
 }
 
 var familySpecs = map[model.GeneratorKind]FamilySpec{
@@ -43,6 +52,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		DefaultInputRole: "helm-input",
 		RoleOwners:       map[string]string{"values": "app-team"},
 		DefaultOwner:     "platform-engineer",
+		WetTargets: []WetTargetTemplate{
+			{Kind: "HelmRelease", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps"},
+			{Kind: "Deployment", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "values.image.tag"},
+			{Kind: "Service", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "values.service.port"},
+		},
 	},
 	model.GeneratorScore: {
 		Kind:             model.GeneratorScore,
@@ -53,6 +67,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		InputRoleRules:   []InputRoleRule{{Role: "score-spec", ExactBasenames: []string{"score.yaml", "score.yml"}}},
 		DefaultInputRole: "score-input",
 		DefaultOwner:     "app-team",
+		WetTargets: []WetTargetTemplate{
+			{Kind: "Application", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps"},
+			{Kind: "Deployment", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "containers.{{container}}.image"},
+			{Kind: "Service", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "service.ports.{{service_port}}.port"},
+		},
 	},
 	model.GeneratorSpringBoot: {
 		Kind:         model.GeneratorSpringBoot,
@@ -71,6 +90,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"app-config-profile": "app-team",
 		},
 		DefaultOwner: "platform-engineer",
+		WetTargets: []WetTargetTemplate{
+			{Kind: "Kustomization", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps"},
+			{Kind: "Deployment", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "server.port"},
+			{Kind: "ConfigMap", NameTemplate: "{{name}}-config", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "spring.datasource.url"},
+		},
 	},
 	model.GeneratorBackstage: {
 		Kind:         model.GeneratorBackstage,
@@ -85,6 +109,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		DefaultInputRole: "backstage-input",
 		RoleOwners:       map[string]string{"app-config": "app-team"},
 		DefaultOwner:     "platform-engineer",
+		WetTargets: []WetTargetTemplate{
+			{Kind: "Application", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "metadata.name"},
+			{Kind: "ConfigMap", NameTemplate: "{{name}}-catalog", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "spec.lifecycle"},
+		},
 	},
 	model.GeneratorAbly: {
 		Kind:         model.GeneratorAbly,
@@ -98,6 +126,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		DefaultInputRole: "provider-config",
 		DefaultOwner:     "app-team",
+		WetTargets: []WetTargetTemplate{
+			{Kind: "ConfigMap", NameTemplate: "{{name}}-ably", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "app.environment"},
+			{Kind: "Secret", NameTemplate: "{{name}}-ably-credentials", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "credentials.api_key_ref"},
+		},
 	},
 	model.GeneratorOpsFlow: {
 		Kind:         model.GeneratorOpsFlow,
@@ -111,6 +143,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		DefaultInputRole: "operations-input",
 		DefaultOwner:     "platform-engineer",
+		WetTargets: []WetTargetTemplate{
+			{Kind: "Workflow", NameTemplate: "{{name}}-workflow", Owner: "platform-runtime", Namespace: "ops", SourceDryPathTemplate: "actions.deploy.image_tag"},
+			{Kind: "Job", NameTemplate: "{{name}}-dry-run", Owner: "platform-runtime", Namespace: "ops", SourceDryPathTemplate: "triggers.schedule"},
+		},
 	},
 }
 
@@ -129,6 +165,7 @@ func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
 		DefaultInputRole: spec.DefaultInputRole,
 		RoleOwners:       copyRoleOwners(spec.RoleOwners),
 		DefaultOwner:     spec.DefaultOwner,
+		WetTargets:       copyWetTargets(spec.WetTargets),
 	}, true
 }
 
@@ -269,6 +306,14 @@ func SupportedResourceKinds() []string {
 	return kinds
 }
 
+func WetTargetTemplates(kind model.GeneratorKind) []WetTargetTemplate {
+	spec, ok := Spec(kind)
+	if !ok {
+		return nil
+	}
+	return copyWetTargets(spec.WetTargets)
+}
+
 func matchesInputRule(rule InputRoleRule, base, ext string) bool {
 	for _, exact := range rule.ExactBasenames {
 		if base == strings.ToLower(exact) {
@@ -312,6 +357,20 @@ func copyRoleOwners(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 	for k, v := range in {
 		out[k] = v
+	}
+	return out
+}
+
+func copyWetTargets(in []WetTargetTemplate) []WetTargetTemplate {
+	out := make([]WetTargetTemplate, 0, len(in))
+	for _, target := range in {
+		out = append(out, WetTargetTemplate{
+			Kind:                  target.Kind,
+			NameTemplate:          target.NameTemplate,
+			Owner:                 target.Owner,
+			Namespace:             target.Namespace,
+			SourceDryPathTemplate: target.SourceDryPathTemplate,
+		})
 	}
 	return out
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -135,3 +135,26 @@ func TestRegistrySchemaRef(t *testing.T) {
 		})
 	}
 }
+
+func TestRegistryWetTargetTemplates(t *testing.T) {
+	score := WetTargetTemplates(model.GeneratorScore)
+	if len(score) != 3 {
+		t.Fatalf("expected 3 score wet target templates, got %d", len(score))
+	}
+	if score[0].Kind != "Application" || score[0].NameTemplate != "{{name}}" {
+		t.Fatalf("unexpected score template[0]: %+v", score[0])
+	}
+	if score[1].SourceDryPathTemplate != "containers.{{container}}.image" {
+		t.Fatalf("unexpected score deployment source path template: %q", score[1].SourceDryPathTemplate)
+	}
+	if score[2].SourceDryPathTemplate != "service.ports.{{service_port}}.port" {
+		t.Fatalf("unexpected score service source path template: %q", score[2].SourceDryPathTemplate)
+	}
+
+	// Ensure returned templates are copies, not direct registry storage.
+	score[0].Kind = "Mutated"
+	again := WetTargetTemplates(model.GeneratorScore)
+	if again[0].Kind != "Application" {
+		t.Fatalf("expected immutable template copy, got %+v", again[0])
+	}
+}


### PR DESCRIPTION
## Summary
- add wet target templates to `internal/registry` per generator family
- refactor importer wet-target construction to use registry templates (including score placeholders)
- add registry tests and update v0.2 roadmap status

## Validation
- go test ./...
- make ci
