### PR TITLE
test(v0.2): lock generators table multi-filter contracts

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -131,6 +131,8 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/generators-empty.golden.json`
   - `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/generators-kind-helm.table.golden.txt`
+  - `cmd/cub-gen/testdata/parity/generators-kind-helm-score.table.golden.txt`
+  - `cmd/cub-gen/testdata/parity/generators-capability-helm-score.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/generators-empty.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
   - `cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt`

--- a/cmd/cub-gen/generators_parity_test.go
+++ b/cmd/cub-gen/generators_parity_test.go
@@ -157,6 +157,28 @@ func TestGeneratorsGoldenTableKindFilter(t *testing.T) {
 	assertGoldenText(t, filepath.Join("testdata", "parity", "generators-kind-helm.table.golden.txt"), out)
 }
 
+func TestGeneratorsGoldenTableKindMultiFilter(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--kind", "helm,score"})
+	if err != nil {
+		t.Fatalf("run generators --kind multi returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+	assertGoldenText(t, filepath.Join("testdata", "parity", "generators-kind-helm-score.table.golden.txt"), out)
+}
+
+func TestGeneratorsGoldenTableCapabilityMultiFilter(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--capability", "inverse-values-patch,inverse-score-patch"})
+	if err != nil {
+		t.Fatalf("run generators --capability multi returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+	assertGoldenText(t, filepath.Join("testdata", "parity", "generators-capability-helm-score.table.golden.txt"), out)
+}
+
 func TestGeneratorsGoldenTableNoMatches(t *testing.T) {
 	out, stderr, err := runWithCapturedIO([]string{"generators", "--profile", "non-existent-profile"})
 	if err != nil {

--- a/cmd/cub-gen/testdata/parity/generators-capability-helm-score.table.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-capability-helm-score.table.golden.txt
@@ -1,0 +1,3 @@
+Kind	Profile	Resource Kind	Resource Type	Capabilities
+helm	helm-paas	HelmRelease	helm.toolkit.fluxcd.io/v2/HelmRelease	render-manifests,values-overrides,inverse-values-patch
+score	scoredev-paas	Application	argoproj.io/v1alpha1/Application	render-manifests,workload-spec,inverse-score-patch

--- a/cmd/cub-gen/testdata/parity/generators-kind-helm-score.table.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-kind-helm-score.table.golden.txt
@@ -1,0 +1,3 @@
+Kind	Profile	Resource Kind	Resource Type	Capabilities
+helm	helm-paas	HelmRelease	helm.toolkit.fluxcd.io/v2/HelmRelease	render-manifests,values-overrides,inverse-values-patch
+score	scoredev-paas	Application	argoproj.io/v1alpha1/Application	render-manifests,workload-spec,inverse-score-patch

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -49,6 +49,7 @@ Implemented in this preview slice:
 31. Refactored inverse edit hint strings into registry-driven templates (`InverseEditHints`) with placeholder rendering for family path hints and overlay-specific messaging.
 32. Improved `generators --help` to render supported kind/profile/capability values directly from the registry for self-discoverable filter usage.
 33. Added comma-separated multi-value filtering support for `generators` (`--kind`, `--profile`, `--capability`) with parity contracts for multi-match outputs.
+34. Added table-mode multi-filter parity contracts for `generators` (kind and capability comma-list flows) to keep human-readable output locked alongside JSON.
 
 ## v0.2 preview invariants
 

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -23,7 +23,7 @@
 - `cmd/cub-gen/generators_parity_test.go`
   - golden generator family JSON contract
   - golden generator family filtered JSON contracts (single + multi-value filters for kind/capability + profile + combined + empty match)
-  - golden generator family table contracts (full + filtered + empty match)
+  - golden generator family table contracts (full + single/multi filtered + empty match)
   - golden generators help output contract
 - `cmd/cub-gen/examples_smoke_test.go`
   - path-mode discover/import for Helm, Score, Spring, Backstage, Ably, Ops (`./examples/...` without alias config)
@@ -92,6 +92,8 @@
 - `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
 - `cmd/cub-gen/testdata/parity/generators-kind-helm.table.golden.txt`
 - `cmd/cub-gen/testdata/parity/generators-empty.table.golden.txt`
+- `cmd/cub-gen/testdata/parity/generators-kind-helm-score.table.golden.txt`
+- `cmd/cub-gen/testdata/parity/generators-capability-helm-score.table.golden.txt`
 - `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
 
 ## Mandatory validation commands


### PR DESCRIPTION
## Summary
- add generators parity tests for table-mode multi-value filters:
  - `--kind helm,score`
  - `--capability inverse-values-patch,inverse-score-patch`
- add new table goldens for both flows
- update parity/test inventory docs and v0.2 roadmap progress

## Why
Completes multi-filter contract coverage for human-readable generators output, matching JSON coverage.

## Validation
- make update-goldens
- go test ./...
- make ci
