### PR TITLE
docs(agentic-gitops): add illustration pack and story-card navigation

### DIFF
--- a/docs/agentic-gitops/00-index/00-gitops7-index.md
+++ b/docs/agentic-gitops/00-index/00-gitops7-index.md
@@ -59,6 +59,12 @@ v6 had three parts (Narrative, Normative, Examples) in one file. v7 splits by
 08 Adoption      → Business case. "How do I start? What's the value?"
 ```
 
+### Illustrated companions
+
+1. `00-index/02-illustrated-cheat-sheet.md` for visual architecture and enforcement flows.
+2. `03-worked-examples/04-eight-example-story-cards.md` for the 2x4 example map and user-story alignment.
+3. `05-rollout/94-demo-illustration-pack.md` for reusable demo diagrams and talk tracks.
+
 ---
 
 ## The Central Claim

--- a/docs/agentic-gitops/00-index/02-illustrated-cheat-sheet.md
+++ b/docs/agentic-gitops/00-index/02-illustrated-cheat-sheet.md
@@ -1,0 +1,68 @@
+# Illustrated Cheat Sheet
+
+**Purpose:** Fast visual reference for the operating model and demo narrative.
+
+Qualification rule:
+Use `Agentic GitOps` only when an active inner reconciliation loop (`WET -> LIVE`) exists via Flux/Argo (or equivalent reconciler). Without that loop, classify the flow as `governed config automation`.
+
+## 1. Three-loop model
+
+```mermaid
+flowchart LR
+  A["DRY intent"] --> B["Generator\n(DRY -> WET)"]
+  B --> C["WET intended state"]
+  C --> D["Flux/Argo reconcile\n(WET -> LIVE)"]
+  D --> E["LIVE runtime"]
+  E --> F["Evidence + verification"]
+  F --> G["Decision + attestation"]
+  G --> C
+```
+
+## 2. Contract triple
+
+```mermaid
+flowchart TB
+  GC["GeneratorContract\nSigned\nDeterministic hash"]
+  PR["ProvenanceRecord\ninput_hash\ntoolchain_version\npolicy_version\nrun_id\nartifacts"]
+  IP["InverseTransformPlan\nOwnershipMap scope\nReplay check\nDecision gate"]
+
+  GC --> PR
+  PR --> IP
+  IP --> WB["PR/MR write-back only"]
+  IP --> DG["ALLOW | ESCALATE | BLOCK"]
+  DG --> AT["Attestation on ALLOW"]
+```
+
+## 3. Enforcement outcomes
+
+```mermaid
+flowchart TD
+  A["Proposed change"] --> B{"Ownership scope valid?"}
+  B -- "No" --> B1["BLOCK"]
+  B -- "Yes" --> C{"Replay hash match?"}
+  C -- "No" --> C1["ESCALATE"]
+  C -- "Yes" --> D{"Policy decision"}
+  D -- "BLOCK" --> D1["Stop"]
+  D -- "ESCALATE" --> D2["Manual approval"]
+  D -- "ALLOW" --> E["Execute"]
+  E --> F{"Verification pass?"}
+  F -- "No" --> F1["Read-only evidence mode"]
+  F -- "Yes" --> G["Attest + ledger append"]
+```
+
+## 4. 2x4 demo map
+
+```mermaid
+flowchart LR
+  subgraph P["Platform/App track"]
+    H["1. Helm PaaS"] --> S["2. Score.dev"] --> SB["3. Spring Boot"] --> A["4. Ably config"]
+  end
+
+  subgraph W["AI work platform track"]
+    J["5. Jesper AI cloud"] --> SW["6. Swamp project"] --> CA["7. ConfigHub Actions"] --> O["8. Ops workflow"]
+  end
+```
+
+## 5. One-line boundary
+
+`Flux/Argo reconcile. ConfigHub decides. Git records.`

--- a/docs/agentic-gitops/00-index/README.md
+++ b/docs/agentic-gitops/00-index/README.md
@@ -3,14 +3,17 @@
 Start with:
 
 1. `00-gitops7-index.md`
-2. `../01-vision/01-introducing-agentic-gitops.md`
-3. `../02-design/00-agentic-gitops-design.md`
+2. `02-illustrated-cheat-sheet.md`
+3. `../01-vision/01-introducing-agentic-gitops.md`
+4. `../02-design/00-agentic-gitops-design.md`
 
 Then review examples and rollout:
 
 1. `../03-worked-examples/01-scoredev-dry-wet-unit-worked-example.md`
 2. `../03-worked-examples/02-traefik-helm-dry-wet-unit-worked-example.md`
-3. `../05-rollout/40-adoption-and-reference.md`
+3. `../03-worked-examples/04-eight-example-story-cards.md`
+4. `../05-rollout/40-adoption-and-reference.md`
+5. `../05-rollout/94-demo-illustration-pack.md`
 
 Then process new feedback inputs:
 

--- a/docs/agentic-gitops/03-worked-examples/04-eight-example-story-cards.md
+++ b/docs/agentic-gitops/03-worked-examples/04-eight-example-story-cards.md
@@ -1,0 +1,49 @@
+# Eight Example Story Cards
+
+**Purpose:** Keep demo narratives simple, fast, and reusable.
+
+Qualification rule:
+Use `Agentic GitOps` only when an active inner reconciliation loop (`WET -> LIVE`) exists via Flux/Argo (or equivalent reconciler). Without that loop, classify the flow as `governed config automation`.
+
+## 1. Example matrix (2x4)
+
+| # | Example | Primary user story | What it proves | Entry script |
+|---|---|---|---|---|
+| 1 | Helm PaaS | "Keep existing Helm + GitOps, add governance." | No migration, explicit DRY/WET governance. | `examples/demo/module-1-helm-import.sh` |
+| 2 | Score.dev PaaS | "Keep Score abstraction, gain provenance + field map." | DRY intent remains simple; WET is auditable. | `examples/demo/module-2-score-field-map.sh` |
+| 3 | Spring Boot PaaS | "App teams stay in framework config." | Framework config to governed WET with ownership routing. | `examples/demo/module-3-spring-ownership.sh` |
+| 4 | Ably config | "App-config platforms need same controls." | Non-K8s style config still fits DRY/WET + inverse mapping. | `examples/demo/module-5-ably-platform.sh` |
+| 5 | Jesper AI cloud | "AI platform requests need governed runtime path." | DRY work request to verifiable WET task flow. | `examples/demo/ai-work-platform/scenario-1-jesper-ai-cloud.sh` |
+| 6 | Swamp project | "Template-heavy AI project still needs provenance." | Generator + provenance + inverse write in mixed repos. | `examples/demo/ai-work-platform/scenario-2-swamp-project.sh` |
+| 7 | ConfigHub Actions | "Execution must be tokened and attested." | Decision authority separated from execution runtime. | `examples/demo/ai-work-platform/scenario-3-confighub-actions.sh` |
+| 8 | Ops workflow | "Operational waves need one governed change identity." | Multi-target ALLOW/ESCALATE/BLOCK with evidence chain. | `examples/demo/ai-work-platform/scenario-4-operations.sh` |
+
+## 2. Story-map illustration
+
+```mermaid
+flowchart LR
+  subgraph Track1["Platform/App"]
+    E1["Helm"] --> E2["Score"] --> E3["Spring"] --> E4["Ably"]
+  end
+
+  subgraph Track2["AI Work Platform"]
+    E5["Jesper"] --> E6["Swamp"] --> E7["Actions"] --> E8["Ops"]
+  end
+```
+
+## 3. Shared value line per card
+
+1. Keep existing GitOps runtime.
+2. Add usable platform API semantics.
+3. Enforce governed mutation path.
+4. Preserve proof chain from intent to outcome.
+
+## 4. Shared proof gates per card
+
+1. Active reconciler loop is visible (`WET -> LIVE`).
+2. Signed generator contract and deterministic hash exist.
+3. Provenance fields are complete and immutable.
+4. OwnershipMap bounds inverse writes.
+5. Decision gate is explicit (`ALLOW|ESCALATE|BLOCK`).
+6. Attestation on allow is present.
+7. Ledger append is visible.

--- a/docs/agentic-gitops/05-rollout/94-demo-illustration-pack.md
+++ b/docs/agentic-gitops/05-rollout/94-demo-illustration-pack.md
@@ -1,0 +1,64 @@
+# Demo Illustration Pack
+
+**Purpose:** Ready-to-use visuals for meetings, demos, and docs.
+
+Qualification rule:
+Use `Agentic GitOps` only when an active inner reconciliation loop (`WET -> LIVE`) exists via Flux/Argo (or equivalent reconciler). Without that loop, classify the flow as `governed config automation`.
+
+## 1. Layered responsibility diagram
+
+```mermaid
+flowchart TB
+  U["Users and Agents"] --> C["ConfigHub API + Governance"]
+  C --> P["Publish layer\nOCI/Git"]
+  P --> R["Runtime reconciliation\nFlux/Argo"]
+  R --> L["LIVE clusters"]
+  L --> O["Observation + Evidence\ncub-scout"]
+  O --> C
+```
+
+## 2. Decision split (review vs deploy)
+
+```mermaid
+flowchart LR
+  A["Change proposal"] --> B["Merge review"]
+  B --> C{"Deploy decision"}
+  C -- "ALLOW" --> D["Execute tokened apply"]
+  C -- "ESCALATE" --> E["Extra approval"]
+  C -- "BLOCK" --> F["Stop"]
+  D --> G["Verify + attest"]
+```
+
+## 3. DRY/WET/LIVE lifecycle
+
+```mermaid
+sequenceDiagram
+  participant Dev as Developer or Agent
+  participant Gen as Generator
+  participant CH as ConfigHub
+  participant GitOps as Flux/Argo
+  participant Live as LIVE Cluster
+  participant Obs as cub-scout
+
+  Dev->>Gen: DRY input
+  Gen->>CH: WET + contract + provenance
+  CH->>GitOps: Publish (OCI/Git)
+  GitOps->>Live: Reconcile
+  Obs->>CH: Evidence + drift
+  CH->>Dev: Decision + attestation result
+```
+
+## 4. Fast demo overlay script (talk track)
+
+1. Show runtime unchanged (Flux/Argo still reconcile).
+2. Show change proposal and decision split.
+3. Show one enforcement event (BLOCK or ESCALATE).
+4. Show successful ALLOW path with attestation.
+5. Show mutation ledger record.
+
+## 5. Reusable slide captions
+
+1. `No controller replacement: runtime stays Flux/Argo.`
+2. `From file edits to governed platform API decisions.`
+3. `Proof-first operations: verify before success claims.`
+4. `One change identity across intent, execution, and outcome.`

--- a/docs/agentic-gitops/README.md
+++ b/docs/agentic-gitops/README.md
@@ -11,13 +11,16 @@ Hard naming rule:
 ## Reading order (core model)
 
 1. `00-index/00-gitops7-index.md`
-2. `01-vision/01-introducing-agentic-gitops.md`
-3. `01-vision/02-next-gen-gitops-ai-era.md`
-4. `02-design/00-agentic-gitops-design.md`
-5. `02-design/80-agentic-gitops-enforcement-matrix.md`
-6. `03-worked-examples/01-scoredev-dry-wet-unit-worked-example.md`
-7. `03-worked-examples/02-traefik-helm-dry-wet-unit-worked-example.md`
-8. `05-rollout/40-adoption-and-reference.md`
+2. `00-index/02-illustrated-cheat-sheet.md`
+3. `01-vision/01-introducing-agentic-gitops.md`
+4. `01-vision/02-next-gen-gitops-ai-era.md`
+5. `02-design/00-agentic-gitops-design.md`
+6. `02-design/80-agentic-gitops-enforcement-matrix.md`
+7. `03-worked-examples/01-scoredev-dry-wet-unit-worked-example.md`
+8. `03-worked-examples/02-traefik-helm-dry-wet-unit-worked-example.md`
+9. `03-worked-examples/04-eight-example-story-cards.md`
+10. `05-rollout/40-adoption-and-reference.md`
+11. `05-rollout/94-demo-illustration-pack.md`
 
 ## Reading order (blog + external feedback)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,3 +41,9 @@ All examples assume:
 - Git + OCI transport
 - Flux or Argo reconciliation
 - ConfigHub governance and API layer on top
+
+## Docs and illustrations
+
+1. `docs/agentic-gitops/00-index/02-illustrated-cheat-sheet.md`
+2. `docs/agentic-gitops/03-worked-examples/04-eight-example-story-cards.md`
+3. `docs/agentic-gitops/05-rollout/94-demo-illustration-pack.md`


### PR DESCRIPTION
## Summary

- What user problem does this change solve?
- What behavior changed?

## Scope

- In scope:
- Out of scope:

## Deterministic Success Criteria (Required)

1. [ ] Criterion 1 (exact input -> exact expected output)
2. [ ] Criterion 2 (exact input -> exact expected output)
3. [ ] Criterion 3 (exact input -> exact expected output)

## Proof Matrix (Required Before Merge)

| Proof tier | Required? | Command(s) | Deterministic assertion |
|---|---|---|---|
| Unit | Yes | `go test ./...` | Core logic output is stable |
| Parity/Golden | If CLI/JSON/table output changed | `go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v` | Contract output is stable |
| Example proof | If user-visible flow changed | `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v` | Docs/example output matches implementation |

## Commands Run

- [ ] `go build ./cmd/cub-gen`
- [ ] `go test ./...`
- [ ] `go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v`
- [ ] `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v` (if user-visible flow changed)
- Additional commands:

## Graceful Degradation / Error Behavior

- Missing metadata behavior:
- Unsupported input behavior:
- How false confidence is avoided:

## Contract / Docs / Parity Updates

- [ ] `PARITY.md` updated (if contract changed)
- [ ] `README.md` and/or docs updated for user-visible changes
- [ ] `test/TEST-INVENTORY.md` updated if test surface changed
