### PR TITLE
feat(v0.2): move field-origin confidence templates into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -52,6 +52,7 @@ Implemented in this preview slice:
 34. Added table-mode multi-filter parity contracts for `generators` (kind and capability comma-list flows) to keep human-readable output locked alongside JSON.
 35. Added optional strict filter validation (`--strict-filters`) for `generators` to fail fast on unknown kind/profile/capability values.
 36. Updated `README.md` generator inventory examples to include multi-value and strict-filter command flows for faster adoption.
+37. Refactored provenance `field_origin_map.confidence` values into registry-driven templates (`FieldOriginConfidences`) to remove importer-local confidence literals while preserving output behavior.
 
 ## v0.2 preview invariants
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -376,7 +376,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
 				SourcePath: "values.yaml",
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.86,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "image_tag", 0.86),
 			},
 		}
 	case model.GeneratorScore:
@@ -387,21 +387,21 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				WetPath:    fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/image", hints.ContainerName),
 				SourcePath: hints.SourcePath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.94,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "image", 0.94),
 			},
 			{
 				DryPath:    fmt.Sprintf("containers.%s.variables.%s", hints.ContainerName, hints.VariableName),
 				WetPath:    fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/env[name=%s]/value", hints.ContainerName, hints.VariableName),
 				SourcePath: hints.SourcePath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.90,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "env_var", 0.90),
 			},
 			{
 				DryPath:    fmt.Sprintf("service.ports.%s.port", hints.ServicePortName),
 				WetPath:    fmt.Sprintf("Service/spec/ports[name=%s]/port", hints.ServicePortName),
 				SourcePath: hints.SourcePath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.91,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "port", 0.91),
 			},
 		}
 	case model.GeneratorSpringBoot:
@@ -412,21 +412,21 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				WetPath:    "Deployment/metadata/labels[app.kubernetes.io/name]",
 				SourcePath: hints.BaseConfigPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.89,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "app_name", 0.89),
 			},
 			{
 				DryPath:    "server.port",
 				WetPath:    "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
 				SourcePath: hints.BaseConfigPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.92,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "server_port_base", 0.92),
 			},
 			{
 				DryPath:    "spring.datasource.url",
 				WetPath:    "ConfigMap/data/application.yaml:spring.datasource.url",
 				SourcePath: hints.BaseConfigPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.78,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "datasource_url", 0.78),
 			},
 		}
 		if hints.ProfileConfigPath != "" {
@@ -435,7 +435,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				WetPath:    "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
 				SourcePath: hints.ProfileConfigPath,
 				Transform:  registry.FieldOriginOverlayTransform(g.Kind),
-				Confidence: 0.88,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "server_port_overlay", 0.88),
 			})
 		}
 		return origins
@@ -447,14 +447,14 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				WetPath:    "Application/metadata/name",
 				SourcePath: hints.CatalogPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.90,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "identity", 0.90),
 			},
 			{
 				DryPath:    "spec.lifecycle",
 				WetPath:    "Application/metadata/labels[lifecycle]",
 				SourcePath: hints.CatalogPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.82,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "lifecycle", 0.82),
 			},
 		}
 	case model.GeneratorAbly:
@@ -465,14 +465,14 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				WetPath:    "ConfigMap/data/ABLY_ENVIRONMENT",
 				SourcePath: hints.BaseConfigPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.90,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "environment", 0.90),
 			},
 			{
 				DryPath:    "channels.inbound",
 				WetPath:    "ConfigMap/data/ABLY_CHANNEL_INBOUND",
 				SourcePath: hints.BaseConfigPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.88,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "channels_base", 0.88),
 			},
 		}
 		if hints.OverlayConfigPath != "" {
@@ -481,7 +481,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				WetPath:    "ConfigMap/data/ABLY_CHANNEL_INBOUND",
 				SourcePath: hints.OverlayConfigPath,
 				Transform:  registry.FieldOriginOverlayTransform(g.Kind),
-				Confidence: 0.84,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "channels_overlay", 0.84),
 			})
 		}
 		return origins
@@ -493,14 +493,14 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				WetPath:    "Workflow/spec/templates[name=deploy]/container/image",
 				SourcePath: hints.BaseSpecPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.87,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "image_tag", 0.87),
 			},
 			{
 				DryPath:    "triggers.schedule",
 				WetPath:    "Workflow/spec/schedule",
 				SourcePath: hints.BaseSpecPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: 0.84,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "schedule_base", 0.84),
 			},
 		}
 		if hints.OverlaySpecPath != "" {
@@ -509,7 +509,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				WetPath:    "Workflow/spec/schedule",
 				SourcePath: hints.OverlaySpecPath,
 				Transform:  registry.FieldOriginOverlayTransform(g.Kind),
-				Confidence: 0.80,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "schedule_overlay", 0.80),
 			})
 		}
 		return origins

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -42,6 +42,7 @@ type FamilySpec struct {
 	InversePatchReasons         map[string]string
 	InverseEditHints            map[string]string
 	InversePatchTemplates       map[string]InversePatchTemplate
+	FieldOriginConfidences      map[string]float64
 	FieldOriginTransform        string
 	FieldOriginOverlayTransform string
 	InputRoleRules              []InputRoleRule
@@ -72,6 +73,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		InversePatchTemplates: map[string]InversePatchTemplate{
 			"image_tag": {EditableBy: "app-team", Confidence: 0.86, RequiresReview: false},
+		},
+		FieldOriginConfidences: map[string]float64{
+			"image_tag": 0.86,
 		},
 		FieldOriginTransform: "helm-template",
 		InputRoleRules: []InputRoleRule{
@@ -110,6 +114,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		InversePatchTemplates: map[string]InversePatchTemplate{
 			"env_var": {EditableBy: "app-team", Confidence: 0.90, RequiresReview: false},
+		},
+		FieldOriginConfidences: map[string]float64{
+			"image":   0.94,
+			"env_var": 0.90,
+			"port":    0.91,
 		},
 		FieldOriginTransform: "score-to-k8s",
 		InputRoleRules:       []InputRoleRule{{Role: "score-spec", ExactBasenames: []string{"score.yaml", "score.yml"}}},
@@ -150,6 +159,12 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"app_name":       {EditableBy: "app-team", Confidence: 0.88, RequiresReview: false},
 			"server_port":    {EditableBy: "app-team", Confidence: 0.91, RequiresReview: false},
 			"datasource_url": {EditableBy: "platform-engineer", Confidence: 0.78, RequiresReview: true},
+		},
+		FieldOriginConfidences: map[string]float64{
+			"app_name":            0.89,
+			"server_port_base":    0.92,
+			"server_port_overlay": 0.88,
+			"datasource_url":      0.78,
 		},
 		FieldOriginTransform:        "spring-config-to-manifest",
 		FieldOriginOverlayTransform: "spring-profile-overlay",
@@ -195,6 +210,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"identity":  {EditableBy: "platform-engineer", Confidence: 0.87, RequiresReview: false},
 			"lifecycle": {EditableBy: "platform-engineer", Confidence: 0.82, RequiresReview: true},
 		},
+		FieldOriginConfidences: map[string]float64{
+			"identity":  0.90,
+			"lifecycle": 0.82,
+		},
 		FieldOriginTransform: "backstage-component-to-application",
 		InputRoleRules: []InputRoleRule{
 			{Role: "catalog-spec", ExactBasenames: []string{"catalog-info.yaml", "catalog-info.yml"}},
@@ -233,6 +252,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		InversePatchTemplates: map[string]InversePatchTemplate{
 			"environment": {EditableBy: "app-team", Confidence: 0.90, RequiresReview: false},
 			"channels":    {EditableBy: "app-team", Confidence: 0.88, RequiresReview: false},
+		},
+		FieldOriginConfidences: map[string]float64{
+			"environment":      0.90,
+			"channels_base":    0.88,
+			"channels_overlay": 0.84,
 		},
 		FieldOriginTransform:        "ably-config-to-runtime",
 		FieldOriginOverlayTransform: "ably-overlay-merge",
@@ -273,6 +297,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"image_tag": {EditableBy: "platform-engineer", Confidence: 0.87, RequiresReview: true},
 			"schedule":  {EditableBy: "platform-engineer", Confidence: 0.84, RequiresReview: true},
 		},
+		FieldOriginConfidences: map[string]float64{
+			"image_tag":        0.87,
+			"schedule_base":    0.84,
+			"schedule_overlay": 0.80,
+		},
 		FieldOriginTransform:        "ops-workflow-to-argo-workflow",
 		FieldOriginOverlayTransform: "ops-workflow-overlay-merge",
 		InputRoleRules: []InputRoleRule{
@@ -304,6 +333,7 @@ func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
 		InversePatchReasons:         copyInversePatchReasons(spec.InversePatchReasons),
 		InverseEditHints:            copyInverseEditHints(spec.InverseEditHints),
 		InversePatchTemplates:       copyInversePatchTemplates(spec.InversePatchTemplates),
+		FieldOriginConfidences:      copyFieldOriginConfidences(spec.FieldOriginConfidences),
 		FieldOriginTransform:        spec.FieldOriginTransform,
 		FieldOriginOverlayTransform: spec.FieldOriginOverlayTransform,
 		InputRoleRules:              copyInputRoleRules(spec.InputRoleRules),
@@ -410,6 +440,17 @@ func FieldOriginOverlayTransform(kind model.GeneratorKind) string {
 		return spec.FieldOriginOverlayTransform
 	}
 	return FieldOriginTransform(kind)
+}
+
+func FieldOriginConfidenceFor(kind model.GeneratorKind, key string, fallback float64) float64 {
+	spec, ok := Spec(kind)
+	if !ok {
+		return fallback
+	}
+	if v, ok := spec.FieldOriginConfidences[key]; ok {
+		return v
+	}
+	return fallback
 }
 
 func SchemaRef(kind model.GeneratorKind, inputPath string) string {
@@ -594,6 +635,17 @@ func copyInversePatchTemplates(in map[string]InversePatchTemplate) map[string]In
 		return nil
 	}
 	out := make(map[string]InversePatchTemplate, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func copyFieldOriginConfidences(in map[string]float64) map[string]float64 {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]float64, len(in))
 	for k, v := range in {
 		out[k] = v
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -74,6 +74,9 @@ func TestRegistryFallbacks(t *testing.T) {
 	if got := FieldOriginOverlayTransform(unknown); got != "generator-transform" {
 		t.Fatalf("expected field origin overlay transform fallback generator-transform, got %q", got)
 	}
+	if got := FieldOriginConfidenceFor(unknown, "image_tag", 0.42); got != 0.42 {
+		t.Fatalf("expected field origin confidence fallback 0.42, got %v", got)
+	}
 	if got := InversePatchReason(unknown, "image_tag", "fallback-reason"); got != "fallback-reason" {
 		t.Fatalf("expected inverse patch reason fallback fallback-reason, got %q", got)
 	}
@@ -201,6 +204,9 @@ func TestRegistryHintDefaults(t *testing.T) {
 	if got := InversePatchReason(model.GeneratorAbly, "channels", "fallback"); got != "Channel mapping is app-level runtime behavior." {
 		t.Fatalf("expected ably channels inverse patch reason, got %q", got)
 	}
+	if got := FieldOriginConfidenceFor(model.GeneratorOpsFlow, "schedule_overlay", 0.0); got != 0.80 {
+		t.Fatalf("expected ops schedule overlay field origin confidence 0.80, got %v", got)
+	}
 	if got := InversePatchTemplateFor(model.GeneratorOpsFlow, "schedule", InversePatchTemplate{}); got.EditableBy != "platform-engineer" || got.Confidence != 0.84 || !got.RequiresReview {
 		t.Fatalf("expected ops schedule inverse patch template, got %+v", got)
 	}
@@ -227,6 +233,10 @@ func TestRegistryHintDefaults(t *testing.T) {
 	spec.InversePatchTemplates["env_var"] = InversePatchTemplate{EditableBy: "mutated", Confidence: 0.01, RequiresReview: true}
 	if got := InversePatchTemplateFor(model.GeneratorScore, "env_var", InversePatchTemplate{}); got.EditableBy != "app-team" || got.Confidence != 0.90 || got.RequiresReview {
 		t.Fatalf("expected immutable inverse patch templates, got %+v", got)
+	}
+	spec.FieldOriginConfidences["env_var"] = 0.01
+	if got := FieldOriginConfidenceFor(model.GeneratorScore, "env_var", 0.0); got != 0.90 {
+		t.Fatalf("expected immutable field origin confidences, got %v", got)
 	}
 	spec.InverseEditHints["env_var"] = "mutated hint"
 	if got := InverseEditHint(model.GeneratorScore, "env_var", "fallback"); got != "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}." {


### PR DESCRIPTION
## Summary
- add registry-owned `FieldOriginConfidences` templates per generator family
- expose `FieldOriginConfidenceFor(kind, key, fallback)` with deterministic fallback semantics
- switch importer `fieldOriginsForGenerator` confidence literals to registry lookups
- add fallback and immutability coverage for field-origin confidence templates
- update v0.2 roadmap status with the shipped slice

## Validation
- go test ./...
- make ci
