### PR TITLE
docs(v0.2): add generators multi/strict quickstart examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ without coupling the core flow to a running ConfigHub backend.
 ./cub-gen generators
 ./cub-gen generators --json | jq '.families[] | {kind, profile, resource_kind}'
 ./cub-gen generators --kind helm
+./cub-gen generators --kind helm,score
 ./cub-gen generators --capability render-manifests
+./cub-gen generators --capability inverse-values-patch,inverse-score-patch
+./cub-gen generators --strict-filters --kind helm,score
 ```
 
 Or run direct mode (import + bundle in one command):

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -51,6 +51,7 @@ Implemented in this preview slice:
 33. Added comma-separated multi-value filtering support for `generators` (`--kind`, `--profile`, `--capability`) with parity contracts for multi-match outputs.
 34. Added table-mode multi-filter parity contracts for `generators` (kind and capability comma-list flows) to keep human-readable output locked alongside JSON.
 35. Added optional strict filter validation (`--strict-filters`) for `generators` to fail fast on unknown kind/profile/capability values.
+36. Updated `README.md` generator inventory examples to include multi-value and strict-filter command flows for faster adoption.
 
 ## v0.2 preview invariants
 


### PR DESCRIPTION
## Summary
- add `generators` quickstart examples for:
  - comma-separated kind filters
  - comma-separated capability filters
  - strict filter mode (`--strict-filters`)
- update v0.2 roadmap progress

## Why
Makes new generator filter capabilities easier to discover and adopt from the README.

## Validation
- go test ./...
