### PR TITLE
refactor(v0.2): move importer hint defaults into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -42,6 +42,7 @@ Implemented in this preview slice:
 24. Extended `cub-gen generators` with deterministic filters (`--kind`, `--profile`, `--capability`) and locked filtered output contracts.
 25. Refactored input schema inference to be registry-driven (`RoleSchemaRefs`) instead of importer-local switch logic, preserving existing schema outputs while reducing per-family branching.
 26. Expanded `generators` parity contracts to lock profile-filter, combined-filter, and empty-match JSON outputs.
+27. Refactored generator hint default paths/labels into registry-driven `HintDefaults`, removing hardcoded importer defaults while preserving output behavior.
 
 ## v0.2 preview invariants
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -606,10 +606,10 @@ type scoreHints struct {
 
 func scorePathHintsFromInputs(repo string, inputs []string) scoreHints {
 	h := scoreHints{
-		SourcePath:      "score.yaml",
-		ContainerName:   "main",
-		VariableName:    "LOG_LEVEL",
-		ServicePortName: "web",
+		SourcePath:      registry.HintDefault(model.GeneratorScore, "source_path", "score.yaml"),
+		ContainerName:   registry.HintDefault(model.GeneratorScore, "container_name", "main"),
+		VariableName:    registry.HintDefault(model.GeneratorScore, "variable_name", "LOG_LEVEL"),
+		ServicePortName: registry.HintDefault(model.GeneratorScore, "service_port_name", "web"),
 	}
 
 	scorePath := firstScoreInputPath(inputs)
@@ -879,8 +879,8 @@ type springHints struct {
 
 func springPathHintsFromInputs(inputs []string) springHints {
 	h := springHints{
-		BuildConfigPath: "pom.xml",
-		BaseConfigPath:  "src/main/resources/application.yaml",
+		BuildConfigPath: registry.HintDefault(model.GeneratorSpringBoot, "build_config_path", "pom.xml"),
+		BaseConfigPath:  registry.HintDefault(model.GeneratorSpringBoot, "base_config_path", "src/main/resources/application.yaml"),
 	}
 
 	for _, in := range inputs {
@@ -906,7 +906,7 @@ func springPathHintsFromInputs(inputs []string) springHints {
 		if h.ProfileConfigPath != "" {
 			h.BaseConfigPath = h.ProfileConfigPath
 		} else {
-			h.BaseConfigPath = "src/main/resources/application.yaml"
+			h.BaseConfigPath = registry.HintDefault(model.GeneratorSpringBoot, "base_config_path", "src/main/resources/application.yaml")
 		}
 	}
 	return h
@@ -926,7 +926,7 @@ type backstageHints struct {
 
 func backstagePathHintsFromInputs(inputs []string) backstageHints {
 	h := backstageHints{
-		CatalogPath: "catalog-info.yaml",
+		CatalogPath: registry.HintDefault(model.GeneratorBackstage, "catalog_path", "catalog-info.yaml"),
 	}
 	for _, in := range inputs {
 		p := filepath.ToSlash(in)
@@ -948,7 +948,7 @@ type ablyHints struct {
 
 func ablyPathHintsFromInputs(inputs []string) ablyHints {
 	h := ablyHints{
-		BaseConfigPath: "ably.yaml",
+		BaseConfigPath: registry.HintDefault(model.GeneratorAbly, "base_config_path", "ably.yaml"),
 	}
 	for _, in := range inputs {
 		p := filepath.ToSlash(in)
@@ -979,7 +979,7 @@ type opsWorkflowHints struct {
 
 func opsWorkflowPathHintsFromInputs(inputs []string) opsWorkflowHints {
 	h := opsWorkflowHints{
-		BaseSpecPath: "operations.yaml",
+		BaseSpecPath: registry.HintDefault(model.GeneratorOpsFlow, "base_spec_path", "operations.yaml"),
 	}
 	for _, in := range inputs {
 		p := filepath.ToSlash(in)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -32,6 +32,7 @@ type FamilySpec struct {
 	ResourceType     string
 	Capabilities     []string
 	RoleSchemaRefs   map[string]string
+	HintDefaults     map[string]string
 	InputRoleRules   []InputRoleRule
 	DefaultInputRole string
 	RoleOwners       map[string]string
@@ -49,6 +50,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		RoleSchemaRefs: map[string]string{
 			"chart": "https://json.schemastore.org/chart",
 		},
+		HintDefaults: map[string]string{
+			"chart_path": "Chart.yaml",
+		},
 		InputRoleRules: []InputRoleRule{
 			{Role: "chart", ExactBasenames: []string{"chart.yaml"}},
 			{Role: "values", Prefixes: []string{"values"}, Extensions: []string{".yaml", ".yml"}},
@@ -63,12 +67,18 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 	},
 	model.GeneratorScore: {
-		Kind:             model.GeneratorScore,
-		Profile:          "scoredev-paas",
-		ResourceKind:     "Application",
-		ResourceType:     "argoproj.io/v1alpha1/Application",
-		Capabilities:     []string{"render-manifests", "workload-spec", "inverse-score-patch"},
-		RoleSchemaRefs:   map[string]string{"score-spec": "https://docs.score.dev/schemas/score-v1b1.json"},
+		Kind:           model.GeneratorScore,
+		Profile:        "scoredev-paas",
+		ResourceKind:   "Application",
+		ResourceType:   "argoproj.io/v1alpha1/Application",
+		Capabilities:   []string{"render-manifests", "workload-spec", "inverse-score-patch"},
+		RoleSchemaRefs: map[string]string{"score-spec": "https://docs.score.dev/schemas/score-v1b1.json"},
+		HintDefaults: map[string]string{
+			"source_path":       "score.yaml",
+			"container_name":    "main",
+			"variable_name":     "LOG_LEVEL",
+			"service_port_name": "web",
+		},
 		InputRoleRules:   []InputRoleRule{{Role: "score-spec", ExactBasenames: []string{"score.yaml", "score.yml"}}},
 		DefaultInputRole: "score-input",
 		DefaultOwner:     "app-team",
@@ -87,6 +97,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		RoleSchemaRefs: map[string]string{
 			"app-config-base":    "https://json.schemastore.org/spring-configuration-metadata",
 			"app-config-profile": "https://json.schemastore.org/spring-configuration-metadata",
+		},
+		HintDefaults: map[string]string{
+			"build_config_path": "pom.xml",
+			"base_config_path":  "src/main/resources/application.yaml",
 		},
 		InputRoleRules: []InputRoleRule{
 			{Role: "build-config", ExactBasenames: []string{"pom.xml", "build.gradle", "build.gradle.kts"}},
@@ -115,6 +129,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"catalog-spec": "https://json.schemastore.org/backstage-catalog-info",
 			"app-config":   "https://json.schemastore.org/backstage-app-config",
 		},
+		HintDefaults: map[string]string{
+			"catalog_path": "catalog-info.yaml",
+		},
 		InputRoleRules: []InputRoleRule{
 			{Role: "catalog-spec", ExactBasenames: []string{"catalog-info.yaml", "catalog-info.yml"}},
 			{Role: "app-config", ExactBasenames: []string{"app-config.yaml", "app-config.yml"}},
@@ -137,6 +154,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"provider-config-base":    "https://schema.confighub.dev/generators/ably-config-v1",
 			"provider-config-overlay": "https://schema.confighub.dev/generators/ably-config-v1",
 		},
+		HintDefaults: map[string]string{
+			"base_config_path": "ably.yaml",
+		},
 		InputRoleRules: []InputRoleRule{
 			{Role: "provider-config-base", ExactBasenames: []string{"ably.yaml", "ably.yml", "ably.json"}},
 			{Role: "provider-config-overlay", Prefixes: []string{"ably-"}, Extensions: []string{".yaml", ".yml", ".json"}},
@@ -157,6 +177,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		RoleSchemaRefs: map[string]string{
 			"operations-base":    "https://schema.confighub.dev/generators/ops-workflow-v1",
 			"operations-overlay": "https://schema.confighub.dev/generators/ops-workflow-v1",
+		},
+		HintDefaults: map[string]string{
+			"base_spec_path": "operations.yaml",
 		},
 		InputRoleRules: []InputRoleRule{
 			{Role: "operations-base", ExactBasenames: []string{"operations.yaml", "operations.yml", "workflow.yaml", "workflow.yml"}},
@@ -183,6 +206,7 @@ func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
 		ResourceType:     spec.ResourceType,
 		Capabilities:     append([]string(nil), spec.Capabilities...),
 		RoleSchemaRefs:   copyRoleSchemaRefs(spec.RoleSchemaRefs),
+		HintDefaults:     copyHintDefaults(spec.HintDefaults),
 		InputRoleRules:   copyInputRoleRules(spec.InputRoleRules),
 		DefaultInputRole: spec.DefaultInputRole,
 		RoleOwners:       copyRoleOwners(spec.RoleOwners),
@@ -221,6 +245,17 @@ func Capabilities(kind model.GeneratorKind) []string {
 		return []string{"render-manifests"}
 	}
 	return append([]string(nil), spec.Capabilities...)
+}
+
+func HintDefault(kind model.GeneratorKind, key, fallback string) string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return fallback
+	}
+	if v, ok := spec.HintDefaults[key]; ok && strings.TrimSpace(v) != "" {
+		return v
+	}
+	return fallback
 }
 
 func SchemaRef(kind model.GeneratorKind, inputPath string) string {
@@ -357,6 +392,17 @@ func copyRoleOwners(in map[string]string) map[string]string {
 }
 
 func copyRoleSchemaRefs(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func copyHintDefaults(in map[string]string) map[string]string {
 	if in == nil {
 		return nil
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -65,6 +65,9 @@ func TestRegistryFallbacks(t *testing.T) {
 	if got := Capabilities(unknown); !reflect.DeepEqual(got, []string{"render-manifests"}) {
 		t.Fatalf("expected capabilities fallback render-manifests, got %+v", got)
 	}
+	if got := HintDefault(unknown, "source_path", "default.yaml"); got != "default.yaml" {
+		t.Fatalf("expected hint default fallback default.yaml, got %q", got)
+	}
 	if got := InputRole(unknown, "any.yaml"); got != "input" {
 		t.Fatalf("expected input role fallback input, got %q", got)
 	}
@@ -156,5 +159,24 @@ func TestRegistryWetTargetTemplates(t *testing.T) {
 	again := WetTargetTemplates(model.GeneratorScore)
 	if again[0].Kind != "Application" {
 		t.Fatalf("expected immutable template copy, got %+v", again[0])
+	}
+}
+
+func TestRegistryHintDefaults(t *testing.T) {
+	if got := HintDefault(model.GeneratorScore, "source_path", "fallback.yaml"); got != "score.yaml" {
+		t.Fatalf("expected score source_path hint default score.yaml, got %q", got)
+	}
+	if got := HintDefault(model.GeneratorSpringBoot, "base_config_path", "fallback.yaml"); got != "src/main/resources/application.yaml" {
+		t.Fatalf("expected spring base_config_path hint default, got %q", got)
+	}
+
+	// Ensure returned specs are copies.
+	spec, ok := Spec(model.GeneratorScore)
+	if !ok {
+		t.Fatalf("expected score spec")
+	}
+	spec.HintDefaults["source_path"] = "mutated.yaml"
+	if got := HintDefault(model.GeneratorScore, "source_path", "fallback.yaml"); got != "score.yaml" {
+		t.Fatalf("expected immutable hint defaults, got %q", got)
 	}
 }

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -43,6 +43,7 @@
 - `internal/detect/detect_test.go`
 - `internal/importer/importer_test.go` (includes generator capability contract assertions)
 - `internal/gitops/flow_test.go`
+- `internal/registry/registry_test.go`
 
 ## Golden artifacts
 


### PR DESCRIPTION
## Summary
- add `HintDefaults` to registry family specs
- add `registry.HintDefault(kind,key,fallback)` helper
- migrate importer hint default initialization (score/spring/backstage/ably/ops) to registry lookups
- add registry tests for hint-default fallback + copy immutability
- update v0.2 roadmap and test inventory docs

## Why
This extends the registry-first architecture to hint strategy defaults, reducing importer hardcoding and lowering per-family maintenance cost.

## Validation
- go test ./...
- make ci
