### PR TITLE
feat(v0.2): move inverse pointer policies into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -53,6 +53,7 @@ Implemented in this preview slice:
 35. Added optional strict filter validation (`--strict-filters`) for `generators` to fail fast on unknown kind/profile/capability values.
 36. Updated `README.md` generator inventory examples to include multi-value and strict-filter command flows for faster adoption.
 37. Refactored provenance `field_origin_map.confidence` values into registry-driven templates (`FieldOriginConfidences`) to remove importer-local confidence literals while preserving output behavior.
+38. Refactored inverse edit pointer ownership/confidence defaults into registry-driven templates (`InversePointerTemplates`) to remove importer-local policy literals while preserving output behavior.
 
 ## v0.2 preview invariants
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -521,17 +521,29 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 func inversePointersForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.InverseEditPointer {
 	switch g.Kind {
 	case model.GeneratorHelm:
+		policy := registry.InversePointerTemplateFor(g.Kind, "image_tag", registry.InversePointerTemplate{
+			Owner: "app-team", Confidence: 0.86,
+		})
 		return []model.InverseEditPointer{
 			{
 				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
 				DryPath:    "values.image.tag",
-				Owner:      "app-team",
+				Owner:      policy.Owner,
 				EditHint:   registry.InverseEditHint(g.Kind, "image_tag", "Edit chart values file and keep chart template unchanged."),
-				Confidence: 0.86,
+				Confidence: policy.Confidence,
 			},
 		}
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
+		imagePolicy := registry.InversePointerTemplateFor(g.Kind, "image", registry.InversePointerTemplate{
+			Owner: "app-team", Confidence: 0.94,
+		})
+		envVarPolicy := registry.InversePointerTemplateFor(g.Kind, "env_var", registry.InversePointerTemplate{
+			Owner: "app-team", Confidence: 0.90,
+		})
+		portPolicy := registry.InversePointerTemplateFor(g.Kind, "port", registry.InversePointerTemplate{
+			Owner: "app-team", Confidence: 0.91,
+		})
 		vars := map[string]string{
 			"source_path":       hints.SourcePath,
 			"container_name":    hints.ContainerName,
@@ -542,27 +554,36 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 			{
 				WetPath:    fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/image", hints.ContainerName),
 				DryPath:    fmt.Sprintf("containers.%s.image", hints.ContainerName),
-				Owner:      "app-team",
+				Owner:      imagePolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "image", "Edit the Score container image in {{source_path}}."), vars),
-				Confidence: 0.94,
+				Confidence: imagePolicy.Confidence,
 			},
 			{
 				WetPath:    fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/env[name=%s]/value", hints.ContainerName, hints.VariableName),
 				DryPath:    fmt.Sprintf("containers.%s.variables.%s", hints.ContainerName, hints.VariableName),
-				Owner:      "app-team",
+				Owner:      envVarPolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "env_var", "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}."), vars),
-				Confidence: 0.90,
+				Confidence: envVarPolicy.Confidence,
 			},
 			{
 				WetPath:    fmt.Sprintf("Service/spec/ports[name=%s]/port", hints.ServicePortName),
 				DryPath:    fmt.Sprintf("service.ports.%s.port", hints.ServicePortName),
-				Owner:      "app-team",
+				Owner:      portPolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "port", "Edit {{service_port_name}} service port in {{source_path}}."), vars),
-				Confidence: 0.91,
+				Confidence: portPolicy.Confidence,
 			},
 		}
 	case model.GeneratorSpringBoot:
 		hints := springPathHintsFromInputs(g.Inputs)
+		appNamePolicy := registry.InversePointerTemplateFor(g.Kind, "app_name", registry.InversePointerTemplate{
+			Owner: "app-team", Confidence: 0.89,
+		})
+		serverPortPolicy := registry.InversePointerTemplateFor(g.Kind, "server_port", registry.InversePointerTemplate{
+			Owner: "app-team", Confidence: 0.91,
+		})
+		datasourcePolicy := registry.InversePointerTemplateFor(g.Kind, "datasource_url", registry.InversePointerTemplate{
+			Owner: "platform-engineer", Confidence: 0.78,
+		})
 		vars := map[string]string{
 			"base_config_path":    hints.BaseConfigPath,
 			"profile_config_path": hints.ProfileConfigPath,
@@ -577,46 +598,58 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 			{
 				WetPath:    "Deployment/metadata/labels[app.kubernetes.io/name]",
 				DryPath:    "spring.application.name",
-				Owner:      "app-team",
+				Owner:      appNamePolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "app_name", "Edit spring.application.name in {{base_config_path}}."), vars),
-				Confidence: 0.89,
+				Confidence: appNamePolicy.Confidence,
 			},
 			{
 				WetPath:    "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort",
 				DryPath:    "server.port",
-				Owner:      "app-team",
+				Owner:      serverPortPolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, serverPortHintKey, serverPortHintFallback), vars),
-				Confidence: 0.91,
+				Confidence: serverPortPolicy.Confidence,
 			},
 			{
 				WetPath:    "ConfigMap/data/application.yaml:spring.datasource.url",
 				DryPath:    "spring.datasource.url",
-				Owner:      "platform-engineer",
+				Owner:      datasourcePolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "datasource_url", "Edit spring.datasource.url in {{base_config_path}} and coordinate with platform ownership rules."), vars),
-				Confidence: 0.78,
+				Confidence: datasourcePolicy.Confidence,
 			},
 		}
 	case model.GeneratorBackstage:
 		hints := backstagePathHintsFromInputs(g.Inputs)
+		namePolicy := registry.InversePointerTemplateFor(g.Kind, "name", registry.InversePointerTemplate{
+			Owner: "platform-engineer", Confidence: 0.90,
+		})
+		lifecyclePolicy := registry.InversePointerTemplateFor(g.Kind, "lifecycle", registry.InversePointerTemplate{
+			Owner: "platform-engineer", Confidence: 0.82,
+		})
 		vars := map[string]string{"catalog_path": hints.CatalogPath}
 		return []model.InverseEditPointer{
 			{
 				WetPath:    "Application/metadata/name",
 				DryPath:    "metadata.name",
-				Owner:      "platform-engineer",
+				Owner:      namePolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "name", "Edit metadata.name in {{catalog_path}}."), vars),
-				Confidence: 0.90,
+				Confidence: namePolicy.Confidence,
 			},
 			{
 				WetPath:    "Application/metadata/labels[lifecycle]",
 				DryPath:    "spec.lifecycle",
-				Owner:      "platform-engineer",
+				Owner:      lifecyclePolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "lifecycle", "Edit spec.lifecycle in {{catalog_path}} and coordinate rollout policy."), vars),
-				Confidence: 0.82,
+				Confidence: lifecyclePolicy.Confidence,
 			},
 		}
 	case model.GeneratorAbly:
 		hints := ablyPathHintsFromInputs(g.Inputs)
+		environmentPolicy := registry.InversePointerTemplateFor(g.Kind, "environment", registry.InversePointerTemplate{
+			Owner: "app-team", Confidence: 0.90,
+		})
+		channelsPolicy := registry.InversePointerTemplateFor(g.Kind, "channels", registry.InversePointerTemplate{
+			Owner: "app-team", Confidence: 0.88,
+		})
 		vars := map[string]string{
 			"base_config_path":    hints.BaseConfigPath,
 			"overlay_config_path": hints.OverlayConfigPath,
@@ -631,20 +664,26 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 			{
 				WetPath:    "ConfigMap/data/ABLY_ENVIRONMENT",
 				DryPath:    "app.environment",
-				Owner:      "app-team",
+				Owner:      environmentPolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "environment", "Edit app.environment in {{base_config_path}}."), vars),
-				Confidence: 0.90,
+				Confidence: environmentPolicy.Confidence,
 			},
 			{
 				WetPath:    "ConfigMap/data/ABLY_CHANNEL_INBOUND",
 				DryPath:    "channels.inbound",
-				Owner:      "app-team",
+				Owner:      channelsPolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, channelsHintKey, channelsHintFallback), vars),
-				Confidence: 0.88,
+				Confidence: channelsPolicy.Confidence,
 			},
 		}
 	case model.GeneratorOpsFlow:
 		hints := opsWorkflowPathHintsFromInputs(g.Inputs)
+		imageTagPolicy := registry.InversePointerTemplateFor(g.Kind, "image_tag", registry.InversePointerTemplate{
+			Owner: "platform-engineer", Confidence: 0.87,
+		})
+		schedulePolicy := registry.InversePointerTemplateFor(g.Kind, "schedule", registry.InversePointerTemplate{
+			Owner: "platform-engineer", Confidence: 0.84,
+		})
 		vars := map[string]string{
 			"base_spec_path":    hints.BaseSpecPath,
 			"overlay_spec_path": hints.OverlaySpecPath,
@@ -659,16 +698,16 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 			{
 				WetPath:    "Workflow/spec/templates[name=deploy]/container/image",
 				DryPath:    "actions.deploy.image_tag",
-				Owner:      "platform-engineer",
+				Owner:      imageTagPolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "image_tag", "Edit actions.deploy.image_tag in {{base_spec_path}}."), vars),
-				Confidence: 0.87,
+				Confidence: imageTagPolicy.Confidence,
 			},
 			{
 				WetPath:    "Workflow/spec/schedule",
 				DryPath:    "triggers.schedule",
-				Owner:      "platform-engineer",
+				Owner:      schedulePolicy.Owner,
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, scheduleHintKey, scheduleHintFallback), vars),
-				Confidence: 0.84,
+				Confidence: schedulePolicy.Confidence,
 			},
 		}
 	default:

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -29,6 +29,11 @@ type InversePatchTemplate struct {
 	RequiresReview bool
 }
 
+type InversePointerTemplate struct {
+	Owner      string
+	Confidence float64
+}
+
 // FamilySpec captures cross-cutting generator-family metadata used by multiple
 // command/runtime layers.
 type FamilySpec struct {
@@ -42,6 +47,7 @@ type FamilySpec struct {
 	InversePatchReasons         map[string]string
 	InverseEditHints            map[string]string
 	InversePatchTemplates       map[string]InversePatchTemplate
+	InversePointerTemplates     map[string]InversePointerTemplate
 	FieldOriginConfidences      map[string]float64
 	FieldOriginTransform        string
 	FieldOriginOverlayTransform string
@@ -73,6 +79,9 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		InversePatchTemplates: map[string]InversePatchTemplate{
 			"image_tag": {EditableBy: "app-team", Confidence: 0.86, RequiresReview: false},
+		},
+		InversePointerTemplates: map[string]InversePointerTemplate{
+			"image_tag": {Owner: "app-team", Confidence: 0.86},
 		},
 		FieldOriginConfidences: map[string]float64{
 			"image_tag": 0.86,
@@ -114,6 +123,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		InversePatchTemplates: map[string]InversePatchTemplate{
 			"env_var": {EditableBy: "app-team", Confidence: 0.90, RequiresReview: false},
+		},
+		InversePointerTemplates: map[string]InversePointerTemplate{
+			"image":   {Owner: "app-team", Confidence: 0.94},
+			"env_var": {Owner: "app-team", Confidence: 0.90},
+			"port":    {Owner: "app-team", Confidence: 0.91},
 		},
 		FieldOriginConfidences: map[string]float64{
 			"image":   0.94,
@@ -159,6 +173,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"app_name":       {EditableBy: "app-team", Confidence: 0.88, RequiresReview: false},
 			"server_port":    {EditableBy: "app-team", Confidence: 0.91, RequiresReview: false},
 			"datasource_url": {EditableBy: "platform-engineer", Confidence: 0.78, RequiresReview: true},
+		},
+		InversePointerTemplates: map[string]InversePointerTemplate{
+			"app_name":       {Owner: "app-team", Confidence: 0.89},
+			"server_port":    {Owner: "app-team", Confidence: 0.91},
+			"datasource_url": {Owner: "platform-engineer", Confidence: 0.78},
 		},
 		FieldOriginConfidences: map[string]float64{
 			"app_name":            0.89,
@@ -210,6 +229,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"identity":  {EditableBy: "platform-engineer", Confidence: 0.87, RequiresReview: false},
 			"lifecycle": {EditableBy: "platform-engineer", Confidence: 0.82, RequiresReview: true},
 		},
+		InversePointerTemplates: map[string]InversePointerTemplate{
+			"name":      {Owner: "platform-engineer", Confidence: 0.90},
+			"lifecycle": {Owner: "platform-engineer", Confidence: 0.82},
+		},
 		FieldOriginConfidences: map[string]float64{
 			"identity":  0.90,
 			"lifecycle": 0.82,
@@ -252,6 +275,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		InversePatchTemplates: map[string]InversePatchTemplate{
 			"environment": {EditableBy: "app-team", Confidence: 0.90, RequiresReview: false},
 			"channels":    {EditableBy: "app-team", Confidence: 0.88, RequiresReview: false},
+		},
+		InversePointerTemplates: map[string]InversePointerTemplate{
+			"environment": {Owner: "app-team", Confidence: 0.90},
+			"channels":    {Owner: "app-team", Confidence: 0.88},
 		},
 		FieldOriginConfidences: map[string]float64{
 			"environment":      0.90,
@@ -297,6 +324,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"image_tag": {EditableBy: "platform-engineer", Confidence: 0.87, RequiresReview: true},
 			"schedule":  {EditableBy: "platform-engineer", Confidence: 0.84, RequiresReview: true},
 		},
+		InversePointerTemplates: map[string]InversePointerTemplate{
+			"image_tag": {Owner: "platform-engineer", Confidence: 0.87},
+			"schedule":  {Owner: "platform-engineer", Confidence: 0.84},
+		},
 		FieldOriginConfidences: map[string]float64{
 			"image_tag":        0.87,
 			"schedule_base":    0.84,
@@ -333,6 +364,7 @@ func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
 		InversePatchReasons:         copyInversePatchReasons(spec.InversePatchReasons),
 		InverseEditHints:            copyInverseEditHints(spec.InverseEditHints),
 		InversePatchTemplates:       copyInversePatchTemplates(spec.InversePatchTemplates),
+		InversePointerTemplates:     copyInversePointerTemplates(spec.InversePointerTemplates),
 		FieldOriginConfidences:      copyFieldOriginConfidences(spec.FieldOriginConfidences),
 		FieldOriginTransform:        spec.FieldOriginTransform,
 		FieldOriginOverlayTransform: spec.FieldOriginOverlayTransform,
@@ -404,6 +436,17 @@ func InversePatchTemplateFor(kind model.GeneratorKind, key string, fallback Inve
 		return fallback
 	}
 	if v, ok := spec.InversePatchTemplates[key]; ok {
+		return v
+	}
+	return fallback
+}
+
+func InversePointerTemplateFor(kind model.GeneratorKind, key string, fallback InversePointerTemplate) InversePointerTemplate {
+	spec, ok := Spec(kind)
+	if !ok {
+		return fallback
+	}
+	if v, ok := spec.InversePointerTemplates[key]; ok {
 		return v
 	}
 	return fallback
@@ -635,6 +678,17 @@ func copyInversePatchTemplates(in map[string]InversePatchTemplate) map[string]In
 		return nil
 	}
 	out := make(map[string]InversePatchTemplate, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func copyInversePointerTemplates(in map[string]InversePointerTemplate) map[string]InversePointerTemplate {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]InversePointerTemplate, len(in))
 	for k, v := range in {
 		out[k] = v
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -85,6 +85,11 @@ func TestRegistryFallbacks(t *testing.T) {
 	}); got.EditableBy != "fallback-owner" || got.Confidence != 1.0 || !got.RequiresReview {
 		t.Fatalf("expected inverse patch template fallback to be returned, got %+v", got)
 	}
+	if got := InversePointerTemplateFor(unknown, "image_tag", InversePointerTemplate{
+		Owner: "fallback-owner", Confidence: 0.77,
+	}); got.Owner != "fallback-owner" || got.Confidence != 0.77 {
+		t.Fatalf("expected inverse pointer template fallback to be returned, got %+v", got)
+	}
 	if got := InverseEditHint(unknown, "image_tag", "fallback-hint"); got != "fallback-hint" {
 		t.Fatalf("expected inverse edit hint fallback fallback-hint, got %q", got)
 	}
@@ -210,6 +215,9 @@ func TestRegistryHintDefaults(t *testing.T) {
 	if got := InversePatchTemplateFor(model.GeneratorOpsFlow, "schedule", InversePatchTemplate{}); got.EditableBy != "platform-engineer" || got.Confidence != 0.84 || !got.RequiresReview {
 		t.Fatalf("expected ops schedule inverse patch template, got %+v", got)
 	}
+	if got := InversePointerTemplateFor(model.GeneratorBackstage, "name", InversePointerTemplate{}); got.Owner != "platform-engineer" || got.Confidence != 0.90 {
+		t.Fatalf("expected backstage name inverse pointer template, got %+v", got)
+	}
 	if got := InverseEditHint(model.GeneratorScore, "env_var", "fallback"); got != "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}." {
 		t.Fatalf("expected score env_var inverse edit hint template, got %q", got)
 	}
@@ -233,6 +241,10 @@ func TestRegistryHintDefaults(t *testing.T) {
 	spec.InversePatchTemplates["env_var"] = InversePatchTemplate{EditableBy: "mutated", Confidence: 0.01, RequiresReview: true}
 	if got := InversePatchTemplateFor(model.GeneratorScore, "env_var", InversePatchTemplate{}); got.EditableBy != "app-team" || got.Confidence != 0.90 || got.RequiresReview {
 		t.Fatalf("expected immutable inverse patch templates, got %+v", got)
+	}
+	spec.InversePointerTemplates["env_var"] = InversePointerTemplate{Owner: "mutated", Confidence: 0.01}
+	if got := InversePointerTemplateFor(model.GeneratorScore, "env_var", InversePointerTemplate{}); got.Owner != "app-team" || got.Confidence != 0.90 {
+		t.Fatalf("expected immutable inverse pointer templates, got %+v", got)
 	}
 	spec.FieldOriginConfidences["env_var"] = 0.01
 	if got := FieldOriginConfidenceFor(model.GeneratorScore, "env_var", 0.0); got != 0.90 {


### PR DESCRIPTION
## Summary
- add registry-owned `InversePointerTemplates` (owner + confidence) per generator family
- expose `InversePointerTemplateFor(kind, key, fallback)` with deterministic fallback behavior
- switch importer inverse edit pointer owner/confidence defaults to registry lookups
- add fallback and immutability tests for inverse pointer templates
- update v0.2 roadmap status with this shipped slice

## Validation
- go test ./...
- make ci
