### PR TITLE
Enforce bridge symmetry matrix in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,6 @@ jobs:
 
       - name: Run contract tests
         run: make test-contracts
+
+      - name: Run bridge symmetry matrix
+        run: make test-bridge-symmetry

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: build test test-parity test-contracts test-examples update-goldens ci
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples update-goldens ci
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
+BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
 
 build:
 	go build ./cmd/cub-gen
@@ -13,10 +14,13 @@ test-contracts:
 
 test-parity: test-contracts
 
+test-bridge-symmetry:
+	go test ./cmd/cub-gen -run '$(BRIDGE_SYMMETRY_PATTERN)' -count=1 -v
+
 test-examples:
 	go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$$' -count=1 -v
 
 update-goldens:
 	UPDATE_GOLDEN=1 go test ./cmd/cub-gen -run 'Golden' -count=1 -v
 
-ci: build test test-contracts test-examples
+ci: build test test-contracts test-bridge-symmetry test-examples

--- a/cmd/cub-gen/examples_bridge_smoke_test.go
+++ b/cmd/cub-gen/examples_bridge_smoke_test.go
@@ -8,42 +8,8 @@ import (
 )
 
 func TestExamplesPathModeBridgeFlow(t *testing.T) {
-	tests := []struct {
-		name            string
-		repoSuffix      string
-		expectedProfile string
-	}{
-		{
-			name:            "helm",
-			repoSuffix:      filepath.Join("examples", "helm-paas"),
-			expectedProfile: "helm-paas",
-		},
-		{
-			name:            "score",
-			repoSuffix:      filepath.Join("examples", "scoredev-paas"),
-			expectedProfile: "scoredev-paas",
-		},
-		{
-			name:            "spring",
-			repoSuffix:      filepath.Join("examples", "springboot-paas"),
-			expectedProfile: "springboot-paas",
-		},
-		{
-			name:            "backstage",
-			repoSuffix:      filepath.Join("examples", "backstage-idp"),
-			expectedProfile: "backstage-idp",
-		},
-		{
-			name:            "ably",
-			repoSuffix:      filepath.Join("examples", "ably-config"),
-			expectedProfile: "ably-config",
-		},
-		{
-			name:            "ops",
-			repoSuffix:      filepath.Join("examples", "ops-workflow"),
-			expectedProfile: "ops-workflow",
-		},
-	}
+	tests := bridgeSymmetryMatrix()
+	assertBridgeSymmetryMatrixCoverage(t, tests)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/cub-gen/examples_matrix_test.go
+++ b/cmd/cub-gen/examples_matrix_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-gen/internal/registry"
+)
+
+type exampleFamilyFixture struct {
+	name            string
+	repoSuffix      string
+	expectedProfile string
+	expectedKind    string
+}
+
+func bridgeSymmetryMatrix() []exampleFamilyFixture {
+	return []exampleFamilyFixture{
+		{
+			name:            "helm",
+			repoSuffix:      filepath.Join("examples", "helm-paas"),
+			expectedProfile: "helm-paas",
+			expectedKind:    "helm",
+		},
+		{
+			name:            "score",
+			repoSuffix:      filepath.Join("examples", "scoredev-paas"),
+			expectedProfile: "scoredev-paas",
+			expectedKind:    "score",
+		},
+		{
+			name:            "spring",
+			repoSuffix:      filepath.Join("examples", "springboot-paas"),
+			expectedProfile: "springboot-paas",
+			expectedKind:    "springboot",
+		},
+		{
+			name:            "backstage",
+			repoSuffix:      filepath.Join("examples", "backstage-idp"),
+			expectedProfile: "backstage-idp",
+			expectedKind:    "backstage",
+		},
+		{
+			name:            "ably",
+			repoSuffix:      filepath.Join("examples", "ably-config"),
+			expectedProfile: "ably-config",
+			expectedKind:    "ably",
+		},
+		{
+			name:            "ops",
+			repoSuffix:      filepath.Join("examples", "ops-workflow"),
+			expectedProfile: "ops-workflow",
+			expectedKind:    "opsworkflow",
+		},
+	}
+}
+
+func TestBridgeSymmetryMatrix(t *testing.T) {
+	matrix := bridgeSymmetryMatrix()
+	if len(matrix) == 0 {
+		t.Fatal("bridge symmetry matrix must not be empty")
+	}
+	assertBridgeSymmetryMatrixCoverage(t, matrix)
+}
+
+func assertBridgeSymmetryMatrixCoverage(t *testing.T, matrix []exampleFamilyFixture) {
+	t.Helper()
+
+	byKind := map[string]exampleFamilyFixture{}
+	for _, fixture := range matrix {
+		if fixture.expectedKind == "" {
+			t.Fatalf("matrix fixture %q has empty expectedKind", fixture.name)
+		}
+		if fixture.expectedProfile == "" {
+			t.Fatalf("matrix fixture %q has empty expectedProfile", fixture.name)
+		}
+		if fixture.repoSuffix == "" {
+			t.Fatalf("matrix fixture %q has empty repoSuffix", fixture.name)
+		}
+		if prev, exists := byKind[fixture.expectedKind]; exists {
+			t.Fatalf("matrix has duplicate kind %q in fixtures %q and %q", fixture.expectedKind, prev.name, fixture.name)
+		}
+		byKind[fixture.expectedKind] = fixture
+	}
+
+	missing := make([]string, 0)
+	for _, kind := range registry.Kinds() {
+		if _, ok := byKind[string(kind)]; !ok {
+			missing = append(missing, string(kind))
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("bridge symmetry matrix missing registry kinds: %s", joinCSV(missing))
+	}
+
+	extras := make([]string, 0)
+	registryKinds := map[string]struct{}{}
+	for _, kind := range registry.Kinds() {
+		registryKinds[string(kind)] = struct{}{}
+	}
+	for kind := range byKind {
+		if _, ok := registryKinds[kind]; !ok {
+			extras = append(extras, kind)
+		}
+	}
+	if len(extras) > 0 {
+		sort.Strings(extras)
+		t.Fatalf("bridge symmetry matrix includes unknown kinds: %s", joinCSV(extras))
+	}
+}
+
+func joinCSV(values []string) string {
+	clone := append([]string(nil), values...)
+	sort.Strings(clone)
+	return strings.Join(clone, ", ")
+}

--- a/cmd/cub-gen/examples_smoke_test.go
+++ b/cmd/cub-gen/examples_smoke_test.go
@@ -8,49 +8,8 @@ import (
 )
 
 func TestExamplesPathModeDiscoverAndImport(t *testing.T) {
-	tests := []struct {
-		name            string
-		repoSuffix      string
-		expectedProfile string
-		expectedKind    string
-	}{
-		{
-			name:            "helm",
-			repoSuffix:      filepath.Join("examples", "helm-paas"),
-			expectedProfile: "helm-paas",
-			expectedKind:    "helm",
-		},
-		{
-			name:            "score",
-			repoSuffix:      filepath.Join("examples", "scoredev-paas"),
-			expectedProfile: "scoredev-paas",
-			expectedKind:    "score",
-		},
-		{
-			name:            "spring",
-			repoSuffix:      filepath.Join("examples", "springboot-paas"),
-			expectedProfile: "springboot-paas",
-			expectedKind:    "springboot",
-		},
-		{
-			name:            "backstage",
-			repoSuffix:      filepath.Join("examples", "backstage-idp"),
-			expectedProfile: "backstage-idp",
-			expectedKind:    "backstage",
-		},
-		{
-			name:            "ably",
-			repoSuffix:      filepath.Join("examples", "ably-config"),
-			expectedProfile: "ably-config",
-			expectedKind:    "ably",
-		},
-		{
-			name:            "ops",
-			repoSuffix:      filepath.Join("examples", "ops-workflow"),
-			expectedProfile: "ops-workflow",
-			expectedKind:    "opsworkflow",
-		},
-	}
+	tests := bridgeSymmetryMatrix()
+	assertBridgeSymmetryMatrixCoverage(t, tests)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -63,6 +63,7 @@ Implemented in this preview slice:
 45. Added strict schema validation gates for `GeneratorContract`, `ProvenanceRecord`, and `InverseTransformPlan` with embedded JSON schemas and importer runtime enforcement.
 46. Enforced `no-triple-no-governed-import` gate with deterministic blocker errors for missing/cardiinality-mismatched contract triples and locked importer error output tests.
 47. Added cross-family triple conformance fixtures for Helm/Score/Spring/Backstage/Ably/Ops with deterministic re-run checks and registry-kind coverage enforcement.
+48. Added explicit bridge symmetry matrix gate in CI (`TestBridgeSymmetryMatrix` + `make test-bridge-symmetry`) to enforce `publish -> verify -> attest -> verify-attestation` family coverage across all registry kinds.
 
 ## v0.2 preview invariants
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -20,6 +20,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 
 - CLI output contract tests in `cmd/cub-gen/gitops_parity_test.go`.
 - Generator inventory contract tests in `cmd/cub-gen/generators_parity_test.go` (full list + JSON/table filter contracts for kind/profile/capability, including comma-separated multi-value filters, combined filters, empty-match behavior, and strict unknown-filter error modes).
+- Bridge symmetry matrix coverage gate in `cmd/cub-gen/examples_matrix_test.go` (fails if any registry generator kind is missing from `publish -> verify -> attest -> verify-attestation` family matrix).
 - Bridge publish golden locks in `cmd/cub-gen/publish_parity_test.go` (import/direct paths for helm/score/spring/backstage/ably/ops).
 - Verify command behavior tests in `cmd/cub-gen/verify_command_test.go`.
 - Verify command golden locks in `cmd/cub-gen/verify_parity_test.go`.
@@ -53,6 +54,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 go build ./cmd/cub-gen
 go test ./...
 go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v
+go test ./cmd/cub-gen -run '^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$' -count=1 -v
 go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v
 ```
 


### PR DESCRIPTION
## Summary
- add explicit bridge symmetry matrix definition shared by example discover/import and bridge-flow tests
- add `TestBridgeSymmetryMatrix` coverage gate that fails when registry kinds are missing from matrix
- wire matrix coverage assertions into bridge and discover/import example test suites
- add explicit CI/Make gate `test-bridge-symmetry` and run it in CI parity job
- update testing + roadmap docs

## Validation
- go test ./...
- make ci

Closes #80
