### PR TITLE
refactor(v0.2): move field origin transform labels into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -43,6 +43,7 @@ Implemented in this preview slice:
 25. Refactored input schema inference to be registry-driven (`RoleSchemaRefs`) instead of importer-local switch logic, preserving existing schema outputs while reducing per-family branching.
 26. Expanded `generators` parity contracts to lock profile-filter, combined-filter, and empty-match JSON outputs.
 27. Refactored generator hint default paths/labels into registry-driven `HintDefaults`, removing hardcoded importer defaults while preserving output behavior.
+28. Refactored provenance `field_origin_map.transform` labels to be registry-driven (`FieldOriginTransform` / `FieldOriginOverlayTransform`) instead of importer string literals.
 
 ## v0.2 preview invariants
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -333,7 +333,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				DryPath:    "values.image.tag",
 				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
 				SourcePath: "values.yaml",
-				Transform:  "helm-template",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.86,
 			},
 		}
@@ -344,21 +344,21 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				DryPath:    fmt.Sprintf("containers.%s.image", hints.ContainerName),
 				WetPath:    fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/image", hints.ContainerName),
 				SourcePath: hints.SourcePath,
-				Transform:  "score-to-k8s",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.94,
 			},
 			{
 				DryPath:    fmt.Sprintf("containers.%s.variables.%s", hints.ContainerName, hints.VariableName),
 				WetPath:    fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/env[name=%s]/value", hints.ContainerName, hints.VariableName),
 				SourcePath: hints.SourcePath,
-				Transform:  "score-to-k8s",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.90,
 			},
 			{
 				DryPath:    fmt.Sprintf("service.ports.%s.port", hints.ServicePortName),
 				WetPath:    fmt.Sprintf("Service/spec/ports[name=%s]/port", hints.ServicePortName),
 				SourcePath: hints.SourcePath,
-				Transform:  "score-to-k8s",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.91,
 			},
 		}
@@ -369,21 +369,21 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				DryPath:    "spring.application.name",
 				WetPath:    "Deployment/metadata/labels[app.kubernetes.io/name]",
 				SourcePath: hints.BaseConfigPath,
-				Transform:  "spring-config-to-manifest",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.89,
 			},
 			{
 				DryPath:    "server.port",
 				WetPath:    "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
 				SourcePath: hints.BaseConfigPath,
-				Transform:  "spring-config-to-manifest",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.92,
 			},
 			{
 				DryPath:    "spring.datasource.url",
 				WetPath:    "ConfigMap/data/application.yaml:spring.datasource.url",
 				SourcePath: hints.BaseConfigPath,
-				Transform:  "spring-config-to-manifest",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.78,
 			},
 		}
@@ -392,7 +392,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				DryPath:    "server.port",
 				WetPath:    "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
 				SourcePath: hints.ProfileConfigPath,
-				Transform:  "spring-profile-overlay",
+				Transform:  registry.FieldOriginOverlayTransform(g.Kind),
 				Confidence: 0.88,
 			})
 		}
@@ -404,14 +404,14 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				DryPath:    "metadata.name",
 				WetPath:    "Application/metadata/name",
 				SourcePath: hints.CatalogPath,
-				Transform:  "backstage-component-to-application",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.90,
 			},
 			{
 				DryPath:    "spec.lifecycle",
 				WetPath:    "Application/metadata/labels[lifecycle]",
 				SourcePath: hints.CatalogPath,
-				Transform:  "backstage-component-to-application",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.82,
 			},
 		}
@@ -422,14 +422,14 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				DryPath:    "app.environment",
 				WetPath:    "ConfigMap/data/ABLY_ENVIRONMENT",
 				SourcePath: hints.BaseConfigPath,
-				Transform:  "ably-config-to-runtime",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.90,
 			},
 			{
 				DryPath:    "channels.inbound",
 				WetPath:    "ConfigMap/data/ABLY_CHANNEL_INBOUND",
 				SourcePath: hints.BaseConfigPath,
-				Transform:  "ably-config-to-runtime",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.88,
 			},
 		}
@@ -438,7 +438,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				DryPath:    "channels.inbound",
 				WetPath:    "ConfigMap/data/ABLY_CHANNEL_INBOUND",
 				SourcePath: hints.OverlayConfigPath,
-				Transform:  "ably-overlay-merge",
+				Transform:  registry.FieldOriginOverlayTransform(g.Kind),
 				Confidence: 0.84,
 			})
 		}
@@ -450,14 +450,14 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				DryPath:    "actions.deploy.image_tag",
 				WetPath:    "Workflow/spec/templates[name=deploy]/container/image",
 				SourcePath: hints.BaseSpecPath,
-				Transform:  "ops-workflow-to-argo-workflow",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.87,
 			},
 			{
 				DryPath:    "triggers.schedule",
 				WetPath:    "Workflow/spec/schedule",
 				SourcePath: hints.BaseSpecPath,
-				Transform:  "ops-workflow-to-argo-workflow",
+				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: 0.84,
 			},
 		}
@@ -466,7 +466,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				DryPath:    "triggers.schedule",
 				WetPath:    "Workflow/spec/schedule",
 				SourcePath: hints.OverlaySpecPath,
-				Transform:  "ops-workflow-overlay-merge",
+				Transform:  registry.FieldOriginOverlayTransform(g.Kind),
 				Confidence: 0.80,
 			})
 		}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -26,18 +26,20 @@ type WetTargetTemplate struct {
 // FamilySpec captures cross-cutting generator-family metadata used by multiple
 // command/runtime layers.
 type FamilySpec struct {
-	Kind             model.GeneratorKind
-	Profile          string
-	ResourceKind     string
-	ResourceType     string
-	Capabilities     []string
-	RoleSchemaRefs   map[string]string
-	HintDefaults     map[string]string
-	InputRoleRules   []InputRoleRule
-	DefaultInputRole string
-	RoleOwners       map[string]string
-	DefaultOwner     string
-	WetTargets       []WetTargetTemplate
+	Kind                        model.GeneratorKind
+	Profile                     string
+	ResourceKind                string
+	ResourceType                string
+	Capabilities                []string
+	RoleSchemaRefs              map[string]string
+	HintDefaults                map[string]string
+	FieldOriginTransform        string
+	FieldOriginOverlayTransform string
+	InputRoleRules              []InputRoleRule
+	DefaultInputRole            string
+	RoleOwners                  map[string]string
+	DefaultOwner                string
+	WetTargets                  []WetTargetTemplate
 }
 
 var familySpecs = map[model.GeneratorKind]FamilySpec{
@@ -53,6 +55,7 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		HintDefaults: map[string]string{
 			"chart_path": "Chart.yaml",
 		},
+		FieldOriginTransform: "helm-template",
 		InputRoleRules: []InputRoleRule{
 			{Role: "chart", ExactBasenames: []string{"chart.yaml"}},
 			{Role: "values", Prefixes: []string{"values"}, Extensions: []string{".yaml", ".yml"}},
@@ -79,9 +82,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"variable_name":     "LOG_LEVEL",
 			"service_port_name": "web",
 		},
-		InputRoleRules:   []InputRoleRule{{Role: "score-spec", ExactBasenames: []string{"score.yaml", "score.yml"}}},
-		DefaultInputRole: "score-input",
-		DefaultOwner:     "app-team",
+		FieldOriginTransform: "score-to-k8s",
+		InputRoleRules:       []InputRoleRule{{Role: "score-spec", ExactBasenames: []string{"score.yaml", "score.yml"}}},
+		DefaultInputRole:     "score-input",
+		DefaultOwner:         "app-team",
 		WetTargets: []WetTargetTemplate{
 			{Kind: "Application", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps"},
 			{Kind: "Deployment", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "containers.{{container}}.image"},
@@ -102,6 +106,8 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"build_config_path": "pom.xml",
 			"base_config_path":  "src/main/resources/application.yaml",
 		},
+		FieldOriginTransform:        "spring-config-to-manifest",
+		FieldOriginOverlayTransform: "spring-profile-overlay",
 		InputRoleRules: []InputRoleRule{
 			{Role: "build-config", ExactBasenames: []string{"pom.xml", "build.gradle", "build.gradle.kts"}},
 			{Role: "app-config-base", ExactBasenames: []string{"application.yaml", "application.yml"}},
@@ -132,6 +138,7 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		HintDefaults: map[string]string{
 			"catalog_path": "catalog-info.yaml",
 		},
+		FieldOriginTransform: "backstage-component-to-application",
 		InputRoleRules: []InputRoleRule{
 			{Role: "catalog-spec", ExactBasenames: []string{"catalog-info.yaml", "catalog-info.yml"}},
 			{Role: "app-config", ExactBasenames: []string{"app-config.yaml", "app-config.yml"}},
@@ -157,6 +164,8 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		HintDefaults: map[string]string{
 			"base_config_path": "ably.yaml",
 		},
+		FieldOriginTransform:        "ably-config-to-runtime",
+		FieldOriginOverlayTransform: "ably-overlay-merge",
 		InputRoleRules: []InputRoleRule{
 			{Role: "provider-config-base", ExactBasenames: []string{"ably.yaml", "ably.yml", "ably.json"}},
 			{Role: "provider-config-overlay", Prefixes: []string{"ably-"}, Extensions: []string{".yaml", ".yml", ".json"}},
@@ -181,6 +190,8 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		HintDefaults: map[string]string{
 			"base_spec_path": "operations.yaml",
 		},
+		FieldOriginTransform:        "ops-workflow-to-argo-workflow",
+		FieldOriginOverlayTransform: "ops-workflow-overlay-merge",
 		InputRoleRules: []InputRoleRule{
 			{Role: "operations-base", ExactBasenames: []string{"operations.yaml", "operations.yml", "workflow.yaml", "workflow.yml"}},
 			{Role: "operations-overlay", Prefixes: []string{"operations-", "workflow-"}, Extensions: []string{".yaml", ".yml"}},
@@ -200,18 +211,20 @@ func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
 		return FamilySpec{}, false
 	}
 	return FamilySpec{
-		Kind:             spec.Kind,
-		Profile:          spec.Profile,
-		ResourceKind:     spec.ResourceKind,
-		ResourceType:     spec.ResourceType,
-		Capabilities:     append([]string(nil), spec.Capabilities...),
-		RoleSchemaRefs:   copyRoleSchemaRefs(spec.RoleSchemaRefs),
-		HintDefaults:     copyHintDefaults(spec.HintDefaults),
-		InputRoleRules:   copyInputRoleRules(spec.InputRoleRules),
-		DefaultInputRole: spec.DefaultInputRole,
-		RoleOwners:       copyRoleOwners(spec.RoleOwners),
-		DefaultOwner:     spec.DefaultOwner,
-		WetTargets:       copyWetTargets(spec.WetTargets),
+		Kind:                        spec.Kind,
+		Profile:                     spec.Profile,
+		ResourceKind:                spec.ResourceKind,
+		ResourceType:                spec.ResourceType,
+		Capabilities:                append([]string(nil), spec.Capabilities...),
+		RoleSchemaRefs:              copyRoleSchemaRefs(spec.RoleSchemaRefs),
+		HintDefaults:                copyHintDefaults(spec.HintDefaults),
+		FieldOriginTransform:        spec.FieldOriginTransform,
+		FieldOriginOverlayTransform: spec.FieldOriginOverlayTransform,
+		InputRoleRules:              copyInputRoleRules(spec.InputRoleRules),
+		DefaultInputRole:            spec.DefaultInputRole,
+		RoleOwners:                  copyRoleOwners(spec.RoleOwners),
+		DefaultOwner:                spec.DefaultOwner,
+		WetTargets:                  copyWetTargets(spec.WetTargets),
 	}, true
 }
 
@@ -256,6 +269,28 @@ func HintDefault(kind model.GeneratorKind, key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func FieldOriginTransform(kind model.GeneratorKind) string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return "generator-transform"
+	}
+	if strings.TrimSpace(spec.FieldOriginTransform) != "" {
+		return spec.FieldOriginTransform
+	}
+	return "generator-transform"
+}
+
+func FieldOriginOverlayTransform(kind model.GeneratorKind) string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return FieldOriginTransform(kind)
+	}
+	if strings.TrimSpace(spec.FieldOriginOverlayTransform) != "" {
+		return spec.FieldOriginOverlayTransform
+	}
+	return FieldOriginTransform(kind)
 }
 
 func SchemaRef(kind model.GeneratorKind, inputPath string) string {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -68,6 +68,12 @@ func TestRegistryFallbacks(t *testing.T) {
 	if got := HintDefault(unknown, "source_path", "default.yaml"); got != "default.yaml" {
 		t.Fatalf("expected hint default fallback default.yaml, got %q", got)
 	}
+	if got := FieldOriginTransform(unknown); got != "generator-transform" {
+		t.Fatalf("expected field origin transform fallback generator-transform, got %q", got)
+	}
+	if got := FieldOriginOverlayTransform(unknown); got != "generator-transform" {
+		t.Fatalf("expected field origin overlay transform fallback generator-transform, got %q", got)
+	}
 	if got := InputRole(unknown, "any.yaml"); got != "input" {
 		t.Fatalf("expected input role fallback input, got %q", got)
 	}
@@ -168,6 +174,15 @@ func TestRegistryHintDefaults(t *testing.T) {
 	}
 	if got := HintDefault(model.GeneratorSpringBoot, "base_config_path", "fallback.yaml"); got != "src/main/resources/application.yaml" {
 		t.Fatalf("expected spring base_config_path hint default, got %q", got)
+	}
+	if got := FieldOriginTransform(model.GeneratorBackstage); got != "backstage-component-to-application" {
+		t.Fatalf("expected backstage field origin transform, got %q", got)
+	}
+	if got := FieldOriginOverlayTransform(model.GeneratorSpringBoot); got != "spring-profile-overlay" {
+		t.Fatalf("expected spring overlay field origin transform, got %q", got)
+	}
+	if got := FieldOriginOverlayTransform(model.GeneratorHelm); got != "helm-template" {
+		t.Fatalf("expected helm overlay transform to fall back to base transform, got %q", got)
 	}
 
 	// Ensure returned specs are copies.


### PR DESCRIPTION
## Summary
- add per-family field-origin transform metadata to registry (`FieldOriginTransform`, `FieldOriginOverlayTransform`)
- add lookup helpers with fallback behavior
- migrate importer `fieldOriginsForGenerator` transform strings to registry lookups
- extend registry tests for transform fallback and per-family values
- update v0.2 roadmap progress

## Why
Keeps provenance mapping semantics registry-owned and reduces importer-local family branching when adding generator families.

## Validation
- go test ./...
- make ci
