### PR TITLE
feat(v0.2): add multi-value generators filters

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -123,7 +123,9 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/verify-attestation-linked-ops.json.golden.json`
   - `cmd/cub-gen/testdata/parity/generators.golden.json`
   - `cmd/cub-gen/testdata/parity/generators-kind-helm.golden.json`
+  - `cmd/cub-gen/testdata/parity/generators-kind-helm-score.golden.json`
   - `cmd/cub-gen/testdata/parity/generators-capability-ops.golden.json`
+  - `cmd/cub-gen/testdata/parity/generators-capability-helm-score.golden.json`
   - `cmd/cub-gen/testdata/parity/generators-profile-spring.golden.json`
   - `cmd/cub-gen/testdata/parity/generators-combined-score.golden.json`
   - `cmd/cub-gen/testdata/parity/generators-empty.golden.json`

--- a/cmd/cub-gen/generators_parity_test.go
+++ b/cmd/cub-gen/generators_parity_test.go
@@ -39,6 +39,22 @@ func TestGeneratorsGoldenJSONKindFilter(t *testing.T) {
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-kind-helm.golden.json"), got)
 }
 
+func TestGeneratorsGoldenJSONKindMultiFilter(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--json", "--kind", "helm,score"})
+	if err != nil {
+		t.Fatalf("run generators --json --kind multi returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal generators kind multi json: %v\noutput=%s", err, out)
+	}
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-kind-helm-score.golden.json"), got)
+}
+
 func TestGeneratorsGoldenJSONCapabilityFilter(t *testing.T) {
 	out, stderr, err := runWithCapturedIO([]string{"generators", "--json", "--capability", "inverse-workflow-patch"})
 	if err != nil {
@@ -53,6 +69,22 @@ func TestGeneratorsGoldenJSONCapabilityFilter(t *testing.T) {
 		t.Fatalf("unmarshal generators capability json: %v\noutput=%s", err, out)
 	}
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-capability-ops.golden.json"), got)
+}
+
+func TestGeneratorsGoldenJSONCapabilityMultiFilter(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--json", "--capability", "inverse-values-patch,inverse-score-patch"})
+	if err != nil {
+		t.Fatalf("run generators --json --capability multi returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal generators capability multi json: %v\noutput=%s", err, out)
+	}
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-capability-helm-score.golden.json"), got)
 }
 
 func TestGeneratorsGoldenJSONProfileFilter(t *testing.T) {

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -108,9 +108,9 @@ func runGenerators(args []string) error {
 }
 
 func listGeneratorFamilies(kindFilter, profileFilter, capabilityFilter string) []generatorFamilyRecord {
-	kindFilter = strings.TrimSpace(strings.ToLower(kindFilter))
-	profileFilter = strings.TrimSpace(strings.ToLower(profileFilter))
-	capabilityFilter = strings.TrimSpace(strings.ToLower(capabilityFilter))
+	kindFilters := parseFilterSet(kindFilter)
+	profileFilters := parseFilterSet(profileFilter)
+	capabilityFilters := parseFilterSet(capabilityFilter)
 
 	kinds := registry.Kinds()
 	out := make([]generatorFamilyRecord, 0, len(kinds))
@@ -127,16 +127,20 @@ func listGeneratorFamilies(kindFilter, profileFilter, capabilityFilter string) [
 			Capabilities: append([]string(nil), spec.Capabilities...),
 		}
 
-		if kindFilter != "" && strings.ToLower(record.Kind) != kindFilter {
-			continue
+		if len(kindFilters) > 0 {
+			if _, ok := kindFilters[strings.ToLower(record.Kind)]; !ok {
+				continue
+			}
 		}
-		if profileFilter != "" && strings.ToLower(record.Profile) != profileFilter {
-			continue
+		if len(profileFilters) > 0 {
+			if _, ok := profileFilters[strings.ToLower(record.Profile)]; !ok {
+				continue
+			}
 		}
-		if capabilityFilter != "" {
+		if len(capabilityFilters) > 0 {
 			matched := false
 			for _, capability := range record.Capabilities {
-				if strings.EqualFold(capability, capabilityFilter) {
+				if _, ok := capabilityFilters[strings.ToLower(capability)]; ok {
 					matched = true
 					break
 				}
@@ -157,9 +161,22 @@ func listGeneratorFamilies(kindFilter, profileFilter, capabilityFilter string) [
 	return out
 }
 
+func parseFilterSet(raw string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, part := range strings.Split(raw, ",") {
+		value := strings.ToLower(strings.TrimSpace(part))
+		if value == "" {
+			continue
+		}
+		out[value] = struct{}{}
+	}
+	return out
+}
+
 func printGeneratorsUsage(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]")
+	fmt.Fprintln(out, "  (KIND/PROFILE/CAPABILITY support comma-separated values)")
 	fmt.Fprintln(out)
 	fmt.Fprintf(out, "Supported kinds: %s\n", strings.Join(supportedGeneratorKinds(), ", "))
 	fmt.Fprintf(out, "Supported profiles: %s\n", strings.Join(supportedGeneratorProfiles(), ", "))

--- a/cmd/cub-gen/testdata/parity/generators-capability-helm-score.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-capability-helm-score.golden.json
@@ -1,0 +1,27 @@
+{
+  "count": 2,
+  "families": [
+    {
+      "capabilities": [
+        "render-manifests",
+        "values-overrides",
+        "inverse-values-patch"
+      ],
+      "kind": "helm",
+      "profile": "helm-paas",
+      "resource_kind": "HelmRelease",
+      "resource_type": "helm.toolkit.fluxcd.io/v2/HelmRelease"
+    },
+    {
+      "capabilities": [
+        "render-manifests",
+        "workload-spec",
+        "inverse-score-patch"
+      ],
+      "kind": "score",
+      "profile": "scoredev-paas",
+      "resource_kind": "Application",
+      "resource_type": "argoproj.io/v1alpha1/Application"
+    }
+  ]
+}

--- a/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
@@ -1,5 +1,6 @@
 Usage:
   cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]
+  (KIND/PROFILE/CAPABILITY support comma-separated values)
 
 Supported kinds: ably, backstage, helm, opsworkflow, score, springboot
 Supported profiles: ably-config, backstage-idp, helm-paas, ops-workflow, scoredev-paas, springboot-paas

--- a/cmd/cub-gen/testdata/parity/generators-kind-helm-score.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-kind-helm-score.golden.json
@@ -1,0 +1,27 @@
+{
+  "count": 2,
+  "families": [
+    {
+      "capabilities": [
+        "render-manifests",
+        "values-overrides",
+        "inverse-values-patch"
+      ],
+      "kind": "helm",
+      "profile": "helm-paas",
+      "resource_kind": "HelmRelease",
+      "resource_type": "helm.toolkit.fluxcd.io/v2/HelmRelease"
+    },
+    {
+      "capabilities": [
+        "render-manifests",
+        "workload-spec",
+        "inverse-score-patch"
+      ],
+      "kind": "score",
+      "profile": "scoredev-paas",
+      "resource_kind": "Application",
+      "resource_type": "argoproj.io/v1alpha1/Application"
+    }
+  ]
+}

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -48,6 +48,7 @@ Implemented in this preview slice:
 30. Refactored inverse patch reason strings into registry-driven templates (`InversePatchReasons`) with placeholder rendering for family path hints.
 31. Refactored inverse edit hint strings into registry-driven templates (`InverseEditHints`) with placeholder rendering for family path hints and overlay-specific messaging.
 32. Improved `generators --help` to render supported kind/profile/capability values directly from the registry for self-discoverable filter usage.
+33. Added comma-separated multi-value filtering support for `generators` (`--kind`, `--profile`, `--capability`) with parity contracts for multi-match outputs.
 
 ## v0.2 preview invariants
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -18,7 +18,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 ### Tier 2: parity/golden
 
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
-- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go` (full list + JSON/table filter contracts for kind/profile/capability, combined filters, and empty-match behavior).
+- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go` (full list + JSON/table filter contracts for kind/profile/capability, including comma-separated multi-value filters, combined filters, and empty-match behavior).
 - Bridge publish golden locks in `cmd/cub-gen/publish_parity_test.go` (import/direct paths for helm/score/spring/backstage/ably/ops).
 - Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
 - Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -22,7 +22,7 @@
   - error mode coverage
 - `cmd/cub-gen/generators_parity_test.go`
   - golden generator family JSON contract
-  - golden generator family filtered JSON contracts (kind + capability + profile + combined + empty match)
+  - golden generator family filtered JSON contracts (single + multi-value filters for kind/capability + profile + combined + empty match)
   - golden generator family table contracts (full + filtered + empty match)
   - golden generators help output contract
 - `cmd/cub-gen/examples_smoke_test.go`
@@ -83,7 +83,9 @@
 - `cmd/cub-gen/testdata/parity/verify-attestation-linked-ops.json.golden.json`
 - `cmd/cub-gen/testdata/parity/generators.golden.json`
 - `cmd/cub-gen/testdata/parity/generators-kind-helm.golden.json`
+- `cmd/cub-gen/testdata/parity/generators-kind-helm-score.golden.json`
 - `cmd/cub-gen/testdata/parity/generators-capability-ops.golden.json`
+- `cmd/cub-gen/testdata/parity/generators-capability-helm-score.golden.json`
 - `cmd/cub-gen/testdata/parity/generators-profile-spring.golden.json`
 - `cmd/cub-gen/testdata/parity/generators-combined-score.golden.json`
 - `cmd/cub-gen/testdata/parity/generators-empty.golden.json`


### PR DESCRIPTION
## Summary
- add comma-separated multi-value OR filtering for `generators`:
  - `--kind`
  - `--profile`
  - `--capability`
- keep deterministic sort/order behavior
- add parity tests and goldens for multi-value kind/capability filters
- update generators help to document comma-separated filter syntax
- update parity/testing inventory docs and v0.2 roadmap

## Why
Improves practical filter usability for generator discovery across multiple families/capabilities in one command.

## Validation
- make update-goldens
- go test ./...
- make ci
