### PR TITLE
feat(v0.2): add registry-backed generators command with parity contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build test test-parity test-contracts test-examples update-goldens ci
 
-PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)
+PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 
 build:
 	go build ./cmd/cub-gen

--- a/PARITY.md
+++ b/PARITY.md
@@ -39,6 +39,7 @@ Contract lock means:
 | Optional verify command | N/A | `verify` (top-level) | matched (local contract) | Verifies schema + digest integrity; non-zero exit on mismatch |
 | Optional attest command | N/A | `attest` (top-level) | matched (local contract) | Emits attestation envelope only from valid verified bundles |
 | Optional verify-attestation command | N/A | `verify-attestation` (top-level) | matched (local contract) | Verifies attestation integrity and optional bundle linkage |
+| Generator inventory command | N/A | `generators` (top-level) | matched (local contract) | Lists registry-backed supported generator families |
 
 ## Flow parity
 
@@ -120,6 +121,9 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/verify-attestation-linked-backstage.json.golden.json`
   - `cmd/cub-gen/testdata/parity/verify-attestation-linked-ably.json.golden.json`
   - `cmd/cub-gen/testdata/parity/verify-attestation-linked-ops.json.golden.json`
+  - `cmd/cub-gen/testdata/parity/generators.golden.json`
+  - `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
+  - `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt`
 - Error-mode tests:
   - `cmd/cub-gen/command_surface_parity_test.go`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - `gitops cleanup`
 - Emits provenance and inverse-edit guidance ("what rendered field came from which DRY field").
 - Stays local and pre-sync in v0.1 and v0.2 preview (no cluster deploys, no ConfigHub backend required).
+- Exposes supported generator families via `cub-gen generators`.
 
 ## Where Flux/Argo/OCI fit
 
@@ -99,6 +100,13 @@ Generate a ConfigHub-ready change bundle from import output:
 
 This emits a deterministic `change-bundle` JSON envelope you can upload later,
 without coupling the core flow to a running ConfigHub backend.
+
+### List supported generator families
+
+```bash
+./cub-gen generators
+./cub-gen generators --json | jq '.families[] | {kind, profile, resource_kind}'
+```
 
 Or run direct mode (import + bundle in one command):
 

--- a/cmd/cub-gen/command_surface_parity_test.go
+++ b/cmd/cub-gen/command_surface_parity_test.go
@@ -38,6 +38,11 @@ func TestTopLevelCommandGoldenHelp(t *testing.T) {
 			args:         []string{"verify-attestation", "--help"},
 			stderrGolden: filepath.Join("testdata", "parity", "verify-attestation-help.stderr.golden.txt"),
 		},
+		{
+			name:         "generators-help",
+			args:         []string{"generators", "--help"},
+			stderrGolden: filepath.Join("testdata", "parity", "generators-help.stderr.golden.txt"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -91,6 +96,11 @@ func TestTopLevelCommandErrorModes(t *testing.T) {
 			name: "verify-attestation-extra-arg",
 			args: []string{"verify-attestation", "extra"},
 			sub:  "usage: cub-gen verify-attestation",
+		},
+		{
+			name: "generators-extra-arg",
+			args: []string{"generators", "extra"},
+			sub:  "usage: cub-gen generators",
 		},
 		{
 			name: "verify-attestation-invalid-json",

--- a/cmd/cub-gen/generators_parity_test.go
+++ b/cmd/cub-gen/generators_parity_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGeneratorsGoldenJSON(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--json"})
+	if err != nil {
+		t.Fatalf("run generators --json returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal generators json: %v\noutput=%s", err, out)
+	}
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators.golden.json"), got)
+}
+
+func TestGeneratorsGoldenTable(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators"})
+	if err != nil {
+		t.Fatalf("run generators returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+	assertGoldenText(t, filepath.Join("testdata", "parity", "generators.table.golden.txt"), out)
+}
+
+func TestGeneratorsGoldenHelp(t *testing.T) {
+	stdout, stderr, err := runWithCapturedIO([]string{"generators", "--help"})
+	if err != nil {
+		t.Fatalf("run generators --help returned error: %v", err)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("expected empty stdout, got: %q", stdout)
+	}
+	assertGoldenText(t, filepath.Join("testdata", "parity", "generators-help.stderr.golden.txt"), stderr)
+}

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -47,12 +47,77 @@ func run(args []string) error {
 		return runAttest(args[1:])
 	case "verify-attestation":
 		return runVerifyAttestation(args[1:])
+	case "generators":
+		return runGenerators(args[1:])
 	case "gitops":
 		return runGitOps(args[1:])
 	default:
 		printUsage(os.Stderr)
 		return fmt.Errorf("unknown command: %s", args[0])
 	}
+}
+
+type generatorFamilyRecord struct {
+	Kind         string   `json:"kind"`
+	Profile      string   `json:"profile"`
+	ResourceKind string   `json:"resource_kind"`
+	ResourceType string   `json:"resource_type"`
+	Capabilities []string `json:"capabilities"`
+}
+
+func runGenerators(args []string) error {
+	fs := flag.NewFlagSet("generators", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	jsonOut := fs.Bool("json", false, "Output JSON")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: cub-gen generators [--json] [--pretty]")
+	}
+
+	records := listGeneratorFamilies()
+	if *jsonOut {
+		return writeJSON(os.Stdout, map[string]any{
+			"count":    len(records),
+			"families": records,
+		}, *pretty)
+	}
+
+	fmt.Println("Kind\tProfile\tResource Kind\tResource Type\tCapabilities")
+	for _, record := range records {
+		fmt.Printf("%s\t%s\t%s\t%s\t%s\n",
+			record.Kind,
+			record.Profile,
+			record.ResourceKind,
+			record.ResourceType,
+			strings.Join(record.Capabilities, ","),
+		)
+	}
+	return nil
+}
+
+func listGeneratorFamilies() []generatorFamilyRecord {
+	kinds := registry.Kinds()
+	out := make([]generatorFamilyRecord, 0, len(kinds))
+	for _, kind := range kinds {
+		spec, ok := registry.Spec(kind)
+		if !ok {
+			continue
+		}
+		out = append(out, generatorFamilyRecord{
+			Kind:         string(spec.Kind),
+			Profile:      spec.Profile,
+			ResourceKind: spec.ResourceKind,
+			ResourceType: spec.ResourceType,
+			Capabilities: append([]string(nil), spec.Capabilities...),
+		})
+	}
+	return out
 }
 
 func runDetect(args []string) error {
@@ -544,6 +609,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen verify [--in FILE|-] [--json] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen generators [--json] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "GitOps parity examples:")
@@ -570,6 +636,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/ably-config ./examples/ably-config | cub-gen attest --in - --verifier ci-bot")
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/ops-workflow ./examples/ops-workflow | cub-gen attest --in - --verifier ci-bot")
 	fmt.Fprintln(out, "  cub-gen verify-attestation --in attestation.json --bundle bundle.json")
+	fmt.Fprintln(out, "  cub-gen generators --json")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Note: gitops commands are local-only prototypes that mirror cub gitops stages.")
 }

--- a/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
@@ -1,0 +1,5 @@
+Usage of generators:
+  -json
+    	Output JSON
+  -pretty
+    	Pretty-print JSON output (default true)

--- a/cmd/cub-gen/testdata/parity/generators.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators.golden.json
@@ -1,0 +1,71 @@
+{
+  "count": 6,
+  "families": [
+    {
+      "capabilities": [
+        "app-config-only",
+        "provider-config",
+        "inverse-provider-config-patch"
+      ],
+      "kind": "ably",
+      "profile": "ably-config",
+      "resource_kind": "ConfigMap",
+      "resource_type": "v1/ConfigMap"
+    },
+    {
+      "capabilities": [
+        "catalog-metadata",
+        "render-manifests",
+        "inverse-catalog-patch"
+      ],
+      "kind": "backstage",
+      "profile": "backstage-idp",
+      "resource_kind": "Component",
+      "resource_type": "backstage.io/v1alpha1/Component"
+    },
+    {
+      "capabilities": [
+        "render-manifests",
+        "values-overrides",
+        "inverse-values-patch"
+      ],
+      "kind": "helm",
+      "profile": "helm-paas",
+      "resource_kind": "HelmRelease",
+      "resource_type": "helm.toolkit.fluxcd.io/v2/HelmRelease"
+    },
+    {
+      "capabilities": [
+        "workflow-plan",
+        "governed-execution-intent",
+        "inverse-workflow-patch"
+      ],
+      "kind": "opsworkflow",
+      "profile": "ops-workflow",
+      "resource_kind": "Workflow",
+      "resource_type": "argoproj.io/v1alpha1/Workflow"
+    },
+    {
+      "capabilities": [
+        "render-manifests",
+        "workload-spec",
+        "inverse-score-patch"
+      ],
+      "kind": "score",
+      "profile": "scoredev-paas",
+      "resource_kind": "Application",
+      "resource_type": "argoproj.io/v1alpha1/Application"
+    },
+    {
+      "capabilities": [
+        "render-app-config",
+        "profile-overrides",
+        "inverse-app-config-patch"
+      ],
+      "kind": "springboot",
+      "profile": "springboot-paas",
+      "resource_kind": "Kustomization",
+      "resource_type": "kustomize.toolkit.fluxcd.io/v1/Kustomization"
+    }
+  ]
+}

--- a/cmd/cub-gen/testdata/parity/generators.table.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators.table.golden.txt
@@ -1,0 +1,7 @@
+Kind	Profile	Resource Kind	Resource Type	Capabilities
+ably	ably-config	ConfigMap	v1/ConfigMap	app-config-only,provider-config,inverse-provider-config-patch
+backstage	backstage-idp	Component	backstage.io/v1alpha1/Component	catalog-metadata,render-manifests,inverse-catalog-patch
+helm	helm-paas	HelmRelease	helm.toolkit.fluxcd.io/v2/HelmRelease	render-manifests,values-overrides,inverse-values-patch
+opsworkflow	ops-workflow	Workflow	argoproj.io/v1alpha1/Workflow	workflow-plan,governed-execution-intent,inverse-workflow-patch
+score	scoredev-paas	Application	argoproj.io/v1alpha1/Application	render-manifests,workload-spec,inverse-score-patch
+springboot	springboot-paas	Kustomization	kustomize.toolkit.fluxcd.io/v1/Kustomization	render-app-config,profile-overrides,inverse-app-config-patch

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -8,6 +8,7 @@ Usage:
   cub-gen verify [--in FILE|-] [--json] [--pretty]
   cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]
   cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]
+  cub-gen generators [--json] [--pretty]
   cub-gen gitops <discover|import|cleanup> [flags]
 
 GitOps parity examples:
@@ -34,5 +35,6 @@ GitOps parity examples:
   cub-gen publish --space my-space ./examples/ably-config ./examples/ably-config | cub-gen attest --in - --verifier ci-bot
   cub-gen publish --space my-space ./examples/ops-workflow ./examples/ops-workflow | cub-gen attest --in - --verifier ci-bot
   cub-gen verify-attestation --in attestation.json --bundle bundle.json
+  cub-gen generators --json
 
 Note: gitops commands are local-only prototypes that mirror cub gitops stages.

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -38,6 +38,7 @@ Implemented in this preview slice:
 20. Extended the family registry to own family-aware input schema resolution, removing importer-local schema switch logic.
 21. Updated `gitops` help to derive supported resource kinds from the family registry, avoiding manual help-text edits when families are added.
 22. Extended the family registry to own wet-manifest target templates, removing importer-local wet target switch logic.
+23. Added `cub-gen generators` command (table + JSON + help golden contracts) to expose registry-backed supported family inventory.
 
 ## v0.2 preview invariants
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -18,6 +18,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 ### Tier 2: parity/golden
 
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
+- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go`.
 - Bridge publish golden locks in `cmd/cub-gen/publish_parity_test.go` (import/direct paths for helm/score/spring/backstage/ably/ops).
 - Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
 - Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.
@@ -27,6 +28,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Verify-attestation golden locks in `cmd/cub-gen/verify_attestation_parity_test.go` (including linked helm/score/spring/backstage/ably/ops JSON contracts).
 - Golden files under `cmd/cub-gen/testdata/parity/`.
 - Includes command help/usage goldens to lock human-facing CLI contract.
+- Includes generator inventory table/JSON/help goldens.
 - Helm example is covered across discover/import/cleanup parity paths.
 - Score, Spring Boot, Backstage IDP, Ably app-config, and Ops workflow discover/import JSON contracts are golden-locked.
 - Score import JSON contract is golden-locked (`gitops-import-score.golden.json`).

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -20,6 +20,10 @@
   - golden cleanup JSON
   - golden discover/import table output
   - error mode coverage
+- `cmd/cub-gen/generators_parity_test.go`
+  - golden generator family JSON contract
+  - golden generator family table contract
+  - golden generators help output contract
 - `cmd/cub-gen/examples_smoke_test.go`
   - path-mode discover/import for Helm, Score, Spring, Backstage, Ably, Ops (`./examples/...` without alias config)
 - `cmd/cub-gen/examples_bridge_smoke_test.go`
@@ -75,6 +79,9 @@
 - `cmd/cub-gen/testdata/parity/verify-attestation-linked-backstage.json.golden.json`
 - `cmd/cub-gen/testdata/parity/verify-attestation-linked-ably.json.golden.json`
 - `cmd/cub-gen/testdata/parity/verify-attestation-linked-ops.json.golden.json`
+- `cmd/cub-gen/testdata/parity/generators.golden.json`
+- `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
+- `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
 
 ## Mandatory validation commands
 


### PR DESCRIPTION
## Summary
- add new top-level `cub-gen generators` command (table + JSON output)
- source generator inventory directly from shared registry metadata
- lock command contracts with new parity goldens (json/table/help)
- update contract test pattern, docs, parity map, and roadmap status

## Validation
- make update-goldens
- go test ./...
- make ci
