### PR TITLE
Enforce no-triple-no-governed-import gate

### DIFF
--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -61,6 +61,7 @@ Implemented in this preview slice:
 43. Added a single 10-minute Flux/Argo/Helm adoption path in `README.md`, with copy/paste commands and explicit parity boundary (`matched|partial|deferred`) language.
 44. Cut release `v0.2-preview.1` from green `main` with release notes covering parity lock, supported families, boundaries, known limits, and adoption references.
 45. Added strict schema validation gates for `GeneratorContract`, `ProvenanceRecord`, and `InverseTransformPlan` with embedded JSON schemas and importer runtime enforcement.
+46. Enforced `no-triple-no-governed-import` gate with deterministic blocker errors for missing/cardiinality-mismatched contract triples and locked importer error output tests.
 
 ## v0.2 preview invariants
 

--- a/internal/contracts/validator.go
+++ b/internal/contracts/validator.go
@@ -3,7 +3,9 @@ package contracts
 import (
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -61,6 +63,24 @@ func ValidateTripleSet(contracts []model.GeneratorContract, provenance []model.P
 		if err := ValidateTriple(contracts[i], provenance[i], inversePlans[i]); err != nil {
 			return fmt.Errorf("contract triple index %d: %w", i, err)
 		}
+	}
+	return nil
+}
+
+// ValidateGovernedImportTriples enforces that governed import artifacts include
+// a complete contract triple for every detected generator.
+func ValidateGovernedImportTriples(detectedGenerators int, contracts []model.GeneratorContract, provenance []model.ProvenanceRecord, inversePlans []model.InverseTransformPlan) error {
+	if detectedGenerators <= 0 {
+		return nil
+	}
+	if len(contracts) == 0 || len(provenance) == 0 || len(inversePlans) == 0 {
+		return fmt.Errorf("governed import blocked: required contract triple missing (detected=%d contracts=%d provenance=%d inverse_plans=%d)", detectedGenerators, len(contracts), len(provenance), len(inversePlans))
+	}
+	if len(contracts) != detectedGenerators || len(provenance) != detectedGenerators || len(inversePlans) != detectedGenerators {
+		return fmt.Errorf("governed import blocked: contract triple cardinality mismatch (detected=%d contracts=%d provenance=%d inverse_plans=%d)", detectedGenerators, len(contracts), len(provenance), len(inversePlans))
+	}
+	if err := ValidateTripleSet(contracts, provenance, inversePlans); err != nil {
+		return fmt.Errorf("governed import blocked: %w", err)
 	}
 	return nil
 }
@@ -158,7 +178,36 @@ func toJSONAny(v any) (any, error) {
 }
 
 func normalizeValidationError(err error) string {
+	var validationErr *jsonschema.ValidationError
+	if errors.As(err, &validationErr) {
+		leaves := flattenValidationErrors(validationErr)
+		parts := make([]string, 0, len(leaves))
+		for _, leaf := range leaves {
+			location := strings.TrimSpace(leaf.InstanceLocation)
+			if location == "" {
+				location = "/"
+			}
+			parts = append(parts, fmt.Sprintf("%s: %s", location, strings.TrimSpace(leaf.Message)))
+		}
+		sort.Strings(parts)
+		return strings.Join(parts, "; ")
+	}
+
 	msg := strings.TrimSpace(err.Error())
 	msg = strings.Join(strings.Fields(msg), " ")
 	return msg
+}
+
+func flattenValidationErrors(err *jsonschema.ValidationError) []*jsonschema.ValidationError {
+	if err == nil {
+		return nil
+	}
+	if len(err.Causes) == 0 {
+		return []*jsonschema.ValidationError{err}
+	}
+	out := make([]*jsonschema.ValidationError, 0, len(err.Causes))
+	for _, cause := range err.Causes {
+		out = append(out, flattenValidationErrors(cause)...)
+	}
+	return out
 }

--- a/internal/contracts/validator_test.go
+++ b/internal/contracts/validator_test.go
@@ -37,6 +37,42 @@ func TestValidateTripleSetCardinalityMismatch(t *testing.T) {
 	}
 }
 
+func TestValidateGovernedImportTriplesMissing(t *testing.T) {
+	err := ValidateGovernedImportTriples(1, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected governed import missing triple error, got nil")
+	}
+
+	expected := "governed import blocked: required contract triple missing (detected=1 contracts=0 provenance=0 inverse_plans=0)"
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestValidateGovernedImportTriplesCardinalityMismatch(t *testing.T) {
+	contract, provenance, inversePlan := validTripleFixture()
+	err := ValidateGovernedImportTriples(
+		2,
+		[]model.GeneratorContract{contract},
+		[]model.ProvenanceRecord{provenance},
+		[]model.InverseTransformPlan{inversePlan},
+	)
+	if err == nil {
+		t.Fatal("expected governed import cardinality mismatch error, got nil")
+	}
+
+	expected := "governed import blocked: contract triple cardinality mismatch (detected=2 contracts=1 provenance=1 inverse_plans=1)"
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestValidateGovernedImportTriplesZeroDetectedAllowed(t *testing.T) {
+	if err := ValidateGovernedImportTriples(0, nil, nil, nil); err != nil {
+		t.Fatalf("expected nil error for zero-detected import, got: %v", err)
+	}
+}
+
 func TestValidateGeneratorContractInvalid(t *testing.T) {
 	contract, _, _ := validTripleFixture()
 	contract.SchemaVersion = "invalid/schema"
@@ -47,6 +83,9 @@ func TestValidateGeneratorContractInvalid(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "generator_contract schema validation failed") {
 		t.Fatalf("expected generator contract validation message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "/schema_version") {
+		t.Fatalf("expected deterministic schema path in error, got: %v", err)
 	}
 }
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -84,8 +84,8 @@ func ImportDetection(detection model.DetectionResult, space string) (model.Impor
 		wetTargets = append(wetTargets, wetManifestTargetsForGenerator(detection, g)...)
 	}
 
-	if err := contracts.ValidateTripleSet(generatorContracts, provenance, inversePlans); err != nil {
-		return model.ImportResult{}, fmt.Errorf("validate contract triple set: %w", err)
+	if err := contracts.ValidateGovernedImportTriples(len(detection.Generators), generatorContracts, provenance, inversePlans); err != nil {
+		return model.ImportResult{}, err
 	}
 
 	return model.ImportResult{

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -537,11 +537,10 @@ func TestImportDetectionFailsOnInvalidContractTriple(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected schema validation error, got nil")
 	}
-	if !strings.Contains(err.Error(), `validate contract triple for generator "gen_invalid" (score):`) {
-		t.Fatalf("expected generator-scoped contract triple error, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "generator_contract schema validation failed") {
-		t.Fatalf("expected contract schema validation failure, got: %v", err)
+
+	expected := `validate contract triple for generator "gen_invalid" (score): generator_contract schema validation failed: /source_ref: length must be >= 1, but got 0`
+	if err.Error() != expected {
+		t.Fatalf("expected deterministic error %q, got %q", expected, err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- add explicit `ValidateGovernedImportTriples` gate to enforce "no contract triple, no governed import"
- block governed import when triple artifacts are missing or cardinality-mismatched relative to detected generators
- normalize schema validation errors into deterministic leaf-path messages
- wire importer to enforce governed-import gate before returning import result
- lock deterministic error outputs in unit/integration tests

## Validation
- go test ./...
- make ci

Closes #78
