### PR TITLE
feat(bridge): map triple artifacts to decision + attestation state

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ See:
 - `CLAUDE.md`
 - `CONTRIBUTING.md`
 - `docs/contracts/canonical-triple-and-storage-boundary.md`
+- `docs/contracts/decision-and-attestation-state.md`
 - `docs/testing/README.md`
 - `docs/workflows/proof-first-delivery.md`
 - `PARITY.md`

--- a/docs/contracts/decision-and-attestation-state.md
+++ b/docs/contracts/decision-and-attestation-state.md
@@ -1,0 +1,70 @@
+# Decision + Attestation State Contract
+
+This contract defines how bridge artifacts move from ingest to governed decision.
+
+## Scope
+
+1. `cub-gen` publishes deterministic change bundles and attestations.
+2. ConfigHub stores governed WET state and decision authority.
+3. Bridge decision records link these by shared `change_id` and digest evidence.
+
+## State model
+
+Decision state is explicit and finite:
+
+1. `INGESTED`: bundle accepted by governed WET ingest.
+2. `ATTESTED`: verified attestation linked to bundle digest.
+3. `ALLOW`: explicit decision to proceed.
+4. `ESCALATE`: explicit decision to require additional approval.
+5. `BLOCK`: explicit decision to stop.
+
+Terminal states are `ALLOW | ESCALATE | BLOCK`.
+
+## Required identity links
+
+Every decision record (`cub.confighub.io/governed-decision-state/v1`) must carry:
+
+1. `change_id`
+2. `bundle_digest`
+3. `state`
+4. `updated_at`
+
+If state is `ATTESTED` or terminal, it must also carry:
+
+1. `attestation_digest` (digest-linked evidence)
+
+If state is terminal, it must also carry:
+
+1. `decision_reason`
+2. `decided_at`
+3. one explicit authority: `approved_by` or `policy_decision_ref`
+
+This enforces the invariant: no implicit deploy.
+
+## Transition rules
+
+Allowed transitions:
+
+1. `INGESTED -> ATTESTED`
+2. `ATTESTED -> ALLOW`
+3. `ATTESTED -> ESCALATE`
+4. `ATTESTED -> BLOCK`
+
+Disallowed:
+
+1. Any terminal decision without attestation linkage.
+2. Any terminal decision without explicit authority.
+3. Any direct `INGESTED -> ALLOW|ESCALATE|BLOCK`.
+
+## Query by `change_id`
+
+Bridge query path:
+
+1. `GET /api/v1/governed-wet-decisions/{change_id}`
+
+The response is validated against the decision-state contract and must return the same `change_id` that was requested.
+
+## Implementation anchors
+
+1. Contract and transition enforcement: `internal/bridge/decision.go`
+2. End-to-end state/query tests: `internal/bridge/decision_test.go`

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -67,6 +67,7 @@ Implemented in this preview slice:
 49. Published canonical triple + storage boundary docs mapping schemas, runtime gates, and Git (DRY linkage) vs ConfigHub (WET governance) responsibilities.
 50. Completed Sprint 2 Go/No-Go gate with documented `GO` outcome and opened post-gate bridge backlog issues (`#95`-`#97`).
 51. Added first bridge ingest path (`internal/bridge`) to map `change-bundle` artifacts into ConfigHub governed WET ingest payloads with idempotency (`change_id + bundle_digest`) and duplicate-safe HTTP `409` handling.
+52. Added governed decision-state bridge contract and runtime transitions (`INGESTED -> ATTESTED -> ALLOW|ESCALATE|BLOCK`) with explicit authority gates, attestation linkage validation, and query-by-`change_id` support in `internal/bridge`.
 
 ## v0.2 preview invariants
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -14,6 +14,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Core detection/import/flow logic tests in `internal/...`.
 - Cross-family contract-triple conformance fixtures in `internal/contracts/triple_conformance_fixtures_test.go` (Helm/Score/Spring/Backstage/Ably/Ops).
 - Bridge ingest client idempotency/error-path tests in `internal/bridge/ingest_test.go`.
+- Bridge decision-state transition/query tests in `internal/bridge/decision_test.go`.
 - Bridge bundle tests in `internal/publish/...`.
 - Attestation model tests in `internal/attest/...`.
 

--- a/internal/bridge/decision.go
+++ b/internal/bridge/decision.go
@@ -1,0 +1,297 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-gen/internal/attest"
+)
+
+const (
+	decisionSchemaVersion  = "cub.confighub.io/governed-decision-state/v1"
+	decisionSource         = "cub-gen"
+	defaultDecisionPath    = "/api/v1/governed-wet-decisions"
+	digestPrefix           = "sha256:"
+	decisionStatusIngested = DecisionState("INGESTED")
+	decisionStatusAttested = DecisionState("ATTESTED")
+	decisionStatusAllow    = DecisionState("ALLOW")
+	decisionStatusEscalate = DecisionState("ESCALATE")
+	decisionStatusBlock    = DecisionState("BLOCK")
+)
+
+var ErrDecisionNotFound = errors.New("decision not found")
+
+type DecisionState string
+
+const (
+	DecisionStateIngested DecisionState = decisionStatusIngested
+	DecisionStateAttested DecisionState = decisionStatusAttested
+	DecisionStateAllow    DecisionState = decisionStatusAllow
+	DecisionStateEscalate DecisionState = decisionStatusEscalate
+	DecisionStateBlock    DecisionState = decisionStatusBlock
+)
+
+// DecisionRecord captures governed decision state for a bridge change_id.
+type DecisionRecord struct {
+	SchemaVersion       string        `json:"schema_version"`
+	Source              string        `json:"source"`
+	ChangeID            string        `json:"change_id"`
+	BundleDigest        string        `json:"bundle_digest"`
+	ArtifactID          string        `json:"artifact_id,omitempty"`
+	IdempotencyKey      string        `json:"idempotency_key,omitempty"`
+	State               DecisionState `json:"state"`
+	AttestationDigest   string        `json:"attestation_digest,omitempty"`
+	AttestationVerifier string        `json:"attestation_verifier,omitempty"`
+	AttestedAt          string        `json:"attested_at,omitempty"`
+	PolicyDecisionRef   string        `json:"policy_decision_ref,omitempty"`
+	ApprovedBy          string        `json:"approved_by,omitempty"`
+	DecisionReason      string        `json:"decision_reason,omitempty"`
+	DecidedAt           string        `json:"decided_at,omitempty"`
+	UpdatedAt           string        `json:"updated_at"`
+}
+
+// DecisionRequest applies a terminal governed decision.
+type DecisionRequest struct {
+	State             DecisionState `json:"state"`
+	PolicyDecisionRef string        `json:"policy_decision_ref,omitempty"`
+	ApprovedBy        string        `json:"approved_by,omitempty"`
+	DecisionReason    string        `json:"decision_reason"`
+}
+
+// DecisionClient holds bridge API connection settings for decision queries.
+type DecisionClient struct {
+	BaseURL      string
+	BearerToken  string
+	EndpointPath string
+	HTTPClient   *http.Client
+}
+
+// NewDecisionRecord initializes decision state from a successful ingest result.
+func NewDecisionRecord(ingest IngestResult, at time.Time) (DecisionRecord, error) {
+	changeID := strings.TrimSpace(ingest.ChangeID)
+	if changeID == "" {
+		return DecisionRecord{}, fmt.Errorf("decision record requires non-empty change_id")
+	}
+	bundleDigest := strings.TrimSpace(ingest.BundleDigest)
+	if bundleDigest == "" {
+		return DecisionRecord{}, fmt.Errorf("decision record requires non-empty bundle_digest")
+	}
+	if !strings.HasPrefix(bundleDigest, digestPrefix) {
+		return DecisionRecord{}, fmt.Errorf("decision record bundle_digest must use %s prefix", digestPrefix)
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+
+	rec := DecisionRecord{
+		SchemaVersion:  decisionSchemaVersion,
+		Source:         decisionSource,
+		ChangeID:       changeID,
+		BundleDigest:   bundleDigest,
+		ArtifactID:     strings.TrimSpace(ingest.ArtifactID),
+		IdempotencyKey: strings.TrimSpace(ingest.IdempotencyKey),
+		State:          DecisionStateIngested,
+		UpdatedAt:      at.UTC().Format(time.RFC3339),
+	}
+	return rec, ValidateDecisionRecord(rec)
+}
+
+// AttachAttestation links verified attestation evidence to a decision record.
+func AttachAttestation(rec DecisionRecord, attestation attest.Record, at time.Time) (DecisionRecord, error) {
+	if err := ValidateDecisionRecord(rec); err != nil {
+		return DecisionRecord{}, err
+	}
+	if rec.State != DecisionStateIngested && rec.State != DecisionStateAttested {
+		return DecisionRecord{}, fmt.Errorf("cannot attach attestation after terminal decision state %q", rec.State)
+	}
+	if err := attest.VerifyRecord(attestation); err != nil {
+		return DecisionRecord{}, fmt.Errorf("verify attestation before decision link: %w", err)
+	}
+	if strings.TrimSpace(attestation.BundleDigest) != rec.BundleDigest {
+		return DecisionRecord{}, fmt.Errorf("attestation bundle digest mismatch: decision=%s attestation=%s", rec.BundleDigest, strings.TrimSpace(attestation.BundleDigest))
+	}
+	if attChangeID := strings.TrimSpace(attestation.ChangeID); attChangeID != "" && attChangeID != rec.ChangeID {
+		return DecisionRecord{}, fmt.Errorf("attestation change_id mismatch: decision=%s attestation=%s", rec.ChangeID, attChangeID)
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+
+	rec.State = DecisionStateAttested
+	rec.AttestationDigest = strings.TrimSpace(attestation.AttestationDigest)
+	rec.AttestationVerifier = strings.TrimSpace(attestation.Verifier)
+	rec.AttestedAt = at.UTC().Format(time.RFC3339)
+	rec.UpdatedAt = rec.AttestedAt
+	return rec, ValidateDecisionRecord(rec)
+}
+
+// ApplyDecision enforces explicit authority semantics and terminal decisions.
+func ApplyDecision(rec DecisionRecord, req DecisionRequest, at time.Time) (DecisionRecord, error) {
+	if err := ValidateDecisionRecord(rec); err != nil {
+		return DecisionRecord{}, err
+	}
+	if rec.State != DecisionStateAttested {
+		return DecisionRecord{}, fmt.Errorf("decision transition requires attested state, got %q", rec.State)
+	}
+	if !isTerminalDecision(req.State) {
+		return DecisionRecord{}, fmt.Errorf("unsupported decision state %q", req.State)
+	}
+	approvedBy := strings.TrimSpace(req.ApprovedBy)
+	policyRef := strings.TrimSpace(req.PolicyDecisionRef)
+	if approvedBy == "" && policyRef == "" {
+		return DecisionRecord{}, fmt.Errorf("explicit decision authority required: set approved_by or policy_decision_ref")
+	}
+	reason := strings.TrimSpace(req.DecisionReason)
+	if reason == "" {
+		return DecisionRecord{}, fmt.Errorf("decision_reason is required")
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	rec.State = req.State
+	rec.ApprovedBy = approvedBy
+	rec.PolicyDecisionRef = policyRef
+	rec.DecisionReason = reason
+	rec.DecidedAt = at.UTC().Format(time.RFC3339)
+	rec.UpdatedAt = rec.DecidedAt
+	return rec, ValidateDecisionRecord(rec)
+}
+
+// ValidateDecisionRecord enforces decision contract invariants.
+func ValidateDecisionRecord(rec DecisionRecord) error {
+	if rec.SchemaVersion != decisionSchemaVersion {
+		return fmt.Errorf("unsupported schema_version %q", rec.SchemaVersion)
+	}
+	if rec.Source != decisionSource {
+		return fmt.Errorf("unsupported source %q", rec.Source)
+	}
+	if strings.TrimSpace(rec.ChangeID) == "" {
+		return fmt.Errorf("missing change_id")
+	}
+	if strings.TrimSpace(rec.BundleDigest) == "" {
+		return fmt.Errorf("missing bundle_digest")
+	}
+	if !strings.HasPrefix(rec.BundleDigest, digestPrefix) {
+		return fmt.Errorf("bundle_digest must use %s prefix", digestPrefix)
+	}
+	switch rec.State {
+	case DecisionStateIngested, DecisionStateAttested, DecisionStateAllow, DecisionStateEscalate, DecisionStateBlock:
+	default:
+		return fmt.Errorf("unsupported state %q", rec.State)
+	}
+	if rec.State != DecisionStateIngested {
+		if strings.TrimSpace(rec.AttestationDigest) == "" {
+			return fmt.Errorf("state %q requires attestation_digest linkage", rec.State)
+		}
+		if !strings.HasPrefix(rec.AttestationDigest, digestPrefix) {
+			return fmt.Errorf("attestation_digest must use %s prefix", digestPrefix)
+		}
+	}
+	if isTerminalDecision(rec.State) {
+		if strings.TrimSpace(rec.DecidedAt) == "" {
+			return fmt.Errorf("state %q requires decided_at", rec.State)
+		}
+		if strings.TrimSpace(rec.DecisionReason) == "" {
+			return fmt.Errorf("state %q requires decision_reason", rec.State)
+		}
+		if strings.TrimSpace(rec.ApprovedBy) == "" && strings.TrimSpace(rec.PolicyDecisionRef) == "" {
+			return fmt.Errorf("state %q requires approved_by or policy_decision_ref", rec.State)
+		}
+	}
+	if strings.TrimSpace(rec.UpdatedAt) == "" {
+		return fmt.Errorf("missing updated_at")
+	}
+	return nil
+}
+
+// QueryDecisionByChangeID resolves governed decision state by change_id.
+func QueryDecisionByChangeID(ctx context.Context, client DecisionClient, changeID string) (DecisionRecord, error) {
+	id := strings.TrimSpace(changeID)
+	if id == "" {
+		return DecisionRecord{}, fmt.Errorf("query decision requires non-empty change_id")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	endpoint, err := resolveDecisionEndpoint(client, id)
+	if err != nil {
+		return DecisionRecord{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return DecisionRecord{}, fmt.Errorf("build decision query request: %w", err)
+	}
+	if token := strings.TrimSpace(client.BearerToken); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	httpClient := client.HTTPClient
+	if httpClient == nil {
+		httpClient = defaultHTTPClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return DecisionRecord{}, fmt.Errorf("send decision query request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// continue
+	case http.StatusNotFound:
+		return DecisionRecord{}, fmt.Errorf("%w: change_id=%s", ErrDecisionNotFound, id)
+	default:
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = "<empty>"
+		}
+		return DecisionRecord{}, fmt.Errorf("decision query failed: status=%d body=%s", resp.StatusCode, msg)
+	}
+
+	var rec DecisionRecord
+	if err := json.Unmarshal(body, &rec); err != nil {
+		return DecisionRecord{}, fmt.Errorf("parse decision query response: %w", err)
+	}
+	if err := ValidateDecisionRecord(rec); err != nil {
+		return DecisionRecord{}, fmt.Errorf("invalid decision query response: %w", err)
+	}
+	if rec.ChangeID != id {
+		return DecisionRecord{}, fmt.Errorf("decision response change_id mismatch: expected %s, got %s", id, rec.ChangeID)
+	}
+	return rec, nil
+}
+
+func resolveDecisionEndpoint(client DecisionClient, changeID string) (string, error) {
+	base := strings.TrimSpace(client.BaseURL)
+	if base == "" {
+		return "", fmt.Errorf("decision client base URL is required")
+	}
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse decision base URL: %w", err)
+	}
+	basePath := strings.TrimSpace(client.EndpointPath)
+	if basePath == "" {
+		basePath = defaultDecisionPath
+	}
+	if !strings.HasPrefix(basePath, "/") {
+		basePath = "/" + basePath
+	}
+	parsed.Path = path.Clean(strings.TrimSuffix(parsed.Path, "/") + basePath + "/" + url.PathEscape(changeID))
+	return parsed.String(), nil
+}
+
+func isTerminalDecision(state DecisionState) bool {
+	return state == DecisionStateAllow || state == DecisionStateEscalate || state == DecisionStateBlock
+}

--- a/internal/bridge/decision_test.go
+++ b/internal/bridge/decision_test.go
@@ -1,0 +1,244 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-gen/internal/attest"
+)
+
+func TestNewDecisionRecordFromIngest(t *testing.T) {
+	bundle := sampleBundle("chg_1")
+	ingest := IngestResult{
+		StatusCode:     http.StatusCreated,
+		ArtifactID:     "wet_art_123",
+		Status:         "created",
+		ChangeID:       bundle.ChangeID,
+		BundleDigest:   bundle.BundleDigest,
+		IdempotencyKey: bundle.ChangeID + ":" + bundle.BundleDigest,
+	}
+	ts := time.Date(2026, 3, 6, 10, 0, 0, 0, time.UTC)
+
+	rec, err := NewDecisionRecord(ingest, ts)
+	if err != nil {
+		t.Fatalf("NewDecisionRecord returned error: %v", err)
+	}
+	if rec.SchemaVersion != decisionSchemaVersion {
+		t.Fatalf("expected schema %q, got %q", decisionSchemaVersion, rec.SchemaVersion)
+	}
+	if rec.Source != decisionSource {
+		t.Fatalf("expected source %q, got %q", decisionSource, rec.Source)
+	}
+	if rec.State != DecisionStateIngested {
+		t.Fatalf("expected state %q, got %q", DecisionStateIngested, rec.State)
+	}
+	if rec.ChangeID != bundle.ChangeID || rec.BundleDigest != bundle.BundleDigest {
+		t.Fatalf("unexpected decision identity linkage: %+v", rec)
+	}
+	if rec.UpdatedAt != ts.Format(time.RFC3339) {
+		t.Fatalf("expected updated_at %q, got %q", ts.Format(time.RFC3339), rec.UpdatedAt)
+	}
+}
+
+func TestAttachAttestationAndAllowDecision(t *testing.T) {
+	bundle := sampleBundle("chg_1")
+	att, err := attest.BuildAt(bundle, time.Date(2026, 3, 6, 10, 1, 0, 0, time.UTC), "ci-bot")
+	if err != nil {
+		t.Fatalf("build attestation: %v", err)
+	}
+	rec, err := NewDecisionRecord(IngestResult{
+		ChangeID:       bundle.ChangeID,
+		BundleDigest:   bundle.BundleDigest,
+		ArtifactID:     "wet_art_123",
+		IdempotencyKey: bundle.ChangeID + ":" + bundle.BundleDigest,
+	}, time.Date(2026, 3, 6, 10, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("new decision: %v", err)
+	}
+
+	attested, err := AttachAttestation(rec, att, time.Date(2026, 3, 6, 10, 2, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("AttachAttestation returned error: %v", err)
+	}
+	if attested.State != DecisionStateAttested {
+		t.Fatalf("expected state %q, got %q", DecisionStateAttested, attested.State)
+	}
+	if attested.AttestationDigest != att.AttestationDigest {
+		t.Fatalf("expected attestation digest %q, got %q", att.AttestationDigest, attested.AttestationDigest)
+	}
+
+	decided, err := ApplyDecision(attested, DecisionRequest{
+		State:          DecisionStateAllow,
+		ApprovedBy:     "platform-approver",
+		DecisionReason: "policy checks passed",
+	}, time.Date(2026, 3, 6, 10, 3, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ApplyDecision returned error: %v", err)
+	}
+	if decided.State != DecisionStateAllow {
+		t.Fatalf("expected state %q, got %q", DecisionStateAllow, decided.State)
+	}
+	if decided.DecidedAt == "" || decided.DecisionReason == "" {
+		t.Fatalf("expected terminal decision fields to be set: %+v", decided)
+	}
+}
+
+func TestApplyDecisionRequiresExplicitAuthority(t *testing.T) {
+	bundle := sampleBundle("chg_1")
+	att, err := attest.BuildAt(bundle, time.Date(2026, 3, 6, 10, 1, 0, 0, time.UTC), "ci-bot")
+	if err != nil {
+		t.Fatalf("build attestation: %v", err)
+	}
+	rec, err := NewDecisionRecord(IngestResult{
+		ChangeID:       bundle.ChangeID,
+		BundleDigest:   bundle.BundleDigest,
+		IdempotencyKey: bundle.ChangeID + ":" + bundle.BundleDigest,
+	}, time.Date(2026, 3, 6, 10, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("new decision: %v", err)
+	}
+	rec, err = AttachAttestation(rec, att, time.Date(2026, 3, 6, 10, 2, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("attach attestation: %v", err)
+	}
+
+	_, err = ApplyDecision(rec, DecisionRequest{
+		State:          DecisionStateAllow,
+		DecisionReason: "missing authority",
+	}, time.Date(2026, 3, 6, 10, 3, 0, 0, time.UTC))
+	if err == nil {
+		t.Fatal("expected explicit authority error, got nil")
+	}
+	expected := "explicit decision authority required: set approved_by or policy_decision_ref"
+	if err.Error() != expected {
+		t.Fatalf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestApplyDecisionRequiresAttestedState(t *testing.T) {
+	bundle := sampleBundle("chg_1")
+	rec, err := NewDecisionRecord(IngestResult{
+		ChangeID:       bundle.ChangeID,
+		BundleDigest:   bundle.BundleDigest,
+		IdempotencyKey: bundle.ChangeID + ":" + bundle.BundleDigest,
+	}, time.Date(2026, 3, 6, 10, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("new decision: %v", err)
+	}
+
+	_, err = ApplyDecision(rec, DecisionRequest{
+		State:          DecisionStateAllow,
+		ApprovedBy:     "platform-approver",
+		DecisionReason: "policy checks passed",
+	}, time.Date(2026, 3, 6, 10, 3, 0, 0, time.UTC))
+	if err == nil {
+		t.Fatal("expected attested-state gate error, got nil")
+	}
+	expected := `decision transition requires attested state, got "INGESTED"`
+	if err.Error() != expected {
+		t.Fatalf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestQueryDecisionByChangeID(t *testing.T) {
+	bundle := sampleBundle("chg_1")
+	att, err := attest.BuildAt(bundle, time.Date(2026, 3, 6, 10, 1, 0, 0, time.UTC), "ci-bot")
+	if err != nil {
+		t.Fatalf("build attestation: %v", err)
+	}
+	ingested, err := NewDecisionRecord(IngestResult{
+		ChangeID:       bundle.ChangeID,
+		BundleDigest:   bundle.BundleDigest,
+		IdempotencyKey: bundle.ChangeID + ":" + bundle.BundleDigest,
+	}, time.Date(2026, 3, 6, 10, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("new decision: %v", err)
+	}
+	attested, err := AttachAttestation(ingested, att, time.Date(2026, 3, 6, 10, 2, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("attach attestation: %v", err)
+	}
+	record, err := ApplyDecision(attested, DecisionRequest{
+		State:             DecisionStateEscalate,
+		PolicyDecisionRef: "policy:123",
+		DecisionReason:    "requires SRE approval",
+	}, time.Date(2026, 3, 6, 10, 3, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("apply decision: %v", err)
+	}
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != defaultDecisionPath+"/chg_1" {
+			t.Fatalf("expected path %s, got %s", defaultDecisionPath+"/chg_1", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(record)
+	}))
+	defer srv.Close()
+
+	out, err := QueryDecisionByChangeID(context.Background(), DecisionClient{
+		BaseURL:     srv.URL,
+		BearerToken: "token-123",
+	}, "chg_1")
+	if err != nil {
+		t.Fatalf("QueryDecisionByChangeID returned error: %v", err)
+	}
+	if gotAuth != "Bearer token-123" {
+		t.Fatalf("expected bearer auth header, got %q", gotAuth)
+	}
+	if out.ChangeID != "chg_1" || out.State != DecisionStateEscalate {
+		t.Fatalf("unexpected decision query response: %+v", out)
+	}
+}
+
+func TestQueryDecisionByChangeIDNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	defer srv.Close()
+
+	_, err := QueryDecisionByChangeID(context.Background(), DecisionClient{BaseURL: srv.URL}, "chg_404")
+	if err == nil {
+		t.Fatal("expected not found error, got nil")
+	}
+	if !errors.Is(err, ErrDecisionNotFound) {
+		t.Fatalf("expected ErrDecisionNotFound, got %v", err)
+	}
+}
+
+func TestQueryDecisionByChangeIDRejectsMismatchedResponse(t *testing.T) {
+	record := DecisionRecord{
+		SchemaVersion:     decisionSchemaVersion,
+		Source:            decisionSource,
+		ChangeID:          "wrong",
+		BundleDigest:      "sha256:digest",
+		State:             DecisionStateIngested,
+		AttestationDigest: "sha256:att",
+		UpdatedAt:         "2026-03-06T10:00:00Z",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(record)
+	}))
+	defer srv.Close()
+
+	_, err := QueryDecisionByChangeID(context.Background(), DecisionClient{BaseURL: srv.URL}, "chg_1")
+	if err == nil {
+		t.Fatal("expected mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "decision response change_id mismatch") {
+		t.Fatalf("expected mismatch error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add governed decision-state contract in internal/bridge with explicit transitions: INGESTED -> ATTESTED -> ALLOW|ESCALATE|BLOCK
- enforce explicit human/policy decision authority and no-implicit-deploy gating rules
- link verified attestation evidence to decision records via change_id and bundle_digest checks
- add decision query-by-change_id bridge path for external lookup
- add unit tests for transitions, authority gating, attestation linkage, and query success/not-found/mismatch paths
- publish decision + attestation contract doc and wire roadmap/testing references

## Validation
- go test ./...
- make ci

Closes #96
