### PR TITLE
Add generator metadata conformance suite

### DIFF
--- a/cmd/cub-gen/generators_conformance_test.go
+++ b/cmd/cub-gen/generators_conformance_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-gen/internal/registry"
+)
+
+type generatorsJSONEnvelope struct {
+	Count    int                     `json:"count"`
+	Families []generatorFamilyRecord `json:"families"`
+}
+
+func TestGeneratorMetadataConformanceRegistryAndList(t *testing.T) {
+	kinds := registry.Kinds()
+	base := listGeneratorFamilies("", "", "", false)
+	details := listGeneratorFamilies("", "", "", true)
+
+	if len(base) != len(kinds) {
+		t.Fatalf("expected %d generator families, got %d", len(kinds), len(base))
+	}
+	if len(details) != len(kinds) {
+		t.Fatalf("expected %d detailed generator families, got %d", len(kinds), len(details))
+	}
+
+	for i, kind := range kinds {
+		spec, ok := registry.Spec(kind)
+		if !ok {
+			t.Fatalf("expected registry spec for kind %q", kind)
+		}
+		if strings.TrimSpace(spec.Profile) == "" {
+			t.Fatalf("kind %q has empty profile", kind)
+		}
+		if strings.TrimSpace(spec.ResourceKind) == "" || strings.TrimSpace(spec.ResourceType) == "" {
+			t.Fatalf("kind %q has incomplete resource mapping: kind=%q type=%q", kind, spec.ResourceKind, spec.ResourceType)
+		}
+		if len(spec.Capabilities) == 0 {
+			t.Fatalf("kind %q has empty capability set", kind)
+		}
+		if len(spec.InversePatchTemplates) == 0 || len(spec.InversePointerTemplates) == 0 || len(spec.FieldOriginConfidences) == 0 {
+			t.Fatalf("kind %q has incomplete policy/provenance metadata templates", kind)
+		}
+
+		baseRecord := base[i]
+		if baseRecord.Kind != string(spec.Kind) {
+			t.Fatalf("base record[%d] kind mismatch: expected %q, got %q", i, spec.Kind, baseRecord.Kind)
+		}
+		if baseRecord.Profile != spec.Profile || baseRecord.ResourceKind != spec.ResourceKind || baseRecord.ResourceType != spec.ResourceType {
+			t.Fatalf("base record[%d] metadata mismatch: %+v vs spec %+v", i, baseRecord, spec)
+		}
+		if !reflect.DeepEqual(baseRecord.Capabilities, spec.Capabilities) {
+			t.Fatalf("base record[%d] capabilities mismatch: expected %+v, got %+v", i, spec.Capabilities, baseRecord.Capabilities)
+		}
+		if baseRecord.Policies != nil {
+			t.Fatalf("base record[%d] unexpectedly includes policies", i)
+		}
+
+		detailRecord := details[i]
+		if detailRecord.Kind != string(spec.Kind) {
+			t.Fatalf("detail record[%d] kind mismatch: expected %q, got %q", i, spec.Kind, detailRecord.Kind)
+		}
+		if detailRecord.Policies == nil {
+			t.Fatalf("detail record[%d] missing policies", i)
+		}
+		expectedPolicies := generatorPolicyRecord(spec)
+		if !reflect.DeepEqual(detailRecord.Policies, expectedPolicies) {
+			t.Fatalf("detail record[%d] policies mismatch: expected %+v, got %+v", i, expectedPolicies, detailRecord.Policies)
+		}
+	}
+}
+
+func TestGeneratorMetadataConformanceCLIJSONSurfaces(t *testing.T) {
+	expectedBase := listGeneratorFamilies("", "", "", false)
+	baseEnvelope := runGeneratorsJSON(t, []string{"generators", "--json"})
+	if baseEnvelope.Count != len(expectedBase) {
+		t.Fatalf("base json count mismatch: expected %d, got %d", len(expectedBase), baseEnvelope.Count)
+	}
+	if !reflect.DeepEqual(baseEnvelope.Families, expectedBase) {
+		t.Fatalf("base json families mismatch\nexpected=%+v\ngot=%+v", expectedBase, baseEnvelope.Families)
+	}
+
+	expectedDetails := listGeneratorFamilies("", "", "", true)
+	detailsEnvelope := runGeneratorsJSON(t, []string{"generators", "--json", "--details"})
+	if detailsEnvelope.Count != len(expectedDetails) {
+		t.Fatalf("details json count mismatch: expected %d, got %d", len(expectedDetails), detailsEnvelope.Count)
+	}
+	if !reflect.DeepEqual(detailsEnvelope.Families, expectedDetails) {
+		t.Fatalf("details json families mismatch\nexpected=%+v\ngot=%+v", expectedDetails, detailsEnvelope.Families)
+	}
+}
+
+func runGeneratorsJSON(t *testing.T, args []string) generatorsJSONEnvelope {
+	t.Helper()
+
+	stdout, stderr, err := runWithCapturedIO(args)
+	if err != nil {
+		t.Fatalf("run %v returned error: %v\nstderr=%s", args, err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("run %v expected empty stderr, got %q", args, stderr)
+	}
+
+	var envelope generatorsJSONEnvelope
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatalf("unmarshal output for %v: %v\noutput=%s", args, err, stdout)
+	}
+	return envelope
+}

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -57,6 +57,7 @@ Implemented in this preview slice:
 39. Added `cub-gen generators --json --details` to expose registry-backed policy/provenance templates (`inverse_patch_templates`, `inverse_pointer_templates`, `field_origin_confidences`) for transparent family introspection.
 40. Refactored rendered object lineage definitions into registry-driven templates (`RenderedLineageTemplates`), removing importer-local per-family lineage literals while preserving output behavior.
 41. Refactored Helm provenance source-path semantics to use registry-driven role/hint metadata (`chart_role`, `values_role`, `primary_values_path`) with deterministic values ordering and preserved parity outputs.
+42. Added generator metadata conformance tests to enforce cross-surface consistency between registry specs, `generators --json`, and `generators --json --details` outputs.
 
 ## v0.2 preview invariants
 


### PR DESCRIPTION
## Summary
- add `cmd/cub-gen/generators_conformance_test.go` with strict conformance checks for generator metadata surfaces
- enforce consistency between registry specs, in-process `listGeneratorFamilies(...)`, and CLI JSON output for both `--json` and `--json --details`
- add hard checks for required per-family metadata (profile, capabilities, policy/provenance templates)
- update v0.2 roadmap status

## Validation
- go test ./...
- make ci

Closes #74
