### PR TITLE
test(v0.2): lock generators filter contracts

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -124,6 +124,9 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/generators.golden.json`
   - `cmd/cub-gen/testdata/parity/generators-kind-helm.golden.json`
   - `cmd/cub-gen/testdata/parity/generators-capability-ops.golden.json`
+  - `cmd/cub-gen/testdata/parity/generators-profile-spring.golden.json`
+  - `cmd/cub-gen/testdata/parity/generators-combined-score.golden.json`
+  - `cmd/cub-gen/testdata/parity/generators-empty.golden.json`
   - `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt`

--- a/cmd/cub-gen/generators_parity_test.go
+++ b/cmd/cub-gen/generators_parity_test.go
@@ -55,6 +55,54 @@ func TestGeneratorsGoldenJSONCapabilityFilter(t *testing.T) {
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-capability-ops.golden.json"), got)
 }
 
+func TestGeneratorsGoldenJSONProfileFilter(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--json", "--profile", "springboot-paas"})
+	if err != nil {
+		t.Fatalf("run generators --json --profile returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal generators profile json: %v\noutput=%s", err, out)
+	}
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-profile-spring.golden.json"), got)
+}
+
+func TestGeneratorsGoldenJSONCombinedFilters(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--json", "--kind", "score", "--profile", "scoredev-paas", "--capability", "workload-spec"})
+	if err != nil {
+		t.Fatalf("run generators --json combined filters returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal generators combined filter json: %v\noutput=%s", err, out)
+	}
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-combined-score.golden.json"), got)
+}
+
+func TestGeneratorsGoldenJSONNoMatches(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--json", "--profile", "non-existent-profile"})
+	if err != nil {
+		t.Fatalf("run generators --json no matches returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal generators no matches json: %v\noutput=%s", err, out)
+	}
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-empty.golden.json"), got)
+}
+
 func TestGeneratorsGoldenTable(t *testing.T) {
 	out, stderr, err := runWithCapturedIO([]string{"generators"})
 	if err != nil {

--- a/cmd/cub-gen/testdata/parity/generators-combined-score.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-combined-score.golden.json
@@ -1,0 +1,16 @@
+{
+  "count": 1,
+  "families": [
+    {
+      "capabilities": [
+        "render-manifests",
+        "workload-spec",
+        "inverse-score-patch"
+      ],
+      "kind": "score",
+      "profile": "scoredev-paas",
+      "resource_kind": "Application",
+      "resource_type": "argoproj.io/v1alpha1/Application"
+    }
+  ]
+}

--- a/cmd/cub-gen/testdata/parity/generators-empty.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-empty.golden.json
@@ -1,0 +1,4 @@
+{
+  "count": 0,
+  "families": []
+}

--- a/cmd/cub-gen/testdata/parity/generators-profile-spring.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-profile-spring.golden.json
@@ -1,0 +1,16 @@
+{
+  "count": 1,
+  "families": [
+    {
+      "capabilities": [
+        "render-app-config",
+        "profile-overrides",
+        "inverse-app-config-patch"
+      ],
+      "kind": "springboot",
+      "profile": "springboot-paas",
+      "resource_kind": "Kustomization",
+      "resource_type": "kustomize.toolkit.fluxcd.io/v1/Kustomization"
+    }
+  ]
+}

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -41,6 +41,7 @@ Implemented in this preview slice:
 23. Added `cub-gen generators` command (table + JSON + help golden contracts) to expose registry-backed supported family inventory.
 24. Extended `cub-gen generators` with deterministic filters (`--kind`, `--profile`, `--capability`) and locked filtered output contracts.
 25. Refactored input schema inference to be registry-driven (`RoleSchemaRefs`) instead of importer-local switch logic, preserving existing schema outputs while reducing per-family branching.
+26. Expanded `generators` parity contracts to lock profile-filter, combined-filter, and empty-match JSON outputs.
 
 ## v0.2 preview invariants
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -18,7 +18,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 ### Tier 2: parity/golden
 
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
-- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go` (full list + kind filter + capability filter).
+- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go` (full list + kind/profile/capability filters, combined filters, and empty-match behavior).
 - Bridge publish golden locks in `cmd/cub-gen/publish_parity_test.go` (import/direct paths for helm/score/spring/backstage/ably/ops).
 - Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
 - Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -22,7 +22,7 @@
   - error mode coverage
 - `cmd/cub-gen/generators_parity_test.go`
   - golden generator family JSON contract
-  - golden generator family filtered JSON contracts (kind + capability)
+  - golden generator family filtered JSON contracts (kind + capability + profile + combined + empty match)
   - golden generator family table contract
   - golden generators help output contract
 - `cmd/cub-gen/examples_smoke_test.go`
@@ -83,6 +83,9 @@
 - `cmd/cub-gen/testdata/parity/generators.golden.json`
 - `cmd/cub-gen/testdata/parity/generators-kind-helm.golden.json`
 - `cmd/cub-gen/testdata/parity/generators-capability-ops.golden.json`
+- `cmd/cub-gen/testdata/parity/generators-profile-spring.golden.json`
+- `cmd/cub-gen/testdata/parity/generators-combined-score.golden.json`
+- `cmd/cub-gen/testdata/parity/generators-empty.golden.json`
 - `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
 - `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
 


### PR DESCRIPTION
## Summary
- add generators parity tests for `--profile` filter
- add generators parity test for combined filters (`--kind + --profile + --capability`)
- add generators parity test for deterministic empty-match output
- add matching JSON goldens and update parity/testing inventory docs

## Why
Completes filter contract coverage for `cub-gen generators` so regressions in filtered output shape/count are caught immediately.

## Validation
- make update-goldens
- go test ./...
- make ci
