### PR TITLE
refactor(v0.2): move inverse patch reasons into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -45,6 +45,7 @@ Implemented in this preview slice:
 27. Refactored generator hint default paths/labels into registry-driven `HintDefaults`, removing hardcoded importer defaults while preserving output behavior.
 28. Refactored provenance `field_origin_map.transform` labels to be registry-driven (`FieldOriginTransform` / `FieldOriginOverlayTransform`) instead of importer string literals.
 29. Expanded `generators` table-mode parity contracts to lock deterministic filtered and empty-match outputs.
+30. Refactored inverse patch reason strings into registry-driven templates (`InversePatchReasons`) with placeholder rendering for family path hints.
 
 ## v0.2 preview invariants
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -211,7 +211,7 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 			EditableBy:     "app-team",
 			Confidence:     0.86,
 			RequiresReview: false,
-			Reason:         "Container image tag maps cleanly to helm values.",
+			Reason:         registry.InversePatchReason(g.Kind, "image_tag", "Container image tag maps cleanly to helm values."),
 		}}
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
@@ -222,7 +222,7 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 			EditableBy:     "app-team",
 			Confidence:     0.90,
 			RequiresReview: false,
-			Reason:         "Score variable maps to a single Kubernetes env var.",
+			Reason:         registry.InversePatchReason(g.Kind, "env_var", "Score variable maps to a single Kubernetes env var."),
 		}}
 	case model.GeneratorSpringBoot:
 		return []model.InversePatch{
@@ -233,7 +233,7 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				EditableBy:     "app-team",
 				Confidence:     0.88,
 				RequiresReview: false,
-				Reason:         "Application identity should be app-editable without platform escalation.",
+				Reason:         registry.InversePatchReason(g.Kind, "app_name", "Application identity should be app-editable without platform escalation."),
 			},
 			{
 				Operation:      "replace",
@@ -242,7 +242,7 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				EditableBy:     "app-team",
 				Confidence:     0.91,
 				RequiresReview: false,
-				Reason:         "Application listener port is an app-level configuration concern.",
+				Reason:         registry.InversePatchReason(g.Kind, "server_port", "Application listener port is an app-level configuration concern."),
 			},
 			{
 				Operation:      "replace",
@@ -251,7 +251,7 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				EditableBy:     "platform-engineer",
 				Confidence:     0.78,
 				RequiresReview: true,
-				Reason:         "Database connectivity impacts shared runtime dependencies.",
+				Reason:         registry.InversePatchReason(g.Kind, "datasource_url", "Database connectivity impacts shared runtime dependencies."),
 			},
 		}
 	case model.GeneratorBackstage:
@@ -264,7 +264,10 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				EditableBy:     "platform-engineer",
 				Confidence:     0.87,
 				RequiresReview: false,
-				Reason:         fmt.Sprintf("Backstage component identity is sourced from %s.", hints.CatalogPath),
+				Reason: renderTargetTemplate(
+					registry.InversePatchReason(g.Kind, "identity", "Backstage component identity is sourced from {{catalog_path}}."),
+					map[string]string{"catalog_path": hints.CatalogPath},
+				),
 			},
 			{
 				Operation:      "replace",
@@ -273,7 +276,7 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				EditableBy:     "platform-engineer",
 				Confidence:     0.82,
 				RequiresReview: true,
-				Reason:         "Lifecycle changes impact platform ownership and support policy.",
+				Reason:         registry.InversePatchReason(g.Kind, "lifecycle", "Lifecycle changes impact platform ownership and support policy."),
 			},
 		}
 	case model.GeneratorAbly:
@@ -286,7 +289,10 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				EditableBy:     "app-team",
 				Confidence:     0.90,
 				RequiresReview: false,
-				Reason:         fmt.Sprintf("Environment is sourced from %s.", hints.BaseConfigPath),
+				Reason: renderTargetTemplate(
+					registry.InversePatchReason(g.Kind, "environment", "Environment is sourced from {{base_config_path}}."),
+					map[string]string{"base_config_path": hints.BaseConfigPath},
+				),
 			},
 			{
 				Operation:      "replace",
@@ -295,7 +301,7 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				EditableBy:     "app-team",
 				Confidence:     0.88,
 				RequiresReview: false,
-				Reason:         "Channel mapping is app-level runtime behavior.",
+				Reason:         registry.InversePatchReason(g.Kind, "channels", "Channel mapping is app-level runtime behavior."),
 			},
 		}
 	case model.GeneratorOpsFlow:
@@ -308,7 +314,10 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				EditableBy:     "platform-engineer",
 				Confidence:     0.87,
 				RequiresReview: true,
-				Reason:         fmt.Sprintf("Deployment action image tag is sourced from %s.", hints.BaseSpecPath),
+				Reason: renderTargetTemplate(
+					registry.InversePatchReason(g.Kind, "image_tag", "Deployment action image tag is sourced from {{base_spec_path}}."),
+					map[string]string{"base_spec_path": hints.BaseSpecPath},
+				),
 			},
 			{
 				Operation:      "replace",
@@ -317,7 +326,7 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				EditableBy:     "platform-engineer",
 				Confidence:     0.84,
 				RequiresReview: true,
-				Reason:         "Schedule changes affect operational execution timing.",
+				Reason:         registry.InversePatchReason(g.Kind, "schedule", "Schedule changes affect operational execution timing."),
 			},
 		}
 	default:

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -33,6 +33,7 @@ type FamilySpec struct {
 	Capabilities                []string
 	RoleSchemaRefs              map[string]string
 	HintDefaults                map[string]string
+	InversePatchReasons         map[string]string
 	FieldOriginTransform        string
 	FieldOriginOverlayTransform string
 	InputRoleRules              []InputRoleRule
@@ -54,6 +55,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		HintDefaults: map[string]string{
 			"chart_path": "Chart.yaml",
+		},
+		InversePatchReasons: map[string]string{
+			"image_tag": "Container image tag maps cleanly to helm values.",
 		},
 		FieldOriginTransform: "helm-template",
 		InputRoleRules: []InputRoleRule{
@@ -82,6 +86,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"variable_name":     "LOG_LEVEL",
 			"service_port_name": "web",
 		},
+		InversePatchReasons: map[string]string{
+			"env_var": "Score variable maps to a single Kubernetes env var.",
+		},
 		FieldOriginTransform: "score-to-k8s",
 		InputRoleRules:       []InputRoleRule{{Role: "score-spec", ExactBasenames: []string{"score.yaml", "score.yml"}}},
 		DefaultInputRole:     "score-input",
@@ -105,6 +112,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		HintDefaults: map[string]string{
 			"build_config_path": "pom.xml",
 			"base_config_path":  "src/main/resources/application.yaml",
+		},
+		InversePatchReasons: map[string]string{
+			"app_name":       "Application identity should be app-editable without platform escalation.",
+			"server_port":    "Application listener port is an app-level configuration concern.",
+			"datasource_url": "Database connectivity impacts shared runtime dependencies.",
 		},
 		FieldOriginTransform:        "spring-config-to-manifest",
 		FieldOriginOverlayTransform: "spring-profile-overlay",
@@ -138,6 +150,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		HintDefaults: map[string]string{
 			"catalog_path": "catalog-info.yaml",
 		},
+		InversePatchReasons: map[string]string{
+			"identity":  "Backstage component identity is sourced from {{catalog_path}}.",
+			"lifecycle": "Lifecycle changes impact platform ownership and support policy.",
+		},
 		FieldOriginTransform: "backstage-component-to-application",
 		InputRoleRules: []InputRoleRule{
 			{Role: "catalog-spec", ExactBasenames: []string{"catalog-info.yaml", "catalog-info.yml"}},
@@ -164,6 +180,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		HintDefaults: map[string]string{
 			"base_config_path": "ably.yaml",
 		},
+		InversePatchReasons: map[string]string{
+			"environment": "Environment is sourced from {{base_config_path}}.",
+			"channels":    "Channel mapping is app-level runtime behavior.",
+		},
 		FieldOriginTransform:        "ably-config-to-runtime",
 		FieldOriginOverlayTransform: "ably-overlay-merge",
 		InputRoleRules: []InputRoleRule{
@@ -189,6 +209,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		HintDefaults: map[string]string{
 			"base_spec_path": "operations.yaml",
+		},
+		InversePatchReasons: map[string]string{
+			"image_tag": "Deployment action image tag is sourced from {{base_spec_path}}.",
+			"schedule":  "Schedule changes affect operational execution timing.",
 		},
 		FieldOriginTransform:        "ops-workflow-to-argo-workflow",
 		FieldOriginOverlayTransform: "ops-workflow-overlay-merge",
@@ -218,6 +242,7 @@ func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
 		Capabilities:                append([]string(nil), spec.Capabilities...),
 		RoleSchemaRefs:              copyRoleSchemaRefs(spec.RoleSchemaRefs),
 		HintDefaults:                copyHintDefaults(spec.HintDefaults),
+		InversePatchReasons:         copyInversePatchReasons(spec.InversePatchReasons),
 		FieldOriginTransform:        spec.FieldOriginTransform,
 		FieldOriginOverlayTransform: spec.FieldOriginOverlayTransform,
 		InputRoleRules:              copyInputRoleRules(spec.InputRoleRules),
@@ -266,6 +291,17 @@ func HintDefault(kind model.GeneratorKind, key, fallback string) string {
 		return fallback
 	}
 	if v, ok := spec.HintDefaults[key]; ok && strings.TrimSpace(v) != "" {
+		return v
+	}
+	return fallback
+}
+
+func InversePatchReason(kind model.GeneratorKind, key, fallback string) string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return fallback
+	}
+	if v, ok := spec.InversePatchReasons[key]; ok && strings.TrimSpace(v) != "" {
 		return v
 	}
 	return fallback
@@ -438,6 +474,17 @@ func copyRoleSchemaRefs(in map[string]string) map[string]string {
 }
 
 func copyHintDefaults(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func copyInversePatchReasons(in map[string]string) map[string]string {
 	if in == nil {
 		return nil
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -74,6 +74,9 @@ func TestRegistryFallbacks(t *testing.T) {
 	if got := FieldOriginOverlayTransform(unknown); got != "generator-transform" {
 		t.Fatalf("expected field origin overlay transform fallback generator-transform, got %q", got)
 	}
+	if got := InversePatchReason(unknown, "image_tag", "fallback-reason"); got != "fallback-reason" {
+		t.Fatalf("expected inverse patch reason fallback fallback-reason, got %q", got)
+	}
 	if got := InputRole(unknown, "any.yaml"); got != "input" {
 		t.Fatalf("expected input role fallback input, got %q", got)
 	}
@@ -184,6 +187,12 @@ func TestRegistryHintDefaults(t *testing.T) {
 	if got := FieldOriginOverlayTransform(model.GeneratorHelm); got != "helm-template" {
 		t.Fatalf("expected helm overlay transform to fall back to base transform, got %q", got)
 	}
+	if got := InversePatchReason(model.GeneratorBackstage, "identity", "fallback"); got != "Backstage component identity is sourced from {{catalog_path}}." {
+		t.Fatalf("expected backstage inverse patch reason template, got %q", got)
+	}
+	if got := InversePatchReason(model.GeneratorAbly, "channels", "fallback"); got != "Channel mapping is app-level runtime behavior." {
+		t.Fatalf("expected ably channels inverse patch reason, got %q", got)
+	}
 
 	// Ensure returned specs are copies.
 	spec, ok := Spec(model.GeneratorScore)
@@ -193,5 +202,9 @@ func TestRegistryHintDefaults(t *testing.T) {
 	spec.HintDefaults["source_path"] = "mutated.yaml"
 	if got := HintDefault(model.GeneratorScore, "source_path", "fallback.yaml"); got != "score.yaml" {
 		t.Fatalf("expected immutable hint defaults, got %q", got)
+	}
+	spec.InversePatchReasons["env_var"] = "mutated reason"
+	if got := InversePatchReason(model.GeneratorScore, "env_var", "fallback"); got != "Score variable maps to a single Kubernetes env var." {
+		t.Fatalf("expected immutable inverse patch reasons, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- add `InversePatchReasons` metadata to family registry specs
- add `registry.InversePatchReason(kind,key,fallback)` helper
- migrate importer inverse patch reason strings to registry lookups
- support placeholder rendering for family hint values (`catalog_path`, `base_config_path`, `base_spec_path`)
- extend registry tests for inverse patch reason fallback + immutability
- update v0.2 roadmap progress

## Why
This continues the registry-first architecture by centralizing inverse patch semantics and reducing importer-local policy strings.

## Validation
- go test ./...
- make ci
