### PR TITLE
test(v0.2): lock sorted strict-filter unknown value ordering

### DIFF
--- a/cmd/cub-gen/generators_parity_test.go
+++ b/cmd/cub-gen/generators_parity_test.go
@@ -239,3 +239,16 @@ func TestGeneratorsStrictFiltersUnknownCapability(t *testing.T) {
 		t.Fatalf("expected unknown capability message in error, got: %q (stderr=%q)", err.Error(), stderr)
 	}
 }
+
+func TestGeneratorsStrictFiltersUnknownKindMultiSorted(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--strict-filters", "--kind", "zzz,aaa"})
+	if err == nil {
+		t.Fatalf("expected strict unknown kind error, got nil")
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected empty stdout, got: %q", out)
+	}
+	if !strings.Contains(err.Error(), "unknown kind filter value(s): aaa, zzz") {
+		t.Fatalf("expected sorted unknown kind values in error, got: %q (stderr=%q)", err.Error(), stderr)
+	}
+}


### PR DESCRIPTION
## Summary
- add parity test for strict kind filter errors with multiple unknown values
- asserts deterministic sorted unknown list in error output (`aaa, zzz`)

## Why
Keeps strict-filter error messaging deterministic and stable for tests/automation.

## Validation
- go test ./...
- make ci
