### PR TITLE
refactor(v0.2): move inverse edit hints into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -46,6 +46,7 @@ Implemented in this preview slice:
 28. Refactored provenance `field_origin_map.transform` labels to be registry-driven (`FieldOriginTransform` / `FieldOriginOverlayTransform`) instead of importer string literals.
 29. Expanded `generators` table-mode parity contracts to lock deterministic filtered and empty-match outputs.
 30. Refactored inverse patch reason strings into registry-driven templates (`InversePatchReasons`) with placeholder rendering for family path hints.
+31. Refactored inverse edit hint strings into registry-driven templates (`InverseEditHints`) with placeholder rendering for family path hints and overlay-specific messaging.
 
 ## v0.2 preview invariants
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -493,111 +493,148 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
 				DryPath:    "values.image.tag",
 				Owner:      "app-team",
-				EditHint:   "Edit chart values file and keep chart template unchanged.",
+				EditHint:   registry.InverseEditHint(g.Kind, "image_tag", "Edit chart values file and keep chart template unchanged."),
 				Confidence: 0.86,
 			},
 		}
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
+		vars := map[string]string{
+			"source_path":       hints.SourcePath,
+			"container_name":    hints.ContainerName,
+			"variable_name":     hints.VariableName,
+			"service_port_name": hints.ServicePortName,
+		}
 		return []model.InverseEditPointer{
 			{
 				WetPath:    fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/image", hints.ContainerName),
 				DryPath:    fmt.Sprintf("containers.%s.image", hints.ContainerName),
 				Owner:      "app-team",
-				EditHint:   fmt.Sprintf("Edit the Score container image in %s.", hints.SourcePath),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "image", "Edit the Score container image in {{source_path}}."), vars),
 				Confidence: 0.94,
 			},
 			{
 				WetPath:    fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/env[name=%s]/value", hints.ContainerName, hints.VariableName),
 				DryPath:    fmt.Sprintf("containers.%s.variables.%s", hints.ContainerName, hints.VariableName),
 				Owner:      "app-team",
-				EditHint:   fmt.Sprintf("Edit %s under containers.%s.variables in %s.", hints.VariableName, hints.ContainerName, hints.SourcePath),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "env_var", "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}."), vars),
 				Confidence: 0.90,
 			},
 			{
 				WetPath:    fmt.Sprintf("Service/spec/ports[name=%s]/port", hints.ServicePortName),
 				DryPath:    fmt.Sprintf("service.ports.%s.port", hints.ServicePortName),
 				Owner:      "app-team",
-				EditHint:   fmt.Sprintf("Edit %s service port in %s.", hints.ServicePortName, hints.SourcePath),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "port", "Edit {{service_port_name}} service port in {{source_path}}."), vars),
 				Confidence: 0.91,
 			},
 		}
 	case model.GeneratorSpringBoot:
 		hints := springPathHintsFromInputs(g.Inputs)
+		vars := map[string]string{
+			"base_config_path":    hints.BaseConfigPath,
+			"profile_config_path": hints.ProfileConfigPath,
+		}
+		serverPortHintKey := "server_port_base"
+		serverPortHintFallback := "Edit server.port in {{base_config_path}}."
+		if hints.ProfileConfigPath != "" {
+			serverPortHintKey = "server_port_overlay"
+			serverPortHintFallback = "Edit server.port in {{profile_config_path}} for environment overrides; use {{base_config_path}} for the default."
+		}
 		return []model.InverseEditPointer{
 			{
 				WetPath:    "Deployment/metadata/labels[app.kubernetes.io/name]",
 				DryPath:    "spring.application.name",
 				Owner:      "app-team",
-				EditHint:   fmt.Sprintf("Edit spring.application.name in %s.", hints.BaseConfigPath),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "app_name", "Edit spring.application.name in {{base_config_path}}."), vars),
 				Confidence: 0.89,
 			},
 			{
 				WetPath:    "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
 				DryPath:    "server.port",
 				Owner:      "app-team",
-				EditHint:   springServerPortEditHint(hints),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, serverPortHintKey, serverPortHintFallback), vars),
 				Confidence: 0.91,
 			},
 			{
 				WetPath:    "ConfigMap/data/application.yaml:spring.datasource.url",
 				DryPath:    "spring.datasource.url",
 				Owner:      "platform-engineer",
-				EditHint:   fmt.Sprintf("Edit spring.datasource.url in %s and coordinate with platform ownership rules.", hints.BaseConfigPath),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "datasource_url", "Edit spring.datasource.url in {{base_config_path}} and coordinate with platform ownership rules."), vars),
 				Confidence: 0.78,
 			},
 		}
 	case model.GeneratorBackstage:
 		hints := backstagePathHintsFromInputs(g.Inputs)
+		vars := map[string]string{"catalog_path": hints.CatalogPath}
 		return []model.InverseEditPointer{
 			{
 				WetPath:    "Application/metadata/name",
 				DryPath:    "metadata.name",
 				Owner:      "platform-engineer",
-				EditHint:   fmt.Sprintf("Edit metadata.name in %s.", hints.CatalogPath),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "name", "Edit metadata.name in {{catalog_path}}."), vars),
 				Confidence: 0.90,
 			},
 			{
 				WetPath:    "Application/metadata/labels[lifecycle]",
 				DryPath:    "spec.lifecycle",
 				Owner:      "platform-engineer",
-				EditHint:   fmt.Sprintf("Edit spec.lifecycle in %s and coordinate rollout policy.", hints.CatalogPath),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "lifecycle", "Edit spec.lifecycle in {{catalog_path}} and coordinate rollout policy."), vars),
 				Confidence: 0.82,
 			},
 		}
 	case model.GeneratorAbly:
 		hints := ablyPathHintsFromInputs(g.Inputs)
+		vars := map[string]string{
+			"base_config_path":    hints.BaseConfigPath,
+			"overlay_config_path": hints.OverlayConfigPath,
+		}
+		channelsHintKey := "channels_base"
+		channelsHintFallback := "Edit channels.inbound in {{base_config_path}}."
+		if hints.OverlayConfigPath != "" {
+			channelsHintKey = "channels_overlay"
+			channelsHintFallback = "Edit channels.inbound in {{overlay_config_path}} for environment-specific behavior; use {{base_config_path}} for defaults."
+		}
 		return []model.InverseEditPointer{
 			{
 				WetPath:    "ConfigMap/data/ABLY_ENVIRONMENT",
 				DryPath:    "app.environment",
 				Owner:      "app-team",
-				EditHint:   fmt.Sprintf("Edit app.environment in %s.", hints.BaseConfigPath),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "environment", "Edit app.environment in {{base_config_path}}."), vars),
 				Confidence: 0.90,
 			},
 			{
 				WetPath:    "ConfigMap/data/ABLY_CHANNEL_INBOUND",
 				DryPath:    "channels.inbound",
 				Owner:      "app-team",
-				EditHint:   ablyInboundChannelEditHint(hints),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, channelsHintKey, channelsHintFallback), vars),
 				Confidence: 0.88,
 			},
 		}
 	case model.GeneratorOpsFlow:
 		hints := opsWorkflowPathHintsFromInputs(g.Inputs)
+		vars := map[string]string{
+			"base_spec_path":    hints.BaseSpecPath,
+			"overlay_spec_path": hints.OverlaySpecPath,
+		}
+		scheduleHintKey := "schedule_base"
+		scheduleHintFallback := "Edit triggers.schedule in {{base_spec_path}}."
+		if hints.OverlaySpecPath != "" {
+			scheduleHintKey = "schedule_overlay"
+			scheduleHintFallback = "Edit triggers.schedule in {{overlay_spec_path}} for environment-specific cadence; use {{base_spec_path}} for defaults."
+		}
 		return []model.InverseEditPointer{
 			{
 				WetPath:    "Workflow/spec/templates[name=deploy]/container/image",
 				DryPath:    "actions.deploy.image_tag",
 				Owner:      "platform-engineer",
-				EditHint:   fmt.Sprintf("Edit actions.deploy.image_tag in %s.", hints.BaseSpecPath),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "image_tag", "Edit actions.deploy.image_tag in {{base_spec_path}}."), vars),
 				Confidence: 0.87,
 			},
 			{
 				WetPath:    "Workflow/spec/schedule",
 				DryPath:    "triggers.schedule",
 				Owner:      "platform-engineer",
-				EditHint:   opsWorkflowScheduleEditHint(hints),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, scheduleHintKey, scheduleHintFallback), vars),
 				Confidence: 0.84,
 			},
 		}
@@ -921,13 +958,6 @@ func springPathHintsFromInputs(inputs []string) springHints {
 	return h
 }
 
-func springServerPortEditHint(h springHints) string {
-	if h.ProfileConfigPath != "" {
-		return fmt.Sprintf("Edit server.port in %s for environment overrides; use %s for the default.", h.ProfileConfigPath, h.BaseConfigPath)
-	}
-	return fmt.Sprintf("Edit server.port in %s.", h.BaseConfigPath)
-}
-
 type backstageHints struct {
 	CatalogPath   string
 	AppConfigPath string
@@ -974,13 +1004,6 @@ func ablyPathHintsFromInputs(inputs []string) ablyHints {
 	return h
 }
 
-func ablyInboundChannelEditHint(h ablyHints) string {
-	if h.OverlayConfigPath != "" {
-		return fmt.Sprintf("Edit channels.inbound in %s for environment-specific behavior; use %s for defaults.", h.OverlayConfigPath, h.BaseConfigPath)
-	}
-	return fmt.Sprintf("Edit channels.inbound in %s.", h.BaseConfigPath)
-}
-
 type opsWorkflowHints struct {
 	BaseSpecPath    string
 	OverlaySpecPath string
@@ -1003,13 +1026,6 @@ func opsWorkflowPathHintsFromInputs(inputs []string) opsWorkflowHints {
 		}
 	}
 	return h
-}
-
-func opsWorkflowScheduleEditHint(h opsWorkflowHints) string {
-	if h.OverlaySpecPath != "" {
-		return fmt.Sprintf("Edit triggers.schedule in %s for environment-specific cadence; use %s for defaults.", h.OverlaySpecPath, h.BaseSpecPath)
-	}
-	return fmt.Sprintf("Edit triggers.schedule in %s.", h.BaseSpecPath)
 }
 
 func inferInputSchema(kind model.GeneratorKind, inputPath string) string {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -34,6 +34,7 @@ type FamilySpec struct {
 	RoleSchemaRefs              map[string]string
 	HintDefaults                map[string]string
 	InversePatchReasons         map[string]string
+	InverseEditHints            map[string]string
 	FieldOriginTransform        string
 	FieldOriginOverlayTransform string
 	InputRoleRules              []InputRoleRule
@@ -58,6 +59,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		InversePatchReasons: map[string]string{
 			"image_tag": "Container image tag maps cleanly to helm values.",
+		},
+		InverseEditHints: map[string]string{
+			"image_tag": "Edit chart values file and keep chart template unchanged.",
 		},
 		FieldOriginTransform: "helm-template",
 		InputRoleRules: []InputRoleRule{
@@ -89,6 +93,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		InversePatchReasons: map[string]string{
 			"env_var": "Score variable maps to a single Kubernetes env var.",
 		},
+		InverseEditHints: map[string]string{
+			"image":   "Edit the Score container image in {{source_path}}.",
+			"env_var": "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}.",
+			"port":    "Edit {{service_port_name}} service port in {{source_path}}.",
+		},
 		FieldOriginTransform: "score-to-k8s",
 		InputRoleRules:       []InputRoleRule{{Role: "score-spec", ExactBasenames: []string{"score.yaml", "score.yml"}}},
 		DefaultInputRole:     "score-input",
@@ -117,6 +126,12 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"app_name":       "Application identity should be app-editable without platform escalation.",
 			"server_port":    "Application listener port is an app-level configuration concern.",
 			"datasource_url": "Database connectivity impacts shared runtime dependencies.",
+		},
+		InverseEditHints: map[string]string{
+			"app_name":            "Edit spring.application.name in {{base_config_path}}.",
+			"server_port_base":    "Edit server.port in {{base_config_path}}.",
+			"server_port_overlay": "Edit server.port in {{profile_config_path}} for environment overrides; use {{base_config_path}} for the default.",
+			"datasource_url":      "Edit spring.datasource.url in {{base_config_path}} and coordinate with platform ownership rules.",
 		},
 		FieldOriginTransform:        "spring-config-to-manifest",
 		FieldOriginOverlayTransform: "spring-profile-overlay",
@@ -154,6 +169,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"identity":  "Backstage component identity is sourced from {{catalog_path}}.",
 			"lifecycle": "Lifecycle changes impact platform ownership and support policy.",
 		},
+		InverseEditHints: map[string]string{
+			"name":      "Edit metadata.name in {{catalog_path}}.",
+			"lifecycle": "Edit spec.lifecycle in {{catalog_path}} and coordinate rollout policy.",
+		},
 		FieldOriginTransform: "backstage-component-to-application",
 		InputRoleRules: []InputRoleRule{
 			{Role: "catalog-spec", ExactBasenames: []string{"catalog-info.yaml", "catalog-info.yml"}},
@@ -183,6 +202,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		InversePatchReasons: map[string]string{
 			"environment": "Environment is sourced from {{base_config_path}}.",
 			"channels":    "Channel mapping is app-level runtime behavior.",
+		},
+		InverseEditHints: map[string]string{
+			"environment":      "Edit app.environment in {{base_config_path}}.",
+			"channels_base":    "Edit channels.inbound in {{base_config_path}}.",
+			"channels_overlay": "Edit channels.inbound in {{overlay_config_path}} for environment-specific behavior; use {{base_config_path}} for defaults.",
 		},
 		FieldOriginTransform:        "ably-config-to-runtime",
 		FieldOriginOverlayTransform: "ably-overlay-merge",
@@ -214,6 +238,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"image_tag": "Deployment action image tag is sourced from {{base_spec_path}}.",
 			"schedule":  "Schedule changes affect operational execution timing.",
 		},
+		InverseEditHints: map[string]string{
+			"image_tag":        "Edit actions.deploy.image_tag in {{base_spec_path}}.",
+			"schedule_base":    "Edit triggers.schedule in {{base_spec_path}}.",
+			"schedule_overlay": "Edit triggers.schedule in {{overlay_spec_path}} for environment-specific cadence; use {{base_spec_path}} for defaults.",
+		},
 		FieldOriginTransform:        "ops-workflow-to-argo-workflow",
 		FieldOriginOverlayTransform: "ops-workflow-overlay-merge",
 		InputRoleRules: []InputRoleRule{
@@ -243,6 +272,7 @@ func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
 		RoleSchemaRefs:              copyRoleSchemaRefs(spec.RoleSchemaRefs),
 		HintDefaults:                copyHintDefaults(spec.HintDefaults),
 		InversePatchReasons:         copyInversePatchReasons(spec.InversePatchReasons),
+		InverseEditHints:            copyInverseEditHints(spec.InverseEditHints),
 		FieldOriginTransform:        spec.FieldOriginTransform,
 		FieldOriginOverlayTransform: spec.FieldOriginOverlayTransform,
 		InputRoleRules:              copyInputRoleRules(spec.InputRoleRules),
@@ -302,6 +332,17 @@ func InversePatchReason(kind model.GeneratorKind, key, fallback string) string {
 		return fallback
 	}
 	if v, ok := spec.InversePatchReasons[key]; ok && strings.TrimSpace(v) != "" {
+		return v
+	}
+	return fallback
+}
+
+func InverseEditHint(kind model.GeneratorKind, key, fallback string) string {
+	spec, ok := Spec(kind)
+	if !ok {
+		return fallback
+	}
+	if v, ok := spec.InverseEditHints[key]; ok && strings.TrimSpace(v) != "" {
 		return v
 	}
 	return fallback
@@ -485,6 +526,17 @@ func copyHintDefaults(in map[string]string) map[string]string {
 }
 
 func copyInversePatchReasons(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func copyInverseEditHints(in map[string]string) map[string]string {
 	if in == nil {
 		return nil
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -77,6 +77,9 @@ func TestRegistryFallbacks(t *testing.T) {
 	if got := InversePatchReason(unknown, "image_tag", "fallback-reason"); got != "fallback-reason" {
 		t.Fatalf("expected inverse patch reason fallback fallback-reason, got %q", got)
 	}
+	if got := InverseEditHint(unknown, "image_tag", "fallback-hint"); got != "fallback-hint" {
+		t.Fatalf("expected inverse edit hint fallback fallback-hint, got %q", got)
+	}
 	if got := InputRole(unknown, "any.yaml"); got != "input" {
 		t.Fatalf("expected input role fallback input, got %q", got)
 	}
@@ -193,6 +196,12 @@ func TestRegistryHintDefaults(t *testing.T) {
 	if got := InversePatchReason(model.GeneratorAbly, "channels", "fallback"); got != "Channel mapping is app-level runtime behavior." {
 		t.Fatalf("expected ably channels inverse patch reason, got %q", got)
 	}
+	if got := InverseEditHint(model.GeneratorScore, "env_var", "fallback"); got != "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}." {
+		t.Fatalf("expected score env_var inverse edit hint template, got %q", got)
+	}
+	if got := InverseEditHint(model.GeneratorSpringBoot, "server_port_overlay", "fallback"); got != "Edit server.port in {{profile_config_path}} for environment overrides; use {{base_config_path}} for the default." {
+		t.Fatalf("expected spring server_port_overlay inverse edit hint template, got %q", got)
+	}
 
 	// Ensure returned specs are copies.
 	spec, ok := Spec(model.GeneratorScore)
@@ -206,5 +215,9 @@ func TestRegistryHintDefaults(t *testing.T) {
 	spec.InversePatchReasons["env_var"] = "mutated reason"
 	if got := InversePatchReason(model.GeneratorScore, "env_var", "fallback"); got != "Score variable maps to a single Kubernetes env var." {
 		t.Fatalf("expected immutable inverse patch reasons, got %q", got)
+	}
+	spec.InverseEditHints["env_var"] = "mutated hint"
+	if got := InverseEditHint(model.GeneratorScore, "env_var", "fallback"); got != "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}." {
+		t.Fatalf("expected immutable inverse edit hints, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- add `InverseEditHints` metadata to family registry specs
- add `registry.InverseEditHint(kind,key,fallback)` helper
- migrate importer inverse edit hint strings to registry-driven templates
- support placeholder rendering for source/base/overlay hint values
- remove now-unused importer edit-hint helper functions
- extend registry tests for inverse edit hint fallback and immutability
- update v0.2 roadmap progress

## Why
Further centralizes family semantics in the registry and reduces importer-local branching/string literals.

## Validation
- go test ./...
- make ci
