### PR TITLE
Add repo-wizard simulation and AI work platform demo track

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Run any module independently:
 ./examples/demo/module-2-score-field-map.sh
 ./examples/demo/module-3-spring-ownership.sh
 ./examples/demo/module-4-bridge-governance.sh
+./examples/demo/module-5-ably-platform.sh
 ```
 
 Or run all modules in one pass:
@@ -42,6 +43,39 @@ Or run all modules in one pass:
 ```
 
 Example repo narratives and ownership maps are documented in `/Users/alexis/Public/github-repos/cub-gen/examples/README.md`.
+
+## Wizard Simulation (Repo-First)
+
+Simulate a future GUI discover/import wizard against any repo fixture:
+
+```bash
+./examples/demo/simulate-repo-wizard.sh ./examples/helm-paas ./examples/helm-paas auto
+./examples/demo/simulate-repo-wizard.sh ./examples/springboot-paas ./examples/springboot-paas springboot-paas
+```
+
+This script walks the same step sequence planned for the GUI:
+1. source selection
+2. discover preview
+3. import graph preview (DRY -> GEN -> WET)
+4. provenance/inverse hint preview
+5. import confirmation + bundle/verify/attest summary
+
+## AI Work Platform Demo Track
+
+Second demo track focused on AI-work platform scenarios:
+
+```bash
+./examples/demo/ai-work-platform/run-all.sh
+```
+
+Or run scenarios individually:
+
+```bash
+./examples/demo/ai-work-platform/scenario-1-jesper-ai-cloud.sh
+./examples/demo/ai-work-platform/scenario-2-swamp-project.sh
+./examples/demo/ai-work-platform/scenario-3-confighub-actions.sh
+./examples/demo/ai-work-platform/scenario-4-operations.sh
+```
 
 ## 10-minute adoption path (Flux/Argo/Helm)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,11 +16,23 @@ These fixtures are intentionally small but realistic enough to demonstrate platf
 - Application code + app config + platform runtime policy split.
 - Shows app/team ownership boundaries in inverse pointers.
 
-## v0.2 preview examples
+4. `ably-config`
+- App-config style platform integration with explicit inverse edit guidance.
+- Included in the core PaaS demo path alongside Spring.
 
-4. `backstage-idp`
-5. `ably-config`
-6. `ops-workflow`
+## AI work platform scenarios
+
+5. `jesper-ai-cloud`
+6. `swamp-project`
+7. `confighub-actions`
+8. `ops-workflow`
+
+Run the AI track scripts under:
+- `examples/demo/ai-work-platform/`
+
+## Additional preview examples
+
+9. `backstage-idp`
 
 ## Demo rule
 

--- a/examples/confighub-actions/README.md
+++ b/examples/confighub-actions/README.md
@@ -1,0 +1,6 @@
+# confighub-actions (AI work platform fixture)
+
+This fixture models governed execution intent for operations/actions workflows.
+
+- Profile expected: `ops-workflow`
+- Team narrative: app/platform requests become explicit workflow actions with approval gates.

--- a/examples/confighub-actions/operations-prod.yaml
+++ b/examples/confighub-actions/operations-prod.yaml
@@ -1,0 +1,8 @@
+workflow:
+  name: confighub-actions-release-prod
+actions:
+  verify:
+    approvals:
+      required: 2
+  deploy:
+    window: business-hours

--- a/examples/confighub-actions/operations.yaml
+++ b/examples/confighub-actions/operations.yaml
@@ -1,0 +1,11 @@
+workflow:
+  name: confighub-actions-release
+actions:
+  plan:
+    type: dry-run
+  verify:
+    type: policy-check
+  deploy:
+    type: apply
+triggers:
+  commit: true

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -1,0 +1,22 @@
+# Demo entrypoints
+
+## Core platform/app track
+
+- `module-1-helm-import.sh`
+- `module-2-score-field-map.sh`
+- `module-3-spring-ownership.sh`
+- `module-4-bridge-governance.sh`
+- `module-5-ably-platform.sh`
+- `run-all-modules.sh`
+
+## GUI-wizard simulation
+
+- `simulate-repo-wizard.sh <repo-path> <render-target-path> [profile-hint]`
+
+## AI work platform track
+
+- `ai-work-platform/scenario-1-jesper-ai-cloud.sh`
+- `ai-work-platform/scenario-2-swamp-project.sh`
+- `ai-work-platform/scenario-3-confighub-actions.sh`
+- `ai-work-platform/scenario-4-operations.sh`
+- `ai-work-platform/run-all.sh`

--- a/examples/demo/ai-work-platform/README.md
+++ b/examples/demo/ai-work-platform/README.md
@@ -1,0 +1,21 @@
+# AI work platform demo track
+
+These demos simulate AI-work platform use cases while keeping the same local-first `cub-gen` import model.
+
+Scenarios:
+
+1. Jesper's AI cloud (`backstage-idp`)  
+   `./examples/demo/ai-work-platform/scenario-1-jesper-ai-cloud.sh`
+
+2. Swamp project (`helm-paas`)  
+   `./examples/demo/ai-work-platform/scenario-2-swamp-project.sh`
+
+3. ConfigHub Actions (`ops-workflow`)  
+   `./examples/demo/ai-work-platform/scenario-3-confighub-actions.sh`
+
+4. Operations workflow (`ops-workflow`)  
+   `./examples/demo/ai-work-platform/scenario-4-operations.sh`
+
+Run all:
+
+`./examples/demo/ai-work-platform/run-all.sh`

--- a/examples/demo/ai-work-platform/run-all.sh
+++ b/examples/demo/ai-work-platform/run-all.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+./examples/demo/ai-work-platform/scenario-1-jesper-ai-cloud.sh
+./examples/demo/ai-work-platform/scenario-2-swamp-project.sh
+./examples/demo/ai-work-platform/scenario-3-confighub-actions.sh
+./examples/demo/ai-work-platform/scenario-4-operations.sh

--- a/examples/demo/ai-work-platform/scenario-1-jesper-ai-cloud.sh
+++ b/examples/demo/ai-work-platform/scenario-1-jesper-ai-cloud.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[ai-demo-1] Jesper AI Cloud: repo-first wizard simulation"
+./examples/demo/simulate-repo-wizard.sh ./examples/jesper-ai-cloud ./examples/jesper-ai-cloud backstage-idp

--- a/examples/demo/ai-work-platform/scenario-2-swamp-project.sh
+++ b/examples/demo/ai-work-platform/scenario-2-swamp-project.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[ai-demo-2] Swamp Project: platform Helm package import"
+./examples/demo/simulate-repo-wizard.sh ./examples/swamp-project ./examples/swamp-project helm-paas

--- a/examples/demo/ai-work-platform/scenario-3-confighub-actions.sh
+++ b/examples/demo/ai-work-platform/scenario-3-confighub-actions.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[ai-demo-3] ConfigHub Actions: governed execution intent import"
+./examples/demo/simulate-repo-wizard.sh ./examples/confighub-actions ./examples/confighub-actions ops-workflow

--- a/examples/demo/ai-work-platform/scenario-4-operations.sh
+++ b/examples/demo/ai-work-platform/scenario-4-operations.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[ai-demo-4] Operations workflow: existing operations example"
+./examples/demo/simulate-repo-wizard.sh ./examples/ops-workflow ./examples/ops-workflow ops-workflow

--- a/examples/demo/module-5-ably-platform.sh
+++ b/examples/demo/module-5-ably-platform.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[module-5] build cub-gen"
+go build -o ./cub-gen ./cmd/cub-gen
+
+echo "[module-5] import ably platform config and show ownership/provenance"
+./cub-gen gitops import --space platform --json ./examples/ably-config ./examples/ably-config \
+  | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets, inverse_edit_pointers: .provenance[0].inverse_edit_pointers}'

--- a/examples/demo/run-all-modules.sh
+++ b/examples/demo/run-all-modules.sh
@@ -8,4 +8,5 @@ cd "$ROOT_DIR"
 ./examples/demo/module-2-score-field-map.sh
 ./examples/demo/module-3-spring-ownership.sh
 ./examples/demo/module-4-bridge-governance.sh
+./examples/demo/module-5-ably-platform.sh
 

--- a/examples/demo/simulate-repo-wizard.sh
+++ b/examples/demo/simulate-repo-wizard.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+REPO_PATH="${1:-./examples/helm-paas}"
+RENDER_TARGET="${2:-$REPO_PATH}"
+SPACE="${SPACE:-platform}"
+PROFILE_HINT="${3:-auto}"
+
+if [ ! -d "$REPO_PATH" ]; then
+  echo "error: repo path not found: $REPO_PATH" >&2
+  exit 1
+fi
+
+echo "[wizard] step 1/5: select source"
+echo "  repo: $REPO_PATH"
+echo "  render-target: $RENDER_TARGET"
+echo "  profile-hint: $PROFILE_HINT"
+echo "  space: $SPACE"
+
+echo "[wizard] build cub-gen"
+go build -o ./cub-gen ./cmd/cub-gen
+
+echo "[wizard] step 2/5: discover generators"
+DISCOVER_JSON="$(./cub-gen gitops discover --space "$SPACE" --json "$REPO_PATH")"
+echo "$DISCOVER_JSON" | jq '{repo: .target_path, discovered_count: (.resources|length), resource_types: [.resources[].resource_type] | unique, resource_names: [.resources[].resource_name]}'
+
+echo "[wizard] step 3/5: preview import graph (DRY -> GEN -> WET)"
+IMPORT_JSON="$(./cub-gen gitops import --space "$SPACE" --json "$REPO_PATH" "$RENDER_TARGET")"
+echo "$IMPORT_JSON" | jq '{profiles: [.discovered[].generator_profile] | unique, dry_units: (.dry_units|length), generator_units: (.generator_units|length), wet_units: (.wet_units|length), links: (.links|length), dry_inputs: (.dry_inputs|length), wet_manifest_targets: (.wet_manifest_targets|length)}'
+
+echo "[wizard] step 4/5: preview provenance and inverse edit hints"
+echo "$IMPORT_JSON" | jq '{sample_field_origin: (.provenance[0].field_origin_map[0] // null), sample_inverse_hint: (.provenance[0].inverse_edit_pointers[0] // null)}'
+
+echo "[wizard] step 5/5: simulate import confirmation + governed bundle"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "$IMPORT_JSON" > "$TMPDIR/import.json"
+./cub-gen publish --in "$TMPDIR/import.json" > "$TMPDIR/bundle.json"
+./cub-gen verify --json --in "$TMPDIR/bundle.json" > "$TMPDIR/verify.json"
+./cub-gen attest --in "$TMPDIR/bundle.json" --verifier ci-bot > "$TMPDIR/attestation.json"
+
+echo "[wizard] result summary"
+jq '{change_id, bundle_digest, summary}' "$TMPDIR/bundle.json"
+jq '{valid, change_id, bundle_digest}' "$TMPDIR/verify.json"

--- a/examples/jesper-ai-cloud/README.md
+++ b/examples/jesper-ai-cloud/README.md
@@ -1,0 +1,6 @@
+# jesper-ai-cloud (AI work platform fixture)
+
+This fixture models an AI platform catalog component and runtime config surface.
+
+- Profile expected: `backstage-idp`
+- Team narrative: platform team curates the AI cloud component contract; app teams consume it via API.

--- a/examples/jesper-ai-cloud/app-config.yaml
+++ b/examples/jesper-ai-cloud/app-config.yaml
@@ -1,0 +1,6 @@
+app:
+  title: Jesper AI Cloud
+organization:
+  name: ConfigHub Platform
+backend:
+  baseUrl: https://ai-cloud.internal.example

--- a/examples/jesper-ai-cloud/catalog-info.yaml
+++ b/examples/jesper-ai-cloud/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: jesper-ai-cloud
+  description: Internal AI cloud platform control-plane component
+  annotations:
+    owner: platform-ai
+spec:
+  type: service
+  lifecycle: production
+  owner: platform-ai

--- a/examples/swamp-project/Chart.yaml
+++ b/examples/swamp-project/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: swamp-runtime
+version: 0.1.0
+appVersion: "0.1.0"
+description: Helm package for swamp project AI runtime.

--- a/examples/swamp-project/README.md
+++ b/examples/swamp-project/README.md
@@ -1,0 +1,6 @@
+# swamp-project (AI work platform fixture)
+
+This fixture models a platform-provided Helm package for an AI experimentation runtime.
+
+- Profile expected: `helm-paas`
+- Team narrative: platform controls chart contract; project team adjusts values overlays.

--- a/examples/swamp-project/templates/deployment.yaml
+++ b/examples/swamp-project/templates/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          env:
+            - name: MODEL_GATEWAY
+              value: {{ .Values.runtime.modelGateway | quote }}

--- a/examples/swamp-project/values-prod.yaml
+++ b/examples/swamp-project/values-prod.yaml
@@ -1,0 +1,5 @@
+replicaCount: 4
+image:
+  tag: v0.1.3
+runtime:
+  modelGateway: mistral-gateway

--- a/examples/swamp-project/values.yaml
+++ b/examples/swamp-project/values.yaml
@@ -1,0 +1,9 @@
+replicaCount: 2
+image:
+  repository: ghcr.io/example/swamp-runtime
+  tag: v0.1.0
+service:
+  type: ClusterIP
+  port: 8080
+runtime:
+  modelGateway: llama-gateway


### PR DESCRIPTION
## Summary
- add `examples/demo/simulate-repo-wizard.sh` to simulate GUI discover/import steps for repo-first flow
- add AI work platform demo track under `examples/demo/ai-work-platform/` with 4 scenarios:
  - Jesper AI Cloud
  - Swamp Project
  - ConfigHub Actions
  - Operations workflow
- add fixture repos for those scenarios:
  - `examples/jesper-ai-cloud` (backstage-idp)
  - `examples/swamp-project` (helm-paas)
  - `examples/confighub-actions` (ops-workflow)
- add Ably as a core module via `examples/demo/module-5-ably-platform.sh`
- update docs in README and examples indexes for both tracks

## Validation
- `go test ./...`
- `make ci`
- `./examples/demo/run-all-modules.sh`
- `./examples/demo/simulate-repo-wizard.sh ./examples/jesper-ai-cloud ./examples/jesper-ai-cloud backstage-idp`
- `./examples/demo/ai-work-platform/run-all.sh`
