### PR TITLE
feat: add generators filters for kind/profile/capability

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -122,6 +122,8 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/verify-attestation-linked-ably.json.golden.json`
   - `cmd/cub-gen/testdata/parity/verify-attestation-linked-ops.json.golden.json`
   - `cmd/cub-gen/testdata/parity/generators.golden.json`
+  - `cmd/cub-gen/testdata/parity/generators-kind-helm.golden.json`
+  - `cmd/cub-gen/testdata/parity/generators-capability-ops.golden.json`
   - `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt`

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ without coupling the core flow to a running ConfigHub backend.
 ```bash
 ./cub-gen generators
 ./cub-gen generators --json | jq '.families[] | {kind, profile, resource_kind}'
+./cub-gen generators --kind helm
+./cub-gen generators --capability render-manifests
 ```
 
 Or run direct mode (import + bundle in one command):

--- a/cmd/cub-gen/generators_parity_test.go
+++ b/cmd/cub-gen/generators_parity_test.go
@@ -23,6 +23,38 @@ func TestGeneratorsGoldenJSON(t *testing.T) {
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators.golden.json"), got)
 }
 
+func TestGeneratorsGoldenJSONKindFilter(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--json", "--kind", "helm"})
+	if err != nil {
+		t.Fatalf("run generators --json --kind returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal generators kind json: %v\noutput=%s", err, out)
+	}
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-kind-helm.golden.json"), got)
+}
+
+func TestGeneratorsGoldenJSONCapabilityFilter(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--json", "--capability", "inverse-workflow-patch"})
+	if err != nil {
+		t.Fatalf("run generators --json --capability returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal generators capability json: %v\noutput=%s", err, out)
+	}
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-capability-ops.golden.json"), got)
+}
+
 func TestGeneratorsGoldenTable(t *testing.T) {
 	out, stderr, err := runWithCapturedIO([]string{"generators"})
 	if err != nil {

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -68,6 +68,9 @@ type generatorFamilyRecord struct {
 func runGenerators(args []string) error {
 	fs := flag.NewFlagSet("generators", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
+	kindFilter := fs.String("kind", "", "Filter by generator kind")
+	profileFilter := fs.String("profile", "", "Filter by generator profile")
+	capabilityFilter := fs.String("capability", "", "Filter by capability")
 	jsonOut := fs.Bool("json", false, "Output JSON")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
 	if err := fs.Parse(args); err != nil {
@@ -77,10 +80,10 @@ func runGenerators(args []string) error {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: cub-gen generators [--json] [--pretty]")
+		return errors.New("usage: cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]")
 	}
 
-	records := listGeneratorFamilies()
+	records := listGeneratorFamilies(*kindFilter, *profileFilter, *capabilityFilter)
 	if *jsonOut {
 		return writeJSON(os.Stdout, map[string]any{
 			"count":    len(records),
@@ -101,7 +104,11 @@ func runGenerators(args []string) error {
 	return nil
 }
 
-func listGeneratorFamilies() []generatorFamilyRecord {
+func listGeneratorFamilies(kindFilter, profileFilter, capabilityFilter string) []generatorFamilyRecord {
+	kindFilter = strings.TrimSpace(strings.ToLower(kindFilter))
+	profileFilter = strings.TrimSpace(strings.ToLower(profileFilter))
+	capabilityFilter = strings.TrimSpace(strings.ToLower(capabilityFilter))
+
 	kinds := registry.Kinds()
 	out := make([]generatorFamilyRecord, 0, len(kinds))
 	for _, kind := range kinds {
@@ -109,12 +116,39 @@ func listGeneratorFamilies() []generatorFamilyRecord {
 		if !ok {
 			continue
 		}
-		out = append(out, generatorFamilyRecord{
+		record := generatorFamilyRecord{
 			Kind:         string(spec.Kind),
 			Profile:      spec.Profile,
 			ResourceKind: spec.ResourceKind,
 			ResourceType: spec.ResourceType,
 			Capabilities: append([]string(nil), spec.Capabilities...),
+		}
+
+		if kindFilter != "" && strings.ToLower(record.Kind) != kindFilter {
+			continue
+		}
+		if profileFilter != "" && strings.ToLower(record.Profile) != profileFilter {
+			continue
+		}
+		if capabilityFilter != "" {
+			matched := false
+			for _, capability := range record.Capabilities {
+				if strings.EqualFold(capability, capabilityFilter) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+
+		out = append(out, generatorFamilyRecord{
+			Kind:         record.Kind,
+			Profile:      record.Profile,
+			ResourceKind: record.ResourceKind,
+			ResourceType: record.ResourceType,
+			Capabilities: record.Capabilities,
 		})
 	}
 	return out
@@ -637,6 +671,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/ops-workflow ./examples/ops-workflow | cub-gen attest --in - --verifier ci-bot")
 	fmt.Fprintln(out, "  cub-gen verify-attestation --in attestation.json --bundle bundle.json")
 	fmt.Fprintln(out, "  cub-gen generators --json")
+	fmt.Fprintln(out, "  cub-gen generators --capability render-manifests")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Note: gitops commands are local-only prototypes that mirror cub gitops stages.")
 }

--- a/cmd/cub-gen/testdata/parity/generators-capability-ops.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-capability-ops.golden.json
@@ -1,0 +1,16 @@
+{
+  "count": 1,
+  "families": [
+    {
+      "capabilities": [
+        "workflow-plan",
+        "governed-execution-intent",
+        "inverse-workflow-patch"
+      ],
+      "kind": "opsworkflow",
+      "profile": "ops-workflow",
+      "resource_kind": "Workflow",
+      "resource_type": "argoproj.io/v1alpha1/Workflow"
+    }
+  ]
+}

--- a/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
@@ -1,5 +1,11 @@
 Usage of generators:
+  -capability string
+    	Filter by capability
   -json
     	Output JSON
+  -kind string
+    	Filter by generator kind
   -pretty
     	Pretty-print JSON output (default true)
+  -profile string
+    	Filter by generator profile

--- a/cmd/cub-gen/testdata/parity/generators-kind-helm.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-kind-helm.golden.json
@@ -1,0 +1,16 @@
+{
+  "count": 1,
+  "families": [
+    {
+      "capabilities": [
+        "render-manifests",
+        "values-overrides",
+        "inverse-values-patch"
+      ],
+      "kind": "helm",
+      "profile": "helm-paas",
+      "resource_kind": "HelmRelease",
+      "resource_type": "helm.toolkit.fluxcd.io/v2/HelmRelease"
+    }
+  ]
+}

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -36,5 +36,6 @@ GitOps parity examples:
   cub-gen publish --space my-space ./examples/ops-workflow ./examples/ops-workflow | cub-gen attest --in - --verifier ci-bot
   cub-gen verify-attestation --in attestation.json --bundle bundle.json
   cub-gen generators --json
+  cub-gen generators --capability render-manifests
 
 Note: gitops commands are local-only prototypes that mirror cub gitops stages.

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -39,6 +39,7 @@ Implemented in this preview slice:
 21. Updated `gitops` help to derive supported resource kinds from the family registry, avoiding manual help-text edits when families are added.
 22. Extended the family registry to own wet-manifest target templates, removing importer-local wet target switch logic.
 23. Added `cub-gen generators` command (table + JSON + help golden contracts) to expose registry-backed supported family inventory.
+24. Extended `cub-gen generators` with deterministic filters (`--kind`, `--profile`, `--capability`) and locked filtered output contracts.
 
 ## v0.2 preview invariants
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -18,7 +18,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 ### Tier 2: parity/golden
 
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
-- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go`.
+- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go` (full list + kind filter + capability filter).
 - Bridge publish golden locks in `cmd/cub-gen/publish_parity_test.go` (import/direct paths for helm/score/spring/backstage/ably/ops).
 - Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
 - Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -22,6 +22,7 @@
   - error mode coverage
 - `cmd/cub-gen/generators_parity_test.go`
   - golden generator family JSON contract
+  - golden generator family filtered JSON contracts (kind + capability)
   - golden generator family table contract
   - golden generators help output contract
 - `cmd/cub-gen/examples_smoke_test.go`
@@ -80,6 +81,8 @@
 - `cmd/cub-gen/testdata/parity/verify-attestation-linked-ably.json.golden.json`
 - `cmd/cub-gen/testdata/parity/verify-attestation-linked-ops.json.golden.json`
 - `cmd/cub-gen/testdata/parity/generators.golden.json`
+- `cmd/cub-gen/testdata/parity/generators-kind-helm.golden.json`
+- `cmd/cub-gen/testdata/parity/generators-capability-ops.golden.json`
 - `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
 - `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
 


### PR DESCRIPTION
## Summary
- add `cub-gen generators` filters: `--kind`, `--profile`, `--capability`
- keep deterministic ordering and output shape
- extend parity tests/goldens for filtered JSON views
- update parity/testing/docs references

## Why
Improves discoverability of generator families for focused workflows without changing existing command contracts.

## Validation
- go test ./...
- make ci
