### PR TITLE
docs(agentic-gitops): fix legacy internal links to canonical paths

### DIFF
--- a/docs/agentic-gitops/00-index/00-gitops7-index.md
+++ b/docs/agentic-gitops/00-index/00-gitops7-index.md
@@ -27,7 +27,7 @@ format. Nothing from v6 is lost; everything is reorganized and expanded.
 | **Field-origin maps and editing as standalone doc** | Extracted from generators doc | 03-field-origin-maps-and-editing.md |
 | **Generators doc as PRD** (product requirements, acceptance criteria, milestones) | Rewritten from v6 | 02-generators-prd.md |
 | **Brian's DRY/WET concern addressed** | Conversation 2026-02-26 | 03-field-origin-maps-and-editing.md |
-| **Day 2 scenarios** (3am incident, fleet visibility, AI audit, config change) | Retained from GitOps6.md | [07-user-experience.md](07-user-experience.md#day-2-scenarios) |
+| **Day 2 scenarios** (3am incident, fleet visibility, AI audit, config change) | Retained from GitOps6.md | [07-user-experience.md](/docs/agentic-gitops/05-rollout/30-user-experience.md#11-day-2-scenarios) |
 | **Lock-in addressed head-on** | dry-wet-config-analysis.md gap analysis | 08-adoption-and-reference.md |
 
 ### Structural changes
@@ -192,14 +192,14 @@ ConfigHub (dry+wet Units; WET deployment contract) ----------+
 
 ## Document Set
 
-1. **[01-introducing-agentic-gitops.md](01-introducing-agentic-gitops.md)** — The problem, the claim, and the invariants
-2. **[02-generators-prd.md](02-generators-prd.md)** — Generator model, maturity levels, provenance requirements
-3. **[03-field-origin-maps-and-editing.md](03-field-origin-maps-and-editing.md)** — Field-origin maps, editing experience, adoption ladder
-4. **[04-app-model-and-contracts.md](04-app-model-and-contracts.md)** — Entities, operating boundary, constraints, operations
-5. **[05-cub-track.md](05-cub-track.md)** — Git-native mutation ledger, ChangeInteractionCard, trust tiers
-6. **[06-governed-execution.md](06-governed-execution.md)** — Two-loop model, evidence, write-back semantics
-7. **[07-user-experience.md](07-user-experience.md)** — Four surfaces, two personas, import flow, AI tooling
-8. **[08-adoption-and-reference.md](08-adoption-and-reference.md)** — Adoption path, value analysis, Day 2 scenarios, FAQ
+1. **[01-introducing-agentic-gitops.md](/docs/agentic-gitops/01-vision/01-introducing-agentic-gitops.md)** — The problem, the claim, and the invariants
+2. **[02-generators-prd.md](/docs/agentic-gitops/02-design/10-generators-prd.md)** — Generator model, maturity levels, provenance requirements
+3. **[03-field-origin-maps-and-editing.md](/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md)** — Field-origin maps, editing experience, adoption ladder
+4. **[04-app-model-and-contracts.md](/docs/agentic-gitops/02-design/30-app-model-and-contracts.md)** — Entities, operating boundary, constraints, operations
+5. **[05-cub-track.md](/docs/agentic-gitops/05-rollout/10-cub-track.md)** — Git-native mutation ledger, ChangeInteractionCard, trust tiers
+6. **[06-governed-execution.md](/docs/agentic-gitops/02-design/40-governed-execution.md)** — Two-loop model, evidence, write-back semantics
+7. **[07-user-experience.md](/docs/agentic-gitops/05-rollout/30-user-experience.md)** — Four surfaces, two personas, import flow, AI tooling
+8. **[08-adoption-and-reference.md](/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md)** — Adoption path, value analysis, Day 2 scenarios, FAQ
 
 ---
 

--- a/docs/agentic-gitops/01-vision/01-introducing-agentic-gitops.md
+++ b/docs/agentic-gitops/01-vision/01-introducing-agentic-gitops.md
@@ -2,7 +2,7 @@
 
 > Configuration is data. Generators are how you get there.
 
-**Part of:** [AI and GitOps v7 Document Set](GitOps7.md)
+**Part of:** [AI and GitOps v7 Document Set](/docs/agentic-gitops/00-index/00-gitops7-index.md)
 **Status:** Planning doc (v7)
 **Date:** 2026-02-28
 
@@ -176,10 +176,10 @@ This document establishes the "why" and the foundational principles. The remaini
 
 | If you want to understand... | Read |
 |-----|------|
-| The generator model and maturity levels | [02 — Generators PRD](02-generators-prd.md) |
-| Field-origin maps and the editing experience | [03 — Field-Origin Maps and Editing](03-field-origin-maps-and-editing.md) |
-| The ConfigHub data model | [04 — App Model and Contracts](04-app-model-and-contracts.md) |
-| cub-track, the mutation ledger | [05 — cub-track](05-cub-track.md) |
-| The governed execution architecture | [06 — Governed Execution](06-governed-execution.md) |
-| What it looks like to use | [07 — User Experience](07-user-experience.md) |
-| How to adopt and the business case | [08 — Adoption and Reference](08-adoption-and-reference.md) |
+| The generator model and maturity levels | [02 — Generators PRD](/docs/agentic-gitops/02-design/10-generators-prd.md) |
+| Field-origin maps and the editing experience | [03 — Field-Origin Maps and Editing](/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md) |
+| The ConfigHub data model | [04 — App Model and Contracts](/docs/agentic-gitops/02-design/30-app-model-and-contracts.md) |
+| cub-track, the mutation ledger | [05 — cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md) |
+| The governed execution architecture | [06 — Governed Execution](/docs/agentic-gitops/02-design/40-governed-execution.md) |
+| What it looks like to use | [07 — User Experience](/docs/agentic-gitops/05-rollout/30-user-experience.md) |
+| How to adopt and the business case | [08 — Adoption and Reference](/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md) |

--- a/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md
+++ b/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md
@@ -3,7 +3,7 @@
 > The field-origin map is the bridge between provenance and usability.
 > It turns "we know where this came from" into "we know where to change it."
 
-**Part of:** [AI and GitOps v7 Document Set](GitOps7.md)
+**Part of:** [AI and GitOps v7 Document Set](/docs/agentic-gitops/00-index/00-gitops7-index.md)
 **Status:** Planning doc (v7)
 **Date:** 2026-02-28
 **Audience:** Product team, platform engineers, app developers
@@ -70,7 +70,7 @@ The map is a generator output artifact. It is produced at render time, stored al
 
 ### Relationship to Provenance
 
-The field-origin map is complementary to the four provenance fields defined in the generator model ([02 -- Generators PRD](02-generators-prd.md)):
+The field-origin map is complementary to the four provenance fields defined in the generator model ([02 -- Generators PRD](/docs/agentic-gitops/02-design/10-generators-prd.md)):
 
 | Provenance field | What it answers | Granularity |
 |-----------------|----------------|-------------|
@@ -413,21 +413,21 @@ The user experience is: **edit in one place (ConfigHub), the system routes the c
 
 This document covers field-origin maps and the editing experience they enable. Related topics are covered in companion documents:
 
-- **[01 -- Introducing Agentic GitOps](01-introducing-agentic-gitops.md)** -- why agentic GitOps exists, classical GitOps gaps, the three invariants, and the generator concept
-- **[02 -- Generators PRD](02-generators-prd.md)** -- generator definition, maturity levels, provenance fields, authoring landscape, and GeneratorOutput envelope
-- **[04 -- App Model and Contracts](04-app-model-and-contracts.md)** -- entity definitions (App, Deployment, Unit, Variant), operating boundary, constraints, operations
-- **[05 -- cub-track](05-cub-track.md)** -- standalone mutation ledger, Change Interaction Cards, overlay drift detection, the explain and suggest commands
-- **[06 -- Governed Execution](06-governed-execution.md)** -- two-loop model, evidence bundles, trust tiers, attestation, write-back semantics
-- **[07 -- User Experience](07-user-experience.md)** -- four surfaces, two personas, import from Git flow, field-origin edit mockups, AI tooling
-- **[08 -- Adoption and Reference](08-adoption-and-reference.md)** -- adoption path, value-per-level table, pricing boundary, worked examples, FAQ
+- **[01 -- Introducing Agentic GitOps](/docs/agentic-gitops/01-vision/01-introducing-agentic-gitops.md)** -- why agentic GitOps exists, classical GitOps gaps, the three invariants, and the generator concept
+- **[02 -- Generators PRD](/docs/agentic-gitops/02-design/10-generators-prd.md)** -- generator definition, maturity levels, provenance fields, authoring landscape, and GeneratorOutput envelope
+- **[04 -- App Model and Contracts](/docs/agentic-gitops/02-design/30-app-model-and-contracts.md)** -- entity definitions (App, Deployment, Unit, Variant), operating boundary, constraints, operations
+- **[05 -- cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md)** -- standalone mutation ledger, Change Interaction Cards, overlay drift detection, the explain and suggest commands
+- **[06 -- Governed Execution](/docs/agentic-gitops/02-design/40-governed-execution.md)** -- two-loop model, evidence bundles, trust tiers, attestation, write-back semantics
+- **[07 -- User Experience](/docs/agentic-gitops/05-rollout/30-user-experience.md)** -- four surfaces, two personas, import from Git flow, field-origin edit mockups, AI tooling
+- **[08 -- Adoption and Reference](/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md)** -- adoption path, value-per-level table, pricing boundary, worked examples, FAQ
 
 ### Key Dependencies
 
 | This document's concept | Depends on | Defined in |
 |------------------------|------------|------------|
-| Field-origin map schema | Generator model, provenance fields | [02 -- Generators PRD](02-generators-prd.md) |
-| ConfigHub editing surface | App, Deployment, Unit entities | [04 -- App Model and Contracts](04-app-model-and-contracts.md) |
-| cub-track redirection | Mutation ledger, Change Interaction Cards | [05 -- cub-track](05-cub-track.md) |
-| Trust tiers for edit approvals | Governed execution model | [06 -- Governed Execution](06-governed-execution.md) |
-| Edit UX mockups | Four surfaces, persona model | [07 -- User Experience](07-user-experience.md) |
-| Adoption ladder business case | Value analysis, pricing boundary | [08 -- Adoption and Reference](08-adoption-and-reference.md) |
+| Field-origin map schema | Generator model, provenance fields | [02 -- Generators PRD](/docs/agentic-gitops/02-design/10-generators-prd.md) |
+| ConfigHub editing surface | App, Deployment, Unit entities | [04 -- App Model and Contracts](/docs/agentic-gitops/02-design/30-app-model-and-contracts.md) |
+| cub-track redirection | Mutation ledger, Change Interaction Cards | [05 -- cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md) |
+| Trust tiers for edit approvals | Governed execution model | [06 -- Governed Execution](/docs/agentic-gitops/02-design/40-governed-execution.md) |
+| Edit UX mockups | Four surfaces, persona model | [07 -- User Experience](/docs/agentic-gitops/05-rollout/30-user-experience.md) |
+| Adoption ladder business case | Value analysis, pricing boundary | [08 -- Adoption and Reference](/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md) |

--- a/docs/agentic-gitops/02-design/30-app-model-and-contracts.md
+++ b/docs/agentic-gitops/02-design/30-app-model-and-contracts.md
@@ -3,7 +3,7 @@
 > Teams think in apps, not in repos or namespaces. The app model makes that
 > the organizing primitive for configuration, governance, and operations.
 
-**Part of:** [AI and GitOps v7 Document Set](GitOps7.md)
+**Part of:** [AI and GitOps v7 Document Set](/docs/agentic-gitops/00-index/00-gitops7-index.md)
 **Status:** Planning doc (v7)
 **Date:** 2026-02-28
 **Audience:** Implementors, API consumers, platform teams
@@ -92,7 +92,7 @@ token scoped to that specific action.
 
 **Editing routes through field-origin maps.** When a user changes a rendered
 field, ConfigHub traces it to its DRY source. cub-track intercepts direct WET
-edits and performs the same redirection. See [03 -- Field-Origin Maps](03-field-origin-maps-and-editing.md).
+edits and performs the same redirection. See [03 -- Field-Origin Maps](/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md).
 
 ### Key clarifications
 
@@ -404,10 +404,10 @@ agents) to discover available operations without executing them.
 
 | Document | Relationship |
 |----------|-------------|
-| [01 -- Introducing Agentic GitOps](01-introducing-agentic-gitops.md) | The "why": classical gaps that the app model and operating boundary address |
-| [02 -- Generators PRD](02-generators-prd.md) | Generator model, maturity levels, and provenance requirements |
-| [03 -- Field-Origin Maps and Editing](03-field-origin-maps-and-editing.md) | How field-origin maps trace WET fields back to DRY sources within the app model |
-| [05 -- cub-track](05-cub-track.md) | Governed mutation history: how cub-track records changes to Units and Deployments |
-| [06 -- Governed Execution](06-governed-execution.md) | The two-loop model, evidence, and decision authority referenced in the operating boundary |
-| [07 -- User Experience](07-user-experience.md) | How app-centric language appears in CLI, TUI, and AI skill interfaces |
-| [08 -- Adoption and Reference](08-adoption-and-reference.md) | Adoption path showing how teams progressively adopt the app model |
+| [01 -- Introducing Agentic GitOps](/docs/agentic-gitops/01-vision/01-introducing-agentic-gitops.md) | The "why": classical gaps that the app model and operating boundary address |
+| [02 -- Generators PRD](/docs/agentic-gitops/02-design/10-generators-prd.md) | Generator model, maturity levels, and provenance requirements |
+| [03 -- Field-Origin Maps and Editing](/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md) | How field-origin maps trace WET fields back to DRY sources within the app model |
+| [05 -- cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md) | Governed mutation history: how cub-track records changes to Units and Deployments |
+| [06 -- Governed Execution](/docs/agentic-gitops/02-design/40-governed-execution.md) | The two-loop model, evidence, and decision authority referenced in the operating boundary |
+| [07 -- User Experience](/docs/agentic-gitops/05-rollout/30-user-experience.md) | How app-centric language appears in CLI, TUI, and AI skill interfaces |
+| [08 -- Adoption and Reference](/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md) | Adoption path showing how teams progressively adopt the app model |

--- a/docs/agentic-gitops/02-design/40-governed-execution.md
+++ b/docs/agentic-gitops/02-design/40-governed-execution.md
@@ -1,6 +1,6 @@
 # Governed Execution: Evidence, Trust, and Write-Back Semantics
 
-**Part of:** [AI and GitOps v7 Document Set](GitOps7.md)
+**Part of:** [AI and GitOps v7 Document Set](/docs/agentic-gitops/00-index/00-gitops7-index.md)
 **Status:** Planning doc (v7)
 **Date:** 2026-02-28
 **Audience:** Security, compliance, SREs, platform teams
@@ -33,7 +33,7 @@ every phase with intent capture, policy gates, and evidence:
 | **Reconcile** | Flux/Argo pull and apply | Flux/Argo pull and apply *(unchanged)* | — (reconcilers are not replaced) |
 | **Observe** | `flux get all` / Argo health check | cub-scout structured evidence: field-level diff + provenance link | Drift is typed, classified, and linked back to the operation that set the expected value |
 | **Respond** | Manual fix or re-sync | Policy-driven: alert, propose-revert, propose-accept, require-approval | Governed reverse flow — no silent overwrite in either direction |
-| **Record** | Git log + Flux/Argo events | [cub-track](05-cub-track.md) ChangeInteractionCard: intent + decision + execution + outcome | Mutation ledger answers "why was this allowed?" not just "what changed" |
+| **Record** | Git log + Flux/Argo events | [cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md) ChangeInteractionCard: intent + decision + execution + outcome | Mutation ledger answers "why was this allowed?" not just "what changed" |
 | **Attest** | *(not modeled)* | Signed attestation: actor, intent revision, artifact digest, observed result | Audit-grade proof that authority, action, and outcome are linked |
 
 The left two columns are what Flux/Argo users already have. The right two columns
@@ -179,7 +179,7 @@ Flux/Argo is trying to apply). It does not compare stored WET against what the
 generator *would* produce from current DRY inputs — that is a staleness check,
 owned by ConfigHub's publishing pipeline via `inputs.digest` comparison.
 
-cub-scout's evidence feeds into the broader system: [cub-track](05-cub-track.md)
+cub-scout's evidence feeds into the broader system: [cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md)
 can enrich mutation records with field-origin data, and ConfigHub can correlate
 evidence with provenance to classify drift causes.
 
@@ -262,7 +262,7 @@ Observed runtime changes **do not** overwrite intent. They produce explicit prop
 
 Write-backs from agents follow the same pattern. An agent changes an operational
 overlay value, proposes it as a merge request, and the mutation is logged via
-[cub-track](05-cub-track.md) in both ConfigHub and Git (depending on scope).
+[cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md) in both ConfigHub and Git (depending on scope).
 
 ### Overlay Edits: Transitional, Not Steady-State
 
@@ -278,7 +278,7 @@ output.
 
 If an overlay is applied to WET:
 
-1. The system records it as a governed mutation ([cub-track](05-cub-track.md) ChangeInteractionCard)
+1. The system records it as a governed mutation ([cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md) ChangeInteractionCard)
 2. `cub-track suggest` flags the field's DRY origin, if one exists
 3. The overlay is classified as "overlay drift from DRY source" — distinct from
    runtime drift
@@ -286,7 +286,7 @@ If an overlay is applied to WET:
    default-worthy, or long-lived
 
 The system should create friction — evidence, staleness detection,
-[cub-track](05-cub-track.md) redirection — that encourages promotion back to DRY
+[cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md) redirection — that encourages promotion back to DRY
 rather than normalizing WET-space editing for generator-backed config.
 
 ---
@@ -302,7 +302,7 @@ In each case, the failure is explicit, surfaced early, and non-destructive.
 | **Generator bug** | Output reproducible via input digest; diff available | Fix generator, re-render; change is explicit and diffable |
 | **Invalid operation** | Validation rejects before rendering | Fix inputs or obtain platform exception |
 | **Manual runtime change** | Detected as drift on next observation | Depends on drift policy; never silently accepted |
-| **Overlay drift from DRY** | WET field changed without `inputs.digest` change; [cub-track](05-cub-track.md) classifies as overlay | Promote to DRY input or expire; `cub-track suggest` redirects to DRY source |
+| **Overlay drift from DRY** | WET field changed without `inputs.digest` change; [cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md) classifies as overlay | Promote to DRY input or expire; `cub-track suggest` redirects to DRY source |
 | **Stale render** | `inputs.digest` changed but WET not re-rendered; detected by ConfigHub publishing pipeline | Re-render from current DRY inputs; diff shows what changed |
 | **Generator version mismatch** | Provenance shows old version; version pinning prevents silent upgrade | Explicit re-render; diff shows changes |
 
@@ -314,11 +314,11 @@ This document is part of the AI and GitOps v7 Document Set. Related documents:
 
 | Document | Covers |
 |----------|--------|
-| [01 — Introducing Agentic GitOps](01-introducing-agentic-gitops.md) | Why agentic GitOps exists, foundational invariants, classical GitOps gaps |
-| [02 — Generators PRD](02-generators-prd.md) | Generator model, maturity levels, authoring landscape |
-| [03 — Field-Origin Maps and Editing](03-field-origin-maps-and-editing.md) | Field-origin maps, editing model, provenance tracking |
-| [04 — App Model and Contracts](04-app-model-and-contracts.md) | Entity definitions, operating boundary, constraints, staging model, operations |
-| [05 — cub-track](05-cub-track.md) | Git-native mutation ledger, ChangeInteractionCard, trust tiers, attestation, adoption stages |
+| [01 — Introducing Agentic GitOps](/docs/agentic-gitops/01-vision/01-introducing-agentic-gitops.md) | Why agentic GitOps exists, foundational invariants, classical GitOps gaps |
+| [02 — Generators PRD](/docs/agentic-gitops/02-design/10-generators-prd.md) | Generator model, maturity levels, authoring landscape |
+| [03 — Field-Origin Maps and Editing](/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md) | Field-origin maps, editing model, provenance tracking |
+| [04 — App Model and Contracts](/docs/agentic-gitops/02-design/30-app-model-and-contracts.md) | Entity definitions, operating boundary, constraints, staging model, operations |
+| [05 — cub-track](/docs/agentic-gitops/05-rollout/10-cub-track.md) | Git-native mutation ledger, ChangeInteractionCard, trust tiers, attestation, adoption stages |
 | **06 — Governed Execution** (this document) | Two-loop model, evidence, write-back semantics, failure modes |
-| [07 — User Experience](07-user-experience.md) | Four surfaces, two personas, import flow, generator UX, AI tooling, skill definition |
-| [08 — Adoption and Reference](08-adoption-and-reference.md) | Adoption path, value analysis, pricing boundary, worked examples, FAQ |
+| [07 — User Experience](/docs/agentic-gitops/05-rollout/30-user-experience.md) | Four surfaces, two personas, import flow, generator UX, AI tooling, skill definition |
+| [08 — Adoption and Reference](/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md) | Adoption path, value analysis, pricing boundary, worked examples, FAQ |

--- a/docs/agentic-gitops/05-rollout/10-cub-track.md
+++ b/docs/agentic-gitops/05-rollout/10-cub-track.md
@@ -5,7 +5,7 @@
 > outcome was. It stores this as structured records linked to Git commits,
 > producing an audit trail that classical GitOps cannot.
 
-**Part of:** [AI and GitOps v7 Document Set](GitOps7.md)
+**Part of:** [AI and GitOps v7 Document Set](/docs/agentic-gitops/00-index/00-gitops7-index.md)
 **Status:** Planning doc (v7)
 **Date:** 2026-02-28
 
@@ -658,7 +658,7 @@ New writes always go to `cub/mutations/v1`; `cub/checkpoints/v1` remains a tempo
 
 ### How does cub-track relate to field-origin maps?
 
-Field-origin maps are produced by generators (see [02-generators-prd.md](02-generators-prd.md)).
+Field-origin maps are produced by generators (see [02-generators-prd.md](/docs/agentic-gitops/02-design/10-generators-prd.md)).
 They map each WET output field to its DRY input source (file, path, line,
 editable_by). cub-track uses field-origin maps in two commands:
 
@@ -689,10 +689,10 @@ would produce. They can coexist, and they require different responses.
 
 | Document | Relationship |
 |----------|-------------|
-| [01 — Introducing Agentic GitOps](01-introducing-agentic-gitops.md) | The "why": classical gaps and invariants that cub-track enforces |
-| [02 — Generators PRD](02-generators-prd.md) | Generator model and field-origin maps that cub-track uses for redirection |
-| [03 — Field-Origin Maps and Editing](03-field-origin-maps-and-editing.md) | The editing model and adoption ladder that cub-track supports |
-| [04 — App Model and Contracts](04-app-model-and-contracts.md) | Operating boundary: cub-track's role vs. ConfigHub, cub-scout, Flux/Argo |
-| [06 — Governed Execution](06-governed-execution.md) | The two-loop model, evidence bundles, and write-back semantics that cub-track feeds into |
-| [07 — User Experience](07-user-experience.md) | cub-track CLI examples, AI skill integration, Day 2 scenarios |
-| [08 — Adoption and Reference](08-adoption-and-reference.md) | Adoption path showing where cub-track fits in the overall journey |
+| [01 — Introducing Agentic GitOps](/docs/agentic-gitops/01-vision/01-introducing-agentic-gitops.md) | The "why": classical gaps and invariants that cub-track enforces |
+| [02 — Generators PRD](/docs/agentic-gitops/02-design/10-generators-prd.md) | Generator model and field-origin maps that cub-track uses for redirection |
+| [03 — Field-Origin Maps and Editing](/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md) | The editing model and adoption ladder that cub-track supports |
+| [04 — App Model and Contracts](/docs/agentic-gitops/02-design/30-app-model-and-contracts.md) | Operating boundary: cub-track's role vs. ConfigHub, cub-scout, Flux/Argo |
+| [06 — Governed Execution](/docs/agentic-gitops/02-design/40-governed-execution.md) | The two-loop model, evidence bundles, and write-back semantics that cub-track feeds into |
+| [07 — User Experience](/docs/agentic-gitops/05-rollout/30-user-experience.md) | cub-track CLI examples, AI skill integration, Day 2 scenarios |
+| [08 — Adoption and Reference](/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md) | Adoption path showing where cub-track fits in the overall journey |

--- a/docs/agentic-gitops/05-rollout/30-user-experience.md
+++ b/docs/agentic-gitops/05-rollout/30-user-experience.md
@@ -1,6 +1,6 @@
 # User Experience: Surfaces, Personas, and Workflows
 
-**Part of:** [AI and GitOps v7 Document Set](GitOps7.md)
+**Part of:** [AI and GitOps v7 Document Set](/docs/agentic-gitops/00-index/00-gitops7-index.md)
 **Status:** Planning doc (v7)
 **Date:** 2026-02-28
 **Audience:** Product team, UX designers, developer advocates
@@ -809,7 +809,7 @@ Loaded when working in any of the related repos. Knows: the two-loop model,
 operating boundary (who owns what), the DRY/WET split, field-origin maps,
 generator maturity levels, the invariants. When you ask "should cub-scout detect
 stale renders?" it can answer "no, that's ConfigHub's publishing pipeline — see
-[06 — Governed Execution](06-governed-execution.md#evidence-and-the-drift-loop)"
+[06 — Governed Execution](/docs/agentic-gitops/02-design/40-governed-execution.md#2-evidence-and-the-drift-loop)"
 without you having to remember.
 
 **3. Doc consistency skill**
@@ -826,14 +826,14 @@ When filing issues or writing PRs in cub-scout or cub-track, pre-fills the
 structure from CLAUDE.md (deterministic tests, graceful degradation, definition
 of done) and frames the work in terms of this strategy. "This PR adds
 `cub-track suggest` — the DRY-source redirection capability from
-[03 — Field-Origin Maps](03-field-origin-maps-and-editing.md#cub-track-as-the-redirection-layer)."
+[03 — Field-Origin Maps](/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md#7-cub-track-as-the-redirection-layer)."
 
 **5. Cross-repo context skill**
 
 The hardest one. When you are in the cub-scout repo working on evidence bundles,
 it knows how that connects to cub-track's ChangeInteractionCards and ConfigHub's
 Units. When you are in cub-track adding the `suggest` command, it knows the
-field-origin map schema from [03 — Field-Origin Maps](03-field-origin-maps-and-editing.md#what-is-a-field-origin-map).
+field-origin map schema from [03 — Field-Origin Maps](/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md#1-what-is-a-field-origin-map).
 
 ### AI Dialog Examples
 
@@ -1300,10 +1300,10 @@ Result: one fleet campaign with explicit governance and complete audit closure.
 
 | Document | Relationship |
 |----------|-------------|
-| [01-introducing-agentic-gitops.md](01-introducing-agentic-gitops.md) | The "why": invariants, classical GitOps gaps, agentic changes |
-| [02-generators-prd.md](02-generators-prd.md) | Generators PRD: DRY-to-WET pipeline, generator lifecycle, maturity levels |
-| [03-field-origin-maps-and-editing.md](03-field-origin-maps-and-editing.md) | Field-origin maps, editing model, authoring landscape |
-| [04-app-model-and-contracts.md](04-app-model-and-contracts.md) | Entity definitions, operating boundary, constraints, operations |
-| [05-cub-track.md](05-cub-track.md) | cub-track: mutation ledger, ChangeInteractionCards, governance |
-| [06-governed-execution.md](06-governed-execution.md) | Two-loop model, evidence, trust tiers, attestation |
-| [08-adoption-and-reference.md](08-adoption-and-reference.md) | Adoption path, value analysis, Day 2 scenarios, FAQ |
+| [01-introducing-agentic-gitops.md](/docs/agentic-gitops/01-vision/01-introducing-agentic-gitops.md) | The "why": invariants, classical GitOps gaps, agentic changes |
+| [02-generators-prd.md](/docs/agentic-gitops/02-design/10-generators-prd.md) | Generators PRD: DRY-to-WET pipeline, generator lifecycle, maturity levels |
+| [03-field-origin-maps-and-editing.md](/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md) | Field-origin maps, editing model, authoring landscape |
+| [04-app-model-and-contracts.md](/docs/agentic-gitops/02-design/30-app-model-and-contracts.md) | Entity definitions, operating boundary, constraints, operations |
+| [05-cub-track.md](/docs/agentic-gitops/05-rollout/10-cub-track.md) | cub-track: mutation ledger, ChangeInteractionCards, governance |
+| [06-governed-execution.md](/docs/agentic-gitops/02-design/40-governed-execution.md) | Two-loop model, evidence, trust tiers, attestation |
+| [08-adoption-and-reference.md](/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md) | Adoption path, value analysis, Day 2 scenarios, FAQ |

--- a/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md
+++ b/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md
@@ -2,7 +2,7 @@
 
 > How to adopt, what value each level delivers, worked examples, key concepts, and FAQ.
 
-**Part of:** [AI and GitOps v7 Document Set](GitOps7.md)
+**Part of:** [AI and GitOps v7 Document Set](/docs/agentic-gitops/00-index/00-gitops7-index.md)
 **Status:** Planning doc (v7)
 **Date:** 2026-02-28
 **Audience:** Decision makers, implementation teams
@@ -967,11 +967,11 @@ This document is part of an 8-document set for ConfigHub's agentic GitOps strate
 
 | Doc | Title | Focus |
 |-----|-------|-------|
-| [01](01-introducing-agentic-gitops.md) | Introducing Agentic GitOps | Why: classical gaps, agentic changes, invariants |
-| [02](02-generators-prd.md) | Generators and Provenance PRD | How: DRY->WET pipeline, maturity levels, generator contract |
-| [03](03-field-origin-maps-and-editing.md) | Field-Origin Maps and the Editing Experience | Tracing: field-origin maps, editing surface, DRY-source integrity |
-| [04](04-app-model-and-contracts.md) | ConfigHub App Model and Contracts | What: entities, operating boundary, constraints, operations |
-| [05](05-cub-track.md) | cub-track: Git-Native Mutation Ledger | Provenance: commit-linked mutation history, change interaction cards |
-| [06](06-governed-execution.md) | Governed Execution | Trust: two-loop model, evidence, attestation, write-back semantics |
-| [07](07-user-experience.md) | User Experience | Feel: four surfaces, two personas, import flow, AI tooling |
-| **[08](08-adoption-and-reference.md)** | **Adoption Path, Value Analysis, and Reference** | **This document** |
+| [01](/docs/agentic-gitops/01-vision/01-introducing-agentic-gitops.md) | Introducing Agentic GitOps | Why: classical gaps, agentic changes, invariants |
+| [02](/docs/agentic-gitops/02-design/10-generators-prd.md) | Generators and Provenance PRD | How: DRY->WET pipeline, maturity levels, generator contract |
+| [03](/docs/agentic-gitops/02-design/20-field-origin-maps-and-editing.md) | Field-Origin Maps and the Editing Experience | Tracing: field-origin maps, editing surface, DRY-source integrity |
+| [04](/docs/agentic-gitops/02-design/30-app-model-and-contracts.md) | ConfigHub App Model and Contracts | What: entities, operating boundary, constraints, operations |
+| [05](/docs/agentic-gitops/05-rollout/10-cub-track.md) | cub-track: Git-Native Mutation Ledger | Provenance: commit-linked mutation history, change interaction cards |
+| [06](/docs/agentic-gitops/02-design/40-governed-execution.md) | Governed Execution | Trust: two-loop model, evidence, attestation, write-back semantics |
+| [07](/docs/agentic-gitops/05-rollout/30-user-experience.md) | User Experience | Feel: four surfaces, two personas, import flow, AI tooling |
+| **[08](/docs/agentic-gitops/05-rollout/40-adoption-and-reference.md)** | **Adoption Path, Value Analysis, and Reference** | **This document** |


### PR DESCRIPTION
## Summary

- What user problem does this change solve?
- What behavior changed?

## Scope

- In scope:
- Out of scope:

## Deterministic Success Criteria (Required)

1. [ ] Criterion 1 (exact input -> exact expected output)
2. [ ] Criterion 2 (exact input -> exact expected output)
3. [ ] Criterion 3 (exact input -> exact expected output)

## Proof Matrix (Required Before Merge)

| Proof tier | Required? | Command(s) | Deterministic assertion |
|---|---|---|---|
| Unit | Yes | `go test ./...` | Core logic output is stable |
| Parity/Golden | If CLI/JSON/table output changed | `go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v` | Contract output is stable |
| Example proof | If user-visible flow changed | `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v` | Docs/example output matches implementation |

## Commands Run

- [ ] `go build ./cmd/cub-gen`
- [ ] `go test ./...`
- [ ] `go test ./cmd/cub-gen -run '^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand)' -count=1 -v`
- [ ] `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v` (if user-visible flow changed)
- Additional commands:

## Graceful Degradation / Error Behavior

- Missing metadata behavior:
- Unsupported input behavior:
- How false confidence is avoided:

## Contract / Docs / Parity Updates

- [ ] `PARITY.md` updated (if contract changed)
- [ ] `README.md` and/or docs updated for user-visible changes
- [ ] `test/TEST-INVENTORY.md` updated if test surface changed
