### PR TITLE
Add 10-minute Flux/Argo/Helm adoption docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,37 @@
 
 This means teams can add `cub-gen` to existing Flux/Argo repos today without changing runtime controllers.
 
+## 10-minute adoption path (Flux/Argo/Helm)
+
+Start with a Helm-based repo and keep your existing runtime model intact.
+
+What stays unchanged:
+
+- Flux/Argo remains the reconciler for WET -> LIVE.
+- Git/OCI remains the transport path.
+- Existing cluster/controller permissions and PR workflow stay in place.
+
+What you add:
+
+- `cub-gen gitops discover` to classify generator roots.
+- `cub-gen gitops import` to emit DRY/WET contracts + provenance/inverse pointers.
+- `cub-gen gitops cleanup` to clear local discover state.
+
+Copy/paste this path:
+
+```bash
+go build -o cub-gen ./cmd/cub-gen
+./cub-gen gitops discover --space platform ./examples/helm-paas
+./cub-gen gitops import --space platform --json ./examples/helm-paas ./examples/helm-paas | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets, provenance: .provenance[0] | {chart_path, values_paths, rendered_object_lineage}}'
+./cub-gen gitops cleanup --space platform ./examples/helm-paas
+```
+
+Boundary language (aligned with `PARITY.md`):
+
+- `matched`: `gitops discover|import|cleanup` command shape and output contracts.
+- `partial`: local state/artifacts stand in for server-side units during this phase.
+- `deferred`: ConfigHub API bridge coupling and runtime reconcile execution.
+
 ## Terminology (locked for v0.1)
 
 | Term | Meaning in cub-gen |
@@ -34,7 +65,7 @@ This means teams can add `cub-gen` to existing Flux/Argo repos today without cha
 | Inverse map | Guidance from changed WET field -> where to edit DRY safely |
 | Pre-sync | `cub-gen` stops before WET->LIVE; Flux/Argo own reconciliation |
 
-## Quickstart (copy/paste)
+## Full quickstart examples (copy/paste)
 
 ```bash
 go build ./cmd/cub-gen

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -58,6 +58,7 @@ Implemented in this preview slice:
 40. Refactored rendered object lineage definitions into registry-driven templates (`RenderedLineageTemplates`), removing importer-local per-family lineage literals while preserving output behavior.
 41. Refactored Helm provenance source-path semantics to use registry-driven role/hint metadata (`chart_role`, `values_role`, `primary_values_path`) with deterministic values ordering and preserved parity outputs.
 42. Added generator metadata conformance tests to enforce cross-surface consistency between registry specs, `generators --json`, and `generators --json --details` outputs.
+43. Added a single 10-minute Flux/Argo/Helm adoption path in `README.md`, with copy/paste commands and explicit parity boundary (`matched|partial|deferred`) language.
 
 ## v0.2 preview invariants
 


### PR DESCRIPTION
## Summary
- add a single `README.md` section for a 10-minute Flux/Argo/Helm operator adoption path
- keep messaging explicit: local-first, no reconciler replacement, zero migration entry
- align boundary wording with `PARITY.md` status language (`matched`, `partial`, `deferred`)
- include copy/paste command block and verify it against the existing Helm example flow
- update v0.2 roadmap status

## Validation
- go test ./...
- make ci
- go build -o cub-gen ./cmd/cub-gen
- ./cub-gen gitops discover --space platform ./examples/helm-paas
- ./cub-gen gitops import --space platform --json ./examples/helm-paas ./examples/helm-paas | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets, provenance: .provenance[0] | {chart_path, values_paths, rendered_object_lineage}}'
- ./cub-gen gitops cleanup --space platform ./examples/helm-paas

Closes #75
