### PR TITLE
feat(v0.2): move inverse patch policy defaults into registry

### DIFF
--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -204,66 +204,87 @@ func capabilitiesForKind(kind model.GeneratorKind) []string {
 func defaultPatchesForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.InversePatch {
 	switch g.Kind {
 	case model.GeneratorHelm:
+		policy := registry.InversePatchTemplateFor(g.Kind, "image_tag", registry.InversePatchTemplate{
+			EditableBy: "app-team", Confidence: 0.86, RequiresReview: false,
+		})
 		return []model.InversePatch{{
 			Operation:      "replace",
 			DryPath:        "values.image.tag",
 			WetPath:        "Deployment/spec/template/spec/containers[0]/image",
-			EditableBy:     "app-team",
-			Confidence:     0.86,
-			RequiresReview: false,
+			EditableBy:     policy.EditableBy,
+			Confidence:     policy.Confidence,
+			RequiresReview: policy.RequiresReview,
 			Reason:         registry.InversePatchReason(g.Kind, "image_tag", "Container image tag maps cleanly to helm values."),
 		}}
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
+		policy := registry.InversePatchTemplateFor(g.Kind, "env_var", registry.InversePatchTemplate{
+			EditableBy: "app-team", Confidence: 0.90, RequiresReview: false,
+		})
 		return []model.InversePatch{{
 			Operation:      "replace",
 			DryPath:        fmt.Sprintf("containers.%s.variables.%s", hints.ContainerName, hints.VariableName),
 			WetPath:        fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/env[name=%s]/value", hints.ContainerName, hints.VariableName),
-			EditableBy:     "app-team",
-			Confidence:     0.90,
-			RequiresReview: false,
+			EditableBy:     policy.EditableBy,
+			Confidence:     policy.Confidence,
+			RequiresReview: policy.RequiresReview,
 			Reason:         registry.InversePatchReason(g.Kind, "env_var", "Score variable maps to a single Kubernetes env var."),
 		}}
 	case model.GeneratorSpringBoot:
+		appNamePolicy := registry.InversePatchTemplateFor(g.Kind, "app_name", registry.InversePatchTemplate{
+			EditableBy: "app-team", Confidence: 0.88, RequiresReview: false,
+		})
+		serverPortPolicy := registry.InversePatchTemplateFor(g.Kind, "server_port", registry.InversePatchTemplate{
+			EditableBy: "app-team", Confidence: 0.91, RequiresReview: false,
+		})
+		datasourcePolicy := registry.InversePatchTemplateFor(g.Kind, "datasource_url", registry.InversePatchTemplate{
+			EditableBy: "platform-engineer", Confidence: 0.78, RequiresReview: true,
+		})
 		return []model.InversePatch{
 			{
 				Operation:      "replace",
 				DryPath:        "spring.application.name",
 				WetPath:        "Deployment/metadata/labels[app.kubernetes.io/name]",
-				EditableBy:     "app-team",
-				Confidence:     0.88,
-				RequiresReview: false,
+				EditableBy:     appNamePolicy.EditableBy,
+				Confidence:     appNamePolicy.Confidence,
+				RequiresReview: appNamePolicy.RequiresReview,
 				Reason:         registry.InversePatchReason(g.Kind, "app_name", "Application identity should be app-editable without platform escalation."),
 			},
 			{
 				Operation:      "replace",
 				DryPath:        "server.port",
 				WetPath:        "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
-				EditableBy:     "app-team",
-				Confidence:     0.91,
-				RequiresReview: false,
+				EditableBy:     serverPortPolicy.EditableBy,
+				Confidence:     serverPortPolicy.Confidence,
+				RequiresReview: serverPortPolicy.RequiresReview,
 				Reason:         registry.InversePatchReason(g.Kind, "server_port", "Application listener port is an app-level configuration concern."),
 			},
 			{
 				Operation:      "replace",
 				DryPath:        "spring.datasource.url",
 				WetPath:        "ConfigMap/data/application.yaml:spring.datasource.url",
-				EditableBy:     "platform-engineer",
-				Confidence:     0.78,
-				RequiresReview: true,
+				EditableBy:     datasourcePolicy.EditableBy,
+				Confidence:     datasourcePolicy.Confidence,
+				RequiresReview: datasourcePolicy.RequiresReview,
 				Reason:         registry.InversePatchReason(g.Kind, "datasource_url", "Database connectivity impacts shared runtime dependencies."),
 			},
 		}
 	case model.GeneratorBackstage:
 		hints := backstagePathHintsFromInputs(g.Inputs)
+		identityPolicy := registry.InversePatchTemplateFor(g.Kind, "identity", registry.InversePatchTemplate{
+			EditableBy: "platform-engineer", Confidence: 0.87, RequiresReview: false,
+		})
+		lifecyclePolicy := registry.InversePatchTemplateFor(g.Kind, "lifecycle", registry.InversePatchTemplate{
+			EditableBy: "platform-engineer", Confidence: 0.82, RequiresReview: true,
+		})
 		return []model.InversePatch{
 			{
 				Operation:      "replace",
 				DryPath:        "metadata.name",
 				WetPath:        "Application/metadata/name",
-				EditableBy:     "platform-engineer",
-				Confidence:     0.87,
-				RequiresReview: false,
+				EditableBy:     identityPolicy.EditableBy,
+				Confidence:     identityPolicy.Confidence,
+				RequiresReview: identityPolicy.RequiresReview,
 				Reason: renderTargetTemplate(
 					registry.InversePatchReason(g.Kind, "identity", "Backstage component identity is sourced from {{catalog_path}}."),
 					map[string]string{"catalog_path": hints.CatalogPath},
@@ -273,22 +294,28 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				Operation:      "replace",
 				DryPath:        "spec.lifecycle",
 				WetPath:        "Application/metadata/labels[lifecycle]",
-				EditableBy:     "platform-engineer",
-				Confidence:     0.82,
-				RequiresReview: true,
+				EditableBy:     lifecyclePolicy.EditableBy,
+				Confidence:     lifecyclePolicy.Confidence,
+				RequiresReview: lifecyclePolicy.RequiresReview,
 				Reason:         registry.InversePatchReason(g.Kind, "lifecycle", "Lifecycle changes impact platform ownership and support policy."),
 			},
 		}
 	case model.GeneratorAbly:
 		hints := ablyPathHintsFromInputs(g.Inputs)
+		environmentPolicy := registry.InversePatchTemplateFor(g.Kind, "environment", registry.InversePatchTemplate{
+			EditableBy: "app-team", Confidence: 0.90, RequiresReview: false,
+		})
+		channelsPolicy := registry.InversePatchTemplateFor(g.Kind, "channels", registry.InversePatchTemplate{
+			EditableBy: "app-team", Confidence: 0.88, RequiresReview: false,
+		})
 		return []model.InversePatch{
 			{
 				Operation:      "replace",
 				DryPath:        "app.environment",
 				WetPath:        "ConfigMap/data/ABLY_ENVIRONMENT",
-				EditableBy:     "app-team",
-				Confidence:     0.90,
-				RequiresReview: false,
+				EditableBy:     environmentPolicy.EditableBy,
+				Confidence:     environmentPolicy.Confidence,
+				RequiresReview: environmentPolicy.RequiresReview,
 				Reason: renderTargetTemplate(
 					registry.InversePatchReason(g.Kind, "environment", "Environment is sourced from {{base_config_path}}."),
 					map[string]string{"base_config_path": hints.BaseConfigPath},
@@ -298,22 +325,28 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				Operation:      "replace",
 				DryPath:        "channels.inbound",
 				WetPath:        "ConfigMap/data/ABLY_CHANNEL_INBOUND",
-				EditableBy:     "app-team",
-				Confidence:     0.88,
-				RequiresReview: false,
+				EditableBy:     channelsPolicy.EditableBy,
+				Confidence:     channelsPolicy.Confidence,
+				RequiresReview: channelsPolicy.RequiresReview,
 				Reason:         registry.InversePatchReason(g.Kind, "channels", "Channel mapping is app-level runtime behavior."),
 			},
 		}
 	case model.GeneratorOpsFlow:
 		hints := opsWorkflowPathHintsFromInputs(g.Inputs)
+		imageTagPolicy := registry.InversePatchTemplateFor(g.Kind, "image_tag", registry.InversePatchTemplate{
+			EditableBy: "platform-engineer", Confidence: 0.87, RequiresReview: true,
+		})
+		schedulePolicy := registry.InversePatchTemplateFor(g.Kind, "schedule", registry.InversePatchTemplate{
+			EditableBy: "platform-engineer", Confidence: 0.84, RequiresReview: true,
+		})
 		return []model.InversePatch{
 			{
 				Operation:      "replace",
 				DryPath:        "actions.deploy.image_tag",
 				WetPath:        "Workflow/spec/templates[name=deploy]/container/image",
-				EditableBy:     "platform-engineer",
-				Confidence:     0.87,
-				RequiresReview: true,
+				EditableBy:     imageTagPolicy.EditableBy,
+				Confidence:     imageTagPolicy.Confidence,
+				RequiresReview: imageTagPolicy.RequiresReview,
 				Reason: renderTargetTemplate(
 					registry.InversePatchReason(g.Kind, "image_tag", "Deployment action image tag is sourced from {{base_spec_path}}."),
 					map[string]string{"base_spec_path": hints.BaseSpecPath},
@@ -323,9 +356,9 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 				Operation:      "replace",
 				DryPath:        "triggers.schedule",
 				WetPath:        "Workflow/spec/schedule",
-				EditableBy:     "platform-engineer",
-				Confidence:     0.84,
-				RequiresReview: true,
+				EditableBy:     schedulePolicy.EditableBy,
+				Confidence:     schedulePolicy.Confidence,
+				RequiresReview: schedulePolicy.RequiresReview,
 				Reason:         registry.InversePatchReason(g.Kind, "schedule", "Schedule changes affect operational execution timing."),
 			},
 		}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -23,6 +23,12 @@ type WetTargetTemplate struct {
 	SourceDryPathTemplate string
 }
 
+type InversePatchTemplate struct {
+	EditableBy     string
+	Confidence     float64
+	RequiresReview bool
+}
+
 // FamilySpec captures cross-cutting generator-family metadata used by multiple
 // command/runtime layers.
 type FamilySpec struct {
@@ -35,6 +41,7 @@ type FamilySpec struct {
 	HintDefaults                map[string]string
 	InversePatchReasons         map[string]string
 	InverseEditHints            map[string]string
+	InversePatchTemplates       map[string]InversePatchTemplate
 	FieldOriginTransform        string
 	FieldOriginOverlayTransform string
 	InputRoleRules              []InputRoleRule
@@ -62,6 +69,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		InverseEditHints: map[string]string{
 			"image_tag": "Edit chart values file and keep chart template unchanged.",
+		},
+		InversePatchTemplates: map[string]InversePatchTemplate{
+			"image_tag": {EditableBy: "app-team", Confidence: 0.86, RequiresReview: false},
 		},
 		FieldOriginTransform: "helm-template",
 		InputRoleRules: []InputRoleRule{
@@ -98,6 +108,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"env_var": "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}.",
 			"port":    "Edit {{service_port_name}} service port in {{source_path}}.",
 		},
+		InversePatchTemplates: map[string]InversePatchTemplate{
+			"env_var": {EditableBy: "app-team", Confidence: 0.90, RequiresReview: false},
+		},
 		FieldOriginTransform: "score-to-k8s",
 		InputRoleRules:       []InputRoleRule{{Role: "score-spec", ExactBasenames: []string{"score.yaml", "score.yml"}}},
 		DefaultInputRole:     "score-input",
@@ -132,6 +145,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"server_port_base":    "Edit server.port in {{base_config_path}}.",
 			"server_port_overlay": "Edit server.port in {{profile_config_path}} for environment overrides; use {{base_config_path}} for the default.",
 			"datasource_url":      "Edit spring.datasource.url in {{base_config_path}} and coordinate with platform ownership rules.",
+		},
+		InversePatchTemplates: map[string]InversePatchTemplate{
+			"app_name":       {EditableBy: "app-team", Confidence: 0.88, RequiresReview: false},
+			"server_port":    {EditableBy: "app-team", Confidence: 0.91, RequiresReview: false},
+			"datasource_url": {EditableBy: "platform-engineer", Confidence: 0.78, RequiresReview: true},
 		},
 		FieldOriginTransform:        "spring-config-to-manifest",
 		FieldOriginOverlayTransform: "spring-profile-overlay",
@@ -173,6 +191,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"name":      "Edit metadata.name in {{catalog_path}}.",
 			"lifecycle": "Edit spec.lifecycle in {{catalog_path}} and coordinate rollout policy.",
 		},
+		InversePatchTemplates: map[string]InversePatchTemplate{
+			"identity":  {EditableBy: "platform-engineer", Confidence: 0.87, RequiresReview: false},
+			"lifecycle": {EditableBy: "platform-engineer", Confidence: 0.82, RequiresReview: true},
+		},
 		FieldOriginTransform: "backstage-component-to-application",
 		InputRoleRules: []InputRoleRule{
 			{Role: "catalog-spec", ExactBasenames: []string{"catalog-info.yaml", "catalog-info.yml"}},
@@ -207,6 +229,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"environment":      "Edit app.environment in {{base_config_path}}.",
 			"channels_base":    "Edit channels.inbound in {{base_config_path}}.",
 			"channels_overlay": "Edit channels.inbound in {{overlay_config_path}} for environment-specific behavior; use {{base_config_path}} for defaults.",
+		},
+		InversePatchTemplates: map[string]InversePatchTemplate{
+			"environment": {EditableBy: "app-team", Confidence: 0.90, RequiresReview: false},
+			"channels":    {EditableBy: "app-team", Confidence: 0.88, RequiresReview: false},
 		},
 		FieldOriginTransform:        "ably-config-to-runtime",
 		FieldOriginOverlayTransform: "ably-overlay-merge",
@@ -243,6 +269,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"schedule_base":    "Edit triggers.schedule in {{base_spec_path}}.",
 			"schedule_overlay": "Edit triggers.schedule in {{overlay_spec_path}} for environment-specific cadence; use {{base_spec_path}} for defaults.",
 		},
+		InversePatchTemplates: map[string]InversePatchTemplate{
+			"image_tag": {EditableBy: "platform-engineer", Confidence: 0.87, RequiresReview: true},
+			"schedule":  {EditableBy: "platform-engineer", Confidence: 0.84, RequiresReview: true},
+		},
 		FieldOriginTransform:        "ops-workflow-to-argo-workflow",
 		FieldOriginOverlayTransform: "ops-workflow-overlay-merge",
 		InputRoleRules: []InputRoleRule{
@@ -273,6 +303,7 @@ func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
 		HintDefaults:                copyHintDefaults(spec.HintDefaults),
 		InversePatchReasons:         copyInversePatchReasons(spec.InversePatchReasons),
 		InverseEditHints:            copyInverseEditHints(spec.InverseEditHints),
+		InversePatchTemplates:       copyInversePatchTemplates(spec.InversePatchTemplates),
 		FieldOriginTransform:        spec.FieldOriginTransform,
 		FieldOriginOverlayTransform: spec.FieldOriginOverlayTransform,
 		InputRoleRules:              copyInputRoleRules(spec.InputRoleRules),
@@ -332,6 +363,17 @@ func InversePatchReason(kind model.GeneratorKind, key, fallback string) string {
 		return fallback
 	}
 	if v, ok := spec.InversePatchReasons[key]; ok && strings.TrimSpace(v) != "" {
+		return v
+	}
+	return fallback
+}
+
+func InversePatchTemplateFor(kind model.GeneratorKind, key string, fallback InversePatchTemplate) InversePatchTemplate {
+	spec, ok := Spec(kind)
+	if !ok {
+		return fallback
+	}
+	if v, ok := spec.InversePatchTemplates[key]; ok {
 		return v
 	}
 	return fallback
@@ -541,6 +583,17 @@ func copyInverseEditHints(in map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func copyInversePatchTemplates(in map[string]InversePatchTemplate) map[string]InversePatchTemplate {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]InversePatchTemplate, len(in))
 	for k, v := range in {
 		out[k] = v
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -77,6 +77,11 @@ func TestRegistryFallbacks(t *testing.T) {
 	if got := InversePatchReason(unknown, "image_tag", "fallback-reason"); got != "fallback-reason" {
 		t.Fatalf("expected inverse patch reason fallback fallback-reason, got %q", got)
 	}
+	if got := InversePatchTemplateFor(unknown, "image_tag", InversePatchTemplate{
+		EditableBy: "fallback-owner", Confidence: 1.0, RequiresReview: true,
+	}); got.EditableBy != "fallback-owner" || got.Confidence != 1.0 || !got.RequiresReview {
+		t.Fatalf("expected inverse patch template fallback to be returned, got %+v", got)
+	}
 	if got := InverseEditHint(unknown, "image_tag", "fallback-hint"); got != "fallback-hint" {
 		t.Fatalf("expected inverse edit hint fallback fallback-hint, got %q", got)
 	}
@@ -196,6 +201,9 @@ func TestRegistryHintDefaults(t *testing.T) {
 	if got := InversePatchReason(model.GeneratorAbly, "channels", "fallback"); got != "Channel mapping is app-level runtime behavior." {
 		t.Fatalf("expected ably channels inverse patch reason, got %q", got)
 	}
+	if got := InversePatchTemplateFor(model.GeneratorOpsFlow, "schedule", InversePatchTemplate{}); got.EditableBy != "platform-engineer" || got.Confidence != 0.84 || !got.RequiresReview {
+		t.Fatalf("expected ops schedule inverse patch template, got %+v", got)
+	}
 	if got := InverseEditHint(model.GeneratorScore, "env_var", "fallback"); got != "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}." {
 		t.Fatalf("expected score env_var inverse edit hint template, got %q", got)
 	}
@@ -215,6 +223,10 @@ func TestRegistryHintDefaults(t *testing.T) {
 	spec.InversePatchReasons["env_var"] = "mutated reason"
 	if got := InversePatchReason(model.GeneratorScore, "env_var", "fallback"); got != "Score variable maps to a single Kubernetes env var." {
 		t.Fatalf("expected immutable inverse patch reasons, got %q", got)
+	}
+	spec.InversePatchTemplates["env_var"] = InversePatchTemplate{EditableBy: "mutated", Confidence: 0.01, RequiresReview: true}
+	if got := InversePatchTemplateFor(model.GeneratorScore, "env_var", InversePatchTemplate{}); got.EditableBy != "app-team" || got.Confidence != 0.90 || got.RequiresReview {
+		t.Fatalf("expected immutable inverse patch templates, got %+v", got)
 	}
 	spec.InverseEditHints["env_var"] = "mutated hint"
 	if got := InverseEditHint(model.GeneratorScore, "env_var", "fallback"); got != "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}." {


### PR DESCRIPTION
## Summary
- add inverse patch policy templates to generator family specs
- expose InversePatchTemplateFor with fallback semantics
- switch importer inverse patch defaults to registry lookups
- add fallback and immutability coverage for inverse patch templates

## Validation
- go test ./...
- make ci
