### PR TITLE
feat(v0.2): show supported filter values in generators help

### DIFF
--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -68,6 +68,9 @@ type generatorFamilyRecord struct {
 func runGenerators(args []string) error {
 	fs := flag.NewFlagSet("generators", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		printGeneratorsUsage(fs.Output())
+	}
 	kindFilter := fs.String("kind", "", "Filter by generator kind")
 	profileFilter := fs.String("profile", "", "Filter by generator profile")
 	capabilityFilter := fs.String("capability", "", "Filter by capability")
@@ -151,6 +154,66 @@ func listGeneratorFamilies(kindFilter, profileFilter, capabilityFilter string) [
 			Capabilities: record.Capabilities,
 		})
 	}
+	return out
+}
+
+func printGeneratorsUsage(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]")
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "Supported kinds: %s\n", strings.Join(supportedGeneratorKinds(), ", "))
+	fmt.Fprintf(out, "Supported profiles: %s\n", strings.Join(supportedGeneratorProfiles(), ", "))
+	fmt.Fprintf(out, "Supported capabilities: %s\n", strings.Join(supportedGeneratorCapabilities(), ", "))
+}
+
+func supportedGeneratorKinds() []string {
+	kinds := registry.Kinds()
+	out := make([]string, 0, len(kinds))
+	for _, kind := range kinds {
+		out = append(out, string(kind))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func supportedGeneratorProfiles() []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(registry.Kinds()))
+	for _, kind := range registry.Kinds() {
+		spec, ok := registry.Spec(kind)
+		if !ok || strings.TrimSpace(spec.Profile) == "" {
+			continue
+		}
+		if _, exists := seen[spec.Profile]; exists {
+			continue
+		}
+		seen[spec.Profile] = struct{}{}
+		out = append(out, spec.Profile)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func supportedGeneratorCapabilities() []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, 16)
+	for _, kind := range registry.Kinds() {
+		spec, ok := registry.Spec(kind)
+		if !ok {
+			continue
+		}
+		for _, capability := range spec.Capabilities {
+			if strings.TrimSpace(capability) == "" {
+				continue
+			}
+			if _, exists := seen[capability]; exists {
+				continue
+			}
+			seen[capability] = struct{}{}
+			out = append(out, capability)
+		}
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
@@ -1,11 +1,6 @@
-Usage of generators:
-  -capability string
-    	Filter by capability
-  -json
-    	Output JSON
-  -kind string
-    	Filter by generator kind
-  -pretty
-    	Pretty-print JSON output (default true)
-  -profile string
-    	Filter by generator profile
+Usage:
+  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]
+
+Supported kinds: ably, backstage, helm, opsworkflow, score, springboot
+Supported profiles: ably-config, backstage-idp, helm-paas, ops-workflow, scoredev-paas, springboot-paas
+Supported capabilities: app-config-only, catalog-metadata, governed-execution-intent, inverse-app-config-patch, inverse-catalog-patch, inverse-provider-config-patch, inverse-score-patch, inverse-values-patch, inverse-workflow-patch, profile-overrides, provider-config, render-app-config, render-manifests, values-overrides, workflow-plan, workload-spec

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -47,6 +47,7 @@ Implemented in this preview slice:
 29. Expanded `generators` table-mode parity contracts to lock deterministic filtered and empty-match outputs.
 30. Refactored inverse patch reason strings into registry-driven templates (`InversePatchReasons`) with placeholder rendering for family path hints.
 31. Refactored inverse edit hint strings into registry-driven templates (`InverseEditHints`) with placeholder rendering for family path hints and overlay-specific messaging.
+32. Improved `generators --help` to render supported kind/profile/capability values directly from the registry for self-discoverable filter usage.
 
 ## v0.2 preview invariants
 


### PR DESCRIPTION
## Summary
- add custom `generators` usage output with supported filter values
- list supported kinds/profiles/capabilities dynamically from registry metadata
- keep behavior deterministic by sorting output lists
- update generators help golden and v0.2 roadmap progress

## Why
Improves CLI self-discovery for `generators` filtering without requiring external docs.

## Validation
- make update-goldens
- go test ./...
- make ci
