### PR TITLE
Add v0.2-preview.1 release notes

### DIFF
--- a/docs/releases/v0.2-preview.1.md
+++ b/docs/releases/v0.2-preview.1.md
@@ -1,0 +1,61 @@
+# cub-gen v0.2-preview.1
+
+Release date: 2026-03-06
+Tag: `v0.2-preview.1`
+
+## Summary
+
+`v0.2-preview.1` closes Sprint 1 and freezes the parity baseline for local-first `cub-gen gitops` flows while expanding generator-family coverage and conformance gates.
+
+## Highlights
+
+1. Parity lock baseline frozen at `v0.2-preview-parity-locked`.
+2. Supported generator families in parity-tested flow:
+   - `helm`
+   - `score`
+   - `springboot`
+   - `backstage`
+   - `ably-config`
+   - `ops-workflow`
+3. Registry-driven metadata surface now includes:
+   - DRY input roles and ownership
+   - Input schema mapping
+   - Wet target templates
+   - Rendered lineage templates
+   - Helm provenance source-path semantics
+   - Policy/provenance templates surfaced via `cub-gen generators --json --details`
+4. Generator metadata conformance suite added to enforce consistency across:
+   - registry specs
+   - `generators --json`
+   - `generators --json --details`
+5. Operator adoption docs now include a single 10-minute Flux/Argo/Helm entry path.
+
+## Boundary (unchanged)
+
+1. `cub-gen` does not replace Flux/Argo reconciliation.
+2. `cub-gen` does not deploy to clusters.
+3. `cub-gen` remains local-first and can run without a ConfigHub backend.
+4. Bridge-coupled API/runtime execution remains deferred to post-Go/No-Go gate work.
+
+## Known limits
+
+1. Discover/import state is local file-backed (parity `partial`), not ConfigHub server state.
+2. `--wait` is accepted for CLI compatibility but is currently a no-op in local mode.
+3. ConfigHub target lookup and live bridge-worker execution are deferred.
+
+## Proof / validation
+
+1. `go test ./...`
+2. `make ci`
+3. Helm adoption path commands verified from `README.md`:
+   - `go build -o cub-gen ./cmd/cub-gen`
+   - `./cub-gen gitops discover --space platform ./examples/helm-paas`
+   - `./cub-gen gitops import --space platform --json ./examples/helm-paas ./examples/helm-paas`
+   - `./cub-gen gitops cleanup --space platform ./examples/helm-paas`
+
+## References
+
+1. Roadmap: `docs/roadmap-v0.2-preview.md`
+2. Parity lock and deferred boundaries: `PARITY.md`
+3. Contract drift checklist: `docs/testing/contract-drift-checklist.md`
+4. Adoption quickstart: `README.md#10-minute-adoption-path-fluxargohelm`

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -59,6 +59,7 @@ Implemented in this preview slice:
 41. Refactored Helm provenance source-path semantics to use registry-driven role/hint metadata (`chart_role`, `values_role`, `primary_values_path`) with deterministic values ordering and preserved parity outputs.
 42. Added generator metadata conformance tests to enforce cross-surface consistency between registry specs, `generators --json`, and `generators --json --details` outputs.
 43. Added a single 10-minute Flux/Argo/Helm adoption path in `README.md`, with copy/paste commands and explicit parity boundary (`matched|partial|deferred`) language.
+44. Cut release `v0.2-preview.1` from green `main` with release notes covering parity lock, supported families, boundaries, known limits, and adoption references.
 
 ## v0.2 preview invariants
 


### PR DESCRIPTION
## Summary
- add `docs/releases/v0.2-preview.1.md` with Sprint 1 closeout release notes
- include required release content: parity lock, supported families, boundary/non-goals, known limits, proof commands, and roadmap/quickstart references
- update v0.2 roadmap status for release cut

## Validation
- go test ./...
- make ci

Part of #76
