### PR TITLE
feat(v0.2): add generators json details for policy introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ without coupling the core flow to a running ConfigHub backend.
 ./cub-gen generators --capability render-manifests
 ./cub-gen generators --capability inverse-values-patch,inverse-score-patch
 ./cub-gen generators --strict-filters --kind helm,score
+./cub-gen generators --json --details | jq '.families[] | {kind, profile, policies}'
 ```
 
 Or run direct mode (import + bundle in one command):

--- a/cmd/cub-gen/generators_parity_test.go
+++ b/cmd/cub-gen/generators_parity_test.go
@@ -135,6 +135,22 @@ func TestGeneratorsGoldenJSONNoMatches(t *testing.T) {
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-empty.golden.json"), got)
 }
 
+func TestGeneratorsGoldenJSONDetails(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--json", "--details"})
+	if err != nil {
+		t.Fatalf("run generators --json --details returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal generators details json: %v\noutput=%s", err, out)
+	}
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "generators-details.golden.json"), got)
+}
+
 func TestGeneratorsGoldenTable(t *testing.T) {
 	out, stderr, err := runWithCapturedIO([]string{"generators"})
 	if err != nil {
@@ -250,5 +266,18 @@ func TestGeneratorsStrictFiltersUnknownKindMultiSorted(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown kind filter value(s): aaa, zzz") {
 		t.Fatalf("expected sorted unknown kind values in error, got: %q (stderr=%q)", err.Error(), stderr)
+	}
+}
+
+func TestGeneratorsDetailsRequiresJSON(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--details"})
+	if err == nil {
+		t.Fatalf("expected details requires json error, got nil")
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected empty stdout, got: %q", out)
+	}
+	if !strings.Contains(err.Error(), "--details requires --json") {
+		t.Fatalf("expected details requires json message, got: %q (stderr=%q)", err.Error(), stderr)
 	}
 }

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -58,11 +58,29 @@ func run(args []string) error {
 }
 
 type generatorFamilyRecord struct {
-	Kind         string   `json:"kind"`
-	Profile      string   `json:"profile"`
-	ResourceKind string   `json:"resource_kind"`
-	ResourceType string   `json:"resource_type"`
-	Capabilities []string `json:"capabilities"`
+	Kind         string                       `json:"kind"`
+	Profile      string                       `json:"profile"`
+	ResourceKind string                       `json:"resource_kind"`
+	ResourceType string                       `json:"resource_type"`
+	Capabilities []string                     `json:"capabilities"`
+	Policies     *generatorFamilyPolicyRecord `json:"policies,omitempty"`
+}
+
+type generatorFamilyPolicyRecord struct {
+	InversePatchTemplates   map[string]inversePatchTemplateRecord   `json:"inverse_patch_templates,omitempty"`
+	InversePointerTemplates map[string]inversePointerTemplateRecord `json:"inverse_pointer_templates,omitempty"`
+	FieldOriginConfidences  map[string]float64                      `json:"field_origin_confidences,omitempty"`
+}
+
+type inversePatchTemplateRecord struct {
+	EditableBy     string  `json:"editable_by"`
+	Confidence     float64 `json:"confidence"`
+	RequiresReview bool    `json:"requires_review"`
+}
+
+type inversePointerTemplateRecord struct {
+	Owner      string  `json:"owner"`
+	Confidence float64 `json:"confidence"`
 }
 
 func runGenerators(args []string) error {
@@ -76,6 +94,7 @@ func runGenerators(args []string) error {
 	capabilityFilter := fs.String("capability", "", "Filter by capability")
 	strictFilters := fs.Bool("strict-filters", false, "Fail on unknown filter values")
 	jsonOut := fs.Bool("json", false, "Output JSON")
+	details := fs.Bool("details", false, "Include policy/provenance template details in JSON output")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -84,7 +103,10 @@ func runGenerators(args []string) error {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]")
+		return errors.New("usage: cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json] [--details] [--pretty]")
+	}
+	if *details && !*jsonOut {
+		return errors.New("--details requires --json")
 	}
 	if *strictFilters {
 		if err := validateGeneratorFilters(*kindFilter, *profileFilter, *capabilityFilter); err != nil {
@@ -92,7 +114,7 @@ func runGenerators(args []string) error {
 		}
 	}
 
-	records := listGeneratorFamilies(*kindFilter, *profileFilter, *capabilityFilter)
+	records := listGeneratorFamilies(*kindFilter, *profileFilter, *capabilityFilter, *details)
 	if *jsonOut {
 		return writeJSON(os.Stdout, map[string]any{
 			"count":    len(records),
@@ -113,7 +135,7 @@ func runGenerators(args []string) error {
 	return nil
 }
 
-func listGeneratorFamilies(kindFilter, profileFilter, capabilityFilter string) []generatorFamilyRecord {
+func listGeneratorFamilies(kindFilter, profileFilter, capabilityFilter string, details bool) []generatorFamilyRecord {
 	kindFilters := parseFilterSet(kindFilter)
 	profileFilters := parseFilterSet(profileFilter)
 	capabilityFilters := parseFilterSet(capabilityFilter)
@@ -131,6 +153,9 @@ func listGeneratorFamilies(kindFilter, profileFilter, capabilityFilter string) [
 			ResourceKind: spec.ResourceKind,
 			ResourceType: spec.ResourceType,
 			Capabilities: append([]string(nil), spec.Capabilities...),
+		}
+		if details {
+			record.Policies = generatorPolicyRecord(spec)
 		}
 
 		if len(kindFilters) > 0 {
@@ -162,9 +187,44 @@ func listGeneratorFamilies(kindFilter, profileFilter, capabilityFilter string) [
 			ResourceKind: record.ResourceKind,
 			ResourceType: record.ResourceType,
 			Capabilities: record.Capabilities,
+			Policies:     record.Policies,
 		})
 	}
 	return out
+}
+
+func generatorPolicyRecord(spec registry.FamilySpec) *generatorFamilyPolicyRecord {
+	policies := &generatorFamilyPolicyRecord{
+		InversePatchTemplates:   map[string]inversePatchTemplateRecord{},
+		InversePointerTemplates: map[string]inversePointerTemplateRecord{},
+		FieldOriginConfidences:  map[string]float64{},
+	}
+	for key, tpl := range spec.InversePatchTemplates {
+		policies.InversePatchTemplates[key] = inversePatchTemplateRecord{
+			EditableBy:     tpl.EditableBy,
+			Confidence:     tpl.Confidence,
+			RequiresReview: tpl.RequiresReview,
+		}
+	}
+	for key, tpl := range spec.InversePointerTemplates {
+		policies.InversePointerTemplates[key] = inversePointerTemplateRecord{
+			Owner:      tpl.Owner,
+			Confidence: tpl.Confidence,
+		}
+	}
+	for key, confidence := range spec.FieldOriginConfidences {
+		policies.FieldOriginConfidences[key] = confidence
+	}
+	if len(policies.InversePatchTemplates) == 0 {
+		policies.InversePatchTemplates = nil
+	}
+	if len(policies.InversePointerTemplates) == 0 {
+		policies.InversePointerTemplates = nil
+	}
+	if len(policies.FieldOriginConfidences) == 0 {
+		policies.FieldOriginConfidences = nil
+	}
+	return policies
 }
 
 func parseFilterSet(raw string) map[string]struct{} {
@@ -181,9 +241,10 @@ func parseFilterSet(raw string) map[string]struct{} {
 
 func printGeneratorsUsage(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
-	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json] [--details] [--pretty]")
 	fmt.Fprintln(out, "  (KIND/PROFILE/CAPABILITY support comma-separated values)")
 	fmt.Fprintln(out, "  use --strict-filters to fail on unknown filter values")
+	fmt.Fprintln(out, "  use --details with --json to include policy/provenance templates")
 	fmt.Fprintln(out)
 	fmt.Fprintf(out, "Supported kinds: %s\n", strings.Join(supportedGeneratorKinds(), ", "))
 	fmt.Fprintf(out, "Supported profiles: %s\n", strings.Join(supportedGeneratorProfiles(), ", "))
@@ -772,7 +833,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen verify [--in FILE|-] [--json] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]")
-	fmt.Fprintln(out, "  cub-gen generators [--json] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json] [--details] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "GitOps parity examples:")
@@ -800,6 +861,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/ops-workflow ./examples/ops-workflow | cub-gen attest --in - --verifier ci-bot")
 	fmt.Fprintln(out, "  cub-gen verify-attestation --in attestation.json --bundle bundle.json")
 	fmt.Fprintln(out, "  cub-gen generators --json")
+	fmt.Fprintln(out, "  cub-gen generators --json --details")
 	fmt.Fprintln(out, "  cub-gen generators --capability render-manifests")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Note: gitops commands are local-only prototypes that mirror cub gitops stages.")

--- a/cmd/cub-gen/testdata/parity/generators-details.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-details.golden.json
@@ -1,0 +1,242 @@
+{
+  "count": 6,
+  "families": [
+    {
+      "capabilities": [
+        "app-config-only",
+        "provider-config",
+        "inverse-provider-config-patch"
+      ],
+      "kind": "ably",
+      "policies": {
+        "field_origin_confidences": {
+          "channels_base": 0.88,
+          "channels_overlay": 0.84,
+          "environment": 0.9
+        },
+        "inverse_patch_templates": {
+          "channels": {
+            "confidence": 0.88,
+            "editable_by": "app-team",
+            "requires_review": false
+          },
+          "environment": {
+            "confidence": 0.9,
+            "editable_by": "app-team",
+            "requires_review": false
+          }
+        },
+        "inverse_pointer_templates": {
+          "channels": {
+            "confidence": 0.88,
+            "owner": "app-team"
+          },
+          "environment": {
+            "confidence": 0.9,
+            "owner": "app-team"
+          }
+        }
+      },
+      "profile": "ably-config",
+      "resource_kind": "ConfigMap",
+      "resource_type": "v1/ConfigMap"
+    },
+    {
+      "capabilities": [
+        "catalog-metadata",
+        "render-manifests",
+        "inverse-catalog-patch"
+      ],
+      "kind": "backstage",
+      "policies": {
+        "field_origin_confidences": {
+          "identity": 0.9,
+          "lifecycle": 0.82
+        },
+        "inverse_patch_templates": {
+          "identity": {
+            "confidence": 0.87,
+            "editable_by": "platform-engineer",
+            "requires_review": false
+          },
+          "lifecycle": {
+            "confidence": 0.82,
+            "editable_by": "platform-engineer",
+            "requires_review": true
+          }
+        },
+        "inverse_pointer_templates": {
+          "lifecycle": {
+            "confidence": 0.82,
+            "owner": "platform-engineer"
+          },
+          "name": {
+            "confidence": 0.9,
+            "owner": "platform-engineer"
+          }
+        }
+      },
+      "profile": "backstage-idp",
+      "resource_kind": "Component",
+      "resource_type": "backstage.io/v1alpha1/Component"
+    },
+    {
+      "capabilities": [
+        "render-manifests",
+        "values-overrides",
+        "inverse-values-patch"
+      ],
+      "kind": "helm",
+      "policies": {
+        "field_origin_confidences": {
+          "image_tag": 0.86
+        },
+        "inverse_patch_templates": {
+          "image_tag": {
+            "confidence": 0.86,
+            "editable_by": "app-team",
+            "requires_review": false
+          }
+        },
+        "inverse_pointer_templates": {
+          "image_tag": {
+            "confidence": 0.86,
+            "owner": "app-team"
+          }
+        }
+      },
+      "profile": "helm-paas",
+      "resource_kind": "HelmRelease",
+      "resource_type": "helm.toolkit.fluxcd.io/v2/HelmRelease"
+    },
+    {
+      "capabilities": [
+        "workflow-plan",
+        "governed-execution-intent",
+        "inverse-workflow-patch"
+      ],
+      "kind": "opsworkflow",
+      "policies": {
+        "field_origin_confidences": {
+          "image_tag": 0.87,
+          "schedule_base": 0.84,
+          "schedule_overlay": 0.8
+        },
+        "inverse_patch_templates": {
+          "image_tag": {
+            "confidence": 0.87,
+            "editable_by": "platform-engineer",
+            "requires_review": true
+          },
+          "schedule": {
+            "confidence": 0.84,
+            "editable_by": "platform-engineer",
+            "requires_review": true
+          }
+        },
+        "inverse_pointer_templates": {
+          "image_tag": {
+            "confidence": 0.87,
+            "owner": "platform-engineer"
+          },
+          "schedule": {
+            "confidence": 0.84,
+            "owner": "platform-engineer"
+          }
+        }
+      },
+      "profile": "ops-workflow",
+      "resource_kind": "Workflow",
+      "resource_type": "argoproj.io/v1alpha1/Workflow"
+    },
+    {
+      "capabilities": [
+        "render-manifests",
+        "workload-spec",
+        "inverse-score-patch"
+      ],
+      "kind": "score",
+      "policies": {
+        "field_origin_confidences": {
+          "env_var": 0.9,
+          "image": 0.94,
+          "port": 0.91
+        },
+        "inverse_patch_templates": {
+          "env_var": {
+            "confidence": 0.9,
+            "editable_by": "app-team",
+            "requires_review": false
+          }
+        },
+        "inverse_pointer_templates": {
+          "env_var": {
+            "confidence": 0.9,
+            "owner": "app-team"
+          },
+          "image": {
+            "confidence": 0.94,
+            "owner": "app-team"
+          },
+          "port": {
+            "confidence": 0.91,
+            "owner": "app-team"
+          }
+        }
+      },
+      "profile": "scoredev-paas",
+      "resource_kind": "Application",
+      "resource_type": "argoproj.io/v1alpha1/Application"
+    },
+    {
+      "capabilities": [
+        "render-app-config",
+        "profile-overrides",
+        "inverse-app-config-patch"
+      ],
+      "kind": "springboot",
+      "policies": {
+        "field_origin_confidences": {
+          "app_name": 0.89,
+          "datasource_url": 0.78,
+          "server_port_base": 0.92,
+          "server_port_overlay": 0.88
+        },
+        "inverse_patch_templates": {
+          "app_name": {
+            "confidence": 0.88,
+            "editable_by": "app-team",
+            "requires_review": false
+          },
+          "datasource_url": {
+            "confidence": 0.78,
+            "editable_by": "platform-engineer",
+            "requires_review": true
+          },
+          "server_port": {
+            "confidence": 0.91,
+            "editable_by": "app-team",
+            "requires_review": false
+          }
+        },
+        "inverse_pointer_templates": {
+          "app_name": {
+            "confidence": 0.89,
+            "owner": "app-team"
+          },
+          "datasource_url": {
+            "confidence": 0.78,
+            "owner": "platform-engineer"
+          },
+          "server_port": {
+            "confidence": 0.91,
+            "owner": "app-team"
+          }
+        }
+      },
+      "profile": "springboot-paas",
+      "resource_kind": "Kustomization",
+      "resource_type": "kustomize.toolkit.fluxcd.io/v1/Kustomization"
+    }
+  ]
+}

--- a/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
@@ -1,7 +1,8 @@
 Usage:
-  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--json] [--pretty]
+  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json] [--details] [--pretty]
   (KIND/PROFILE/CAPABILITY support comma-separated values)
   use --strict-filters to fail on unknown filter values
+  use --details with --json to include policy/provenance templates
 
 Supported kinds: ably, backstage, helm, opsworkflow, score, springboot
 Supported profiles: ably-config, backstage-idp, helm-paas, ops-workflow, scoredev-paas, springboot-paas

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -8,7 +8,7 @@ Usage:
   cub-gen verify [--in FILE|-] [--json] [--pretty]
   cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]
   cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]
-  cub-gen generators [--json] [--pretty]
+  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json] [--details] [--pretty]
   cub-gen gitops <discover|import|cleanup> [flags]
 
 GitOps parity examples:
@@ -36,6 +36,7 @@ GitOps parity examples:
   cub-gen publish --space my-space ./examples/ops-workflow ./examples/ops-workflow | cub-gen attest --in - --verifier ci-bot
   cub-gen verify-attestation --in attestation.json --bundle bundle.json
   cub-gen generators --json
+  cub-gen generators --json --details
   cub-gen generators --capability render-manifests
 
 Note: gitops commands are local-only prototypes that mirror cub gitops stages.

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -54,6 +54,7 @@ Implemented in this preview slice:
 36. Updated `README.md` generator inventory examples to include multi-value and strict-filter command flows for faster adoption.
 37. Refactored provenance `field_origin_map.confidence` values into registry-driven templates (`FieldOriginConfidences`) to remove importer-local confidence literals while preserving output behavior.
 38. Refactored inverse edit pointer ownership/confidence defaults into registry-driven templates (`InversePointerTemplates`) to remove importer-local policy literals while preserving output behavior.
+39. Added `cub-gen generators --json --details` to expose registry-backed policy/provenance templates (`inverse_patch_templates`, `inverse_pointer_templates`, `field_origin_confidences`) for transparent family introspection.
 
 ## v0.2 preview invariants
 


### PR DESCRIPTION
## Summary
- add `cub-gen generators --details` (JSON-only) to expose per-family policy/provenance templates
- include `inverse_patch_templates`, `inverse_pointer_templates`, and `field_origin_confidences` in detailed JSON output
- enforce `--details` usage with `--json` for explicit UX
- add parity tests + golden contract for details output and help text updates
- document details command in README and v0.2 roadmap

## Validation
- go test ./...
- make ci
