### PR TITLE
feat(generators): add markdown introspection output

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ without coupling the core flow to a running ConfigHub backend.
 ./cub-gen generators --capability inverse-values-patch,inverse-score-patch
 ./cub-gen generators --strict-filters --kind helm,score
 ./cub-gen generators --json --details | jq '.families[] | {kind, profile, policies}'
+./cub-gen generators --markdown
+./cub-gen generators --markdown --details
 ```
 
 `--details` exposes full family policy/provenance templates, including:

--- a/cmd/cub-gen/generators_parity_test.go
+++ b/cmd/cub-gen/generators_parity_test.go
@@ -206,6 +206,28 @@ func TestGeneratorsGoldenTableNoMatches(t *testing.T) {
 	assertGoldenText(t, filepath.Join("testdata", "parity", "generators-empty.table.golden.txt"), out)
 }
 
+func TestGeneratorsGoldenMarkdown(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--markdown"})
+	if err != nil {
+		t.Fatalf("run generators --markdown returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+	assertGoldenText(t, filepath.Join("testdata", "parity", "generators.markdown.golden.md"), out)
+}
+
+func TestGeneratorsGoldenMarkdownDetails(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--markdown", "--details"})
+	if err != nil {
+		t.Fatalf("run generators --markdown --details returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %q", stderr)
+	}
+	assertGoldenText(t, filepath.Join("testdata", "parity", "generators-details.markdown.golden.md"), out)
+}
+
 func TestGeneratorsGoldenHelp(t *testing.T) {
 	stdout, stderr, err := runWithCapturedIO([]string{"generators", "--help"})
 	if err != nil {
@@ -277,7 +299,20 @@ func TestGeneratorsDetailsRequiresJSON(t *testing.T) {
 	if strings.TrimSpace(out) != "" {
 		t.Fatalf("expected empty stdout, got: %q", out)
 	}
-	if !strings.Contains(err.Error(), "--details requires --json") {
+	if !strings.Contains(err.Error(), "--details requires --json or --markdown") {
 		t.Fatalf("expected details requires json message, got: %q (stderr=%q)", err.Error(), stderr)
+	}
+}
+
+func TestGeneratorsMarkdownCannotCombineJSON(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{"generators", "--json", "--markdown"})
+	if err == nil {
+		t.Fatalf("expected markdown/json conflict error, got nil")
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected empty stdout, got: %q", out)
+	}
+	if !strings.Contains(err.Error(), "--markdown cannot be combined with --json") {
+		t.Fatalf("expected markdown/json conflict message, got: %q (stderr=%q)", err.Error(), stderr)
 	}
 }

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -133,7 +133,8 @@ func runGenerators(args []string) error {
 	capabilityFilter := fs.String("capability", "", "Filter by capability")
 	strictFilters := fs.Bool("strict-filters", false, "Fail on unknown filter values")
 	jsonOut := fs.Bool("json", false, "Output JSON")
-	details := fs.Bool("details", false, "Include policy/provenance template details in JSON output")
+	markdownOut := fs.Bool("markdown", false, "Output Markdown")
+	details := fs.Bool("details", false, "Include policy/provenance template details in JSON or Markdown output")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -142,10 +143,13 @@ func runGenerators(args []string) error {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json] [--details] [--pretty]")
+		return errors.New("usage: cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]")
 	}
-	if *details && !*jsonOut {
-		return errors.New("--details requires --json")
+	if *jsonOut && *markdownOut {
+		return errors.New("--markdown cannot be combined with --json")
+	}
+	if *details && !*jsonOut && !*markdownOut {
+		return errors.New("--details requires --json or --markdown")
 	}
 	if *strictFilters {
 		if err := validateGeneratorFilters(*kindFilter, *profileFilter, *capabilityFilter); err != nil {
@@ -160,6 +164,9 @@ func runGenerators(args []string) error {
 			"families": records,
 		}, *pretty)
 	}
+	if *markdownOut {
+		return writeGeneratorsMarkdown(os.Stdout, records, *details)
+	}
 
 	fmt.Println("Kind\tProfile\tResource Kind\tResource Type\tCapabilities")
 	for _, record := range records {
@@ -172,6 +179,202 @@ func runGenerators(args []string) error {
 		)
 	}
 	return nil
+}
+
+func writeGeneratorsMarkdown(out io.Writer, records []generatorFamilyRecord, details bool) error {
+	fmt.Fprintln(out, "# Generator Families")
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "Total: %d\n\n", len(records))
+	fmt.Fprintln(out, "| Kind | Profile | Resource Kind | Resource Type | Capabilities |")
+	fmt.Fprintln(out, "| --- | --- | --- | --- | --- |")
+	for _, record := range records {
+		fmt.Fprintf(out, "| `%s` | `%s` | `%s` | `%s` | %s |\n",
+			markdownCell(record.Kind),
+			markdownCell(record.Profile),
+			markdownCell(record.ResourceKind),
+			markdownCell(record.ResourceType),
+			markdownCell(strings.Join(record.Capabilities, ", ")),
+		)
+	}
+
+	if !details {
+		return nil
+	}
+
+	for _, record := range records {
+		if record.Policies == nil {
+			continue
+		}
+		policies := record.Policies
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "## `%s`\n\n", markdownCell(record.Kind))
+		fmt.Fprintf(out, "- Profile: `%s`\n", markdownCell(record.Profile))
+		fmt.Fprintf(out, "- Resource: `%s` (`%s`)\n", markdownCell(record.ResourceKind), markdownCell(record.ResourceType))
+		fmt.Fprintf(out, "- Capabilities: %s\n", markdownCell(strings.Join(record.Capabilities, ", ")))
+		if policies.DefaultInputRole != "" {
+			fmt.Fprintf(out, "- Default input role: `%s`\n", markdownCell(policies.DefaultInputRole))
+		}
+		if policies.DefaultOwner != "" {
+			fmt.Fprintf(out, "- Default owner: `%s`\n", markdownCell(policies.DefaultOwner))
+		}
+		if policies.FieldOriginTransform != "" {
+			fmt.Fprintf(out, "- Field-origin transform: `%s`\n", markdownCell(policies.FieldOriginTransform))
+		}
+		if policies.FieldOriginOverlayTransform != "" {
+			fmt.Fprintf(out, "- Field-origin overlay transform: `%s`\n", markdownCell(policies.FieldOriginOverlayTransform))
+		}
+
+		if len(policies.InputRoleRules) > 0 {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "### Input Role Rules")
+			fmt.Fprintln(out, "| Role | Exact basenames | Prefixes | Extensions |")
+			fmt.Fprintln(out, "| --- | --- | --- | --- |")
+			for _, rule := range policies.InputRoleRules {
+				fmt.Fprintf(out, "| `%s` | %s | %s | %s |\n",
+					markdownCell(rule.Role),
+					markdownCell(strings.Join(rule.ExactBasenames, ", ")),
+					markdownCell(strings.Join(rule.Prefixes, ", ")),
+					markdownCell(strings.Join(rule.Extensions, ", ")),
+				)
+			}
+		}
+
+		if len(policies.RoleOwners) > 0 {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "### Role Owners")
+			fmt.Fprintln(out, "| Role | Owner |")
+			fmt.Fprintln(out, "| --- | --- |")
+			for _, key := range sortedMapKeys(policies.RoleOwners) {
+				fmt.Fprintf(out, "| `%s` | `%s` |\n", markdownCell(key), markdownCell(policies.RoleOwners[key]))
+			}
+		}
+
+		if len(policies.InversePatchTemplates) > 0 {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "### Inverse Patch Templates")
+			fmt.Fprintln(out, "| Key | Editable by | Confidence | Requires review |")
+			fmt.Fprintln(out, "| --- | --- | --- | --- |")
+			for _, key := range sortedMapKeys(policies.InversePatchTemplates) {
+				tpl := policies.InversePatchTemplates[key]
+				fmt.Fprintf(out, "| `%s` | `%s` | %.2f | `%t` |\n",
+					markdownCell(key),
+					markdownCell(tpl.EditableBy),
+					tpl.Confidence,
+					tpl.RequiresReview,
+				)
+			}
+		}
+
+		if len(policies.InversePointerTemplates) > 0 {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "### Inverse Pointer Templates")
+			fmt.Fprintln(out, "| Key | Owner | Confidence |")
+			fmt.Fprintln(out, "| --- | --- | --- |")
+			for _, key := range sortedMapKeys(policies.InversePointerTemplates) {
+				tpl := policies.InversePointerTemplates[key]
+				fmt.Fprintf(out, "| `%s` | `%s` | %.2f |\n",
+					markdownCell(key),
+					markdownCell(tpl.Owner),
+					tpl.Confidence,
+				)
+			}
+		}
+
+		if len(policies.FieldOriginConfidences) > 0 {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "### Field Origin Confidences")
+			fmt.Fprintln(out, "| Key | Confidence |")
+			fmt.Fprintln(out, "| --- | --- |")
+			for _, key := range sortedMapKeys(policies.FieldOriginConfidences) {
+				fmt.Fprintf(out, "| `%s` | %.2f |\n", markdownCell(key), policies.FieldOriginConfidences[key])
+			}
+		}
+
+		if len(policies.HintDefaults) > 0 {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "### Hint Defaults")
+			fmt.Fprintln(out, "| Key | Value |")
+			fmt.Fprintln(out, "| --- | --- |")
+			for _, key := range sortedMapKeys(policies.HintDefaults) {
+				fmt.Fprintf(out, "| `%s` | `%s` |\n", markdownCell(key), markdownCell(policies.HintDefaults[key]))
+			}
+		}
+
+		if len(policies.InversePatchReasons) > 0 {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "### Inverse Patch Reasons")
+			fmt.Fprintln(out, "| Key | Reason |")
+			fmt.Fprintln(out, "| --- | --- |")
+			for _, key := range sortedMapKeys(policies.InversePatchReasons) {
+				fmt.Fprintf(out, "| `%s` | %s |\n", markdownCell(key), markdownCell(policies.InversePatchReasons[key]))
+			}
+		}
+
+		if len(policies.InverseEditHints) > 0 {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "### Inverse Edit Hints")
+			fmt.Fprintln(out, "| Key | Hint |")
+			fmt.Fprintln(out, "| --- | --- |")
+			for _, key := range sortedMapKeys(policies.InverseEditHints) {
+				fmt.Fprintf(out, "| `%s` | %s |\n", markdownCell(key), markdownCell(policies.InverseEditHints[key]))
+			}
+		}
+
+		if len(policies.WetTargets) > 0 {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "### WET Targets")
+			fmt.Fprintln(out, "| Kind | Name template | Owner | Namespace | Source DRY path template |")
+			fmt.Fprintln(out, "| --- | --- | --- | --- | --- |")
+			for _, target := range policies.WetTargets {
+				fmt.Fprintf(out, "| `%s` | `%s` | `%s` | `%s` | `%s` |\n",
+					markdownCell(target.Kind),
+					markdownCell(target.NameTemplate),
+					markdownCell(target.Owner),
+					markdownCell(target.Namespace),
+					markdownCell(target.SourceDryPathTemplate),
+				)
+			}
+		}
+
+		if len(policies.RenderedLineageTemplates) > 0 {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "### Rendered Lineage Templates")
+			fmt.Fprintln(out, "| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |")
+			fmt.Fprintln(out, "| --- | --- | --- | --- | --- | --- | --- | --- |")
+			for _, tpl := range policies.RenderedLineageTemplates {
+				fmt.Fprintf(out, "| `%s` | `%s` | `%s` | `%s` | `%s` | `%t` | `%s` | `%t` |\n",
+					markdownCell(tpl.Kind),
+					markdownCell(tpl.NameTemplate),
+					markdownCell(tpl.Namespace),
+					markdownCell(tpl.SourcePathHint),
+					markdownCell(tpl.SourcePathHintFallback),
+					tpl.SourcePathHintMulti,
+					markdownCell(tpl.SourceDryPathTemplate),
+					tpl.Optional,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func markdownCell(value string) string {
+	value = strings.ReplaceAll(value, "|", "\\|")
+	value = strings.ReplaceAll(value, "\n", "<br/>")
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
+}
+
+func sortedMapKeys[T any](m map[string]T) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func listGeneratorFamilies(kindFilter, profileFilter, capabilityFilter string, details bool) []generatorFamilyRecord {
@@ -350,10 +553,10 @@ func parseFilterSet(raw string) map[string]struct{} {
 
 func printGeneratorsUsage(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
-	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json] [--details] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]")
 	fmt.Fprintln(out, "  (KIND/PROFILE/CAPABILITY support comma-separated values)")
 	fmt.Fprintln(out, "  use --strict-filters to fail on unknown filter values")
-	fmt.Fprintln(out, "  use --details with --json to include policy/provenance templates")
+	fmt.Fprintln(out, "  use --details with --json or --markdown to include policy/provenance templates")
 	fmt.Fprintln(out)
 	fmt.Fprintf(out, "Supported kinds: %s\n", strings.Join(supportedGeneratorKinds(), ", "))
 	fmt.Fprintf(out, "Supported profiles: %s\n", strings.Join(supportedGeneratorProfiles(), ", "))
@@ -942,7 +1145,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen verify [--in FILE|-] [--json] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]")
-	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json] [--details] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out, "  cub-gen bridge <ingest|decision|promote> [flags]")
 	fmt.Fprintln(out)
@@ -975,6 +1178,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123")
 	fmt.Fprintln(out, "  cub-gen generators --json")
 	fmt.Fprintln(out, "  cub-gen generators --json --details")
+	fmt.Fprintln(out, "  cub-gen generators --markdown --details")
 	fmt.Fprintln(out, "  cub-gen generators --capability render-manifests")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Note: gitops commands are local-only prototypes that mirror cub gitops stages.")

--- a/cmd/cub-gen/testdata/parity/generators-details.markdown.golden.md
+++ b/cmd/cub-gen/testdata/parity/generators-details.markdown.golden.md
@@ -1,0 +1,570 @@
+# Generator Families
+
+Total: 8
+
+| Kind | Profile | Resource Kind | Resource Type | Capabilities |
+| --- | --- | --- | --- | --- |
+| `ably` | `ably-config` | `ConfigMap` | `v1/ConfigMap` | app-config-only, provider-config, inverse-provider-config-patch |
+| `backstage` | `backstage-idp` | `Component` | `backstage.io/v1alpha1/Component` | catalog-metadata, render-manifests, inverse-catalog-patch |
+| `c3agent` | `c3agent` | `ConfigMap` | `v1/ConfigMap` | fleet-config, agent-orchestration, inverse-fleet-config-patch |
+| `helm` | `helm-paas` | `HelmRelease` | `helm.toolkit.fluxcd.io/v2/HelmRelease` | render-manifests, values-overrides, inverse-values-patch |
+| `opsworkflow` | `ops-workflow` | `Workflow` | `argoproj.io/v1alpha1/Workflow` | workflow-plan, governed-execution-intent, inverse-workflow-patch |
+| `score` | `scoredev-paas` | `Application` | `argoproj.io/v1alpha1/Application` | render-manifests, workload-spec, inverse-score-patch |
+| `springboot` | `springboot-paas` | `Kustomization` | `kustomize.toolkit.fluxcd.io/v1/Kustomization` | render-app-config, profile-overrides, inverse-app-config-patch |
+| `swamp` | `swamp` | `Workflow` | `swamp.dev/v1/Workflow` | workflow-automation, model-orchestration, inverse-workflow-patch |
+
+## `ably`
+
+- Profile: `ably-config`
+- Resource: `ConfigMap` (`v1/ConfigMap`)
+- Capabilities: app-config-only, provider-config, inverse-provider-config-patch
+- Default input role: `provider-config`
+- Default owner: `app-team`
+- Field-origin transform: `ably-config-to-runtime`
+- Field-origin overlay transform: `ably-overlay-merge`
+
+### Input Role Rules
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `provider-config-base` | ably.yaml, ably.yml, ably.json | - | - |
+| `provider-config-overlay` | - | ably- | .yaml, .yml, .json |
+
+### Inverse Patch Templates
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `channels` | `app-team` | 0.88 | `false` |
+| `environment` | `app-team` | 0.90 | `false` |
+
+### Inverse Pointer Templates
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `channels` | `app-team` | 0.88 |
+| `environment` | `app-team` | 0.90 |
+
+### Field Origin Confidences
+| Key | Confidence |
+| --- | --- |
+| `channels_base` | 0.88 |
+| `channels_overlay` | 0.84 |
+| `environment` | 0.90 |
+
+### Hint Defaults
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `ably.yaml` |
+
+### Inverse Patch Reasons
+| Key | Reason |
+| --- | --- |
+| `channels` | Channel mapping is app-level runtime behavior. |
+| `environment` | Environment is sourced from {{base_config_path}}. |
+
+### Inverse Edit Hints
+| Key | Hint |
+| --- | --- |
+| `channels_base` | Edit channels.inbound in {{base_config_path}}. |
+| `channels_overlay` | Edit channels.inbound in {{overlay_config_path}} for environment-specific behavior; use {{base_config_path}} for defaults. |
+| `environment` | Edit app.environment in {{base_config_path}}. |
+
+### WET Targets
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-ably` | `platform-runtime` | `apps` | `app.environment` |
+| `Secret` | `{{name}}-ably-credentials` | `platform-runtime` | `apps` | `credentials.api_key_ref` |
+
+### Rendered Lineage Templates
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-ably` | `apps` | `base_config_path` | `-` | `false` | `app.environment` | `false` |
+| `Secret` | `{{name}}-ably-credentials` | `apps` | `base_config_path` | `-` | `false` | `credentials.api_key_ref` | `false` |
+| `ConfigMap` | `{{name}}-ably` | `apps` | `overlay_config_path` | `-` | `false` | `channels.inbound` | `true` |
+
+## `backstage`
+
+- Profile: `backstage-idp`
+- Resource: `Component` (`backstage.io/v1alpha1/Component`)
+- Capabilities: catalog-metadata, render-manifests, inverse-catalog-patch
+- Default input role: `backstage-input`
+- Default owner: `platform-engineer`
+- Field-origin transform: `backstage-component-to-application`
+
+### Input Role Rules
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `catalog-spec` | catalog-info.yaml, catalog-info.yml | - | - |
+| `app-config` | app-config.yaml, app-config.yml | - | - |
+
+### Role Owners
+| Role | Owner |
+| --- | --- |
+| `app-config` | `app-team` |
+
+### Inverse Patch Templates
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `identity` | `platform-engineer` | 0.87 | `false` |
+| `lifecycle` | `platform-engineer` | 0.82 | `true` |
+
+### Inverse Pointer Templates
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `lifecycle` | `platform-engineer` | 0.82 |
+| `name` | `platform-engineer` | 0.90 |
+
+### Field Origin Confidences
+| Key | Confidence |
+| --- | --- |
+| `identity` | 0.90 |
+| `lifecycle` | 0.82 |
+
+### Hint Defaults
+| Key | Value |
+| --- | --- |
+| `catalog_path` | `catalog-info.yaml` |
+
+### Inverse Patch Reasons
+| Key | Reason |
+| --- | --- |
+| `identity` | Backstage component identity is sourced from {{catalog_path}}. |
+| `lifecycle` | Lifecycle changes impact platform ownership and support policy. |
+
+### Inverse Edit Hints
+| Key | Hint |
+| --- | --- |
+| `lifecycle` | Edit spec.lifecycle in {{catalog_path}} and coordinate rollout policy. |
+| `name` | Edit metadata.name in {{catalog_path}}. |
+
+### WET Targets
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `platform-runtime` | `apps` | `metadata.name` |
+| `ConfigMap` | `{{name}}-catalog` | `platform-runtime` | `apps` | `spec.lifecycle` |
+
+### Rendered Lineage Templates
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `apps` | `catalog_path` | `-` | `false` | `metadata.name` | `false` |
+| `ConfigMap` | `{{name}}-catalog` | `apps` | `catalog_path` | `-` | `false` | `spec.lifecycle` | `false` |
+
+## `c3agent`
+
+- Profile: `c3agent`
+- Resource: `ConfigMap` (`v1/ConfigMap`)
+- Capabilities: fleet-config, agent-orchestration, inverse-fleet-config-patch
+- Default input role: `fleet-config`
+- Default owner: `app-team`
+- Field-origin transform: `c3agent-config-to-runtime`
+- Field-origin overlay transform: `c3agent-overlay-merge`
+
+### Input Role Rules
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `fleet-config-base` | c3agent.yaml, c3agent.yml, c3agent.json | - | - |
+| `fleet-config-overlay` | - | c3agent- | .yaml, .yml, .json |
+
+### Inverse Patch Templates
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `component_ports` | `platform-engineer` | 0.84 | `true` |
+| `credentials` | `platform-engineer` | 0.86 | `true` |
+| `fleet_config` | `app-team` | 0.91 | `false` |
+
+### Inverse Pointer Templates
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `component_ports` | `platform-engineer` | 0.84 |
+| `credentials` | `platform-engineer` | 0.86 |
+| `fleet_config` | `app-team` | 0.91 |
+
+### Field Origin Confidences
+| Key | Confidence |
+| --- | --- |
+| `component_ports_base` | 0.84 |
+| `component_ports_overlay` | 0.80 |
+| `credentials` | 0.86 |
+| `fleet_config` | 0.91 |
+
+### Hint Defaults
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `c3agent.yaml` |
+
+### Inverse Patch Reasons
+| Key | Reason |
+| --- | --- |
+| `component_ports` | Component port changes affect platform networking and service mesh. |
+| `credentials` | Credential references impact platform secret management. |
+| `fleet_config` | Fleet configuration (model, concurrency) is sourced from {{base_config_path}}. |
+
+### Inverse Edit Hints
+| Key | Hint |
+| --- | --- |
+| `component_ports_base` | Edit components.controlplane.grpc_port in {{base_config_path}}. |
+| `component_ports_overlay` | Edit component ports in {{overlay_config_path}} for environment-specific values; use {{base_config_path}} for defaults. |
+| `credentials` | Edit credentials section in {{base_config_path}} and coordinate with platform secret management. |
+| `fleet_config` | Edit fleet.agent_model or fleet.max_concurrent_tasks in {{base_config_path}}. |
+
+### WET Targets
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-fleet-config` | `platform-runtime` | `apps` | `fleet.agent_model` |
+| `Secret` | `{{name}}-fleet-credentials` | `platform-runtime` | `apps` | `credentials.anthropic_key_ref` |
+
+### Rendered Lineage Templates
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-fleet-config` | `apps` | `base_config_path` | `-` | `false` | `fleet.agent_model` | `false` |
+| `Secret` | `{{name}}-fleet-credentials` | `apps` | `base_config_path` | `-` | `false` | `credentials.anthropic_key_ref` | `false` |
+| `ConfigMap` | `{{name}}-fleet-config` | `apps` | `overlay_config_path` | `-` | `false` | `fleet.max_concurrent_tasks` | `true` |
+
+## `helm`
+
+- Profile: `helm-paas`
+- Resource: `HelmRelease` (`helm.toolkit.fluxcd.io/v2/HelmRelease`)
+- Capabilities: render-manifests, values-overrides, inverse-values-patch
+- Default input role: `helm-input`
+- Default owner: `platform-engineer`
+- Field-origin transform: `helm-template`
+
+### Input Role Rules
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `chart` | chart.yaml | - | - |
+| `values` | - | values | .yaml, .yml |
+
+### Role Owners
+| Role | Owner |
+| --- | --- |
+| `values` | `app-team` |
+
+### Inverse Patch Templates
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `image_tag` | `app-team` | 0.86 | `false` |
+
+### Inverse Pointer Templates
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `image_tag` | `app-team` | 0.86 |
+
+### Field Origin Confidences
+| Key | Confidence |
+| --- | --- |
+| `image_tag` | 0.86 |
+
+### Hint Defaults
+| Key | Value |
+| --- | --- |
+| `chart_path` | `Chart.yaml` |
+| `chart_role` | `chart` |
+| `primary_values_path` | `values.yaml` |
+| `values_role` | `values` |
+
+### Inverse Patch Reasons
+| Key | Reason |
+| --- | --- |
+| `image_tag` | Container image tag maps cleanly to helm values. |
+
+### Inverse Edit Hints
+| Key | Hint |
+| --- | --- |
+| `image_tag` | Edit chart values file and keep chart template unchanged. |
+
+### WET Targets
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `HelmRelease` | `{{name}}` | `platform-runtime` | `apps` | `-` |
+| `Deployment` | `{{name}}` | `platform-runtime` | `apps` | `values.image.tag` |
+| `Service` | `{{name}}` | `platform-runtime` | `apps` | `values.service.port` |
+
+### Rendered Lineage Templates
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `HelmRelease` | `{{name}}` | `apps` | `chart_path` | `-` | `false` | `Chart.yaml` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `values_paths` | `chart_path` | `true` | `values.image.tag` | `false` |
+| `Service` | `{{name}}` | `apps` | `values_paths` | `chart_path` | `true` | `values.service.port` | `false` |
+
+## `opsworkflow`
+
+- Profile: `ops-workflow`
+- Resource: `Workflow` (`argoproj.io/v1alpha1/Workflow`)
+- Capabilities: workflow-plan, governed-execution-intent, inverse-workflow-patch
+- Default input role: `operations-input`
+- Default owner: `platform-engineer`
+- Field-origin transform: `ops-workflow-to-argo-workflow`
+- Field-origin overlay transform: `ops-workflow-overlay-merge`
+
+### Input Role Rules
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `operations-base` | operations.yaml, operations.yml, workflow.yaml, workflow.yml | - | - |
+| `operations-overlay` | - | operations-, workflow- | .yaml, .yml |
+
+### Inverse Patch Templates
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `image_tag` | `platform-engineer` | 0.87 | `true` |
+| `schedule` | `platform-engineer` | 0.84 | `true` |
+
+### Inverse Pointer Templates
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `image_tag` | `platform-engineer` | 0.87 |
+| `schedule` | `platform-engineer` | 0.84 |
+
+### Field Origin Confidences
+| Key | Confidence |
+| --- | --- |
+| `image_tag` | 0.87 |
+| `schedule_base` | 0.84 |
+| `schedule_overlay` | 0.80 |
+
+### Hint Defaults
+| Key | Value |
+| --- | --- |
+| `base_spec_path` | `operations.yaml` |
+
+### Inverse Patch Reasons
+| Key | Reason |
+| --- | --- |
+| `image_tag` | Deployment action image tag is sourced from {{base_spec_path}}. |
+| `schedule` | Schedule changes affect operational execution timing. |
+
+### Inverse Edit Hints
+| Key | Hint |
+| --- | --- |
+| `image_tag` | Edit actions.deploy.image_tag in {{base_spec_path}}. |
+| `schedule_base` | Edit triggers.schedule in {{base_spec_path}}. |
+| `schedule_overlay` | Edit triggers.schedule in {{overlay_spec_path}} for environment-specific cadence; use {{base_spec_path}} for defaults. |
+
+### WET Targets
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `platform-runtime` | `ops` | `actions.deploy.image_tag` |
+| `Job` | `{{name}}-dry-run` | `platform-runtime` | `ops` | `triggers.schedule` |
+
+### Rendered Lineage Templates
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `ops` | `base_spec_path` | `-` | `false` | `actions.deploy.image_tag` | `false` |
+| `Job` | `{{name}}-dry-run` | `ops` | `base_spec_path` | `-` | `false` | `triggers.schedule` | `false` |
+| `Workflow` | `{{name}}-workflow` | `ops` | `overlay_spec_path` | `-` | `false` | `triggers.schedule` | `true` |
+
+## `score`
+
+- Profile: `scoredev-paas`
+- Resource: `Application` (`argoproj.io/v1alpha1/Application`)
+- Capabilities: render-manifests, workload-spec, inverse-score-patch
+- Default input role: `score-input`
+- Default owner: `app-team`
+- Field-origin transform: `score-to-k8s`
+
+### Input Role Rules
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `score-spec` | score.yaml, score.yml | - | - |
+
+### Inverse Patch Templates
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `env_var` | `app-team` | 0.90 | `false` |
+
+### Inverse Pointer Templates
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `env_var` | `app-team` | 0.90 |
+| `image` | `app-team` | 0.94 |
+| `port` | `app-team` | 0.91 |
+
+### Field Origin Confidences
+| Key | Confidence |
+| --- | --- |
+| `env_var` | 0.90 |
+| `image` | 0.94 |
+| `port` | 0.91 |
+
+### Hint Defaults
+| Key | Value |
+| --- | --- |
+| `container_name` | `main` |
+| `service_port_name` | `web` |
+| `source_path` | `score.yaml` |
+| `variable_name` | `LOG_LEVEL` |
+
+### Inverse Patch Reasons
+| Key | Reason |
+| --- | --- |
+| `env_var` | Score variable maps to a single Kubernetes env var. |
+
+### Inverse Edit Hints
+| Key | Hint |
+| --- | --- |
+| `env_var` | Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}. |
+| `image` | Edit the Score container image in {{source_path}}. |
+| `port` | Edit {{service_port_name}} service port in {{source_path}}. |
+
+### WET Targets
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `platform-runtime` | `apps` | `-` |
+| `Deployment` | `{{name}}` | `platform-runtime` | `apps` | `containers.{{container}}.image` |
+| `Service` | `{{name}}` | `platform-runtime` | `apps` | `service.ports.{{service_port}}.port` |
+
+### Rendered Lineage Templates
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `apps` | `source_path` | `-` | `false` | `metadata.name` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `source_path` | `-` | `false` | `containers.{{container_name}}.image` | `false` |
+| `Service` | `{{name}}` | `apps` | `source_path` | `-` | `false` | `service.ports.{{service_port_name}}.port` | `false` |
+
+## `springboot`
+
+- Profile: `springboot-paas`
+- Resource: `Kustomization` (`kustomize.toolkit.fluxcd.io/v1/Kustomization`)
+- Capabilities: render-app-config, profile-overrides, inverse-app-config-patch
+- Default input role: `spring-input`
+- Default owner: `platform-engineer`
+- Field-origin transform: `spring-config-to-manifest`
+- Field-origin overlay transform: `spring-profile-overlay`
+
+### Input Role Rules
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `build-config` | pom.xml, build.gradle, build.gradle.kts | - | - |
+| `app-config-base` | application.yaml, application.yml | - | - |
+| `app-config-profile` | - | application- | .yaml, .yml |
+
+### Role Owners
+| Role | Owner |
+| --- | --- |
+| `app-config-base` | `app-team` |
+| `app-config-profile` | `app-team` |
+
+### Inverse Patch Templates
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `app_name` | `app-team` | 0.88 | `false` |
+| `datasource_url` | `platform-engineer` | 0.78 | `true` |
+| `server_port` | `app-team` | 0.91 | `false` |
+
+### Inverse Pointer Templates
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `app_name` | `app-team` | 0.89 |
+| `datasource_url` | `platform-engineer` | 0.78 |
+| `server_port` | `app-team` | 0.91 |
+
+### Field Origin Confidences
+| Key | Confidence |
+| --- | --- |
+| `app_name` | 0.89 |
+| `datasource_url` | 0.78 |
+| `server_port_base` | 0.92 |
+| `server_port_overlay` | 0.88 |
+
+### Hint Defaults
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `src/main/resources/application.yaml` |
+| `build_config_path` | `pom.xml` |
+
+### Inverse Patch Reasons
+| Key | Reason |
+| --- | --- |
+| `app_name` | Application identity should be app-editable without platform escalation. |
+| `datasource_url` | Database connectivity impacts shared runtime dependencies. |
+| `server_port` | Application listener port is an app-level configuration concern. |
+
+### Inverse Edit Hints
+| Key | Hint |
+| --- | --- |
+| `app_name` | Edit spring.application.name in {{base_config_path}}. |
+| `datasource_url` | Edit spring.datasource.url in {{base_config_path}} and coordinate with platform ownership rules. |
+| `server_port_base` | Edit server.port in {{base_config_path}}. |
+| `server_port_overlay` | Edit server.port in {{profile_config_path}} for environment overrides; use {{base_config_path}} for the default. |
+
+### WET Targets
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Kustomization` | `{{name}}` | `platform-runtime` | `apps` | `-` |
+| `Deployment` | `{{name}}` | `platform-runtime` | `apps` | `server.port` |
+| `ConfigMap` | `{{name}}-config` | `platform-runtime` | `apps` | `spring.datasource.url` |
+
+### Rendered Lineage Templates
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Kustomization` | `{{name}}` | `apps` | `build_config_path` | `-` | `false` | `build` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `base_config_path` | `-` | `false` | `spring.application.name` | `false` |
+| `ConfigMap` | `{{name}}-config` | `apps` | `base_config_path` | `-` | `false` | `spring.datasource.url` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `profile_config_path` | `base_config_path` | `false` | `server.port` | `false` |
+
+## `swamp`
+
+- Profile: `swamp`
+- Resource: `Workflow` (`swamp.dev/v1/Workflow`)
+- Capabilities: workflow-automation, model-orchestration, inverse-workflow-patch
+- Default input role: `swamp-input`
+- Default owner: `app-team`
+- Field-origin transform: `swamp-workflow-to-execution`
+- Field-origin overlay transform: `swamp-overlay-merge`
+
+### Input Role Rules
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `swamp-config-base` | .swamp.yaml, .swamp.yml | - | - |
+| `swamp-workflow` | - | workflow- | .yaml, .yml |
+
+### Inverse Patch Templates
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `model_binding` | `app-team` | 0.88 | `false` |
+| `vault_config` | `platform-engineer` | 0.85 | `true` |
+| `workflow_definition` | `app-team` | 0.90 | `false` |
+
+### Inverse Pointer Templates
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `model_binding` | `app-team` | 0.88 |
+| `vault_config` | `platform-engineer` | 0.85 |
+| `workflow_definition` | `app-team` | 0.90 |
+
+### Field Origin Confidences
+| Key | Confidence |
+| --- | --- |
+| `model_binding_base` | 0.88 |
+| `model_binding_workflow` | 0.84 |
+| `vault_config` | 0.85 |
+| `workflow_definition` | 0.90 |
+
+### Hint Defaults
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `.swamp.yaml` |
+
+### Inverse Patch Reasons
+| Key | Reason |
+| --- | --- |
+| `model_binding` | Model bindings define which automation models execute in workflows. |
+| `vault_config` | Vault configuration impacts platform credential infrastructure. |
+| `workflow_definition` | Workflow job and step definitions are app-level automation intent. |
+
+### Inverse Edit Hints
+| Key | Hint |
+| --- | --- |
+| `model_binding_base` | Edit model references in {{base_config_path}}. |
+| `model_binding_workflow` | Edit model method bindings in {{workflow_path}} for task-specific overrides. |
+| `vault_config` | Edit vaults section in {{base_config_path}} and coordinate with platform secret infrastructure. |
+| `workflow_definition` | Edit jobs and steps in the workflow YAML file. |
+
+### WET Targets
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `platform-runtime` | `apps` | `jobs[].steps[].task` |
+| `ConfigMap` | `{{name}}-swamp-config` | `platform-runtime` | `apps` | `swamp.version` |
+
+### Rendered Lineage Templates
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `apps` | `base_config_path` | `-` | `false` | `vaults.default.type` | `false` |
+| `ConfigMap` | `{{name}}-swamp-config` | `apps` | `base_config_path` | `-` | `false` | `swamp.version` | `false` |
+| `Workflow` | `{{name}}-workflow` | `apps` | `workflow_path` | `-` | `false` | `jobs[].steps[].task` | `true` |

--- a/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
@@ -1,8 +1,8 @@
 Usage:
-  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json] [--details] [--pretty]
+  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]
   (KIND/PROFILE/CAPABILITY support comma-separated values)
   use --strict-filters to fail on unknown filter values
-  use --details with --json to include policy/provenance templates
+  use --details with --json or --markdown to include policy/provenance templates
 
 Supported kinds: ably, backstage, c3agent, helm, opsworkflow, score, springboot, swamp
 Supported profiles: ably-config, backstage-idp, c3agent, helm-paas, ops-workflow, scoredev-paas, springboot-paas, swamp

--- a/cmd/cub-gen/testdata/parity/generators.markdown.golden.md
+++ b/cmd/cub-gen/testdata/parity/generators.markdown.golden.md
@@ -1,0 +1,14 @@
+# Generator Families
+
+Total: 8
+
+| Kind | Profile | Resource Kind | Resource Type | Capabilities |
+| --- | --- | --- | --- | --- |
+| `ably` | `ably-config` | `ConfigMap` | `v1/ConfigMap` | app-config-only, provider-config, inverse-provider-config-patch |
+| `backstage` | `backstage-idp` | `Component` | `backstage.io/v1alpha1/Component` | catalog-metadata, render-manifests, inverse-catalog-patch |
+| `c3agent` | `c3agent` | `ConfigMap` | `v1/ConfigMap` | fleet-config, agent-orchestration, inverse-fleet-config-patch |
+| `helm` | `helm-paas` | `HelmRelease` | `helm.toolkit.fluxcd.io/v2/HelmRelease` | render-manifests, values-overrides, inverse-values-patch |
+| `opsworkflow` | `ops-workflow` | `Workflow` | `argoproj.io/v1alpha1/Workflow` | workflow-plan, governed-execution-intent, inverse-workflow-patch |
+| `score` | `scoredev-paas` | `Application` | `argoproj.io/v1alpha1/Application` | render-manifests, workload-spec, inverse-score-patch |
+| `springboot` | `springboot-paas` | `Kustomization` | `kustomize.toolkit.fluxcd.io/v1/Kustomization` | render-app-config, profile-overrides, inverse-app-config-patch |
+| `swamp` | `swamp` | `Workflow` | `swamp.dev/v1/Workflow` | workflow-automation, model-orchestration, inverse-workflow-patch |

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -8,7 +8,7 @@ Usage:
   cub-gen verify [--in FILE|-] [--json] [--pretty]
   cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]
   cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]
-  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json] [--details] [--pretty]
+  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]
   cub-gen gitops <discover|import|cleanup> [flags]
   cub-gen bridge <ingest|decision|promote> [flags]
 
@@ -41,6 +41,7 @@ GitOps parity examples:
   cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123
   cub-gen generators --json
   cub-gen generators --json --details
+  cub-gen generators --markdown --details
   cub-gen generators --capability render-manifests
 
 Note: gitops commands are local-only prototypes that mirror cub gitops stages.

--- a/docs/releases/v0.2-preview.1.md
+++ b/docs/releases/v0.2-preview.1.md
@@ -33,6 +33,9 @@ Tag: `v0.2-preview.1`
    - registry specs
    - `generators --json`
    - `generators --json --details`
+5. Added Markdown introspection surface for platform owners:
+   - `generators --markdown`
+   - `generators --markdown --details`
 5. Operator adoption docs now include a single 10-minute Flux/Argo/Helm entry path.
 
 ## Boundary (unchanged)

--- a/docs/roadmap-v0.2-preview.md
+++ b/docs/roadmap-v0.2-preview.md
@@ -70,6 +70,7 @@ Implemented in this preview slice:
 52. Added governed decision-state bridge contract and runtime transitions (`INGESTED -> ATTESTED -> ALLOW|ESCALATE|BLOCK`) with explicit authority gates, attestation linkage validation, and query-by-`change_id` support in `internal/bridge`.
 53. Added PR<->MR linkage and upstream DRY promotion guardrail state machine with explicit separate-review enforcement before protected platform-DRY merge.
 54. Expanded `cub-gen generators --json --details` with full policy/provenance template fields (`hint_defaults`, inverse reasons/hints, input role rules/defaults, role ownership defaults, wet target templates, rendered lineage templates, and field-origin transform labels) and updated parity golden contracts.
+55. Added `cub-gen generators --markdown` (+ `--details`) so platform owners can inspect family policy/provenance templates in GitHub-friendly Markdown without `jq` pipelines.
 
 ## v0.2 preview invariants
 


### PR DESCRIPTION
## Summary

Adds a Markdown output surface for generator inventory and policy/provenance introspection so platform owners can review generator behavior without `jq` pipelines.

## What changed

- Added `--markdown` mode to `cub-gen generators`.
- Added `--details` support for Markdown output (full per-family sections).
- Added guardrails:
  - `--markdown` cannot be combined with `--json`.
  - `--details` now requires `--json` or `--markdown`.
- Added deterministic Markdown rendering for:
  - input role rules
  - role owners
  - inverse patch templates
  - inverse pointer templates
  - field-origin confidences
  - hint defaults
  - inverse reasons/hints
  - wet target templates
  - rendered lineage templates
- Updated command help usage and top-level examples.
- Added parity tests + golden contracts:
  - `TestGeneratorsGoldenMarkdown`
  - `TestGeneratorsGoldenMarkdownDetails`
  - `TestGeneratorsMarkdownCannotCombineJSON`
- Updated docs (`README`, roadmap, release notes).

## Validation

- `go test ./cmd/cub-gen -count=1`
- `make ci`

