### PR TITLE
Move Helm provenance source-path semantics into registry

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -56,6 +56,7 @@ Implemented in this preview slice:
 38. Refactored inverse edit pointer ownership/confidence defaults into registry-driven templates (`InversePointerTemplates`) to remove importer-local policy literals while preserving output behavior.
 39. Added `cub-gen generators --json --details` to expose registry-backed policy/provenance templates (`inverse_patch_templates`, `inverse_pointer_templates`, `field_origin_confidences`) for transparent family introspection.
 40. Refactored rendered object lineage definitions into registry-driven templates (`RenderedLineageTemplates`), removing importer-local per-family lineage literals while preserving output behavior.
+41. Refactored Helm provenance source-path semantics to use registry-driven role/hint metadata (`chart_role`, `values_role`, `primary_values_path`) with deterministic values ordering and preserved parity outputs.
 
 ## v0.2 preview invariants
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -136,6 +136,7 @@ func buildProvenance(changeID, space string, detection model.DetectionResult, g 
 	outputURI := fmt.Sprintf("oci://example.local/%s/%s:latest", space, sanitizeName(g.Name))
 	outputDigest := digestFor(strings.Join([]string{changeID, g.ID, outputURI}, "|"))
 	inputDigest := digestFor(strings.Join(g.Inputs, "|"))
+	helmPaths := helmProvenancePathsForGenerator(g)
 
 	return model.ProvenanceRecord{
 		SchemaVersion:    provenanceSchema,
@@ -152,8 +153,8 @@ func buildProvenance(changeID, space string, detection model.DetectionResult, g 
 			URI:    outputURI,
 			Digest: outputDigest,
 		}},
-		ChartPath:           chartPathForGenerator(g),
-		ValuesPaths:         valuesPathsForGenerator(g),
+		ChartPath:           helmPaths.ChartPath,
+		ValuesPaths:         helmPaths.ValuesPaths,
 		RenderedLineage:     renderedLineageForGenerator(detection, g),
 		FieldOriginMap:      fieldOriginsForGenerator(detection, g),
 		InverseEditPointers: inversePointersForGenerator(detection, g),
@@ -370,11 +371,12 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 func fieldOriginsForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.FieldOrigin {
 	switch g.Kind {
 	case model.GeneratorHelm:
+		hints := helmProvenancePathsForGenerator(g)
 		return []model.FieldOrigin{
 			{
 				DryPath:    "values.image.tag",
 				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
-				SourcePath: "values.yaml",
+				SourcePath: hints.PrimaryValuesPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "image_tag", 0.86),
 			},
@@ -882,31 +884,75 @@ func renderTargetTemplate(template string, vars map[string]string) string {
 	return out
 }
 
-func chartPathForGenerator(g model.GeneratorDetection) string {
+type helmProvenancePaths struct {
+	ChartPath         string
+	ValuesPaths       []string
+	PrimaryValuesPath string
+}
+
+func helmProvenancePathsForGenerator(g model.GeneratorDetection) helmProvenancePaths {
 	if g.Kind != model.GeneratorHelm {
-		return ""
+		return helmProvenancePaths{}
 	}
-	for _, in := range g.Inputs {
-		if strings.EqualFold(filepath.Base(in), "chart.yaml") {
+
+	chartRole := strings.TrimSpace(registry.HintDefault(g.Kind, "chart_role", "chart"))
+	if chartRole == "" {
+		chartRole = "chart"
+	}
+	valuesRole := strings.TrimSpace(registry.HintDefault(g.Kind, "values_role", "values"))
+	if valuesRole == "" {
+		valuesRole = "values"
+	}
+	primaryValuesBase := strings.TrimSpace(registry.HintDefault(g.Kind, "primary_values_path", "values.yaml"))
+	if primaryValuesBase == "" {
+		primaryValuesBase = "values.yaml"
+	}
+
+	chartPath := firstInputPathForRole(g.Kind, g.Inputs, chartRole)
+	valuesPaths := inputPathsForRole(g.Kind, g.Inputs, valuesRole)
+	if len(valuesPaths) == 0 && chartPath != "" {
+		valuesPaths = []string{chartPath}
+	}
+
+	primaryValuesPath := primaryValuesBase
+	if selected := selectPreferredPathByBase(valuesPaths, primaryValuesBase); selected != "" {
+		primaryValuesPath = selected
+	}
+
+	return helmProvenancePaths{
+		ChartPath:         chartPath,
+		ValuesPaths:       valuesPaths,
+		PrimaryValuesPath: primaryValuesPath,
+	}
+}
+
+func firstInputPathForRole(kind model.GeneratorKind, inputs []string, role string) string {
+	for _, in := range inputs {
+		if registry.InputRole(kind, in) == role {
 			return in
 		}
 	}
 	return ""
 }
 
-func valuesPathsForGenerator(g model.GeneratorDetection) []string {
-	if g.Kind != model.GeneratorHelm {
-		return nil
-	}
-	out := make([]string, 0, len(g.Inputs))
-	for _, in := range g.Inputs {
-		base := strings.ToLower(filepath.Base(in))
-		if strings.HasPrefix(base, "values") && (strings.HasSuffix(base, ".yaml") || strings.HasSuffix(base, ".yml")) {
+func inputPathsForRole(kind model.GeneratorKind, inputs []string, role string) []string {
+	out := make([]string, 0, len(inputs))
+	for _, in := range inputs {
+		if registry.InputRole(kind, in) == role {
 			out = append(out, in)
 		}
 	}
 	sort.Strings(out)
 	return out
+}
+
+func selectPreferredPathByBase(paths []string, preferredBase string) string {
+	for _, p := range paths {
+		if strings.EqualFold(filepath.Base(p), preferredBase) {
+			return p
+		}
+	}
+	return ""
 }
 
 func renderedLineageForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.RenderedObjectLineage {
@@ -986,13 +1032,10 @@ func lineageTemplateContext(detection model.DetectionResult, g model.GeneratorDe
 
 	switch g.Kind {
 	case model.GeneratorHelm:
-		chart := chartPathForGenerator(g)
-		values := valuesPathsForGenerator(g)
-		if len(values) == 0 && chart != "" {
-			values = []string{chart}
-		}
-		singleHints["chart_path"] = chart
-		multiHints["values_paths"] = values
+		helmPaths := helmProvenancePathsForGenerator(g)
+		singleHints["chart_path"] = helmPaths.ChartPath
+		singleHints["primary_values_path"] = helmPaths.PrimaryValuesPath
+		multiHints["values_paths"] = helmPaths.ValuesPaths
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
 		singleHints["source_path"] = hints.SourcePath

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -195,11 +195,18 @@ func TestImportRepoHelmDryWetContract(t *testing.T) {
 	if !containsString(prov.ValuesPaths, "values.yaml") || !containsString(prov.ValuesPaths, "values-prod.yaml") {
 		t.Fatalf("expected values paths to include values.yaml and values-prod.yaml, got %+v", prov.ValuesPaths)
 	}
+	expectedValuesOrder := []string{"values-prod.yaml", "values.yaml"}
+	if !reflect.DeepEqual(prov.ValuesPaths, expectedValuesOrder) {
+		t.Fatalf("expected deterministic values path order %+v, got %+v", expectedValuesOrder, prov.ValuesPaths)
+	}
 	if !renderedLineageHasKind(prov.RenderedLineage, "Deployment") || !renderedLineageHasKind(prov.RenderedLineage, "Service") {
 		t.Fatalf("expected rendered lineage to include Deployment and Service, got %+v", prov.RenderedLineage)
 	}
 	if !renderedLineageHasSourcePath(prov.RenderedLineage, "values.yaml") || !renderedLineageHasSourcePath(prov.RenderedLineage, "values-prod.yaml") {
 		t.Fatalf("expected rendered lineage to include both Helm values source paths, got %+v", prov.RenderedLineage)
+	}
+	if !fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "values.yaml") {
+		t.Fatalf("expected Helm field origin values.image.tag to resolve source_path values.yaml, got %+v", prov.FieldOriginMap)
 	}
 
 	if !dryInputHasRolePath(result.DryInputs, "chart", "Chart.yaml") {
@@ -512,6 +519,15 @@ service:
 func fieldOriginHasDryPath(v []model.FieldOrigin, dryPath string) bool {
 	for _, item := range v {
 		if item.DryPath == dryPath {
+			return true
+		}
+	}
+	return false
+}
+
+func fieldOriginHasDryPathSourcePath(v []model.FieldOrigin, dryPath, sourcePath string) bool {
+	for _, item := range v {
+		if item.DryPath == dryPath && item.SourcePath == sourcePath {
 			return true
 		}
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -81,7 +81,10 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"chart": "https://json.schemastore.org/chart",
 		},
 		HintDefaults: map[string]string{
-			"chart_path": "Chart.yaml",
+			"chart_path":          "Chart.yaml",
+			"chart_role":          "chart",
+			"values_role":         "values",
+			"primary_values_path": "values.yaml",
 		},
 		InversePatchReasons: map[string]string{
 			"image_tag": "Container image tag maps cleanly to helm values.",

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -204,6 +204,15 @@ func TestRegistryWetTargetTemplates(t *testing.T) {
 }
 
 func TestRegistryHintDefaults(t *testing.T) {
+	if got := HintDefault(model.GeneratorHelm, "chart_role", "fallback-role"); got != "chart" {
+		t.Fatalf("expected helm chart_role hint default chart, got %q", got)
+	}
+	if got := HintDefault(model.GeneratorHelm, "values_role", "fallback-role"); got != "values" {
+		t.Fatalf("expected helm values_role hint default values, got %q", got)
+	}
+	if got := HintDefault(model.GeneratorHelm, "primary_values_path", "fallback.yaml"); got != "values.yaml" {
+		t.Fatalf("expected helm primary_values_path hint default values.yaml, got %q", got)
+	}
 	if got := HintDefault(model.GeneratorScore, "source_path", "fallback.yaml"); got != "score.yaml" {
 		t.Fatalf("expected score source_path hint default score.yaml, got %q", got)
 	}


### PR DESCRIPTION
## Summary
- move Helm chart/values source-path role semantics behind registry hint metadata (`chart_role`, `values_role`, `primary_values_path`)
- replace importer-local Helm file matching with role-driven path helpers that use registry input-role classification
- preserve deterministic `values_paths` ordering and existing provenance/lineage parity outputs
- extend importer + registry tests and update v0.2 roadmap progress

## Validation
- go test ./...
- make ci

Closes #73
