### PR TITLE
docs: refresh handover after generator visibility improvements

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-03-08
 **Repo**: `github.com/confighub/cub-gen`
-**Branch**: `main` (up to date, PRs #109 and #110 merged)
+**Branch**: `main` (up to date, PRs #109, #110, #112, and #113 merged)
 
 ---
 
@@ -38,6 +38,23 @@ Full implementation across all layers:
 
 **PR #110** — shipped and merged. CI green.
 
+### 3. Fixed swamp path semantics + expanded details payload + added Markdown introspection
+
+Delivered in two follow-up PRs:
+
+- **PR #112** (`fix(swamp)...` + details payload expansion):
+  - Corrected swamp model-binding dry path to `jobs[].steps[].task.modelIdOrName`.
+  - Added nested swamp workflow detection support (`workflow-*.yaml|yml` in child directories).
+  - Expanded `cub-gen generators --json --details` to include full policy/provenance templates (role rules/defaults, hint defaults, inverse reasons/hints, wet targets, lineage templates, transform labels).
+  - Updated parity goldens + docs (`README`, roadmap, release notes).
+- **PR #113** (`feat(generators): add markdown introspection output`):
+  - Added `cub-gen generators --markdown`.
+  - Added `cub-gen generators --markdown --details`.
+  - Added guardrails:
+    - `--markdown` cannot be combined with `--json`.
+    - `--details` requires `--json` or `--markdown`.
+  - Added parity tests + golden contracts for Markdown output.
+
 ---
 
 ## Current state of main
@@ -46,6 +63,9 @@ Full implementation across all layers:
 - All tests pass (`make ci` green)
 - All 4 AI work platform demo scenarios pass
 - Golden files generated for all generators
+- Platform-owner visibility now available via:
+  - `cub-gen generators --json --details`
+  - `cub-gen generators --markdown --details`
 
 ---
 
@@ -60,14 +80,14 @@ The generator "triple" (contract + provenance + inverse transform plan) is the c
 - Which changes need review
 - How to edit WET back to DRY
 
-**Today this is invisible.** The triples are embedded as Go struct literals in `internal/registry/registry.go`. Platform owners cannot see them without reading Go code or piping `--json` through `jq`.
+The triple source-of-truth is still Go struct literals in `internal/registry/registry.go`. Visibility is now much better (`--json --details` and `--markdown --details`), but authoring still requires Go edits.
 
 ### Two personas with different needs
 
 | Persona | Need | Current experience |
 |---|---|---|
-| **Platform owner** | See the mapping, check it, modify it, create new generators | Must read Go code or JSON blobs |
-| **Application owner** | "Magic, it just works" | Existing wizard + JSON pipeline is fine |
+| **Platform owner** | See the mapping, check it, modify it, create new generators | Can inspect rich Markdown/JSON details; still needs Go to author |
+| **Application owner** | "Magic, it just works" | Existing wizard + import/publish pipeline is fine |
 
 ### Three approaches were designed (see plan file)
 
@@ -91,9 +111,14 @@ The plan file at `.claude/plans/snappy-frolicking-blossom.md` contains concrete,
 - Docs auto-generated from YAML (Approach B)
 - ✅ Best of both, ⚠️ most implementation effort
 
-### User's decision
+### User's decision and where we are now
 
 The user approved the plan with all three approaches documented. They want to **evaluate all three with concrete examples** before choosing. The plan file contains full worked specimens of each approach.
+
+Status after PR #113:
+
+- We now have an operational slice of **Approach B** (readability/inspection).
+- We have not yet started **Approach A** (YAML-first authoring) or **Approach C** (YAML + generated docs).
 
 ---
 
@@ -170,8 +195,14 @@ go build -o ./cub-gen ./cmd/cub-gen
 # See all generators (table)
 ./cub-gen generators
 
-# See c3agent triple as JSON
-./cub-gen gitops import --space platform --json ./examples/c3agent ./examples/c3agent | jq .
+# See all generator triples as JSON details
+./cub-gen generators --json --details | jq '.families[] | {kind, profile, policies}'
+
+# See all generator triples as Markdown details
+./cub-gen generators --markdown --details
+
+# See c3agent triple from import flow
+./cub-gen gitops import --space platform --json ./examples/c3agent ./examples/c3agent | jq '{generator_kind: .discovered[0].generator_kind, contracts: .contracts[0], inverse_transform_plans: .inverse_transform_plans[0]}'
 
 # Run all demos
 ./examples/demo/ai-work-platform/run-all.sh

--- a/docs/decisions/2026-03-08-generator-visibility-markdown-surface.md
+++ b/docs/decisions/2026-03-08-generator-visibility-markdown-surface.md
@@ -1,0 +1,67 @@
+# Decision: Add Markdown Generator Visibility Surface
+
+Date: 2026-03-08
+Status: accepted
+Related PRs: #112, #113
+
+## Context
+
+Generator triples (contract + provenance + inverse plan) are central to cub-gen, but platform owners needed a readable surface without inspecting Go structs or building `jq` pipelines.
+
+Before this decision:
+
+1. `cub-gen generators` only had table and JSON output.
+2. Rich policy/provenance templates were available only via JSON details.
+3. Practical review in GitHub/Markdown contexts was awkward.
+
+## Decision
+
+Add a first-class Markdown output mode for generator inventory and triple inspection.
+
+Implemented command surface:
+
+1. `cub-gen generators --markdown`
+2. `cub-gen generators --markdown --details`
+
+Guardrails:
+
+1. `--markdown` cannot be combined with `--json`.
+2. `--details` requires `--json` or `--markdown`.
+
+`--markdown --details` includes deterministic, sorted sections for:
+
+1. input role rules and defaults
+2. role ownership
+3. inverse patch templates
+4. inverse pointer templates
+5. field-origin confidences
+6. hint defaults
+7. inverse reasons and edit hints
+8. WET targets
+9. rendered lineage templates
+
+## Rationale
+
+1. Improves platform-owner readability immediately with minimal architectural churn.
+2. Preserves existing Go registry source-of-truth while reducing inspection friction.
+3. Keeps output contract stable via golden tests.
+4. Creates a bridge toward generated docs (Approach B) and potential YAML-first authoring (Approach A/C).
+
+## Consequences
+
+Positive:
+
+1. Faster review/adoption for new generator families.
+2. Better copy/paste artifacts for design reviews and docs.
+3. Deterministic output suitable for CI parity locking.
+
+Trade-offs:
+
+1. Authoring still requires Go edits in `internal/registry/registry.go`.
+2. Markdown output is verbose for `--details` (intended for inspection, not terse CLI output).
+
+## Follow-up
+
+1. Evaluate whether to add `cub-gen generators --markdown --kind <kind>` snippets directly into docs automation.
+2. Decide between YAML-first registry (Approach A) and combined YAML + generated docs (Approach C).
+3. If Approach A/C is selected, keep Markdown surface as compatibility layer during migration.


### PR DESCRIPTION
## Summary

Updates session handover and decision docs to reflect the now-merged generator visibility improvements.

## Changes

- Updated `HANDOVER.md` with:
  - merged PR state through #113
  - swamp path/semantics fixes from #112
  - expanded details payload in `generators --json --details`
  - markdown introspection surface (`generators --markdown --details`)
  - current next-step framing for Approach A/B/C
  - updated quick verification commands
- Added decision note:
  - `docs/decisions/2026-03-08-generator-visibility-markdown-surface.md`

## Why

Keeps project context accurate for the next autonomous session and makes the visibility architecture decision explicit.
