### PR TITLE
docs(v0.2): freeze parity baseline and add contract drift checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ go test ./... -v
 |---|---|
 | Detection/import logic | Unit tests in `internal/...` |
 | CLI output/flags | Contract/golden tests in `cmd/cub-gen/*_parity_test.go` |
-| Command contract change | `make test-contracts` + `PARITY.md` update |
+| Command contract change | Follow `docs/testing/contract-drift-checklist.md` + `PARITY.md` update |
 | New user-visible flow | `make test-examples` + docs/example update |
 
 ## Pull request checklist
@@ -35,6 +35,7 @@ go test ./... -v
 2. Include deterministic success criteria.
 3. Include commands run and outcome summary.
 4. Confirm docs/parity updates when relevant.
+5. For contract drift, confirm checklist completion in `docs/testing/contract-drift-checklist.md`.
 
 ## Mandatory commands before PR
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -10,6 +10,21 @@ Status values:
 
 Current lock level: `v0.2-preview-parity-locked` (2026-03-06 expanded contract baseline)
 
+## v0.2 closeout freeze
+
+As part of Sprint 1 closeout, the v0.2 parity baseline is now explicitly frozen.
+
+Freeze scope:
+
+1. `gitops discover|import|cleanup` command names and arity.
+2. `generators` flags and output contracts (table + JSON + `--details` JSON).
+3. Top-level help + subcommand help surfaces captured in parity goldens.
+4. Bridge command contracts (`publish`, `verify`, `attest`, `verify-attestation`) and golden outputs.
+
+When a change needs to modify any frozen contract, it must follow the contract drift checklist:
+
+1. `docs/testing/contract-drift-checklist.md`
+
 Contract lock means:
 - command names/arity for `discover|import|cleanup` are frozen for v0.1
 - JSON and table output contracts are golden-tested
@@ -132,10 +147,11 @@ Contract lock means:
   - `cmd/cub-gen/testdata/parity/generators.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/generators-kind-helm.table.golden.txt`
   - `cmd/cub-gen/testdata/parity/generators-kind-helm-score.table.golden.txt`
-  - `cmd/cub-gen/testdata/parity/generators-capability-helm-score.table.golden.txt`
-  - `cmd/cub-gen/testdata/parity/generators-empty.table.golden.txt`
-  - `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
-  - `cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt`
+- `cmd/cub-gen/testdata/parity/generators-capability-helm-score.table.golden.txt`
+- `cmd/cub-gen/testdata/parity/generators-empty.table.golden.txt`
+- `cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt`
+- `cmd/cub-gen/testdata/parity/generators-details.golden.json`
+- `cmd/cub-gen/testdata/parity/verify-attestation-tampered.stderr.golden.txt`
 - Error-mode tests:
   - `cmd/cub-gen/command_surface_parity_test.go`
   - `cmd/cub-gen/gitops_parity_test.go`

--- a/docs/testing/contract-drift-checklist.md
+++ b/docs/testing/contract-drift-checklist.md
@@ -1,0 +1,38 @@
+# Contract Drift Checklist (v0.2 Freeze)
+
+Use this checklist whenever a PR intentionally changes a frozen CLI/help/JSON/table contract.
+
+## Preconditions
+
+1. Link the change to an issue that explicitly justifies why contract drift is required.
+2. Confirm the drift is intentional (not incidental refactor fallout).
+
+## Required update sequence
+
+1. Update behavior in code/tests.
+2. Regenerate goldens intentionally:
+
+```bash
+UPDATE_GOLDEN=1 go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)' -count=1 -v
+```
+
+3. Verify full proof suite:
+
+```bash
+go test ./...
+make ci
+```
+
+4. Update parity and docs in the same PR:
+   - `PARITY.md` (contract lock references and proof artifacts)
+   - User-facing docs (`README.md` and/or roadmap docs) if command UX changed
+5. Include a concise before/after contract summary in the PR body.
+
+## Merge gate
+
+Do not merge a contract-drift PR unless all are true:
+
+1. Goldens updated intentionally with `UPDATE_GOLDEN=1`.
+2. `go test ./...` passes.
+3. `make ci` passes.
+4. `PARITY.md` and relevant docs are updated.

--- a/docs/workflows/proof-first-delivery.md
+++ b/docs/workflows/proof-first-delivery.md
@@ -15,6 +15,10 @@ This is the inherited delivery model from cub-scout, trimmed for cub-gen scope.
 9. Update docs/parity/examples.
 10. Mark done only after final pass post-doc updates.
 
+If the task changes a frozen contract surface, run the additional checklist:
+
+1. `docs/testing/contract-drift-checklist.md`
+
 ## Proof matrix template
 
 | Proof tier | Required? | Command | Assertion |


### PR DESCRIPTION
## Summary
- add explicit v0.2 closeout parity freeze section to `PARITY.md`
- add a required contract drift checklist at `docs/testing/contract-drift-checklist.md`
- wire checklist references into `CONTRIBUTING.md` and proof-first workflow docs
- include `generators-details` artifact in parity proof references

## Validation
- go test ./...
- make ci

Closes #71
