### PR TITLE
test(v0.2): lock generators table filter contracts

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -128,6 +128,8 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/generators-combined-score.golden.json`
   - `cmd/cub-gen/testdata/parity/generators-empty.golden.json`
   - `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
+  - `cmd/cub-gen/testdata/parity/generators-kind-helm.table.golden.txt`
+  - `cmd/cub-gen/testdata/parity/generators-empty.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt`
 - Error-mode tests:

--- a/cmd/cub-gen/generators_parity_test.go
+++ b/cmd/cub-gen/generators_parity_test.go
@@ -114,6 +114,28 @@ func TestGeneratorsGoldenTable(t *testing.T) {
 	assertGoldenText(t, filepath.Join("testdata", "parity", "generators.table.golden.txt"), out)
 }
 
+func TestGeneratorsGoldenTableKindFilter(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--kind", "helm"})
+	if err != nil {
+		t.Fatalf("run generators --kind returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+	assertGoldenText(t, filepath.Join("testdata", "parity", "generators-kind-helm.table.golden.txt"), out)
+}
+
+func TestGeneratorsGoldenTableNoMatches(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--profile", "non-existent-profile"})
+	if err != nil {
+		t.Fatalf("run generators --profile no matches returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+	assertGoldenText(t, filepath.Join("testdata", "parity", "generators-empty.table.golden.txt"), out)
+}
+
 func TestGeneratorsGoldenHelp(t *testing.T) {
 	stdout, stderr, err := runWithCapturedIO([]string{"generators", "--help"})
 	if err != nil {

--- a/cmd/cub-gen/testdata/parity/generators-empty.table.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-empty.table.golden.txt
@@ -1,0 +1,1 @@
+Kind	Profile	Resource Kind	Resource Type	Capabilities

--- a/cmd/cub-gen/testdata/parity/generators-kind-helm.table.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-kind-helm.table.golden.txt
@@ -1,0 +1,2 @@
+Kind	Profile	Resource Kind	Resource Type	Capabilities
+helm	helm-paas	HelmRelease	helm.toolkit.fluxcd.io/v2/HelmRelease	render-manifests,values-overrides,inverse-values-patch

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -44,6 +44,7 @@ Implemented in this preview slice:
 26. Expanded `generators` parity contracts to lock profile-filter, combined-filter, and empty-match JSON outputs.
 27. Refactored generator hint default paths/labels into registry-driven `HintDefaults`, removing hardcoded importer defaults while preserving output behavior.
 28. Refactored provenance `field_origin_map.transform` labels to be registry-driven (`FieldOriginTransform` / `FieldOriginOverlayTransform`) instead of importer string literals.
+29. Expanded `generators` table-mode parity contracts to lock deterministic filtered and empty-match outputs.
 
 ## v0.2 preview invariants
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -18,7 +18,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 ### Tier 2: parity/golden
 
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
-- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go` (full list + kind/profile/capability filters, combined filters, and empty-match behavior).
+- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go` (full list + JSON/table filter contracts for kind/profile/capability, combined filters, and empty-match behavior).
 - Bridge publish golden locks in `cmd/cub-gen/publish_parity_test.go` (import/direct paths for helm/score/spring/backstage/ably/ops).
 - Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
 - Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -23,7 +23,7 @@
 - `cmd/cub-gen/generators_parity_test.go`
   - golden generator family JSON contract
   - golden generator family filtered JSON contracts (kind + capability + profile + combined + empty match)
-  - golden generator family table contract
+  - golden generator family table contracts (full + filtered + empty match)
   - golden generators help output contract
 - `cmd/cub-gen/examples_smoke_test.go`
   - path-mode discover/import for Helm, Score, Spring, Backstage, Ably, Ops (`./examples/...` without alias config)
@@ -88,6 +88,8 @@
 - `cmd/cub-gen/testdata/parity/generators-combined-score.golden.json`
 - `cmd/cub-gen/testdata/parity/generators-empty.golden.json`
 - `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
+- `cmd/cub-gen/testdata/parity/generators-kind-helm.table.golden.txt`
+- `cmd/cub-gen/testdata/parity/generators-empty.table.golden.txt`
 - `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
 
 ## Mandatory validation commands


### PR DESCRIPTION
## Summary
- add generators parity tests for filtered table output (`--kind helm`)
- add generators parity test for empty-match table output
- add new table goldens for filtered and empty states
- update parity/testing inventory docs and v0.2 roadmap

## Why
Completes `generators` output contract locking for both JSON and table modes.

## Validation
- make update-goldens
- go test ./...
- make ci
