### PR TITLE
Add schema validation gate for contract triple

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -60,6 +60,7 @@ Implemented in this preview slice:
 42. Added generator metadata conformance tests to enforce cross-surface consistency between registry specs, `generators --json`, and `generators --json --details` outputs.
 43. Added a single 10-minute Flux/Argo/Helm adoption path in `README.md`, with copy/paste commands and explicit parity boundary (`matched|partial|deferred`) language.
 44. Cut release `v0.2-preview.1` from green `main` with release notes covering parity lock, supported families, boundaries, known limits, and adoption references.
+45. Added strict schema validation gates for `GeneratorContract`, `ProvenanceRecord`, and `InverseTransformPlan` with embedded JSON schemas and importer runtime enforcement.
 
 ## v0.2 preview invariants
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/confighub/cub-gen
 
 go 1.22
+
+require github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=

--- a/internal/contracts/schemas/generator-contract.v1.schema.json
+++ b/internal/contracts/schemas/generator-contract.v1.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "cub.confighub.io/schemas/generator-contract.v1",
+  "title": "Generator Contract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generator_id",
+    "name",
+    "kind",
+    "profile",
+    "version",
+    "source_repo",
+    "source_ref",
+    "source_path",
+    "inputs",
+    "output_format",
+    "transport",
+    "capabilities",
+    "deterministic"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "cub.confighub.io/generator-contract/v1"
+    },
+    "generator_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "kind": {
+      "type": "string",
+      "minLength": 1
+    },
+    "profile": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_repo": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_path": {
+      "type": "string"
+    },
+    "inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "schema_ref",
+          "required"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "schema_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "required": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "output_format": {
+      "type": "string",
+      "minLength": 1
+    },
+    "transport": {
+      "type": "string",
+      "minLength": 1
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "deterministic": {
+      "type": "boolean"
+    }
+  }
+}

--- a/internal/contracts/schemas/inverse-transform-plan.v1.schema.json
+++ b/internal/contracts/schemas/inverse-transform-plan.v1.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "cub.confighub.io/schemas/inverse-transform-plan.v1",
+  "title": "Inverse Transform Plan v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "plan_id",
+    "change_id",
+    "source_kind",
+    "source_ref",
+    "target_unit_id",
+    "status",
+    "patches",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "cub.confighub.io/inverse-transform-plan/v1"
+    },
+    "plan_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "change_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_kind": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_ref": {
+      "type": "string"
+    },
+    "target_unit_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "patches": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "op",
+          "dry_path",
+          "wet_path",
+          "editable_by",
+          "confidence",
+          "requires_review",
+          "reason"
+        ],
+        "properties": {
+          "op": {
+            "type": "string",
+            "minLength": 1
+          },
+          "dry_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "wet_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "editable_by": {
+            "type": "string",
+            "minLength": 1
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "requires_review": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/internal/contracts/schemas/provenance.v1.schema.json
+++ b/internal/contracts/schemas/provenance.v1.schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "cub.confighub.io/schemas/provenance.v1",
+  "title": "Provenance Record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "provenance_id",
+    "change_id",
+    "generator_id",
+    "generator_name",
+    "generator_profile",
+    "version",
+    "input_digest",
+    "sources",
+    "outputs",
+    "field_origin_map",
+    "inverse_edit_pointers",
+    "rendered_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "cub.confighub.io/provenance/v1"
+    },
+    "provenance_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "change_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generator_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generator_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generator_profile": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "input_digest": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "role",
+          "uri",
+          "revision",
+          "path"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uri": {
+            "type": "string",
+            "minLength": 1
+          },
+          "revision": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "outputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "role",
+          "uri",
+          "digest"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uri": {
+            "type": "string",
+            "minLength": 1
+          },
+          "digest": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "chart_path": {
+      "type": "string"
+    },
+    "values_paths": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "rendered_object_lineage": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "source_path": {
+            "type": "string"
+          },
+          "source_dry_path": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "field_origin_map": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "dry_path",
+          "wet_path",
+          "source_path",
+          "transform",
+          "confidence"
+        ],
+        "properties": {
+          "dry_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "wet_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "transform": {
+            "type": "string",
+            "minLength": 1
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
+        }
+      }
+    },
+    "inverse_edit_pointers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "wet_path",
+          "dry_path",
+          "owner",
+          "edit_hint",
+          "confidence"
+        ],
+        "properties": {
+          "wet_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "dry_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 1
+          },
+          "edit_hint": {
+            "type": "string",
+            "minLength": 1
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
+        }
+      }
+    },
+    "rendered_at": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/internal/contracts/validator.go
+++ b/internal/contracts/validator.go
@@ -1,0 +1,164 @@
+package contracts
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/confighub/cub-gen/internal/model"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+const (
+	generatorContractSchemaName = "schemas/generator-contract.v1.schema.json"
+	provenanceSchemaName        = "schemas/provenance.v1.schema.json"
+	inversePlanSchemaName       = "schemas/inverse-transform-plan.v1.schema.json"
+)
+
+//go:embed schemas/generator-contract.v1.schema.json
+var generatorContractSchemaJSON string
+
+//go:embed schemas/provenance.v1.schema.json
+var provenanceSchemaJSON string
+
+//go:embed schemas/inverse-transform-plan.v1.schema.json
+var inversePlanSchemaJSON string
+
+type compiledSchemas struct {
+	generatorContract *jsonschema.Schema
+	provenanceRecord  *jsonschema.Schema
+	inversePlan       *jsonschema.Schema
+}
+
+var (
+	schemasOnce sync.Once
+	schemas     compiledSchemas
+	schemasErr  error
+)
+
+// ValidateTriple validates one generator contract triple.
+func ValidateTriple(contract model.GeneratorContract, provenance model.ProvenanceRecord, inversePlan model.InverseTransformPlan) error {
+	if err := ValidateGeneratorContract(contract); err != nil {
+		return err
+	}
+	if err := ValidateProvenanceRecord(provenance); err != nil {
+		return err
+	}
+	if err := ValidateInverseTransformPlan(inversePlan); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateTripleSet validates a full import triple set.
+func ValidateTripleSet(contracts []model.GeneratorContract, provenance []model.ProvenanceRecord, inversePlans []model.InverseTransformPlan) error {
+	if len(contracts) != len(provenance) || len(contracts) != len(inversePlans) {
+		return fmt.Errorf("contract triple cardinality mismatch: contracts=%d provenance=%d inverse_plans=%d", len(contracts), len(provenance), len(inversePlans))
+	}
+	for i := range contracts {
+		if err := ValidateTriple(contracts[i], provenance[i], inversePlans[i]); err != nil {
+			return fmt.Errorf("contract triple index %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// ValidateGeneratorContract validates one generator contract record.
+func ValidateGeneratorContract(contract model.GeneratorContract) error {
+	s, err := loadSchemas()
+	if err != nil {
+		return err
+	}
+	return validateRecord("generator_contract", s.generatorContract, contract)
+}
+
+// ValidateProvenanceRecord validates one provenance record.
+func ValidateProvenanceRecord(provenance model.ProvenanceRecord) error {
+	s, err := loadSchemas()
+	if err != nil {
+		return err
+	}
+	return validateRecord("provenance_record", s.provenanceRecord, provenance)
+}
+
+// ValidateInverseTransformPlan validates one inverse transform plan.
+func ValidateInverseTransformPlan(inversePlan model.InverseTransformPlan) error {
+	s, err := loadSchemas()
+	if err != nil {
+		return err
+	}
+	return validateRecord("inverse_transform_plan", s.inversePlan, inversePlan)
+}
+
+func loadSchemas() (compiledSchemas, error) {
+	schemasOnce.Do(func() {
+		schemas, schemasErr = compileSchemas()
+	})
+	if schemasErr != nil {
+		return compiledSchemas{}, fmt.Errorf("load contract schemas: %w", schemasErr)
+	}
+	return schemas, nil
+}
+
+func compileSchemas() (compiledSchemas, error) {
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(generatorContractSchemaName, strings.NewReader(generatorContractSchemaJSON)); err != nil {
+		return compiledSchemas{}, fmt.Errorf("add %s: %w", generatorContractSchemaName, err)
+	}
+	if err := compiler.AddResource(provenanceSchemaName, strings.NewReader(provenanceSchemaJSON)); err != nil {
+		return compiledSchemas{}, fmt.Errorf("add %s: %w", provenanceSchemaName, err)
+	}
+	if err := compiler.AddResource(inversePlanSchemaName, strings.NewReader(inversePlanSchemaJSON)); err != nil {
+		return compiledSchemas{}, fmt.Errorf("add %s: %w", inversePlanSchemaName, err)
+	}
+
+	generatorContract, err := compiler.Compile(generatorContractSchemaName)
+	if err != nil {
+		return compiledSchemas{}, fmt.Errorf("compile %s: %w", generatorContractSchemaName, err)
+	}
+	provenanceRecord, err := compiler.Compile(provenanceSchemaName)
+	if err != nil {
+		return compiledSchemas{}, fmt.Errorf("compile %s: %w", provenanceSchemaName, err)
+	}
+	inversePlan, err := compiler.Compile(inversePlanSchemaName)
+	if err != nil {
+		return compiledSchemas{}, fmt.Errorf("compile %s: %w", inversePlanSchemaName, err)
+	}
+
+	return compiledSchemas{
+		generatorContract: generatorContract,
+		provenanceRecord:  provenanceRecord,
+		inversePlan:       inversePlan,
+	}, nil
+}
+
+func validateRecord(label string, schema *jsonschema.Schema, record any) error {
+	payload, err := toJSONAny(record)
+	if err != nil {
+		return fmt.Errorf("%s marshal for schema validation: %w", label, err)
+	}
+	if err := schema.Validate(payload); err != nil {
+		return fmt.Errorf("%s schema validation failed: %s", label, normalizeValidationError(err))
+	}
+	return nil
+}
+
+func toJSONAny(v any) (any, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func normalizeValidationError(err error) string {
+	msg := strings.TrimSpace(err.Error())
+	msg = strings.Join(strings.Fields(msg), " ")
+	return msg
+}

--- a/internal/contracts/validator_test.go
+++ b/internal/contracts/validator_test.go
@@ -1,0 +1,158 @@
+package contracts
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-gen/internal/model"
+)
+
+func TestValidateTripleSetValid(t *testing.T) {
+	contract, provenance, inversePlan := validTripleFixture()
+	if err := ValidateTriple(contract, provenance, inversePlan); err != nil {
+		t.Fatalf("expected valid triple, got error: %v", err)
+	}
+
+	if err := ValidateTripleSet(
+		[]model.GeneratorContract{contract},
+		[]model.ProvenanceRecord{provenance},
+		[]model.InverseTransformPlan{inversePlan},
+	); err != nil {
+		t.Fatalf("expected valid triple set, got error: %v", err)
+	}
+}
+
+func TestValidateTripleSetCardinalityMismatch(t *testing.T) {
+	contract, provenance, _ := validTripleFixture()
+	err := ValidateTripleSet(
+		[]model.GeneratorContract{contract},
+		[]model.ProvenanceRecord{provenance},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected cardinality mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "contract triple cardinality mismatch") {
+		t.Fatalf("expected cardinality mismatch message, got: %v", err)
+	}
+}
+
+func TestValidateGeneratorContractInvalid(t *testing.T) {
+	contract, _, _ := validTripleFixture()
+	contract.SchemaVersion = "invalid/schema"
+
+	err := ValidateGeneratorContract(contract)
+	if err == nil {
+		t.Fatal("expected generator contract validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "generator_contract schema validation failed") {
+		t.Fatalf("expected generator contract validation message, got: %v", err)
+	}
+}
+
+func TestValidateProvenanceRecordInvalid(t *testing.T) {
+	_, provenance, _ := validTripleFixture()
+	provenance.FieldOriginMap[0].Confidence = 1.3
+
+	err := ValidateProvenanceRecord(provenance)
+	if err == nil {
+		t.Fatal("expected provenance validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "provenance_record schema validation failed") {
+		t.Fatalf("expected provenance validation message, got: %v", err)
+	}
+}
+
+func TestValidateInverseTransformPlanInvalid(t *testing.T) {
+	_, _, inversePlan := validTripleFixture()
+	inversePlan.Patches[0].Confidence = -0.1
+
+	err := ValidateInverseTransformPlan(inversePlan)
+	if err == nil {
+		t.Fatal("expected inverse plan validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "inverse_transform_plan schema validation failed") {
+		t.Fatalf("expected inverse plan validation message, got: %v", err)
+	}
+}
+
+func validTripleFixture() (model.GeneratorContract, model.ProvenanceRecord, model.InverseTransformPlan) {
+	contract := model.GeneratorContract{
+		SchemaVersion: "cub.confighub.io/generator-contract/v1",
+		GeneratorID:   "gen_123",
+		Name:          "payments-api",
+		Kind:          "helm",
+		Profile:       "helm-paas",
+		Version:       "0.2.0",
+		SourceRepo:    "/tmp/repo",
+		SourceRef:     "HEAD",
+		SourcePath:    "",
+		Inputs: []model.GeneratorInput{
+			{Name: "input_01", SchemaRef: "https://json.schemastore.org/chart", Required: true},
+		},
+		OutputFormat:  "kubernetes/yaml",
+		Transport:     "oci+git",
+		Capabilities:  []string{"render-manifests"},
+		Deterministic: true,
+	}
+
+	provenance := model.ProvenanceRecord{
+		SchemaVersion:    "cub.confighub.io/provenance/v1",
+		ProvenanceID:     "prov_123",
+		ChangeID:         "chg_123",
+		GeneratorID:      "gen_123",
+		GeneratorName:    "payments-api",
+		GeneratorProfile: "helm-paas",
+		Version:          "0.2.0",
+		InputDigest:      "sha256:abc",
+		Sources: []model.SourceRef{
+			{Role: "generator-input", URI: "git+file:///tmp/repo#HEAD:Chart.yaml", Revision: "HEAD", Path: "Chart.yaml"},
+		},
+		Outputs: []model.OutputRef{
+			{Role: "rendered-manifests", URI: "oci://example.local/platform/payments-api:latest", Digest: "sha256:def"},
+		},
+		FieldOriginMap: []model.FieldOrigin{
+			{
+				DryPath:    "values.image.tag",
+				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+				SourcePath: "values.yaml",
+				Transform:  "helm-template",
+				Confidence: 0.86,
+			},
+		},
+		InverseEditPointers: []model.InverseEditPointer{
+			{
+				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+				DryPath:    "values.image.tag",
+				Owner:      "app-team",
+				EditHint:   "Edit chart values file and keep chart template unchanged.",
+				Confidence: 0.86,
+			},
+		},
+		RenderedAt: "2026-03-06T00:00:00Z",
+	}
+
+	inversePlan := model.InverseTransformPlan{
+		SchemaVersion: "cub.confighub.io/inverse-transform-plan/v1",
+		PlanID:        "inv_123",
+		ChangeID:      "chg_123",
+		SourceKind:    "helm",
+		SourceRef:     "",
+		TargetUnitID:  "dry_123",
+		Status:        "draft",
+		Patches: []model.InversePatch{
+			{
+				Operation:      "replace",
+				DryPath:        "values.image.tag",
+				WetPath:        "Deployment/spec/template/spec/containers[0]/image",
+				EditableBy:     "app-team",
+				Confidence:     0.86,
+				RequiresReview: false,
+				Reason:         "Container image tag maps cleanly to helm values.",
+			},
+		},
+		CreatedAt: "2026-03-06T00:00:00Z",
+	}
+
+	return contract, provenance, inversePlan
+}

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/confighub/cub-gen/internal/contracts"
 	"github.com/confighub/cub-gen/internal/detect"
 	"github.com/confighub/cub-gen/internal/model"
 	"github.com/confighub/cub-gen/internal/registry"
@@ -47,7 +48,7 @@ func ImportDetection(detection model.DetectionResult, space string) (model.Impor
 
 	units := make([]model.UnitRef, 0, len(detection.Generators)*3)
 	links := make([]model.UnitLink, 0, len(detection.Generators))
-	contracts := make([]model.GeneratorContract, 0, len(detection.Generators))
+	generatorContracts := make([]model.GeneratorContract, 0, len(detection.Generators))
 	provenance := make([]model.ProvenanceRecord, 0, len(detection.Generators))
 	inversePlans := make([]model.InverseTransformPlan, 0, len(detection.Generators))
 	dryInputs := make([]model.DryInputRef, 0, len(detection.Generators)*3)
@@ -70,11 +71,21 @@ func ImportDetection(detection model.DetectionResult, space string) (model.Impor
 		})
 
 		contract := buildContract(detection, g)
-		contracts = append(contracts, contract)
-		provenance = append(provenance, buildProvenance(changeID, space, detection, g, importedAt))
-		inversePlans = append(inversePlans, buildInversePlan(changeID, dryUnitID, detection, g, importedAt))
+		provenanceRecord := buildProvenance(changeID, space, detection, g, importedAt)
+		inversePlan := buildInversePlan(changeID, dryUnitID, detection, g, importedAt)
+		if err := contracts.ValidateTriple(contract, provenanceRecord, inversePlan); err != nil {
+			return model.ImportResult{}, fmt.Errorf("validate contract triple for generator %q (%s): %w", g.ID, g.Kind, err)
+		}
+
+		generatorContracts = append(generatorContracts, contract)
+		provenance = append(provenance, provenanceRecord)
+		inversePlans = append(inversePlans, inversePlan)
 		dryInputs = append(dryInputs, dryInputsForGenerator(g)...)
 		wetTargets = append(wetTargets, wetManifestTargetsForGenerator(detection, g)...)
+	}
+
+	if err := contracts.ValidateTripleSet(generatorContracts, provenance, inversePlans); err != nil {
+		return model.ImportResult{}, fmt.Errorf("validate contract triple set: %w", err)
 	}
 
 	return model.ImportResult{
@@ -86,7 +97,7 @@ func ImportDetection(detection model.DetectionResult, space string) (model.Impor
 		Detection:          detection,
 		Units:              units,
 		Links:              links,
-		GeneratorContracts: contracts,
+		GeneratorContracts: generatorContracts,
 		Provenance:         provenance,
 		InversePlans:       inversePlans,
 		DryInputs:          dryInputs,

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -516,6 +516,35 @@ service:
 	}
 }
 
+func TestImportDetectionFailsOnInvalidContractTriple(t *testing.T) {
+	repo := t.TempDir()
+	detection := model.DetectionResult{
+		Repo: repo,
+		Ref:  "",
+		Generators: []model.GeneratorDetection{
+			{
+				ID:      "gen_invalid",
+				Kind:    model.GeneratorScore,
+				Profile: "scoredev-paas",
+				Name:    "invalid-score",
+				Root:    "",
+				Inputs:  []string{"score.yaml"},
+			},
+		},
+	}
+
+	_, err := ImportDetection(detection, "platform")
+	if err == nil {
+		t.Fatal("expected schema validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), `validate contract triple for generator "gen_invalid" (score):`) {
+		t.Fatalf("expected generator-scoped contract triple error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "generator_contract schema validation failed") {
+		t.Fatalf("expected contract schema validation failure, got: %v", err)
+	}
+}
+
 func fieldOriginHasDryPath(v []model.FieldOrigin, dryPath string) bool {
 	for _, item := range v {
 		if item.DryPath == dryPath {


### PR DESCRIPTION
## Summary
- add explicit JSON schema assets for the contract triple:
  - `generator-contract.v1`
  - `provenance.v1`
  - `inverse-transform-plan.v1`
- add `internal/contracts` validator module with embedded schema compilation and runtime record/set validation
- wire importer pipeline to fail fast on invalid triple artifacts with generator-scoped errors
- add unit coverage for valid/invalid triple validation and importer integration coverage for explicit triple-validation failure
- update v0.2 roadmap status

## Validation
- go test ./...
- make ci

Closes #77
