### PR TITLE
Move rendered lineage templates into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -55,6 +55,7 @@ Implemented in this preview slice:
 37. Refactored provenance `field_origin_map.confidence` values into registry-driven templates (`FieldOriginConfidences`) to remove importer-local confidence literals while preserving output behavior.
 38. Refactored inverse edit pointer ownership/confidence defaults into registry-driven templates (`InversePointerTemplates`) to remove importer-local policy literals while preserving output behavior.
 39. Added `cub-gen generators --json --details` to expose registry-backed policy/provenance templates (`inverse_patch_templates`, `inverse_pointer_templates`, `field_origin_confidences`) for transparent family introspection.
+40. Refactored rendered object lineage definitions into registry-driven templates (`RenderedLineageTemplates`), removing importer-local per-family lineage literals while preserving output behavior.
 
 ## v0.2 preview invariants
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -910,83 +910,134 @@ func valuesPathsForGenerator(g model.GeneratorDetection) []string {
 }
 
 func renderedLineageForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.RenderedObjectLineage {
+	templates := registry.RenderedLineageTemplates(g.Kind)
+	if len(templates) == 0 {
+		return nil
+	}
+	vars, singleHints, multiHints := lineageTemplateContext(detection, g)
+
+	lineage := make([]model.RenderedObjectLineage, 0, len(templates))
+	for i := 0; i < len(templates); i++ {
+		tpl := templates[i]
+		if tpl.SourcePathHintMulti {
+			// Preserve legacy order for repeated-source templates:
+			// emit all contiguous templates per source path before moving on.
+			j := i + 1
+			for j < len(templates) {
+				next := templates[j]
+				if !next.SourcePathHintMulti ||
+					next.SourcePathHint != tpl.SourcePathHint ||
+					next.SourcePathHintFallback != tpl.SourcePathHintFallback {
+					break
+				}
+				j++
+			}
+
+			sourcePaths := lineageSourcePathsForTemplate(tpl, singleHints, multiHints)
+			if len(sourcePaths) > 0 {
+				for _, sourcePath := range sourcePaths {
+					for k := i; k < j; k++ {
+						groupTpl := templates[k]
+						if strings.TrimSpace(sourcePath) == "" && groupTpl.Optional {
+							continue
+						}
+						lineage = append(lineage, model.RenderedObjectLineage{
+							Kind:          groupTpl.Kind,
+							Name:          renderTargetTemplate(groupTpl.NameTemplate, vars),
+							Namespace:     groupTpl.Namespace,
+							SourcePath:    sourcePath,
+							SourceDryPath: renderTargetTemplate(groupTpl.SourceDryPathTemplate, vars),
+						})
+					}
+				}
+			}
+
+			i = j - 1
+			continue
+		}
+
+		sourcePaths := lineageSourcePathsForTemplate(tpl, singleHints, multiHints)
+		if len(sourcePaths) == 0 {
+			continue
+		}
+
+		name := renderTargetTemplate(tpl.NameTemplate, vars)
+		sourceDryPath := renderTargetTemplate(tpl.SourceDryPathTemplate, vars)
+		for _, sourcePath := range sourcePaths {
+			if strings.TrimSpace(sourcePath) == "" && tpl.Optional {
+				continue
+			}
+			lineage = append(lineage, model.RenderedObjectLineage{
+				Kind:          tpl.Kind,
+				Name:          name,
+				Namespace:     tpl.Namespace,
+				SourcePath:    sourcePath,
+				SourceDryPath: sourceDryPath,
+			})
+		}
+	}
+	return lineage
+}
+
+func lineageTemplateContext(detection model.DetectionResult, g model.GeneratorDetection) (map[string]string, map[string]string, map[string][]string) {
+	vars := map[string]string{"name": g.Name}
+	singleHints := map[string]string{}
+	multiHints := map[string][]string{}
+
 	switch g.Kind {
 	case model.GeneratorHelm:
 		chart := chartPathForGenerator(g)
 		values := valuesPathsForGenerator(g)
-		if len(values) == 0 {
-			// Fall back to chart path if no values files were detected.
-			if chart != "" {
-				values = []string{chart}
-			}
+		if len(values) == 0 && chart != "" {
+			values = []string{chart}
 		}
-		lineage := []model.RenderedObjectLineage{
-			{Kind: "HelmRelease", Name: g.Name, Namespace: "apps", SourcePath: chart, SourceDryPath: "Chart.yaml"},
-		}
-		for _, vp := range values {
-			lineage = append(lineage,
-				model.RenderedObjectLineage{Kind: "Deployment", Name: g.Name, Namespace: "apps", SourcePath: vp, SourceDryPath: "values.image.tag"},
-				model.RenderedObjectLineage{Kind: "Service", Name: g.Name, Namespace: "apps", SourcePath: vp, SourceDryPath: "values.service.port"},
-			)
-		}
-		return lineage
+		singleHints["chart_path"] = chart
+		multiHints["values_paths"] = values
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
-		return []model.RenderedObjectLineage{
-			{Kind: "Application", Name: g.Name, Namespace: "apps", SourcePath: hints.SourcePath, SourceDryPath: "metadata.name"},
-			{Kind: "Deployment", Name: g.Name, Namespace: "apps", SourcePath: hints.SourcePath, SourceDryPath: fmt.Sprintf("containers.%s.image", hints.ContainerName)},
-			{Kind: "Service", Name: g.Name, Namespace: "apps", SourcePath: hints.SourcePath, SourceDryPath: fmt.Sprintf("service.ports.%s.port", hints.ServicePortName)},
-		}
+		singleHints["source_path"] = hints.SourcePath
+		vars["container_name"] = hints.ContainerName
+		vars["service_port_name"] = hints.ServicePortName
 	case model.GeneratorSpringBoot:
 		hints := springPathHintsFromInputs(g.Inputs)
-		lineage := []model.RenderedObjectLineage{
-			{Kind: "Kustomization", Name: g.Name, Namespace: "apps", SourcePath: hints.BuildConfigPath, SourceDryPath: "build"},
-			{Kind: "Deployment", Name: g.Name, Namespace: "apps", SourcePath: hints.BaseConfigPath, SourceDryPath: "spring.application.name"},
-			{Kind: "ConfigMap", Name: g.Name + "-config", Namespace: "apps", SourcePath: hints.BaseConfigPath, SourceDryPath: "spring.datasource.url"},
-		}
-		if hints.ProfileConfigPath != "" {
-			lineage = append(lineage, model.RenderedObjectLineage{
-				Kind: "Deployment", Name: g.Name, Namespace: "apps", SourcePath: hints.ProfileConfigPath, SourceDryPath: "server.port",
-			})
-		} else {
-			lineage = append(lineage, model.RenderedObjectLineage{
-				Kind: "Deployment", Name: g.Name, Namespace: "apps", SourcePath: hints.BaseConfigPath, SourceDryPath: "server.port",
-			})
-		}
-		return lineage
+		singleHints["build_config_path"] = hints.BuildConfigPath
+		singleHints["base_config_path"] = hints.BaseConfigPath
+		singleHints["profile_config_path"] = hints.ProfileConfigPath
 	case model.GeneratorBackstage:
 		hints := backstagePathHintsFromInputs(g.Inputs)
-		return []model.RenderedObjectLineage{
-			{Kind: "Application", Name: g.Name, Namespace: "apps", SourcePath: hints.CatalogPath, SourceDryPath: "metadata.name"},
-			{Kind: "ConfigMap", Name: g.Name + "-catalog", Namespace: "apps", SourcePath: hints.CatalogPath, SourceDryPath: "spec.lifecycle"},
-		}
+		singleHints["catalog_path"] = hints.CatalogPath
 	case model.GeneratorAbly:
 		hints := ablyPathHintsFromInputs(g.Inputs)
-		lineage := []model.RenderedObjectLineage{
-			{Kind: "ConfigMap", Name: g.Name + "-ably", Namespace: "apps", SourcePath: hints.BaseConfigPath, SourceDryPath: "app.environment"},
-			{Kind: "Secret", Name: g.Name + "-ably-credentials", Namespace: "apps", SourcePath: hints.BaseConfigPath, SourceDryPath: "credentials.api_key_ref"},
-		}
-		if hints.OverlayConfigPath != "" {
-			lineage = append(lineage, model.RenderedObjectLineage{
-				Kind: "ConfigMap", Name: g.Name + "-ably", Namespace: "apps", SourcePath: hints.OverlayConfigPath, SourceDryPath: "channels.inbound",
-			})
-		}
-		return lineage
+		singleHints["base_config_path"] = hints.BaseConfigPath
+		singleHints["overlay_config_path"] = hints.OverlayConfigPath
 	case model.GeneratorOpsFlow:
 		hints := opsWorkflowPathHintsFromInputs(g.Inputs)
-		lineage := []model.RenderedObjectLineage{
-			{Kind: "Workflow", Name: g.Name + "-workflow", Namespace: "ops", SourcePath: hints.BaseSpecPath, SourceDryPath: "actions.deploy.image_tag"},
-			{Kind: "Job", Name: g.Name + "-dry-run", Namespace: "ops", SourcePath: hints.BaseSpecPath, SourceDryPath: "triggers.schedule"},
+		singleHints["base_spec_path"] = hints.BaseSpecPath
+		singleHints["overlay_spec_path"] = hints.OverlaySpecPath
+	}
+
+	return vars, singleHints, multiHints
+}
+
+func lineageSourcePathsForTemplate(tpl registry.RenderedLineageTemplate, singleHints map[string]string, multiHints map[string][]string) []string {
+	if tpl.SourcePathHintMulti {
+		sourcePaths := append([]string(nil), multiHints[tpl.SourcePathHint]...)
+		if len(sourcePaths) == 0 && tpl.SourcePathHintFallback != "" {
+			if fallback := strings.TrimSpace(singleHints[tpl.SourcePathHintFallback]); fallback != "" {
+				sourcePaths = []string{fallback}
+			}
 		}
-		if hints.OverlaySpecPath != "" {
-			lineage = append(lineage, model.RenderedObjectLineage{
-				Kind: "Workflow", Name: g.Name + "-workflow", Namespace: "ops", SourcePath: hints.OverlaySpecPath, SourceDryPath: "triggers.schedule",
-			})
-		}
-		return lineage
-	default:
+		return sourcePaths
+	}
+
+	sourcePath := strings.TrimSpace(singleHints[tpl.SourcePathHint])
+	if sourcePath == "" && tpl.SourcePathHintFallback != "" {
+		sourcePath = strings.TrimSpace(singleHints[tpl.SourcePathHintFallback])
+	}
+	if sourcePath == "" && tpl.Optional {
 		return nil
 	}
+	return []string{sourcePath}
 }
 
 type springHints struct {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -23,6 +23,17 @@ type WetTargetTemplate struct {
 	SourceDryPathTemplate string
 }
 
+type RenderedLineageTemplate struct {
+	Kind                   string
+	NameTemplate           string
+	Namespace              string
+	SourcePathHint         string
+	SourcePathHintFallback string
+	SourcePathHintMulti    bool
+	SourceDryPathTemplate  string
+	Optional               bool
+}
+
 type InversePatchTemplate struct {
 	EditableBy     string
 	Confidence     float64
@@ -49,6 +60,7 @@ type FamilySpec struct {
 	InversePatchTemplates       map[string]InversePatchTemplate
 	InversePointerTemplates     map[string]InversePointerTemplate
 	FieldOriginConfidences      map[string]float64
+	RenderedLineageTemplates    []RenderedLineageTemplate
 	FieldOriginTransform        string
 	FieldOriginOverlayTransform string
 	InputRoleRules              []InputRoleRule
@@ -85,6 +97,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		},
 		FieldOriginConfidences: map[string]float64{
 			"image_tag": 0.86,
+		},
+		RenderedLineageTemplates: []RenderedLineageTemplate{
+			{Kind: "HelmRelease", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "chart_path", SourceDryPathTemplate: "Chart.yaml"},
+			{Kind: "Deployment", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "values_paths", SourcePathHintFallback: "chart_path", SourcePathHintMulti: true, SourceDryPathTemplate: "values.image.tag"},
+			{Kind: "Service", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "values_paths", SourcePathHintFallback: "chart_path", SourcePathHintMulti: true, SourceDryPathTemplate: "values.service.port"},
 		},
 		FieldOriginTransform: "helm-template",
 		InputRoleRules: []InputRoleRule{
@@ -133,6 +150,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"image":   0.94,
 			"env_var": 0.90,
 			"port":    0.91,
+		},
+		RenderedLineageTemplates: []RenderedLineageTemplate{
+			{Kind: "Application", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "source_path", SourceDryPathTemplate: "metadata.name"},
+			{Kind: "Deployment", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "source_path", SourceDryPathTemplate: "containers.{{container_name}}.image"},
+			{Kind: "Service", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "source_path", SourceDryPathTemplate: "service.ports.{{service_port_name}}.port"},
 		},
 		FieldOriginTransform: "score-to-k8s",
 		InputRoleRules:       []InputRoleRule{{Role: "score-spec", ExactBasenames: []string{"score.yaml", "score.yml"}}},
@@ -184,6 +206,12 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"server_port_base":    0.92,
 			"server_port_overlay": 0.88,
 			"datasource_url":      0.78,
+		},
+		RenderedLineageTemplates: []RenderedLineageTemplate{
+			{Kind: "Kustomization", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "build_config_path", SourceDryPathTemplate: "build"},
+			{Kind: "Deployment", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "base_config_path", SourceDryPathTemplate: "spring.application.name"},
+			{Kind: "ConfigMap", NameTemplate: "{{name}}-config", Namespace: "apps", SourcePathHint: "base_config_path", SourceDryPathTemplate: "spring.datasource.url"},
+			{Kind: "Deployment", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "profile_config_path", SourcePathHintFallback: "base_config_path", SourceDryPathTemplate: "server.port"},
 		},
 		FieldOriginTransform:        "spring-config-to-manifest",
 		FieldOriginOverlayTransform: "spring-profile-overlay",
@@ -237,6 +265,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"identity":  0.90,
 			"lifecycle": 0.82,
 		},
+		RenderedLineageTemplates: []RenderedLineageTemplate{
+			{Kind: "Application", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "catalog_path", SourceDryPathTemplate: "metadata.name"},
+			{Kind: "ConfigMap", NameTemplate: "{{name}}-catalog", Namespace: "apps", SourcePathHint: "catalog_path", SourceDryPathTemplate: "spec.lifecycle"},
+		},
 		FieldOriginTransform: "backstage-component-to-application",
 		InputRoleRules: []InputRoleRule{
 			{Role: "catalog-spec", ExactBasenames: []string{"catalog-info.yaml", "catalog-info.yml"}},
@@ -284,6 +316,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"environment":      0.90,
 			"channels_base":    0.88,
 			"channels_overlay": 0.84,
+		},
+		RenderedLineageTemplates: []RenderedLineageTemplate{
+			{Kind: "ConfigMap", NameTemplate: "{{name}}-ably", Namespace: "apps", SourcePathHint: "base_config_path", SourceDryPathTemplate: "app.environment"},
+			{Kind: "Secret", NameTemplate: "{{name}}-ably-credentials", Namespace: "apps", SourcePathHint: "base_config_path", SourceDryPathTemplate: "credentials.api_key_ref"},
+			{Kind: "ConfigMap", NameTemplate: "{{name}}-ably", Namespace: "apps", SourcePathHint: "overlay_config_path", SourceDryPathTemplate: "channels.inbound", Optional: true},
 		},
 		FieldOriginTransform:        "ably-config-to-runtime",
 		FieldOriginOverlayTransform: "ably-overlay-merge",
@@ -333,6 +370,11 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"schedule_base":    0.84,
 			"schedule_overlay": 0.80,
 		},
+		RenderedLineageTemplates: []RenderedLineageTemplate{
+			{Kind: "Workflow", NameTemplate: "{{name}}-workflow", Namespace: "ops", SourcePathHint: "base_spec_path", SourceDryPathTemplate: "actions.deploy.image_tag"},
+			{Kind: "Job", NameTemplate: "{{name}}-dry-run", Namespace: "ops", SourcePathHint: "base_spec_path", SourceDryPathTemplate: "triggers.schedule"},
+			{Kind: "Workflow", NameTemplate: "{{name}}-workflow", Namespace: "ops", SourcePathHint: "overlay_spec_path", SourceDryPathTemplate: "triggers.schedule", Optional: true},
+		},
 		FieldOriginTransform:        "ops-workflow-to-argo-workflow",
 		FieldOriginOverlayTransform: "ops-workflow-overlay-merge",
 		InputRoleRules: []InputRoleRule{
@@ -366,6 +408,7 @@ func Spec(kind model.GeneratorKind) (FamilySpec, bool) {
 		InversePatchTemplates:       copyInversePatchTemplates(spec.InversePatchTemplates),
 		InversePointerTemplates:     copyInversePointerTemplates(spec.InversePointerTemplates),
 		FieldOriginConfidences:      copyFieldOriginConfidences(spec.FieldOriginConfidences),
+		RenderedLineageTemplates:    copyRenderedLineageTemplates(spec.RenderedLineageTemplates),
 		FieldOriginTransform:        spec.FieldOriginTransform,
 		FieldOriginOverlayTransform: spec.FieldOriginOverlayTransform,
 		InputRoleRules:              copyInputRoleRules(spec.InputRoleRules),
@@ -582,6 +625,14 @@ func WetTargetTemplates(kind model.GeneratorKind) []WetTargetTemplate {
 	return copyWetTargets(spec.WetTargets)
 }
 
+func RenderedLineageTemplates(kind model.GeneratorKind) []RenderedLineageTemplate {
+	spec, ok := Spec(kind)
+	if !ok {
+		return nil
+	}
+	return copyRenderedLineageTemplates(spec.RenderedLineageTemplates)
+}
+
 func matchesInputRule(rule InputRoleRule, base, ext string) bool {
 	for _, exact := range rule.ExactBasenames {
 		if base == strings.ToLower(exact) {
@@ -702,6 +753,23 @@ func copyFieldOriginConfidences(in map[string]float64) map[string]float64 {
 	out := make(map[string]float64, len(in))
 	for k, v := range in {
 		out[k] = v
+	}
+	return out
+}
+
+func copyRenderedLineageTemplates(in []RenderedLineageTemplate) []RenderedLineageTemplate {
+	out := make([]RenderedLineageTemplate, 0, len(in))
+	for _, tpl := range in {
+		out = append(out, RenderedLineageTemplate{
+			Kind:                   tpl.Kind,
+			NameTemplate:           tpl.NameTemplate,
+			Namespace:              tpl.Namespace,
+			SourcePathHint:         tpl.SourcePathHint,
+			SourcePathHintFallback: tpl.SourcePathHintFallback,
+			SourcePathHintMulti:    tpl.SourcePathHintMulti,
+			SourceDryPathTemplate:  tpl.SourceDryPathTemplate,
+			Optional:               tpl.Optional,
+		})
 	}
 	return out
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -93,6 +93,9 @@ func TestRegistryFallbacks(t *testing.T) {
 	if got := InverseEditHint(unknown, "image_tag", "fallback-hint"); got != "fallback-hint" {
 		t.Fatalf("expected inverse edit hint fallback fallback-hint, got %q", got)
 	}
+	if got := RenderedLineageTemplates(unknown); got != nil {
+		t.Fatalf("expected rendered lineage templates fallback nil, got %+v", got)
+	}
 	if got := InputRole(unknown, "any.yaml"); got != "input" {
 		t.Fatalf("expected input role fallback input, got %q", got)
 	}
@@ -184,6 +187,19 @@ func TestRegistryWetTargetTemplates(t *testing.T) {
 	again := WetTargetTemplates(model.GeneratorScore)
 	if again[0].Kind != "Application" {
 		t.Fatalf("expected immutable template copy, got %+v", again[0])
+	}
+
+	springLineage := RenderedLineageTemplates(model.GeneratorSpringBoot)
+	if len(springLineage) != 4 {
+		t.Fatalf("expected 4 spring rendered lineage templates, got %d", len(springLineage))
+	}
+	if springLineage[3].SourcePathHint != "profile_config_path" || springLineage[3].SourcePathHintFallback != "base_config_path" {
+		t.Fatalf("unexpected spring profile lineage template: %+v", springLineage[3])
+	}
+	springLineage[0].Kind = "Mutated"
+	againLineage := RenderedLineageTemplates(model.GeneratorSpringBoot)
+	if againLineage[0].Kind != "Kustomization" {
+		t.Fatalf("expected immutable rendered lineage template copy, got %+v", againLineage[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `RenderedLineageTemplate` metadata to the registry family spec and populate all generator families
- refactor importer lineage generation to render from registry templates instead of hard-coded kind switches
- preserve legacy Helm lineage ordering by interleaving contiguous repeated-source templates per values path
- extend registry tests and roadmap notes for the new template-driven lineage path

## Validation
- go test ./...
- make ci

Closes #72
