### PR TITLE
feat(bridge): add PR-MR linkage and upstream DRY promotion flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ See:
 - `CONTRIBUTING.md`
 - `docs/contracts/canonical-triple-and-storage-boundary.md`
 - `docs/contracts/decision-and-attestation-state.md`
+- `docs/contracts/pr-mr-linkage-and-dry-promotion.md`
 - `docs/testing/README.md`
 - `docs/workflows/proof-first-delivery.md`
 - `PARITY.md`

--- a/docs/contracts/pr-mr-linkage-and-dry-promotion.md
+++ b/docs/contracts/pr-mr-linkage-and-dry-promotion.md
@@ -1,0 +1,46 @@
+# PR<->MR Linkage and Upstream DRY Promotion Contract
+
+This contract defines the bidirectional handoff between Git PR workflow and ConfigHub MR workflow for governed promotion.
+
+## Goal
+
+Use one shared `change_id` to correlate:
+
+1. Git PR (code/config change in app overlay DRY)
+2. ConfigHub MR (governed WET decision flow)
+3. Upstream platform DRY promotion PR/MR (reusable default promotion)
+
+## Correlation model
+
+Canonical review-link record (`cub.confighub.io/pr-mr-promotion-flow/v1`) includes:
+
+1. `change_id`
+2. `git_pr` (`repo`, `number`, `url`, optional `commit_sha`)
+3. `confighub_mr` (`id`, `url`, optional status)
+4. `status` (`OPEN|MERGED`)
+5. `updated_at`
+
+This enables PR<->MR cross-navigation and deterministic audit joins.
+
+## Promotion flow (recommended path)
+
+1. App team ships feature + config change in app DRY (bounded app overlay) and opens Git PR.
+2. ConfigHub renders/evaluates, posts evidence, and opens/updates MR in ConfigHub.
+3. Platform engineer merge-approves the app change in ConfigHub MR.
+4. ConfigHub records governed decision (`ALLOW | ESCALATE | BLOCK`).
+5. On `ALLOW` + successful rollout, ConfigHub opens promotion PR/MR to upstream platform DRY/base when reusable.
+6. Platform maintainers perform separate platform review and merge upstream promotion PR in Git.
+7. App overlay is reduced/removed to avoid long-lived drift.
+
+## Guardrails (anti-pattern blockers)
+
+Blocked by contract:
+
+1. Promotion merge without prior `ALLOW`.
+2. Promotion merge without separate platform review approval.
+3. Direct auto-write into protected upstream platform DRY without a reviewable PR/MR.
+
+## Implementation anchors
+
+1. Correlation + promotion state machine: `internal/bridge/workflow.go`
+2. Gate tests and happy-path proof: `internal/bridge/workflow_test.go`

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -68,6 +68,7 @@ Implemented in this preview slice:
 50. Completed Sprint 2 Go/No-Go gate with documented `GO` outcome and opened post-gate bridge backlog issues (`#95`-`#97`).
 51. Added first bridge ingest path (`internal/bridge`) to map `change-bundle` artifacts into ConfigHub governed WET ingest payloads with idempotency (`change_id + bundle_digest`) and duplicate-safe HTTP `409` handling.
 52. Added governed decision-state bridge contract and runtime transitions (`INGESTED -> ATTESTED -> ALLOW|ESCALATE|BLOCK`) with explicit authority gates, attestation linkage validation, and query-by-`change_id` support in `internal/bridge`.
+53. Added PR<->MR linkage and upstream DRY promotion guardrail state machine with explicit separate-review enforcement before protected platform-DRY merge.
 
 ## v0.2 preview invariants
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -15,6 +15,7 @@ This repo inherits cub-scout quality discipline with scope adjusted for `cub-gen
 - Cross-family contract-triple conformance fixtures in `internal/contracts/triple_conformance_fixtures_test.go` (Helm/Score/Spring/Backstage/Ably/Ops).
 - Bridge ingest client idempotency/error-path tests in `internal/bridge/ingest_test.go`.
 - Bridge decision-state transition/query tests in `internal/bridge/decision_test.go`.
+- Bridge PR/MR linkage + promotion guardrail tests in `internal/bridge/workflow_test.go`.
 - Bridge bundle tests in `internal/publish/...`.
 - Attestation model tests in `internal/attest/...`.
 

--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -1,0 +1,272 @@
+package bridge
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	workflowSchemaVersion  = "cub.confighub.io/pr-mr-promotion-flow/v1"
+	reviewLinkStatusOpen   = "OPEN"
+	reviewLinkStatusMerged = "MERGED"
+)
+
+type PullRequestRef struct {
+	Repo      string `json:"repo"`
+	Number    int    `json:"number"`
+	URL       string `json:"url"`
+	CommitSHA string `json:"commit_sha,omitempty"`
+}
+
+type MergeRequestRef struct {
+	ID     string `json:"id"`
+	URL    string `json:"url"`
+	Status string `json:"status,omitempty"`
+}
+
+// ReviewLink correlates one change_id across Git PR and ConfigHub MR records.
+type ReviewLink struct {
+	SchemaVersion string          `json:"schema_version"`
+	ChangeID      string          `json:"change_id"`
+	GitPR         PullRequestRef  `json:"git_pr"`
+	ConfigHubMR   MergeRequestRef `json:"confighub_mr"`
+	Status        string          `json:"status"`
+	UpdatedAt     string          `json:"updated_at"`
+}
+
+type PromotionState string
+
+const (
+	PromotionStateAwaitingDecision  PromotionState = "AWAITING_DECISION"
+	PromotionStateDecisionBlocked   PromotionState = "DECISION_BLOCKED"
+	PromotionStateReadyForPromotion PromotionState = "READY_FOR_PROMOTION"
+	PromotionStatePromotionPROpen   PromotionState = "PROMOTION_PR_OPEN"
+	PromotionStatePromoted          PromotionState = "PROMOTED"
+)
+
+// PromotionFlow enforces explicit review gates for app-overlay to platform-DRY promotion.
+type PromotionFlow struct {
+	SchemaVersion            string         `json:"schema_version"`
+	ChangeID                 string         `json:"change_id"`
+	ReviewLink               ReviewLink     `json:"review_link"`
+	GovernanceDecision       DecisionState  `json:"governance_decision,omitempty"`
+	GovernanceDecisionRef    string         `json:"governance_decision_ref,omitempty"`
+	DeploymentVerified       bool           `json:"deployment_verified"`
+	PromotionPR              PullRequestRef `json:"promotion_pr"`
+	PlatformReviewApproved   bool           `json:"platform_review_approved"`
+	PlatformReviewApprovedBy string         `json:"platform_review_approved_by,omitempty"`
+	PlatformReviewApprovedAt string         `json:"platform_review_approved_at,omitempty"`
+	PromotionMerged          bool           `json:"promotion_merged"`
+	PromotionMergedBy        string         `json:"promotion_merged_by,omitempty"`
+	PromotionMergedAt        string         `json:"promotion_merged_at,omitempty"`
+	State                    PromotionState `json:"state"`
+	UpdatedAt                string         `json:"updated_at"`
+}
+
+func NewReviewLink(changeID string, pr PullRequestRef, mr MergeRequestRef, at time.Time) (ReviewLink, error) {
+	rec := ReviewLink{
+		SchemaVersion: workflowSchemaVersion,
+		ChangeID:      strings.TrimSpace(changeID),
+		GitPR:         pr,
+		ConfigHubMR:   mr,
+		Status:        reviewLinkStatusOpen,
+		UpdatedAt:     normalizeTime(at),
+	}
+	return rec, ValidateReviewLink(rec)
+}
+
+func ValidateReviewLink(rec ReviewLink) error {
+	if rec.SchemaVersion != workflowSchemaVersion {
+		return fmt.Errorf("unsupported schema_version %q", rec.SchemaVersion)
+	}
+	if strings.TrimSpace(rec.ChangeID) == "" {
+		return fmt.Errorf("missing change_id")
+	}
+	if strings.TrimSpace(rec.GitPR.Repo) == "" {
+		return fmt.Errorf("missing git_pr.repo")
+	}
+	if rec.GitPR.Number <= 0 {
+		return fmt.Errorf("git_pr.number must be > 0")
+	}
+	if strings.TrimSpace(rec.GitPR.URL) == "" {
+		return fmt.Errorf("missing git_pr.url")
+	}
+	if strings.TrimSpace(rec.ConfigHubMR.ID) == "" {
+		return fmt.Errorf("missing confighub_mr.id")
+	}
+	if strings.TrimSpace(rec.ConfigHubMR.URL) == "" {
+		return fmt.Errorf("missing confighub_mr.url")
+	}
+	switch strings.TrimSpace(rec.Status) {
+	case reviewLinkStatusOpen, reviewLinkStatusMerged:
+	default:
+		return fmt.Errorf("unsupported review-link status %q", rec.Status)
+	}
+	if strings.TrimSpace(rec.UpdatedAt) == "" {
+		return fmt.Errorf("missing updated_at")
+	}
+	return nil
+}
+
+func NewPromotionFlow(link ReviewLink, at time.Time) (PromotionFlow, error) {
+	if err := ValidateReviewLink(link); err != nil {
+		return PromotionFlow{}, err
+	}
+	rec := PromotionFlow{
+		SchemaVersion: workflowSchemaVersion,
+		ChangeID:      link.ChangeID,
+		ReviewLink:    link,
+		State:         PromotionStateAwaitingDecision,
+		UpdatedAt:     normalizeTime(at),
+	}
+	return rec, ValidatePromotionFlow(rec)
+}
+
+// ApplyGovernanceDecision records explicit ALLOW|ESCALATE|BLOCK outcome before promotion.
+func ApplyGovernanceDecision(flow PromotionFlow, decision DecisionState, decisionRef string, at time.Time) (PromotionFlow, error) {
+	if err := ValidatePromotionFlow(flow); err != nil {
+		return PromotionFlow{}, err
+	}
+	switch decision {
+	case DecisionStateAllow, DecisionStateEscalate, DecisionStateBlock:
+	default:
+		return PromotionFlow{}, fmt.Errorf("unsupported governance decision %q", decision)
+	}
+	flow.GovernanceDecision = decision
+	flow.GovernanceDecisionRef = strings.TrimSpace(decisionRef)
+	if decision == DecisionStateAllow {
+		flow.State = PromotionStateReadyForPromotion
+	} else {
+		flow.State = PromotionStateDecisionBlocked
+	}
+	flow.UpdatedAt = normalizeTime(at)
+	return flow, ValidatePromotionFlow(flow)
+}
+
+// MarkDeploymentVerified records successful rollout before upstream DRY promotion.
+func MarkDeploymentVerified(flow PromotionFlow, at time.Time) (PromotionFlow, error) {
+	if err := ValidatePromotionFlow(flow); err != nil {
+		return PromotionFlow{}, err
+	}
+	if flow.GovernanceDecision != DecisionStateAllow {
+		return PromotionFlow{}, fmt.Errorf("deployment verification requires ALLOW decision, got %q", flow.GovernanceDecision)
+	}
+	flow.DeploymentVerified = true
+	flow.State = PromotionStateReadyForPromotion
+	flow.UpdatedAt = normalizeTime(at)
+	return flow, ValidatePromotionFlow(flow)
+}
+
+// OpenPromotionPR starts a separate upstream platform-DRY review gate.
+func OpenPromotionPR(flow PromotionFlow, pr PullRequestRef, at time.Time) (PromotionFlow, error) {
+	if err := ValidatePromotionFlow(flow); err != nil {
+		return PromotionFlow{}, err
+	}
+	if flow.GovernanceDecision != DecisionStateAllow {
+		return PromotionFlow{}, fmt.Errorf("promotion PR requires ALLOW decision, got %q", flow.GovernanceDecision)
+	}
+	if !flow.DeploymentVerified {
+		return PromotionFlow{}, fmt.Errorf("promotion PR requires deployment_verified=true")
+	}
+	if strings.TrimSpace(pr.Repo) == "" || pr.Number <= 0 || strings.TrimSpace(pr.URL) == "" {
+		return PromotionFlow{}, fmt.Errorf("promotion PR requires repo, number, and url")
+	}
+	flow.PromotionPR = pr
+	flow.State = PromotionStatePromotionPROpen
+	flow.UpdatedAt = normalizeTime(at)
+	return flow, ValidatePromotionFlow(flow)
+}
+
+// ApprovePlatformReview marks required upstream review gate as satisfied.
+func ApprovePlatformReview(flow PromotionFlow, approvedBy string, at time.Time) (PromotionFlow, error) {
+	if err := ValidatePromotionFlow(flow); err != nil {
+		return PromotionFlow{}, err
+	}
+	if flow.State != PromotionStatePromotionPROpen {
+		return PromotionFlow{}, fmt.Errorf("platform review approval requires promotion PR open, got %q", flow.State)
+	}
+	name := strings.TrimSpace(approvedBy)
+	if name == "" {
+		return PromotionFlow{}, fmt.Errorf("platform review approval requires non-empty approver")
+	}
+	flow.PlatformReviewApproved = true
+	flow.PlatformReviewApprovedBy = name
+	flow.PlatformReviewApprovedAt = normalizeTime(at)
+	flow.UpdatedAt = flow.PlatformReviewApprovedAt
+	return flow, ValidatePromotionFlow(flow)
+}
+
+// MergePromotionPR enforces separate upstream review before merging platform DRY promotion.
+func MergePromotionPR(flow PromotionFlow, mergedBy string, at time.Time) (PromotionFlow, error) {
+	if err := ValidatePromotionFlow(flow); err != nil {
+		return PromotionFlow{}, err
+	}
+	if flow.State != PromotionStatePromotionPROpen {
+		return PromotionFlow{}, fmt.Errorf("promotion merge requires promotion PR open, got %q", flow.State)
+	}
+	if !flow.PlatformReviewApproved {
+		return PromotionFlow{}, fmt.Errorf("guardrail: cannot merge platform DRY promotion without separate platform review approval")
+	}
+	name := strings.TrimSpace(mergedBy)
+	if name == "" {
+		return PromotionFlow{}, fmt.Errorf("promotion merge requires non-empty merged_by")
+	}
+	flow.PromotionMerged = true
+	flow.PromotionMergedBy = name
+	flow.PromotionMergedAt = normalizeTime(at)
+	flow.State = PromotionStatePromoted
+	flow.UpdatedAt = flow.PromotionMergedAt
+	flow.ReviewLink.Status = reviewLinkStatusMerged
+	flow.ReviewLink.UpdatedAt = flow.UpdatedAt
+	return flow, ValidatePromotionFlow(flow)
+}
+
+func ValidatePromotionFlow(flow PromotionFlow) error {
+	if flow.SchemaVersion != workflowSchemaVersion {
+		return fmt.Errorf("unsupported schema_version %q", flow.SchemaVersion)
+	}
+	if strings.TrimSpace(flow.ChangeID) == "" {
+		return fmt.Errorf("missing change_id")
+	}
+	if err := ValidateReviewLink(flow.ReviewLink); err != nil {
+		return err
+	}
+	if flow.ChangeID != flow.ReviewLink.ChangeID {
+		return fmt.Errorf("review link change_id mismatch: flow=%s review_link=%s", flow.ChangeID, flow.ReviewLink.ChangeID)
+	}
+	switch flow.State {
+	case PromotionStateAwaitingDecision, PromotionStateDecisionBlocked, PromotionStateReadyForPromotion, PromotionStatePromotionPROpen, PromotionStatePromoted:
+	default:
+		return fmt.Errorf("unsupported promotion state %q", flow.State)
+	}
+	if flow.State == PromotionStateReadyForPromotion || flow.State == PromotionStatePromotionPROpen || flow.State == PromotionStatePromoted {
+		if flow.GovernanceDecision != DecisionStateAllow {
+			return fmt.Errorf("state %q requires ALLOW decision", flow.State)
+		}
+	}
+	if flow.State == PromotionStatePromotionPROpen || flow.State == PromotionStatePromoted {
+		if strings.TrimSpace(flow.PromotionPR.Repo) == "" || flow.PromotionPR.Number <= 0 || strings.TrimSpace(flow.PromotionPR.URL) == "" {
+			return fmt.Errorf("state %q requires promotion_pr linkage", flow.State)
+		}
+	}
+	if flow.State == PromotionStatePromoted {
+		if !flow.PlatformReviewApproved {
+			return fmt.Errorf("state %q requires platform_review_approved=true", flow.State)
+		}
+		if !flow.PromotionMerged {
+			return fmt.Errorf("state %q requires promotion_merged=true", flow.State)
+		}
+	}
+	if strings.TrimSpace(flow.UpdatedAt) == "" {
+		return fmt.Errorf("missing updated_at")
+	}
+	return nil
+}
+
+func normalizeTime(at time.Time) string {
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	return at.UTC().Format(time.RFC3339)
+}

--- a/internal/bridge/workflow_test.go
+++ b/internal/bridge/workflow_test.go
@@ -1,0 +1,178 @@
+package bridge
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReviewLinkValidation(t *testing.T) {
+	link, err := NewReviewLink(
+		"chg_1",
+		PullRequestRef{
+			Repo:      "github.com/confighub/app-repo",
+			Number:    42,
+			URL:       "https://github.com/confighub/app-repo/pull/42",
+			CommitSHA: "abc123",
+		},
+		MergeRequestRef{
+			ID:     "mr_123",
+			URL:    "https://confighub.local/spaces/platform/merge-requests/mr_123",
+			Status: "OPEN",
+		},
+		time.Date(2026, 3, 6, 11, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("NewReviewLink returned error: %v", err)
+	}
+	if link.SchemaVersion != workflowSchemaVersion {
+		t.Fatalf("expected schema %q, got %q", workflowSchemaVersion, link.SchemaVersion)
+	}
+	if link.ChangeID != "chg_1" {
+		t.Fatalf("expected change_id chg_1, got %q", link.ChangeID)
+	}
+	if link.Status != reviewLinkStatusOpen {
+		t.Fatalf("expected review-link status %q, got %q", reviewLinkStatusOpen, link.Status)
+	}
+}
+
+func TestPromotionFlowHappyPath(t *testing.T) {
+	link, err := NewReviewLink(
+		"chg_1",
+		PullRequestRef{
+			Repo:   "github.com/confighub/app-repo",
+			Number: 42,
+			URL:    "https://github.com/confighub/app-repo/pull/42",
+		},
+		MergeRequestRef{
+			ID:  "mr_123",
+			URL: "https://confighub.local/spaces/platform/merge-requests/mr_123",
+		},
+		time.Date(2026, 3, 6, 11, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("NewReviewLink returned error: %v", err)
+	}
+	flow, err := NewPromotionFlow(link, time.Date(2026, 3, 6, 11, 1, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewPromotionFlow returned error: %v", err)
+	}
+
+	flow, err = ApplyGovernanceDecision(flow, DecisionStateAllow, "decision_123", time.Date(2026, 3, 6, 11, 2, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ApplyGovernanceDecision returned error: %v", err)
+	}
+	flow, err = MarkDeploymentVerified(flow, time.Date(2026, 3, 6, 11, 3, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("MarkDeploymentVerified returned error: %v", err)
+	}
+	flow, err = OpenPromotionPR(flow, PullRequestRef{
+		Repo:   "github.com/confighub/platform-dry",
+		Number: 7,
+		URL:    "https://github.com/confighub/platform-dry/pull/7",
+	}, time.Date(2026, 3, 6, 11, 4, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("OpenPromotionPR returned error: %v", err)
+	}
+	flow, err = ApprovePlatformReview(flow, "platform-owner", time.Date(2026, 3, 6, 11, 5, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ApprovePlatformReview returned error: %v", err)
+	}
+	flow, err = MergePromotionPR(flow, "platform-owner", time.Date(2026, 3, 6, 11, 6, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("MergePromotionPR returned error: %v", err)
+	}
+
+	if flow.State != PromotionStatePromoted {
+		t.Fatalf("expected state %q, got %q", PromotionStatePromoted, flow.State)
+	}
+	if !flow.PlatformReviewApproved || !flow.PromotionMerged {
+		t.Fatalf("expected review + merge gates true, got flow=%+v", flow)
+	}
+	if flow.ReviewLink.Status != reviewLinkStatusMerged {
+		t.Fatalf("expected review-link status %q, got %q", reviewLinkStatusMerged, flow.ReviewLink.Status)
+	}
+}
+
+func TestPromotionFlowRequiresAllowBeforePromotion(t *testing.T) {
+	link, err := NewReviewLink(
+		"chg_1",
+		PullRequestRef{
+			Repo:   "github.com/confighub/app-repo",
+			Number: 42,
+			URL:    "https://github.com/confighub/app-repo/pull/42",
+		},
+		MergeRequestRef{
+			ID:  "mr_123",
+			URL: "https://confighub.local/spaces/platform/merge-requests/mr_123",
+		},
+		time.Date(2026, 3, 6, 11, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("NewReviewLink returned error: %v", err)
+	}
+	flow, err := NewPromotionFlow(link, time.Date(2026, 3, 6, 11, 1, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewPromotionFlow returned error: %v", err)
+	}
+	flow, err = ApplyGovernanceDecision(flow, DecisionStateEscalate, "decision_123", time.Date(2026, 3, 6, 11, 2, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ApplyGovernanceDecision returned error: %v", err)
+	}
+
+	_, err = MarkDeploymentVerified(flow, time.Date(2026, 3, 6, 11, 3, 0, 0, time.UTC))
+	if err == nil {
+		t.Fatal("expected ALLOW gate error, got nil")
+	}
+	expected := `deployment verification requires ALLOW decision, got "ESCALATE"`
+	if err.Error() != expected {
+		t.Fatalf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestPromotionFlowGuardrailBlocksMergeWithoutPlatformReview(t *testing.T) {
+	link, err := NewReviewLink(
+		"chg_1",
+		PullRequestRef{
+			Repo:   "github.com/confighub/app-repo",
+			Number: 42,
+			URL:    "https://github.com/confighub/app-repo/pull/42",
+		},
+		MergeRequestRef{
+			ID:  "mr_123",
+			URL: "https://confighub.local/spaces/platform/merge-requests/mr_123",
+		},
+		time.Date(2026, 3, 6, 11, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("NewReviewLink returned error: %v", err)
+	}
+	flow, err := NewPromotionFlow(link, time.Date(2026, 3, 6, 11, 1, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewPromotionFlow returned error: %v", err)
+	}
+	flow, err = ApplyGovernanceDecision(flow, DecisionStateAllow, "decision_123", time.Date(2026, 3, 6, 11, 2, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ApplyGovernanceDecision returned error: %v", err)
+	}
+	flow, err = MarkDeploymentVerified(flow, time.Date(2026, 3, 6, 11, 3, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("MarkDeploymentVerified returned error: %v", err)
+	}
+	flow, err = OpenPromotionPR(flow, PullRequestRef{
+		Repo:   "github.com/confighub/platform-dry",
+		Number: 7,
+		URL:    "https://github.com/confighub/platform-dry/pull/7",
+	}, time.Date(2026, 3, 6, 11, 4, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("OpenPromotionPR returned error: %v", err)
+	}
+
+	_, err = MergePromotionPR(flow, "platform-owner", time.Date(2026, 3, 6, 11, 5, 0, 0, time.UTC))
+	if err == nil {
+		t.Fatal("expected separate review guardrail error, got nil")
+	}
+	expected := "guardrail: cannot merge platform DRY promotion without separate platform review approval"
+	if err.Error() != expected {
+		t.Fatalf("expected %q, got %q", expected, err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- add review-link contract for Git PR <-> ConfigHub MR correlation via shared change_id
- add promotion state machine for app overlay -> platform DRY promotion with explicit governance and rollout gates
- enforce anti-pattern guardrail: no promotion merge to protected upstream DRY without separate platform review approval
- add workflow tests for happy path, ALLOW gate enforcement, and merge-guardrail blocking
- document PR<->MR linkage and promotion model and update roadmap/testing references

## Validation
- go test ./...
- make ci

Closes #97
