### PR TITLE
feat(v0.2): add strict generators filter validation

### DIFF
--- a/cmd/cub-gen/generators_parity_test.go
+++ b/cmd/cub-gen/generators_parity_test.go
@@ -200,3 +200,42 @@ func TestGeneratorsGoldenHelp(t *testing.T) {
 	}
 	assertGoldenText(t, filepath.Join("testdata", "parity", "generators-help.stderr.golden.txt"), stderr)
 }
+
+func TestGeneratorsStrictFiltersUnknownKind(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--strict-filters", "--kind", "not-a-kind"})
+	if err == nil {
+		t.Fatalf("expected strict unknown kind error, got nil")
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected empty stdout, got: %q", out)
+	}
+	if !strings.Contains(err.Error(), "unknown kind filter value(s): not-a-kind") {
+		t.Fatalf("expected unknown kind message in error, got: %q (stderr=%q)", err.Error(), stderr)
+	}
+}
+
+func TestGeneratorsStrictFiltersUnknownProfile(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--strict-filters", "--profile", "not-a-profile"})
+	if err == nil {
+		t.Fatalf("expected strict unknown profile error, got nil")
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected empty stdout, got: %q", out)
+	}
+	if !strings.Contains(err.Error(), "unknown profile filter value(s): not-a-profile") {
+		t.Fatalf("expected unknown profile message in error, got: %q (stderr=%q)", err.Error(), stderr)
+	}
+}
+
+func TestGeneratorsStrictFiltersUnknownCapability(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--strict-filters", "--capability", "not-a-capability"})
+	if err == nil {
+		t.Fatalf("expected strict unknown capability error, got nil")
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected empty stdout, got: %q", out)
+	}
+	if !strings.Contains(err.Error(), "unknown capability filter value(s): not-a-capability") {
+		t.Fatalf("expected unknown capability message in error, got: %q (stderr=%q)", err.Error(), stderr)
+	}
+}

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -74,6 +74,7 @@ func runGenerators(args []string) error {
 	kindFilter := fs.String("kind", "", "Filter by generator kind")
 	profileFilter := fs.String("profile", "", "Filter by generator profile")
 	capabilityFilter := fs.String("capability", "", "Filter by capability")
+	strictFilters := fs.Bool("strict-filters", false, "Fail on unknown filter values")
 	jsonOut := fs.Bool("json", false, "Output JSON")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
 	if err := fs.Parse(args); err != nil {
@@ -84,6 +85,11 @@ func runGenerators(args []string) error {
 	}
 	if fs.NArg() != 0 {
 		return errors.New("usage: cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]")
+	}
+	if *strictFilters {
+		if err := validateGeneratorFilters(*kindFilter, *profileFilter, *capabilityFilter); err != nil {
+			return err
+		}
 	}
 
 	records := listGeneratorFamilies(*kindFilter, *profileFilter, *capabilityFilter)
@@ -177,6 +183,7 @@ func printGeneratorsUsage(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]")
 	fmt.Fprintln(out, "  (KIND/PROFILE/CAPABILITY support comma-separated values)")
+	fmt.Fprintln(out, "  use --strict-filters to fail on unknown filter values")
 	fmt.Fprintln(out)
 	fmt.Fprintf(out, "Supported kinds: %s\n", strings.Join(supportedGeneratorKinds(), ", "))
 	fmt.Fprintf(out, "Supported profiles: %s\n", strings.Join(supportedGeneratorProfiles(), ", "))
@@ -231,6 +238,48 @@ func supportedGeneratorCapabilities() []string {
 		}
 	}
 	sort.Strings(out)
+	return out
+}
+
+func validateGeneratorFilters(kindFilter, profileFilter, capabilityFilter string) error {
+	unknownKinds := unknownFilterValues(kindFilter, stringSliceToSet(supportedGeneratorKinds()))
+	if len(unknownKinds) > 0 {
+		return fmt.Errorf("unknown kind filter value(s): %s (supported: %s)", strings.Join(unknownKinds, ", "), strings.Join(supportedGeneratorKinds(), ", "))
+	}
+
+	unknownProfiles := unknownFilterValues(profileFilter, stringSliceToSet(supportedGeneratorProfiles()))
+	if len(unknownProfiles) > 0 {
+		return fmt.Errorf("unknown profile filter value(s): %s (supported: %s)", strings.Join(unknownProfiles, ", "), strings.Join(supportedGeneratorProfiles(), ", "))
+	}
+
+	unknownCapabilities := unknownFilterValues(capabilityFilter, stringSliceToSet(supportedGeneratorCapabilities()))
+	if len(unknownCapabilities) > 0 {
+		return fmt.Errorf("unknown capability filter value(s): %s (supported: %s)", strings.Join(unknownCapabilities, ", "), strings.Join(supportedGeneratorCapabilities(), ", "))
+	}
+
+	return nil
+}
+
+func unknownFilterValues(raw string, supported map[string]struct{}) []string {
+	unknown := make([]string, 0)
+	for value := range parseFilterSet(raw) {
+		if _, ok := supported[value]; !ok {
+			unknown = append(unknown, value)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+func stringSliceToSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		key := strings.ToLower(strings.TrimSpace(value))
+		if key == "" {
+			continue
+		}
+		out[key] = struct{}{}
+	}
 	return out
 }
 

--- a/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
@@ -1,6 +1,7 @@
 Usage:
   cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]
   (KIND/PROFILE/CAPABILITY support comma-separated values)
+  use --strict-filters to fail on unknown filter values
 
 Supported kinds: ably, backstage, helm, opsworkflow, score, springboot
 Supported profiles: ably-config, backstage-idp, helm-paas, ops-workflow, scoredev-paas, springboot-paas

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -50,6 +50,7 @@ Implemented in this preview slice:
 32. Improved `generators --help` to render supported kind/profile/capability values directly from the registry for self-discoverable filter usage.
 33. Added comma-separated multi-value filtering support for `generators` (`--kind`, `--profile`, `--capability`) with parity contracts for multi-match outputs.
 34. Added table-mode multi-filter parity contracts for `generators` (kind and capability comma-list flows) to keep human-readable output locked alongside JSON.
+35. Added optional strict filter validation (`--strict-filters`) for `generators` to fail fast on unknown kind/profile/capability values.
 
 ## v0.2 preview invariants
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -18,7 +18,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 ### Tier 2: parity/golden
 
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
-- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go` (full list + JSON/table filter contracts for kind/profile/capability, including comma-separated multi-value filters, combined filters, and empty-match behavior).
+- Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go` (full list + JSON/table filter contracts for kind/profile/capability, including comma-separated multi-value filters, combined filters, empty-match behavior, and strict unknown-filter error modes).
 - Bridge publish golden locks in `cmd/cub-gen/publish_parity_test.go` (import/direct paths for helm/score/spring/backstage/ably/ops).
 - Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
 - Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.

--- a/test/TEST-INVENTORY.md
+++ b/test/TEST-INVENTORY.md
@@ -25,6 +25,7 @@
   - golden generator family filtered JSON contracts (single + multi-value filters for kind/capability + profile + combined + empty match)
   - golden generator family table contracts (full + single/multi filtered + empty match)
   - golden generators help output contract
+  - strict filter validation errors for unknown kind/profile/capability (`--strict-filters`)
 - `cmd/cub-gen/examples_smoke_test.go`
   - path-mode discover/import for Helm, Score, Spring, Backstage, Ably, Ops (`./examples/...` without alias config)
 - `cmd/cub-gen/examples_bridge_smoke_test.go`


### PR DESCRIPTION
## Summary
- add optional `--strict-filters` to `generators`
- validate kind/profile/capability filter values against supported registry metadata when strict mode is enabled
- return explicit errors for unknown filter values (including comma-separated inputs)
- update help output to document strict mode
- add tests for strict unknown kind/profile/capability paths
- update testing inventory/docs and v0.2 roadmap

## Why
Prevents silent no-match outcomes from filter typos when users want explicit validation behavior.

## Validation
- make update-goldens
- go test ./...
- make ci
