### PR TITLE
Enrich core demo examples into realistic platform+app repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Or run all modules in one pass:
 ./examples/demo/run-all-modules.sh
 ```
 
+Example repo narratives and ownership maps are documented in `/Users/alexis/Public/github-repos/cub-gen/examples/README.md`.
+
 ## 10-minute adoption path (Flux/Argo/Helm)
 
 Start with a Helm-based repo and keep your existing runtime model intact.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,31 @@
+# Example repos for demo narratives
+
+These fixtures are intentionally small but realistic enough to demonstrate platform + app collaboration and governance turns.
+
+## Core examples (MVP demos)
+
+1. `helm-paas`
+- Platform-owned chart contract + app-owned values overlays.
+- Shows DRY value edits, env rollout, and guarded promotion.
+
+2. `scoredev-paas`
+- App-first workload intent with platform contracts/policies.
+- Shows field-origin and inverse-edit mapping.
+
+3. `springboot-paas`
+- Application code + app config + platform runtime policy split.
+- Shows app/team ownership boundaries in inverse pointers.
+
+## v0.2 preview examples
+
+4. `backstage-idp`
+5. `ably-config`
+6. `ops-workflow`
+
+## Demo rule
+
+All examples assume:
+- Kubernetes runtime
+- Git + OCI transport
+- Flux or Argo reconciliation
+- ConfigHub governance and API layer on top

--- a/examples/helm-paas/Chart.yaml
+++ b/examples/helm-paas/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v2
 name: payments-api
 version: 0.1.0
 appVersion: "1.0.0"
+description: Platform-managed chart contract for payments-api.
+type: application

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -1,0 +1,34 @@
+# helm-paas example (platform + app)
+
+This fixture models a realistic platform + app repo where a platform team owns the chart contract and runtime guardrails, while an app team owns selected values.
+
+## Narrative turns
+
+1. App feature change
+- App team bumps `image.tag` and toggles an app flag in `values.yaml`.
+- `cub-gen gitops import` shows this as app-editable DRY (`values.*`) with inverse pointers.
+
+2. Environment rollout
+- Ops applies override in `values-prod.yaml` for replicas/resources.
+- Import output keeps the env override lineage explicit.
+
+3. Governed decision
+- Bundle + attestation move through `bridge decision` state.
+- Platform approver issues explicit `ALLOW | ESCALATE | BLOCK`.
+
+4. Promotion upstream
+- After successful rollout, promotion path opens a platform DRY PR for reusable defaults.
+
+## Ownership map
+
+- Platform-owned DRY: `Chart.yaml`, `templates/*`, `platform/*`
+- App-owned DRY: `values.yaml`, selected keys in `values-prod.yaml`
+- Runtime reconcile: Flux/Argo consume WET artifacts via Git/OCI
+
+## Key files
+
+- Chart: `Chart.yaml`
+- App defaults: `values.yaml`
+- Prod overrides: `values-prod.yaml`
+- Flux transport sample: `gitops/flux/helmrelease.yaml`
+- Argo transport sample: `gitops/argo/application.yaml`

--- a/examples/helm-paas/apps/payments-api/owner-values.md
+++ b/examples/helm-paas/apps/payments-api/owner-values.md
@@ -1,0 +1,13 @@
+# App owner editable keys
+
+App team is expected to edit only:
+
+- `image.tag`
+- `appConfig.featureFlags.*`
+- `appConfig.logLevel`
+
+Platform review required before changing:
+
+- `service.*`
+- `resources.*`
+- `templates/*`

--- a/examples/helm-paas/docs/user-stories.md
+++ b/examples/helm-paas/docs/user-stories.md
@@ -1,0 +1,6 @@
+# User stories served by this fixture
+
+1. As an app engineer, I can ship feature flags without editing templates.
+2. As a platform engineer, I can verify runtime policy requirements before ALLOW.
+3. As a reviewer, I can see DRY->WET provenance for image and resource changes.
+4. As an operator, I can keep Flux/Argo unchanged while adopting governed mutation flow.

--- a/examples/helm-paas/gitops/argo/application.yaml
+++ b/examples/helm-paas/gitops/argo/application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: payments-api
+  namespace: argocd
+spec:
+  project: platform-apps
+  source:
+    repoURL: oci://ghcr.io/example/platform-manifests
+    targetRevision: latest
+    path: payments-api
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: apps
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/helm-paas/gitops/flux/helmrelease.yaml
+++ b/examples/helm-paas/gitops/flux/helmrelease.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: payments-api
+  namespace: apps
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: payments-api
+    namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: payments-api-values

--- a/examples/helm-paas/platform/base/network-policy.yaml
+++ b/examples/helm-paas/platform/base/network-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: payments-api-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: payments-api
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              name: shared-services

--- a/examples/helm-paas/platform/base/runtime-policy.yaml
+++ b/examples/helm-paas/platform/base/runtime-policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: platform.confighub.io/v1alpha1
+kind: RuntimePolicy
+metadata:
+  name: payments-api-defaults
+spec:
+  owner: platform-engineering
+  requireReadinessProbe: true
+  requireResourceLimits: true
+  allowedNamespaces:
+    - apps

--- a/examples/helm-paas/platform/overlays/prod/resource-baseline.yaml
+++ b/examples/helm-paas/platform/overlays/prod/resource-baseline.yaml
@@ -1,0 +1,9 @@
+apiVersion: platform.confighub.io/v1alpha1
+kind: RuntimeBaseline
+metadata:
+  name: payments-api-prod
+spec:
+  environment: prod
+  minReplicas: 3
+  maxReplicas: 12
+  targetCPUUtilizationPercentage: 65

--- a/examples/helm-paas/templates/deployment.yaml
+++ b/examples/helm-paas/templates/deployment.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/part-of: commerce-platform
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -15,5 +18,13 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.port }}
+          env:
+            - name: LOG_LEVEL
+              value: "{{ .Values.appConfig.logLevel }}"
+            - name: FEATURE_FAST_CHECKOUT
+              value: "{{ .Values.appConfig.featureFlags.fastCheckout }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/examples/helm-paas/values-prod.yaml
+++ b/examples/helm-paas/values-prod.yaml
@@ -1,3 +1,16 @@
 replicaCount: 4
+
 image:
   tag: v1.0.3
+
+appConfig:
+  featureFlags:
+    fastCheckout: true
+
+resources:
+  requests:
+    cpu: 300m
+    memory: 384Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi

--- a/examples/helm-paas/values.yaml
+++ b/examples/helm-paas/values.yaml
@@ -1,7 +1,23 @@
 replicaCount: 2
+
 image:
   repository: ghcr.io/example/payments-api
   tag: v1.0.0
+  pullPolicy: IfNotPresent
+
 service:
   type: ClusterIP
   port: 8080
+
+appConfig:
+  featureFlags:
+    fastCheckout: false
+  logLevel: info
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi

--- a/examples/scoredev-paas/README.md
+++ b/examples/scoredev-paas/README.md
@@ -1,0 +1,26 @@
+# scoredev-paas example (platform + app)
+
+This fixture demonstrates app-first DRY intent (`score.yaml`) with platform contracts and GitOps transport.
+
+## Narrative turns
+
+1. Prompt-first app change
+- Developer updates workload image and env vars in `score.yaml`.
+- `cub-gen` maps each change to WET field lineage.
+
+2. Platform guardrail check
+- Platform policy checks required probes/resources from contract files.
+- Decision path remains explicit (`ALLOW | ESCALATE | BLOCK`).
+
+3. Runtime rollout
+- Flux/Argo syncs WET manifests.
+- ConfigHub keeps attestation + provenance continuity.
+
+4. Promotion
+- Reusable app conventions can be promoted to platform defaults.
+
+## Ownership map
+
+- App-owned DRY: `score.yaml`, `app/*`
+- Platform-owned DRY: `platform/contracts/*`, `platform/policies/*`
+- Runtime reconcile: Flux/Argo

--- a/examples/scoredev-paas/app/package.json
+++ b/examples/scoredev-paas/app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "checkout-api",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node src/server.js"
+  }
+}

--- a/examples/scoredev-paas/app/src/server.js
+++ b/examples/scoredev-paas/app/src/server.js
@@ -1,0 +1,19 @@
+const http = require("http");
+
+const port = process.env.PORT || 8080;
+const logLevel = process.env.LOG_LEVEL || "info";
+
+const server = http.createServer((req, res) => {
+  if (req.url === "/healthz") {
+    res.writeHead(200);
+    res.end("ok");
+    return;
+  }
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ service: "checkout-api", logLevel }));
+});
+
+server.listen(port, () => {
+  console.log(`checkout-api listening on ${port} (LOG_LEVEL=${logLevel})`);
+});

--- a/examples/scoredev-paas/docs/user-stories.md
+++ b/examples/scoredev-paas/docs/user-stories.md
@@ -1,0 +1,6 @@
+# User stories served by this fixture
+
+1. As an app engineer, I can express service intent without hand-authoring K8s YAML.
+2. As a platform engineer, I can enforce class contracts and policy before rollout.
+3. As an approver, I can audit env-var-level provenance and inverse pointers.
+4. As a GitOps team, I can keep Flux/Argo workflow unchanged.

--- a/examples/scoredev-paas/gitops/argo/application.yaml
+++ b/examples/scoredev-paas/gitops/argo/application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: checkout-api
+  namespace: argocd
+spec:
+  project: platform-apps
+  source:
+    repoURL: oci://ghcr.io/example/platform-manifests
+    targetRevision: latest
+    path: checkout-api
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: apps
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/scoredev-paas/gitops/flux/kustomization.yaml
+++ b/examples/scoredev-paas/gitops/flux/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: checkout-api
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./checkout-api
+  prune: true
+  sourceRef:
+    kind: OCIRepository
+    name: platform-manifests

--- a/examples/scoredev-paas/platform/contracts/workload-class.yaml
+++ b/examples/scoredev-paas/platform/contracts/workload-class.yaml
@@ -1,0 +1,12 @@
+apiVersion: platform.confighub.io/v1alpha1
+kind: WorkloadClass
+metadata:
+  name: web-api-standard
+spec:
+  requiredProbes:
+    - readiness
+    - liveness
+  requiredResources:
+    requests:
+      cpu: 100m
+      memory: 128Mi

--- a/examples/scoredev-paas/platform/policies/network-egress.yaml
+++ b/examples/scoredev-paas/platform/policies/network-egress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: checkout-api-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: checkout-api
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              name: data-services

--- a/examples/scoredev-paas/score.yaml
+++ b/examples/scoredev-paas/score.yaml
@@ -1,6 +1,9 @@
 apiVersion: score.dev/v1b1
+kind: Workload
 metadata:
   name: checkout-api
+  annotations:
+    owner: app-team-checkout
 containers:
   main:
     image: ghcr.io/example/checkout-api:v1.0.0

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -1,0 +1,25 @@
+# springboot-paas example (platform + app)
+
+This fixture models a typical internal Java service repo where app teams edit business config and platform teams own runtime and shared dependency policy.
+
+## Narrative turns
+
+1. Feature rollout
+- App team changes `server.port` and feature flags in `application-prod.yaml`.
+- `cub-gen` reports those edits as app-team DRY with inverse pointers.
+
+2. Platform safety check
+- Platform verifies datasource/runtime boundaries and policy evidence.
+- Governance decision is explicit before apply.
+
+3. Runtime reconciliation
+- Flux/Argo reconciles rendered WET manifests from Git/OCI.
+
+4. Upstream promotion
+- Reusable app-level defaults can be promoted to platform base after successful rollout.
+
+## Ownership map
+
+- App-owned DRY: `src/main/resources/application*.yaml`, `src/main/java/*`
+- Platform-owned DRY: `platform/*`
+- Runtime reconcile: Flux/Argo

--- a/examples/springboot-paas/docs/user-stories.md
+++ b/examples/springboot-paas/docs/user-stories.md
@@ -1,0 +1,6 @@
+# User stories served by this fixture
+
+1. As an app engineer, I can ship Java app changes plus bounded config edits in one flow.
+2. As a platform engineer, I can keep datasource/runtime controls under policy ownership.
+3. As a reviewer, I can trace `server.port`/`spring.application.name` provenance into WET fields.
+4. As a GitOps operator, I can keep Flux/Argo as reconciler while adding governance evidence.

--- a/examples/springboot-paas/gitops/argo/application.yaml
+++ b/examples/springboot-paas/gitops/argo/application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: inventory-api
+  namespace: argocd
+spec:
+  project: platform-apps
+  source:
+    repoURL: oci://ghcr.io/example/platform-manifests
+    targetRevision: latest
+    path: inventory-api
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: apps
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/springboot-paas/gitops/flux/kustomization.yaml
+++ b/examples/springboot-paas/gitops/flux/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: inventory-api
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./inventory-api
+  prune: true
+  sourceRef:
+    kind: OCIRepository
+    name: platform-manifests

--- a/examples/springboot-paas/platform/base/runtime-policy.yaml
+++ b/examples/springboot-paas/platform/base/runtime-policy.yaml
@@ -1,0 +1,8 @@
+apiVersion: platform.confighub.io/v1alpha1
+kind: RuntimePolicy
+metadata:
+  name: inventory-api-defaults
+spec:
+  owner: platform-engineering
+  requireActuatorHealth: true
+  managedDatasource: postgres-shared

--- a/examples/springboot-paas/platform/overlays/prod/slo-policy.yaml
+++ b/examples/springboot-paas/platform/overlays/prod/slo-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: platform.confighub.io/v1alpha1
+kind: ServiceLevelPolicy
+metadata:
+  name: inventory-api-prod
+spec:
+  availabilityTarget: "99.9%"
+  p95LatencyMs: 250

--- a/examples/springboot-paas/pom.xml
+++ b/examples/springboot-paas/pom.xml
@@ -5,4 +5,21 @@
   <groupId>com.example</groupId>
   <artifactId>inventory-api</artifactId>
   <version>0.0.1-SNAPSHOT</version>
+  <name>inventory-api</name>
+  <properties>
+    <java.version>21</java.version>
+    <spring.boot.version>3.3.2</spring.boot.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${spring.boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${spring.boot.version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/examples/springboot-paas/src/main/java/com/example/inventory/InventoryApplication.java
+++ b/examples/springboot-paas/src/main/java/com/example/inventory/InventoryApplication.java
@@ -1,0 +1,11 @@
+package com.example.inventory;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class InventoryApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(InventoryApplication.class, args);
+    }
+}

--- a/examples/springboot-paas/src/main/java/com/example/inventory/api/InventoryController.java
+++ b/examples/springboot-paas/src/main/java/com/example/inventory/api/InventoryController.java
@@ -1,0 +1,14 @@
+package com.example.inventory.api;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class InventoryController {
+
+    @GetMapping("/healthz")
+    public Map<String, String> health() {
+        return Map.of("status", "ok", "service", "inventory-api");
+    }
+}

--- a/examples/springboot-paas/src/main/java/com/example/inventory/service/InventoryService.java
+++ b/examples/springboot-paas/src/main/java/com/example/inventory/service/InventoryService.java
@@ -1,0 +1,10 @@
+package com.example.inventory.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class InventoryService {
+    public String reservationMode() {
+        return "strict";
+    }
+}

--- a/examples/springboot-paas/src/main/resources/application-prod.yaml
+++ b/examples/springboot-paas/src/main/resources/application-prod.yaml
@@ -1,2 +1,5 @@
 server:
   port: 8081
+feature:
+  inventory:
+    reservationMode: strict

--- a/examples/springboot-paas/src/main/resources/application.yaml
+++ b/examples/springboot-paas/src/main/resources/application.yaml
@@ -6,3 +6,8 @@ spring:
     username: inventory
 server:
   port: 8080
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info


### PR DESCRIPTION
## Summary
- upgrade core fixtures (`helm-paas`, `scoredev-paas`, `springboot-paas`) to look like realistic platform + app repos
- add narrative docs and user-story docs for each core fixture
- add GitOps transport samples for both Flux and Argo in each core fixture
- add platform ownership/policy examples and app ownership hints
- add spring boot source files so spring example is now a real app scaffold
- add top-level examples guide at `examples/README.md`
- link example narratives from root README

## Verification
- `go test ./...`
- `make ci`
- `./examples/demo/run-all-modules.sh`
