### PR TITLE
feat(styles): ship three triple-expression styles for all 8 generators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples update-goldens ci
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples update-goldens sync-triple-styles ci
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -22,5 +22,8 @@ test-examples:
 
 update-goldens:
 	UPDATE_GOLDEN=1 go test ./cmd/cub-gen -run 'Golden' -count=1 -v
+
+sync-triple-styles:
+	go run ./cmd/cub-gen-style-sync
 
 ci: build test test-contracts test-bridge-symmetry test-examples

--- a/README.md
+++ b/README.md
@@ -223,6 +223,26 @@ without coupling the core flow to a running ConfigHub backend.
 `role_owners`, `default_owner`, `wet_targets`, `rendered_lineage_templates`,
 `field_origin_transform`, and `field_origin_overlay_transform`.
 
+### Compare triple expression styles (all 8 generators)
+
+The repo also includes three full style projections for every generator kind:
+
+1. Style A YAML: `/docs/triple-styles/style-a-yaml/*.yaml`
+2. Style B Markdown: `/docs/triple-styles/style-b-markdown/*.md`
+3. Style C YAML+Markdown pair: `/docs/triple-styles/style-c-yaml-plus-docs/<kind>/`
+
+Index:
+
+1. `/docs/triple-styles/README.md`
+
+Regenerate these style projections:
+
+```bash
+make sync-triple-styles
+# or
+go run ./cmd/cub-gen-style-sync
+```
+
 Or run direct mode (import + bundle in one command):
 
 ```bash

--- a/cmd/cub-gen-style-sync/main.go
+++ b/cmd/cub-gen-style-sync/main.go
@@ -1,0 +1,504 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/confighub/cub-gen/internal/registry"
+)
+
+func main() {
+	fs := flag.NewFlagSet("cub-gen-style-sync", flag.ExitOnError)
+	outDir := fs.String("out", filepath.Join("docs", "triple-styles"), "Output directory")
+	_ = fs.Parse(os.Args[1:])
+
+	if err := syncStyles(*outDir); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("synced triple styles to %s\n", *outDir)
+}
+
+type styleModel struct {
+	Kind         string
+	Profile      string
+	ResourceKind string
+	ResourceType string
+	Capabilities []string
+
+	Contract contractModel
+
+	Provenance provenanceModel
+
+	Inverse inverseModel
+
+	Hints map[string]string
+}
+
+type contractModel struct {
+	InputRoleRules   []registry.InputRoleRule
+	DefaultInputRole string
+	RoleOwners       map[string]string
+	DefaultOwner     string
+	RoleSchemaRefs   map[string]string
+	WetTargets       []registry.WetTargetTemplate
+}
+
+type provenanceModel struct {
+	FieldOriginTransform        string
+	FieldOriginOverlayTransform string
+	FieldOriginConfidences      map[string]float64
+	RenderedLineageTemplates    []registry.RenderedLineageTemplate
+}
+
+type inverseModel struct {
+	InversePatchTemplates   map[string]registry.InversePatchTemplate
+	InversePointerTemplates map[string]registry.InversePointerTemplate
+	InversePatchReasons     map[string]string
+	InverseEditHints        map[string]string
+}
+
+func syncStyles(root string) error {
+	styleA := filepath.Join(root, "style-a-yaml")
+	styleB := filepath.Join(root, "style-b-markdown")
+	styleC := filepath.Join(root, "style-c-yaml-plus-docs")
+
+	for _, path := range []string{styleA, styleB, styleC} {
+		if err := os.RemoveAll(path); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			return err
+		}
+	}
+
+	kinds := registry.Kinds()
+	entries := make([]styleModel, 0, len(kinds))
+	for _, kind := range kinds {
+		spec, ok := registry.Spec(kind)
+		if !ok {
+			continue
+		}
+		entries = append(entries, styleModel{
+			Kind:         string(spec.Kind),
+			Profile:      spec.Profile,
+			ResourceKind: spec.ResourceKind,
+			ResourceType: spec.ResourceType,
+			Capabilities: append([]string(nil), spec.Capabilities...),
+			Contract: contractModel{
+				InputRoleRules:   append([]registry.InputRoleRule(nil), spec.InputRoleRules...),
+				DefaultInputRole: spec.DefaultInputRole,
+				RoleOwners:       copyMap(spec.RoleOwners),
+				DefaultOwner:     spec.DefaultOwner,
+				RoleSchemaRefs:   copyMap(spec.RoleSchemaRefs),
+				WetTargets:       append([]registry.WetTargetTemplate(nil), spec.WetTargets...),
+			},
+			Provenance: provenanceModel{
+				FieldOriginTransform:        spec.FieldOriginTransform,
+				FieldOriginOverlayTransform: spec.FieldOriginOverlayTransform,
+				FieldOriginConfidences:      copyMapFloat(spec.FieldOriginConfidences),
+				RenderedLineageTemplates:    append([]registry.RenderedLineageTemplate(nil), spec.RenderedLineageTemplates...),
+			},
+			Inverse: inverseModel{
+				InversePatchTemplates:   copyMapPatch(spec.InversePatchTemplates),
+				InversePointerTemplates: copyMapPointer(spec.InversePointerTemplates),
+				InversePatchReasons:     copyMap(spec.InversePatchReasons),
+				InverseEditHints:        copyMap(spec.InverseEditHints),
+			},
+			Hints: copyMap(spec.HintDefaults),
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Kind < entries[j].Kind })
+
+	for _, entry := range entries {
+		yamlOut := renderYAML(entry)
+		markdownOut := renderMarkdown(entry)
+
+		styleAPath := filepath.Join(styleA, entry.Kind+".yaml")
+		if err := os.WriteFile(styleAPath, []byte(yamlOut), 0o644); err != nil {
+			return err
+		}
+
+		styleBPath := filepath.Join(styleB, entry.Kind+".md")
+		if err := os.WriteFile(styleBPath, []byte(markdownOut), 0o644); err != nil {
+			return err
+		}
+
+		styleCKind := filepath.Join(styleC, entry.Kind)
+		if err := os.MkdirAll(styleCKind, 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(styleCKind, "triple.yaml"), []byte(yamlOut), 0o644); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(styleCKind, "triple.md"), []byte(markdownOut), 0o644); err != nil {
+			return err
+		}
+	}
+
+	index := renderIndex(entries)
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte(index), 0o644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func renderIndex(entries []styleModel) string {
+	var b strings.Builder
+	b.WriteString("# Triple Style Comparison\n\n")
+	b.WriteString("This folder provides three fully populated representations of the generator triple model for all supported generator kinds.\n\n")
+	b.WriteString("1. Style A (`style-a-yaml`): YAML-first representation.\n")
+	b.WriteString("2. Style B (`style-b-markdown`): human-readable markdown + tables.\n")
+	b.WriteString("3. Style C (`style-c-yaml-plus-docs`): YAML + markdown pair per kind.\n\n")
+	b.WriteString("Canonical runtime source remains Go registry specs in `internal/registry/registry.go`.\n\n")
+	b.WriteString("| Kind | Style A | Style B | Style C |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, entry := range entries {
+		fmt.Fprintf(&b, "| `%s` | [yaml](style-a-yaml/%s.yaml) | [markdown](style-b-markdown/%s.md) | [pair](style-c-yaml-plus-docs/%s/) |\n",
+			entry.Kind, entry.Kind, entry.Kind, entry.Kind)
+	}
+	b.WriteString("\n## Regenerate\n\n")
+	b.WriteString("```bash\n")
+	b.WriteString("go run ./cmd/cub-gen-style-sync\n")
+	b.WriteString("```\n")
+	return b.String()
+}
+
+func renderYAML(entry styleModel) string {
+	var b strings.Builder
+	w := yamlWriter{b: &b}
+
+	w.line(0, "kind: %s", yamlQuote(entry.Kind))
+	w.line(0, "profile: %s", yamlQuote(entry.Profile))
+	w.line(0, "resource_kind: %s", yamlQuote(entry.ResourceKind))
+	w.line(0, "resource_type: %s", yamlQuote(entry.ResourceType))
+
+	w.line(0, "capabilities:")
+	for _, c := range entry.Capabilities {
+		w.line(1, "- %s", yamlQuote(c))
+	}
+
+	w.line(0, "contract:")
+	w.line(1, "default_input_role: %s", yamlQuote(entry.Contract.DefaultInputRole))
+	w.line(1, "default_owner: %s", yamlQuote(entry.Contract.DefaultOwner))
+
+	w.line(1, "input_role_rules:")
+	for _, rule := range entry.Contract.InputRoleRules {
+		w.line(2, "- role: %s", yamlQuote(rule.Role))
+		w.stringSlice(3, "exact_basenames", rule.ExactBasenames)
+		w.stringSlice(3, "prefixes", rule.Prefixes)
+		w.stringSlice(3, "extensions", rule.Extensions)
+	}
+
+	w.line(1, "role_owners:")
+	writeMapStringString(&w, 2, entry.Contract.RoleOwners)
+
+	w.line(1, "role_schema_refs:")
+	writeMapStringString(&w, 2, entry.Contract.RoleSchemaRefs)
+
+	w.line(1, "wet_targets:")
+	for _, target := range entry.Contract.WetTargets {
+		w.line(2, "- kind: %s", yamlQuote(target.Kind))
+		w.line(3, "name_template: %s", yamlQuote(target.NameTemplate))
+		w.line(3, "owner: %s", yamlQuote(target.Owner))
+		w.line(3, "namespace: %s", yamlQuote(target.Namespace))
+		w.line(3, "source_dry_path_template: %s", yamlQuote(target.SourceDryPathTemplate))
+	}
+
+	w.line(0, "provenance:")
+	w.line(1, "field_origin_transform: %s", yamlQuote(entry.Provenance.FieldOriginTransform))
+	w.line(1, "field_origin_overlay_transform: %s", yamlQuote(entry.Provenance.FieldOriginOverlayTransform))
+	w.line(1, "field_origin_confidences:")
+	writeMapStringFloat(&w, 2, entry.Provenance.FieldOriginConfidences)
+
+	w.line(1, "rendered_lineage_templates:")
+	for _, tpl := range entry.Provenance.RenderedLineageTemplates {
+		w.line(2, "- kind: %s", yamlQuote(tpl.Kind))
+		w.line(3, "name_template: %s", yamlQuote(tpl.NameTemplate))
+		w.line(3, "namespace: %s", yamlQuote(tpl.Namespace))
+		w.line(3, "source_path_hint: %s", yamlQuote(tpl.SourcePathHint))
+		w.line(3, "source_path_hint_fallback: %s", yamlQuote(tpl.SourcePathHintFallback))
+		w.line(3, "source_path_hint_multi: %t", tpl.SourcePathHintMulti)
+		w.line(3, "source_dry_path_template: %s", yamlQuote(tpl.SourceDryPathTemplate))
+		w.line(3, "optional: %t", tpl.Optional)
+	}
+
+	w.line(0, "inverse:")
+	w.line(1, "inverse_patch_templates:")
+	for _, key := range sortedKeysPatch(entry.Inverse.InversePatchTemplates) {
+		tpl := entry.Inverse.InversePatchTemplates[key]
+		w.line(2, "%s:", key)
+		w.line(3, "editable_by: %s", yamlQuote(tpl.EditableBy))
+		w.line(3, "confidence: %.2f", tpl.Confidence)
+		w.line(3, "requires_review: %t", tpl.RequiresReview)
+	}
+
+	w.line(1, "inverse_pointer_templates:")
+	for _, key := range sortedKeysPointer(entry.Inverse.InversePointerTemplates) {
+		tpl := entry.Inverse.InversePointerTemplates[key]
+		w.line(2, "%s:", key)
+		w.line(3, "owner: %s", yamlQuote(tpl.Owner))
+		w.line(3, "confidence: %.2f", tpl.Confidence)
+	}
+
+	w.line(1, "inverse_patch_reasons:")
+	writeMapStringString(&w, 2, entry.Inverse.InversePatchReasons)
+
+	w.line(1, "inverse_edit_hints:")
+	writeMapStringString(&w, 2, entry.Inverse.InverseEditHints)
+
+	w.line(0, "hints:")
+	w.line(1, "defaults:")
+	writeMapStringString(&w, 2, entry.Hints)
+
+	return b.String()
+}
+
+func renderMarkdown(entry styleModel) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s Triple\n\n", entry.Kind)
+	fmt.Fprintf(&b, "- Profile: `%s`\n", entry.Profile)
+	fmt.Fprintf(&b, "- Resource: `%s` (`%s`)\n", entry.ResourceKind, entry.ResourceType)
+	fmt.Fprintf(&b, "- Capabilities: %s\n\n", strings.Join(entry.Capabilities, ", "))
+
+	b.WriteString("```mermaid\n")
+	b.WriteString("flowchart LR\n")
+	b.WriteString("  dry[\"DRY Inputs\"] --> gen[\"Generator\"] --> wet[\"WET Targets\"]\n")
+	b.WriteString("```\n\n")
+
+	b.WriteString("## Contract\n\n")
+	fmt.Fprintf(&b, "- Default input role: `%s`\n", entry.Contract.DefaultInputRole)
+	fmt.Fprintf(&b, "- Default owner: `%s`\n\n", entry.Contract.DefaultOwner)
+	b.WriteString("### Input role rules\n\n")
+	b.WriteString("| Role | Exact basenames | Prefixes | Extensions |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, rule := range entry.Contract.InputRoleRules {
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n",
+			rule.Role,
+			mdCell(strings.Join(rule.ExactBasenames, ", ")),
+			mdCell(strings.Join(rule.Prefixes, ", ")),
+			mdCell(strings.Join(rule.Extensions, ", ")),
+		)
+	}
+	b.WriteString("\n### Role owners\n\n")
+	b.WriteString("| Role | Owner |\n")
+	b.WriteString("| --- | --- |\n")
+	for _, key := range sortedKeysString(entry.Contract.RoleOwners) {
+		fmt.Fprintf(&b, "| `%s` | `%s` |\n", key, entry.Contract.RoleOwners[key])
+	}
+
+	b.WriteString("\n### Role schema refs\n\n")
+	b.WriteString("| Role | Schema ref |\n")
+	b.WriteString("| --- | --- |\n")
+	for _, key := range sortedKeysString(entry.Contract.RoleSchemaRefs) {
+		fmt.Fprintf(&b, "| `%s` | `%s` |\n", key, entry.Contract.RoleSchemaRefs[key])
+	}
+
+	b.WriteString("\n### WET targets\n\n")
+	b.WriteString("| Kind | Name template | Owner | Namespace | Source DRY path template |\n")
+	b.WriteString("| --- | --- | --- | --- | --- |\n")
+	for _, target := range entry.Contract.WetTargets {
+		fmt.Fprintf(&b, "| `%s` | `%s` | `%s` | `%s` | `%s` |\n",
+			target.Kind,
+			target.NameTemplate,
+			target.Owner,
+			target.Namespace,
+			target.SourceDryPathTemplate,
+		)
+	}
+
+	b.WriteString("\n## Provenance\n\n")
+	fmt.Fprintf(&b, "- Field-origin transform: `%s`\n", entry.Provenance.FieldOriginTransform)
+	fmt.Fprintf(&b, "- Field-origin overlay transform: `%s`\n\n", entry.Provenance.FieldOriginOverlayTransform)
+	b.WriteString("### Field-origin confidences\n\n")
+	b.WriteString("| Key | Confidence |\n")
+	b.WriteString("| --- | --- |\n")
+	for _, key := range sortedKeysFloat(entry.Provenance.FieldOriginConfidences) {
+		fmt.Fprintf(&b, "| `%s` | %.2f |\n", key, entry.Provenance.FieldOriginConfidences[key])
+	}
+
+	b.WriteString("\n### Rendered lineage templates\n\n")
+	b.WriteString("| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |\n")
+	b.WriteString("| --- | --- | --- | --- | --- | --- | --- | --- |\n")
+	for _, tpl := range entry.Provenance.RenderedLineageTemplates {
+		fmt.Fprintf(&b, "| `%s` | `%s` | `%s` | `%s` | `%s` | `%t` | `%s` | `%t` |\n",
+			tpl.Kind,
+			tpl.NameTemplate,
+			tpl.Namespace,
+			tpl.SourcePathHint,
+			tpl.SourcePathHintFallback,
+			tpl.SourcePathHintMulti,
+			tpl.SourceDryPathTemplate,
+			tpl.Optional,
+		)
+	}
+
+	b.WriteString("\n## Inverse\n\n")
+	b.WriteString("### Inverse patch templates\n\n")
+	b.WriteString("| Key | Editable by | Confidence | Requires review |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, key := range sortedKeysPatch(entry.Inverse.InversePatchTemplates) {
+		tpl := entry.Inverse.InversePatchTemplates[key]
+		fmt.Fprintf(&b, "| `%s` | `%s` | %.2f | `%t` |\n", key, tpl.EditableBy, tpl.Confidence, tpl.RequiresReview)
+	}
+
+	b.WriteString("\n### Inverse pointer templates\n\n")
+	b.WriteString("| Key | Owner | Confidence |\n")
+	b.WriteString("| --- | --- | --- |\n")
+	for _, key := range sortedKeysPointer(entry.Inverse.InversePointerTemplates) {
+		tpl := entry.Inverse.InversePointerTemplates[key]
+		fmt.Fprintf(&b, "| `%s` | `%s` | %.2f |\n", key, tpl.Owner, tpl.Confidence)
+	}
+
+	b.WriteString("\n### Inverse patch reasons\n\n")
+	b.WriteString("| Key | Reason |\n")
+	b.WriteString("| --- | --- |\n")
+	for _, key := range sortedKeysString(entry.Inverse.InversePatchReasons) {
+		fmt.Fprintf(&b, "| `%s` | %s |\n", key, mdCell(entry.Inverse.InversePatchReasons[key]))
+	}
+
+	b.WriteString("\n### Inverse edit hints\n\n")
+	b.WriteString("| Key | Hint |\n")
+	b.WriteString("| --- | --- |\n")
+	for _, key := range sortedKeysString(entry.Inverse.InverseEditHints) {
+		fmt.Fprintf(&b, "| `%s` | %s |\n", key, mdCell(entry.Inverse.InverseEditHints[key]))
+	}
+
+	b.WriteString("\n### Hint defaults\n\n")
+	b.WriteString("| Key | Value |\n")
+	b.WriteString("| --- | --- |\n")
+	for _, key := range sortedKeysString(entry.Hints) {
+		fmt.Fprintf(&b, "| `%s` | `%s` |\n", key, entry.Hints[key])
+	}
+
+	return b.String()
+}
+
+type yamlWriter struct {
+	b *strings.Builder
+}
+
+func (w yamlWriter) line(indent int, format string, args ...any) {
+	w.b.WriteString(strings.Repeat("  ", indent))
+	w.b.WriteString(fmt.Sprintf(format, args...))
+	w.b.WriteByte('\n')
+}
+
+func (w yamlWriter) stringSlice(indent int, key string, values []string) {
+	w.line(indent, "%s:", key)
+	if len(values) == 0 {
+		w.line(indent+1, "[]")
+		return
+	}
+	for _, value := range values {
+		w.line(indent+1, "- %s", yamlQuote(value))
+	}
+}
+
+func writeMapStringString(w *yamlWriter, indent int, values map[string]string) {
+	keys := sortedKeysString(values)
+	if len(keys) == 0 {
+		w.line(indent, "{}")
+		return
+	}
+	for _, key := range keys {
+		w.line(indent, "%s: %s", key, yamlQuote(values[key]))
+	}
+}
+
+func writeMapStringFloat(w *yamlWriter, indent int, values map[string]float64) {
+	keys := sortedKeysFloat(values)
+	if len(keys) == 0 {
+		w.line(indent, "{}")
+		return
+	}
+	for _, key := range keys {
+		w.line(indent, "%s: %.2f", key, values[key])
+	}
+}
+
+func yamlQuote(value string) string {
+	return strconv.Quote(value)
+}
+
+func mdCell(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	value = strings.ReplaceAll(value, "|", "\\|")
+	value = strings.ReplaceAll(value, "\n", "<br/>")
+	return value
+}
+
+func copyMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func copyMapFloat(in map[string]float64) map[string]float64 {
+	out := make(map[string]float64, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func copyMapPatch(in map[string]registry.InversePatchTemplate) map[string]registry.InversePatchTemplate {
+	out := make(map[string]registry.InversePatchTemplate, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func copyMapPointer(in map[string]registry.InversePointerTemplate) map[string]registry.InversePointerTemplate {
+	out := make(map[string]registry.InversePointerTemplate, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func sortedKeysString(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeysFloat(values map[string]float64) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeysPatch(values map[string]registry.InversePatchTemplate) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeysPointer(values map[string]registry.InversePointerTemplate) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/cub-gen-style-sync/main_test.go
+++ b/cmd/cub-gen-style-sync/main_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-gen/internal/registry"
+)
+
+func TestSyncStylesGeneratesAllKindsAcrossThreeStyles(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "triple-styles")
+	if err := syncStyles(root); err != nil {
+		t.Fatalf("syncStyles: %v", err)
+	}
+
+	kinds := registry.Kinds()
+	if len(kinds) == 0 {
+		t.Fatal("expected non-empty generator kind list")
+	}
+
+	for _, kind := range kinds {
+		name := string(kind)
+		t.Run(name, func(t *testing.T) {
+			styleAPath := filepath.Join(root, "style-a-yaml", name+".yaml")
+			styleBPath := filepath.Join(root, "style-b-markdown", name+".md")
+			styleCYaml := filepath.Join(root, "style-c-yaml-plus-docs", name, "triple.yaml")
+			styleCMd := filepath.Join(root, "style-c-yaml-plus-docs", name, "triple.md")
+
+			assertFileContains(t, styleAPath, `kind: "`+name+`"`)
+			assertFileContains(t, styleBPath, "# "+name+" Triple")
+			assertFileContains(t, styleCYaml, `kind: "`+name+`"`)
+			assertFileContains(t, styleCMd, "# "+name+" Triple")
+		})
+	}
+
+	indexPath := filepath.Join(root, "README.md")
+	index := mustReadFile(t, indexPath)
+	for _, kind := range kinds {
+		name := string(kind)
+		if !strings.Contains(index, "style-a-yaml/"+name+".yaml") {
+			t.Fatalf("index missing style A link for %s", name)
+		}
+		if !strings.Contains(index, "style-b-markdown/"+name+".md") {
+			t.Fatalf("index missing style B link for %s", name)
+		}
+		if !strings.Contains(index, "style-c-yaml-plus-docs/"+name+"/") {
+			t.Fatalf("index missing style C link for %s", name)
+		}
+	}
+}
+
+func TestCheckedInTripleStylesAreInSync(t *testing.T) {
+	generated := filepath.Join(t.TempDir(), "triple-styles")
+	if err := syncStyles(generated); err != nil {
+		t.Fatalf("syncStyles: %v", err)
+	}
+
+	checkedIn := filepath.Join(repoRoot(t), "docs", "triple-styles")
+	if _, err := os.Stat(checkedIn); err != nil {
+		t.Fatalf("expected checked-in triple styles at %s: %v", checkedIn, err)
+	}
+
+	generatedFiles := mustListFiles(t, generated)
+	checkedInFiles := mustListFiles(t, checkedIn)
+	if !equalStringSlices(generatedFiles, checkedInFiles) {
+		t.Fatalf("checked-in triple styles file list differs\nwant=%v\ngot=%v", generatedFiles, checkedInFiles)
+	}
+
+	for _, rel := range generatedFiles {
+		want := mustReadFile(t, filepath.Join(generated, rel))
+		got := mustReadFile(t, filepath.Join(checkedIn, rel))
+		if got != want {
+			t.Fatalf("checked-in triple styles content drift at %s\nrun: go run ./cmd/cub-gen-style-sync", rel)
+		}
+	}
+}
+
+func assertFileContains(t *testing.T, path, want string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(b), want) {
+		t.Fatalf("file %s missing %q", path, want)
+	}
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func mustListFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find repo root from %s", file)
+		}
+		dir = parent
+	}
+}

--- a/docs/triple-styles/README.md
+++ b/docs/triple-styles/README.md
@@ -1,0 +1,26 @@
+# Triple Style Comparison
+
+This folder provides three fully populated representations of the generator triple model for all supported generator kinds.
+
+1. Style A (`style-a-yaml`): YAML-first representation.
+2. Style B (`style-b-markdown`): human-readable markdown + tables.
+3. Style C (`style-c-yaml-plus-docs`): YAML + markdown pair per kind.
+
+Canonical runtime source remains Go registry specs in `internal/registry/registry.go`.
+
+| Kind | Style A | Style B | Style C |
+| --- | --- | --- | --- |
+| `ably` | [yaml](style-a-yaml/ably.yaml) | [markdown](style-b-markdown/ably.md) | [pair](style-c-yaml-plus-docs/ably/) |
+| `backstage` | [yaml](style-a-yaml/backstage.yaml) | [markdown](style-b-markdown/backstage.md) | [pair](style-c-yaml-plus-docs/backstage/) |
+| `c3agent` | [yaml](style-a-yaml/c3agent.yaml) | [markdown](style-b-markdown/c3agent.md) | [pair](style-c-yaml-plus-docs/c3agent/) |
+| `helm` | [yaml](style-a-yaml/helm.yaml) | [markdown](style-b-markdown/helm.md) | [pair](style-c-yaml-plus-docs/helm/) |
+| `opsworkflow` | [yaml](style-a-yaml/opsworkflow.yaml) | [markdown](style-b-markdown/opsworkflow.md) | [pair](style-c-yaml-plus-docs/opsworkflow/) |
+| `score` | [yaml](style-a-yaml/score.yaml) | [markdown](style-b-markdown/score.md) | [pair](style-c-yaml-plus-docs/score/) |
+| `springboot` | [yaml](style-a-yaml/springboot.yaml) | [markdown](style-b-markdown/springboot.md) | [pair](style-c-yaml-plus-docs/springboot/) |
+| `swamp` | [yaml](style-a-yaml/swamp.yaml) | [markdown](style-b-markdown/swamp.md) | [pair](style-c-yaml-plus-docs/swamp/) |
+
+## Regenerate
+
+```bash
+go run ./cmd/cub-gen-style-sync
+```

--- a/docs/triple-styles/style-a-yaml/ably.yaml
+++ b/docs/triple-styles/style-a-yaml/ably.yaml
@@ -1,0 +1,105 @@
+kind: "ably"
+profile: "ably-config"
+resource_kind: "ConfigMap"
+resource_type: "v1/ConfigMap"
+capabilities:
+  - "app-config-only"
+  - "provider-config"
+  - "inverse-provider-config-patch"
+contract:
+  default_input_role: "provider-config"
+  default_owner: "app-team"
+  input_role_rules:
+    - role: "provider-config-base"
+      exact_basenames:
+        - "ably.yaml"
+        - "ably.yml"
+        - "ably.json"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "provider-config-overlay"
+      exact_basenames:
+        []
+      prefixes:
+        - "ably-"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
+  role_owners:
+    {}
+  role_schema_refs:
+    provider-config-base: "https://schema.confighub.dev/generators/ably-config-v1"
+    provider-config-overlay: "https://schema.confighub.dev/generators/ably-config-v1"
+  wet_targets:
+    - kind: "ConfigMap"
+      name_template: "{{name}}-ably"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "app.environment"
+    - kind: "Secret"
+      name_template: "{{name}}-ably-credentials"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "credentials.api_key_ref"
+provenance:
+  field_origin_transform: "ably-config-to-runtime"
+  field_origin_overlay_transform: "ably-overlay-merge"
+  field_origin_confidences:
+    channels_base: 0.88
+    channels_overlay: 0.84
+    environment: 0.90
+  rendered_lineage_templates:
+    - kind: "ConfigMap"
+      name_template: "{{name}}-ably"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "app.environment"
+      optional: false
+    - kind: "Secret"
+      name_template: "{{name}}-ably-credentials"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "credentials.api_key_ref"
+      optional: false
+    - kind: "ConfigMap"
+      name_template: "{{name}}-ably"
+      namespace: "apps"
+      source_path_hint: "overlay_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "channels.inbound"
+      optional: true
+inverse:
+  inverse_patch_templates:
+    channels:
+      editable_by: "app-team"
+      confidence: 0.88
+      requires_review: false
+    environment:
+      editable_by: "app-team"
+      confidence: 0.90
+      requires_review: false
+  inverse_pointer_templates:
+    channels:
+      owner: "app-team"
+      confidence: 0.88
+    environment:
+      owner: "app-team"
+      confidence: 0.90
+  inverse_patch_reasons:
+    channels: "Channel mapping is app-level runtime behavior."
+    environment: "Environment is sourced from {{base_config_path}}."
+  inverse_edit_hints:
+    channels_base: "Edit channels.inbound in {{base_config_path}}."
+    channels_overlay: "Edit channels.inbound in {{overlay_config_path}} for environment-specific behavior; use {{base_config_path}} for defaults."
+    environment: "Edit app.environment in {{base_config_path}}."
+hints:
+  defaults:
+    base_config_path: "ably.yaml"

--- a/docs/triple-styles/style-a-yaml/backstage.yaml
+++ b/docs/triple-styles/style-a-yaml/backstage.yaml
@@ -1,0 +1,93 @@
+kind: "backstage"
+profile: "backstage-idp"
+resource_kind: "Component"
+resource_type: "backstage.io/v1alpha1/Component"
+capabilities:
+  - "catalog-metadata"
+  - "render-manifests"
+  - "inverse-catalog-patch"
+contract:
+  default_input_role: "backstage-input"
+  default_owner: "platform-engineer"
+  input_role_rules:
+    - role: "catalog-spec"
+      exact_basenames:
+        - "catalog-info.yaml"
+        - "catalog-info.yml"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "app-config"
+      exact_basenames:
+        - "app-config.yaml"
+        - "app-config.yml"
+      prefixes:
+        []
+      extensions:
+        []
+  role_owners:
+    app-config: "app-team"
+  role_schema_refs:
+    app-config: "https://json.schemastore.org/backstage-app-config"
+    catalog-spec: "https://json.schemastore.org/backstage-catalog-info"
+  wet_targets:
+    - kind: "Application"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "metadata.name"
+    - kind: "ConfigMap"
+      name_template: "{{name}}-catalog"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "spec.lifecycle"
+provenance:
+  field_origin_transform: "backstage-component-to-application"
+  field_origin_overlay_transform: ""
+  field_origin_confidences:
+    identity: 0.90
+    lifecycle: 0.82
+  rendered_lineage_templates:
+    - kind: "Application"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "catalog_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "metadata.name"
+      optional: false
+    - kind: "ConfigMap"
+      name_template: "{{name}}-catalog"
+      namespace: "apps"
+      source_path_hint: "catalog_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "spec.lifecycle"
+      optional: false
+inverse:
+  inverse_patch_templates:
+    identity:
+      editable_by: "platform-engineer"
+      confidence: 0.87
+      requires_review: false
+    lifecycle:
+      editable_by: "platform-engineer"
+      confidence: 0.82
+      requires_review: true
+  inverse_pointer_templates:
+    lifecycle:
+      owner: "platform-engineer"
+      confidence: 0.82
+    name:
+      owner: "platform-engineer"
+      confidence: 0.90
+  inverse_patch_reasons:
+    identity: "Backstage component identity is sourced from {{catalog_path}}."
+    lifecycle: "Lifecycle changes impact platform ownership and support policy."
+  inverse_edit_hints:
+    lifecycle: "Edit spec.lifecycle in {{catalog_path}} and coordinate rollout policy."
+    name: "Edit metadata.name in {{catalog_path}}."
+hints:
+  defaults:
+    catalog_path: "catalog-info.yaml"

--- a/docs/triple-styles/style-a-yaml/c3agent.yaml
+++ b/docs/triple-styles/style-a-yaml/c3agent.yaml
@@ -1,0 +1,115 @@
+kind: "c3agent"
+profile: "c3agent"
+resource_kind: "ConfigMap"
+resource_type: "v1/ConfigMap"
+capabilities:
+  - "fleet-config"
+  - "agent-orchestration"
+  - "inverse-fleet-config-patch"
+contract:
+  default_input_role: "fleet-config"
+  default_owner: "app-team"
+  input_role_rules:
+    - role: "fleet-config-base"
+      exact_basenames:
+        - "c3agent.yaml"
+        - "c3agent.yml"
+        - "c3agent.json"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "fleet-config-overlay"
+      exact_basenames:
+        []
+      prefixes:
+        - "c3agent-"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
+  role_owners:
+    {}
+  role_schema_refs:
+    fleet-config-base: "https://schema.confighub.dev/generators/c3agent-v1"
+    fleet-config-overlay: "https://schema.confighub.dev/generators/c3agent-v1"
+  wet_targets:
+    - kind: "ConfigMap"
+      name_template: "{{name}}-fleet-config"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "fleet.agent_model"
+    - kind: "Secret"
+      name_template: "{{name}}-fleet-credentials"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "credentials.anthropic_key_ref"
+provenance:
+  field_origin_transform: "c3agent-config-to-runtime"
+  field_origin_overlay_transform: "c3agent-overlay-merge"
+  field_origin_confidences:
+    component_ports_base: 0.84
+    component_ports_overlay: 0.80
+    credentials: 0.86
+    fleet_config: 0.91
+  rendered_lineage_templates:
+    - kind: "ConfigMap"
+      name_template: "{{name}}-fleet-config"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "fleet.agent_model"
+      optional: false
+    - kind: "Secret"
+      name_template: "{{name}}-fleet-credentials"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "credentials.anthropic_key_ref"
+      optional: false
+    - kind: "ConfigMap"
+      name_template: "{{name}}-fleet-config"
+      namespace: "apps"
+      source_path_hint: "overlay_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "fleet.max_concurrent_tasks"
+      optional: true
+inverse:
+  inverse_patch_templates:
+    component_ports:
+      editable_by: "platform-engineer"
+      confidence: 0.84
+      requires_review: true
+    credentials:
+      editable_by: "platform-engineer"
+      confidence: 0.86
+      requires_review: true
+    fleet_config:
+      editable_by: "app-team"
+      confidence: 0.91
+      requires_review: false
+  inverse_pointer_templates:
+    component_ports:
+      owner: "platform-engineer"
+      confidence: 0.84
+    credentials:
+      owner: "platform-engineer"
+      confidence: 0.86
+    fleet_config:
+      owner: "app-team"
+      confidence: 0.91
+  inverse_patch_reasons:
+    component_ports: "Component port changes affect platform networking and service mesh."
+    credentials: "Credential references impact platform secret management."
+    fleet_config: "Fleet configuration (model, concurrency) is sourced from {{base_config_path}}."
+  inverse_edit_hints:
+    component_ports_base: "Edit components.controlplane.grpc_port in {{base_config_path}}."
+    component_ports_overlay: "Edit component ports in {{overlay_config_path}} for environment-specific values; use {{base_config_path}} for defaults."
+    credentials: "Edit credentials section in {{base_config_path}} and coordinate with platform secret management."
+    fleet_config: "Edit fleet.agent_model or fleet.max_concurrent_tasks in {{base_config_path}}."
+hints:
+  defaults:
+    base_config_path: "c3agent.yaml"

--- a/docs/triple-styles/style-a-yaml/helm.yaml
+++ b/docs/triple-styles/style-a-yaml/helm.yaml
@@ -1,0 +1,97 @@
+kind: "helm"
+profile: "helm-paas"
+resource_kind: "HelmRelease"
+resource_type: "helm.toolkit.fluxcd.io/v2/HelmRelease"
+capabilities:
+  - "render-manifests"
+  - "values-overrides"
+  - "inverse-values-patch"
+contract:
+  default_input_role: "helm-input"
+  default_owner: "platform-engineer"
+  input_role_rules:
+    - role: "chart"
+      exact_basenames:
+        - "chart.yaml"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "values"
+      exact_basenames:
+        []
+      prefixes:
+        - "values"
+      extensions:
+        - ".yaml"
+        - ".yml"
+  role_owners:
+    values: "app-team"
+  role_schema_refs:
+    chart: "https://json.schemastore.org/chart"
+  wet_targets:
+    - kind: "HelmRelease"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: ""
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "values.image.tag"
+    - kind: "Service"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "values.service.port"
+provenance:
+  field_origin_transform: "helm-template"
+  field_origin_overlay_transform: ""
+  field_origin_confidences:
+    image_tag: 0.86
+  rendered_lineage_templates:
+    - kind: "HelmRelease"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "chart_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "Chart.yaml"
+      optional: false
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "values_paths"
+      source_path_hint_fallback: "chart_path"
+      source_path_hint_multi: true
+      source_dry_path_template: "values.image.tag"
+      optional: false
+    - kind: "Service"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "values_paths"
+      source_path_hint_fallback: "chart_path"
+      source_path_hint_multi: true
+      source_dry_path_template: "values.service.port"
+      optional: false
+inverse:
+  inverse_patch_templates:
+    image_tag:
+      editable_by: "app-team"
+      confidence: 0.86
+      requires_review: false
+  inverse_pointer_templates:
+    image_tag:
+      owner: "app-team"
+      confidence: 0.86
+  inverse_patch_reasons:
+    image_tag: "Container image tag maps cleanly to helm values."
+  inverse_edit_hints:
+    image_tag: "Edit chart values file and keep chart template unchanged."
+hints:
+  defaults:
+    chart_path: "Chart.yaml"
+    chart_role: "chart"
+    primary_values_path: "values.yaml"
+    values_role: "values"

--- a/docs/triple-styles/style-a-yaml/opsworkflow.yaml
+++ b/docs/triple-styles/style-a-yaml/opsworkflow.yaml
@@ -1,0 +1,106 @@
+kind: "opsworkflow"
+profile: "ops-workflow"
+resource_kind: "Workflow"
+resource_type: "argoproj.io/v1alpha1/Workflow"
+capabilities:
+  - "workflow-plan"
+  - "governed-execution-intent"
+  - "inverse-workflow-patch"
+contract:
+  default_input_role: "operations-input"
+  default_owner: "platform-engineer"
+  input_role_rules:
+    - role: "operations-base"
+      exact_basenames:
+        - "operations.yaml"
+        - "operations.yml"
+        - "workflow.yaml"
+        - "workflow.yml"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "operations-overlay"
+      exact_basenames:
+        []
+      prefixes:
+        - "operations-"
+        - "workflow-"
+      extensions:
+        - ".yaml"
+        - ".yml"
+  role_owners:
+    {}
+  role_schema_refs:
+    operations-base: "https://schema.confighub.dev/generators/ops-workflow-v1"
+    operations-overlay: "https://schema.confighub.dev/generators/ops-workflow-v1"
+  wet_targets:
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      owner: "platform-runtime"
+      namespace: "ops"
+      source_dry_path_template: "actions.deploy.image_tag"
+    - kind: "Job"
+      name_template: "{{name}}-dry-run"
+      owner: "platform-runtime"
+      namespace: "ops"
+      source_dry_path_template: "triggers.schedule"
+provenance:
+  field_origin_transform: "ops-workflow-to-argo-workflow"
+  field_origin_overlay_transform: "ops-workflow-overlay-merge"
+  field_origin_confidences:
+    image_tag: 0.87
+    schedule_base: 0.84
+    schedule_overlay: 0.80
+  rendered_lineage_templates:
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      namespace: "ops"
+      source_path_hint: "base_spec_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "actions.deploy.image_tag"
+      optional: false
+    - kind: "Job"
+      name_template: "{{name}}-dry-run"
+      namespace: "ops"
+      source_path_hint: "base_spec_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "triggers.schedule"
+      optional: false
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      namespace: "ops"
+      source_path_hint: "overlay_spec_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "triggers.schedule"
+      optional: true
+inverse:
+  inverse_patch_templates:
+    image_tag:
+      editable_by: "platform-engineer"
+      confidence: 0.87
+      requires_review: true
+    schedule:
+      editable_by: "platform-engineer"
+      confidence: 0.84
+      requires_review: true
+  inverse_pointer_templates:
+    image_tag:
+      owner: "platform-engineer"
+      confidence: 0.87
+    schedule:
+      owner: "platform-engineer"
+      confidence: 0.84
+  inverse_patch_reasons:
+    image_tag: "Deployment action image tag is sourced from {{base_spec_path}}."
+    schedule: "Schedule changes affect operational execution timing."
+  inverse_edit_hints:
+    image_tag: "Edit actions.deploy.image_tag in {{base_spec_path}}."
+    schedule_base: "Edit triggers.schedule in {{base_spec_path}}."
+    schedule_overlay: "Edit triggers.schedule in {{overlay_spec_path}} for environment-specific cadence; use {{base_spec_path}} for defaults."
+hints:
+  defaults:
+    base_spec_path: "operations.yaml"

--- a/docs/triple-styles/style-a-yaml/score.yaml
+++ b/docs/triple-styles/style-a-yaml/score.yaml
@@ -1,0 +1,100 @@
+kind: "score"
+profile: "scoredev-paas"
+resource_kind: "Application"
+resource_type: "argoproj.io/v1alpha1/Application"
+capabilities:
+  - "render-manifests"
+  - "workload-spec"
+  - "inverse-score-patch"
+contract:
+  default_input_role: "score-input"
+  default_owner: "app-team"
+  input_role_rules:
+    - role: "score-spec"
+      exact_basenames:
+        - "score.yaml"
+        - "score.yml"
+      prefixes:
+        []
+      extensions:
+        []
+  role_owners:
+    {}
+  role_schema_refs:
+    score-spec: "https://docs.score.dev/schemas/score-v1b1.json"
+  wet_targets:
+    - kind: "Application"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: ""
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "containers.{{container}}.image"
+    - kind: "Service"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "service.ports.{{service_port}}.port"
+provenance:
+  field_origin_transform: "score-to-k8s"
+  field_origin_overlay_transform: ""
+  field_origin_confidences:
+    env_var: 0.90
+    image: 0.94
+    port: 0.91
+  rendered_lineage_templates:
+    - kind: "Application"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "source_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "metadata.name"
+      optional: false
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "source_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "containers.{{container_name}}.image"
+      optional: false
+    - kind: "Service"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "source_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "service.ports.{{service_port_name}}.port"
+      optional: false
+inverse:
+  inverse_patch_templates:
+    env_var:
+      editable_by: "app-team"
+      confidence: 0.90
+      requires_review: false
+  inverse_pointer_templates:
+    env_var:
+      owner: "app-team"
+      confidence: 0.90
+    image:
+      owner: "app-team"
+      confidence: 0.94
+    port:
+      owner: "app-team"
+      confidence: 0.91
+  inverse_patch_reasons:
+    env_var: "Score variable maps to a single Kubernetes env var."
+  inverse_edit_hints:
+    env_var: "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}."
+    image: "Edit the Score container image in {{source_path}}."
+    port: "Edit {{service_port_name}} service port in {{source_path}}."
+hints:
+  defaults:
+    container_name: "main"
+    service_port_name: "web"
+    source_path: "score.yaml"
+    variable_name: "LOG_LEVEL"

--- a/docs/triple-styles/style-a-yaml/springboot.yaml
+++ b/docs/triple-styles/style-a-yaml/springboot.yaml
@@ -1,0 +1,137 @@
+kind: "springboot"
+profile: "springboot-paas"
+resource_kind: "Kustomization"
+resource_type: "kustomize.toolkit.fluxcd.io/v1/Kustomization"
+capabilities:
+  - "render-app-config"
+  - "profile-overrides"
+  - "inverse-app-config-patch"
+contract:
+  default_input_role: "spring-input"
+  default_owner: "platform-engineer"
+  input_role_rules:
+    - role: "build-config"
+      exact_basenames:
+        - "pom.xml"
+        - "build.gradle"
+        - "build.gradle.kts"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "app-config-base"
+      exact_basenames:
+        - "application.yaml"
+        - "application.yml"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "app-config-profile"
+      exact_basenames:
+        []
+      prefixes:
+        - "application-"
+      extensions:
+        - ".yaml"
+        - ".yml"
+  role_owners:
+    app-config-base: "app-team"
+    app-config-profile: "app-team"
+  role_schema_refs:
+    app-config-base: "https://json.schemastore.org/spring-configuration-metadata"
+    app-config-profile: "https://json.schemastore.org/spring-configuration-metadata"
+  wet_targets:
+    - kind: "Kustomization"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: ""
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "server.port"
+    - kind: "ConfigMap"
+      name_template: "{{name}}-config"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "spring.datasource.url"
+provenance:
+  field_origin_transform: "spring-config-to-manifest"
+  field_origin_overlay_transform: "spring-profile-overlay"
+  field_origin_confidences:
+    app_name: 0.89
+    datasource_url: 0.78
+    server_port_base: 0.92
+    server_port_overlay: 0.88
+  rendered_lineage_templates:
+    - kind: "Kustomization"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "build_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "build"
+      optional: false
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "spring.application.name"
+      optional: false
+    - kind: "ConfigMap"
+      name_template: "{{name}}-config"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "spring.datasource.url"
+      optional: false
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "profile_config_path"
+      source_path_hint_fallback: "base_config_path"
+      source_path_hint_multi: false
+      source_dry_path_template: "server.port"
+      optional: false
+inverse:
+  inverse_patch_templates:
+    app_name:
+      editable_by: "app-team"
+      confidence: 0.88
+      requires_review: false
+    datasource_url:
+      editable_by: "platform-engineer"
+      confidence: 0.78
+      requires_review: true
+    server_port:
+      editable_by: "app-team"
+      confidence: 0.91
+      requires_review: false
+  inverse_pointer_templates:
+    app_name:
+      owner: "app-team"
+      confidence: 0.89
+    datasource_url:
+      owner: "platform-engineer"
+      confidence: 0.78
+    server_port:
+      owner: "app-team"
+      confidence: 0.91
+  inverse_patch_reasons:
+    app_name: "Application identity should be app-editable without platform escalation."
+    datasource_url: "Database connectivity impacts shared runtime dependencies."
+    server_port: "Application listener port is an app-level configuration concern."
+  inverse_edit_hints:
+    app_name: "Edit spring.application.name in {{base_config_path}}."
+    datasource_url: "Edit spring.datasource.url in {{base_config_path}} and coordinate with platform ownership rules."
+    server_port_base: "Edit server.port in {{base_config_path}}."
+    server_port_overlay: "Edit server.port in {{profile_config_path}} for environment overrides; use {{base_config_path}} for the default."
+hints:
+  defaults:
+    base_config_path: "src/main/resources/application.yaml"
+    build_config_path: "pom.xml"

--- a/docs/triple-styles/style-a-yaml/swamp.yaml
+++ b/docs/triple-styles/style-a-yaml/swamp.yaml
@@ -1,0 +1,113 @@
+kind: "swamp"
+profile: "swamp"
+resource_kind: "Workflow"
+resource_type: "swamp.dev/v1/Workflow"
+capabilities:
+  - "workflow-automation"
+  - "model-orchestration"
+  - "inverse-workflow-patch"
+contract:
+  default_input_role: "swamp-input"
+  default_owner: "app-team"
+  input_role_rules:
+    - role: "swamp-config-base"
+      exact_basenames:
+        - ".swamp.yaml"
+        - ".swamp.yml"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "swamp-workflow"
+      exact_basenames:
+        []
+      prefixes:
+        - "workflow-"
+      extensions:
+        - ".yaml"
+        - ".yml"
+  role_owners:
+    {}
+  role_schema_refs:
+    swamp-config-base: "https://schema.confighub.dev/generators/swamp-v1"
+    swamp-workflow: "https://schema.confighub.dev/generators/swamp-workflow-v1"
+  wet_targets:
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "jobs[].steps[].task"
+    - kind: "ConfigMap"
+      name_template: "{{name}}-swamp-config"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "swamp.version"
+provenance:
+  field_origin_transform: "swamp-workflow-to-execution"
+  field_origin_overlay_transform: "swamp-overlay-merge"
+  field_origin_confidences:
+    model_binding_base: 0.88
+    model_binding_workflow: 0.84
+    vault_config: 0.85
+    workflow_definition: 0.90
+  rendered_lineage_templates:
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "vaults.default.type"
+      optional: false
+    - kind: "ConfigMap"
+      name_template: "{{name}}-swamp-config"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "swamp.version"
+      optional: false
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      namespace: "apps"
+      source_path_hint: "workflow_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "jobs[].steps[].task"
+      optional: true
+inverse:
+  inverse_patch_templates:
+    model_binding:
+      editable_by: "app-team"
+      confidence: 0.88
+      requires_review: false
+    vault_config:
+      editable_by: "platform-engineer"
+      confidence: 0.85
+      requires_review: true
+    workflow_definition:
+      editable_by: "app-team"
+      confidence: 0.90
+      requires_review: false
+  inverse_pointer_templates:
+    model_binding:
+      owner: "app-team"
+      confidence: 0.88
+    vault_config:
+      owner: "platform-engineer"
+      confidence: 0.85
+    workflow_definition:
+      owner: "app-team"
+      confidence: 0.90
+  inverse_patch_reasons:
+    model_binding: "Model bindings define which automation models execute in workflows."
+    vault_config: "Vault configuration impacts platform credential infrastructure."
+    workflow_definition: "Workflow job and step definitions are app-level automation intent."
+  inverse_edit_hints:
+    model_binding_base: "Edit model references in {{base_config_path}}."
+    model_binding_workflow: "Edit model method bindings in {{workflow_path}} for task-specific overrides."
+    vault_config: "Edit vaults section in {{base_config_path}} and coordinate with platform secret infrastructure."
+    workflow_definition: "Edit jobs and steps in the workflow YAML file."
+hints:
+  defaults:
+    base_config_path: ".swamp.yaml"

--- a/docs/triple-styles/style-b-markdown/ably.md
+++ b/docs/triple-styles/style-b-markdown/ably.md
@@ -1,0 +1,99 @@
+# ably Triple
+
+- Profile: `ably-config`
+- Resource: `ConfigMap` (`v1/ConfigMap`)
+- Capabilities: app-config-only, provider-config, inverse-provider-config-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `provider-config`
+- Default owner: `app-team`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `provider-config-base` | ably.yaml, ably.yml, ably.json | - | - |
+| `provider-config-overlay` | - | ably- | .yaml, .yml, .json |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `provider-config-base` | `https://schema.confighub.dev/generators/ably-config-v1` |
+| `provider-config-overlay` | `https://schema.confighub.dev/generators/ably-config-v1` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-ably` | `platform-runtime` | `apps` | `app.environment` |
+| `Secret` | `{{name}}-ably-credentials` | `platform-runtime` | `apps` | `credentials.api_key_ref` |
+
+## Provenance
+
+- Field-origin transform: `ably-config-to-runtime`
+- Field-origin overlay transform: `ably-overlay-merge`
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `channels_base` | 0.88 |
+| `channels_overlay` | 0.84 |
+| `environment` | 0.90 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-ably` | `apps` | `base_config_path` | `` | `false` | `app.environment` | `false` |
+| `Secret` | `{{name}}-ably-credentials` | `apps` | `base_config_path` | `` | `false` | `credentials.api_key_ref` | `false` |
+| `ConfigMap` | `{{name}}-ably` | `apps` | `overlay_config_path` | `` | `false` | `channels.inbound` | `true` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `channels` | `app-team` | 0.88 | `false` |
+| `environment` | `app-team` | 0.90 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `channels` | `app-team` | 0.88 |
+| `environment` | `app-team` | 0.90 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `channels` | Channel mapping is app-level runtime behavior. |
+| `environment` | Environment is sourced from {{base_config_path}}. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `channels_base` | Edit channels.inbound in {{base_config_path}}. |
+| `channels_overlay` | Edit channels.inbound in {{overlay_config_path}} for environment-specific behavior; use {{base_config_path}} for defaults. |
+| `environment` | Edit app.environment in {{base_config_path}}. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `ably.yaml` |

--- a/docs/triple-styles/style-b-markdown/backstage.md
+++ b/docs/triple-styles/style-b-markdown/backstage.md
@@ -1,0 +1,97 @@
+# backstage Triple
+
+- Profile: `backstage-idp`
+- Resource: `Component` (`backstage.io/v1alpha1/Component`)
+- Capabilities: catalog-metadata, render-manifests, inverse-catalog-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `backstage-input`
+- Default owner: `platform-engineer`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `catalog-spec` | catalog-info.yaml, catalog-info.yml | - | - |
+| `app-config` | app-config.yaml, app-config.yml | - | - |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+| `app-config` | `app-team` |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `app-config` | `https://json.schemastore.org/backstage-app-config` |
+| `catalog-spec` | `https://json.schemastore.org/backstage-catalog-info` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `platform-runtime` | `apps` | `metadata.name` |
+| `ConfigMap` | `{{name}}-catalog` | `platform-runtime` | `apps` | `spec.lifecycle` |
+
+## Provenance
+
+- Field-origin transform: `backstage-component-to-application`
+- Field-origin overlay transform: ``
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `identity` | 0.90 |
+| `lifecycle` | 0.82 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `apps` | `catalog_path` | `` | `false` | `metadata.name` | `false` |
+| `ConfigMap` | `{{name}}-catalog` | `apps` | `catalog_path` | `` | `false` | `spec.lifecycle` | `false` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `identity` | `platform-engineer` | 0.87 | `false` |
+| `lifecycle` | `platform-engineer` | 0.82 | `true` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `lifecycle` | `platform-engineer` | 0.82 |
+| `name` | `platform-engineer` | 0.90 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `identity` | Backstage component identity is sourced from {{catalog_path}}. |
+| `lifecycle` | Lifecycle changes impact platform ownership and support policy. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `lifecycle` | Edit spec.lifecycle in {{catalog_path}} and coordinate rollout policy. |
+| `name` | Edit metadata.name in {{catalog_path}}. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `catalog_path` | `catalog-info.yaml` |

--- a/docs/triple-styles/style-b-markdown/c3agent.md
+++ b/docs/triple-styles/style-b-markdown/c3agent.md
@@ -1,0 +1,104 @@
+# c3agent Triple
+
+- Profile: `c3agent`
+- Resource: `ConfigMap` (`v1/ConfigMap`)
+- Capabilities: fleet-config, agent-orchestration, inverse-fleet-config-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `fleet-config`
+- Default owner: `app-team`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `fleet-config-base` | c3agent.yaml, c3agent.yml, c3agent.json | - | - |
+| `fleet-config-overlay` | - | c3agent- | .yaml, .yml, .json |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `fleet-config-base` | `https://schema.confighub.dev/generators/c3agent-v1` |
+| `fleet-config-overlay` | `https://schema.confighub.dev/generators/c3agent-v1` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-fleet-config` | `platform-runtime` | `apps` | `fleet.agent_model` |
+| `Secret` | `{{name}}-fleet-credentials` | `platform-runtime` | `apps` | `credentials.anthropic_key_ref` |
+
+## Provenance
+
+- Field-origin transform: `c3agent-config-to-runtime`
+- Field-origin overlay transform: `c3agent-overlay-merge`
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `component_ports_base` | 0.84 |
+| `component_ports_overlay` | 0.80 |
+| `credentials` | 0.86 |
+| `fleet_config` | 0.91 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-fleet-config` | `apps` | `base_config_path` | `` | `false` | `fleet.agent_model` | `false` |
+| `Secret` | `{{name}}-fleet-credentials` | `apps` | `base_config_path` | `` | `false` | `credentials.anthropic_key_ref` | `false` |
+| `ConfigMap` | `{{name}}-fleet-config` | `apps` | `overlay_config_path` | `` | `false` | `fleet.max_concurrent_tasks` | `true` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `component_ports` | `platform-engineer` | 0.84 | `true` |
+| `credentials` | `platform-engineer` | 0.86 | `true` |
+| `fleet_config` | `app-team` | 0.91 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `component_ports` | `platform-engineer` | 0.84 |
+| `credentials` | `platform-engineer` | 0.86 |
+| `fleet_config` | `app-team` | 0.91 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `component_ports` | Component port changes affect platform networking and service mesh. |
+| `credentials` | Credential references impact platform secret management. |
+| `fleet_config` | Fleet configuration (model, concurrency) is sourced from {{base_config_path}}. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `component_ports_base` | Edit components.controlplane.grpc_port in {{base_config_path}}. |
+| `component_ports_overlay` | Edit component ports in {{overlay_config_path}} for environment-specific values; use {{base_config_path}} for defaults. |
+| `credentials` | Edit credentials section in {{base_config_path}} and coordinate with platform secret management. |
+| `fleet_config` | Edit fleet.agent_model or fleet.max_concurrent_tasks in {{base_config_path}}. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `c3agent.yaml` |

--- a/docs/triple-styles/style-b-markdown/helm.md
+++ b/docs/triple-styles/style-b-markdown/helm.md
@@ -1,0 +1,96 @@
+# helm Triple
+
+- Profile: `helm-paas`
+- Resource: `HelmRelease` (`helm.toolkit.fluxcd.io/v2/HelmRelease`)
+- Capabilities: render-manifests, values-overrides, inverse-values-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `helm-input`
+- Default owner: `platform-engineer`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `chart` | chart.yaml | - | - |
+| `values` | - | values | .yaml, .yml |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+| `values` | `app-team` |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `chart` | `https://json.schemastore.org/chart` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `HelmRelease` | `{{name}}` | `platform-runtime` | `apps` | `` |
+| `Deployment` | `{{name}}` | `platform-runtime` | `apps` | `values.image.tag` |
+| `Service` | `{{name}}` | `platform-runtime` | `apps` | `values.service.port` |
+
+## Provenance
+
+- Field-origin transform: `helm-template`
+- Field-origin overlay transform: ``
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `image_tag` | 0.86 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `HelmRelease` | `{{name}}` | `apps` | `chart_path` | `` | `false` | `Chart.yaml` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `values_paths` | `chart_path` | `true` | `values.image.tag` | `false` |
+| `Service` | `{{name}}` | `apps` | `values_paths` | `chart_path` | `true` | `values.service.port` | `false` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `image_tag` | `app-team` | 0.86 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `image_tag` | `app-team` | 0.86 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `image_tag` | Container image tag maps cleanly to helm values. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `image_tag` | Edit chart values file and keep chart template unchanged. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `chart_path` | `Chart.yaml` |
+| `chart_role` | `chart` |
+| `primary_values_path` | `values.yaml` |
+| `values_role` | `values` |

--- a/docs/triple-styles/style-b-markdown/opsworkflow.md
+++ b/docs/triple-styles/style-b-markdown/opsworkflow.md
@@ -1,0 +1,99 @@
+# opsworkflow Triple
+
+- Profile: `ops-workflow`
+- Resource: `Workflow` (`argoproj.io/v1alpha1/Workflow`)
+- Capabilities: workflow-plan, governed-execution-intent, inverse-workflow-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `operations-input`
+- Default owner: `platform-engineer`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `operations-base` | operations.yaml, operations.yml, workflow.yaml, workflow.yml | - | - |
+| `operations-overlay` | - | operations-, workflow- | .yaml, .yml |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `operations-base` | `https://schema.confighub.dev/generators/ops-workflow-v1` |
+| `operations-overlay` | `https://schema.confighub.dev/generators/ops-workflow-v1` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `platform-runtime` | `ops` | `actions.deploy.image_tag` |
+| `Job` | `{{name}}-dry-run` | `platform-runtime` | `ops` | `triggers.schedule` |
+
+## Provenance
+
+- Field-origin transform: `ops-workflow-to-argo-workflow`
+- Field-origin overlay transform: `ops-workflow-overlay-merge`
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `image_tag` | 0.87 |
+| `schedule_base` | 0.84 |
+| `schedule_overlay` | 0.80 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `ops` | `base_spec_path` | `` | `false` | `actions.deploy.image_tag` | `false` |
+| `Job` | `{{name}}-dry-run` | `ops` | `base_spec_path` | `` | `false` | `triggers.schedule` | `false` |
+| `Workflow` | `{{name}}-workflow` | `ops` | `overlay_spec_path` | `` | `false` | `triggers.schedule` | `true` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `image_tag` | `platform-engineer` | 0.87 | `true` |
+| `schedule` | `platform-engineer` | 0.84 | `true` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `image_tag` | `platform-engineer` | 0.87 |
+| `schedule` | `platform-engineer` | 0.84 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `image_tag` | Deployment action image tag is sourced from {{base_spec_path}}. |
+| `schedule` | Schedule changes affect operational execution timing. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `image_tag` | Edit actions.deploy.image_tag in {{base_spec_path}}. |
+| `schedule_base` | Edit triggers.schedule in {{base_spec_path}}. |
+| `schedule_overlay` | Edit triggers.schedule in {{overlay_spec_path}} for environment-specific cadence; use {{base_spec_path}} for defaults. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `base_spec_path` | `operations.yaml` |

--- a/docs/triple-styles/style-b-markdown/score.md
+++ b/docs/triple-styles/style-b-markdown/score.md
@@ -1,0 +1,100 @@
+# score Triple
+
+- Profile: `scoredev-paas`
+- Resource: `Application` (`argoproj.io/v1alpha1/Application`)
+- Capabilities: render-manifests, workload-spec, inverse-score-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `score-input`
+- Default owner: `app-team`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `score-spec` | score.yaml, score.yml | - | - |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `score-spec` | `https://docs.score.dev/schemas/score-v1b1.json` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `platform-runtime` | `apps` | `` |
+| `Deployment` | `{{name}}` | `platform-runtime` | `apps` | `containers.{{container}}.image` |
+| `Service` | `{{name}}` | `platform-runtime` | `apps` | `service.ports.{{service_port}}.port` |
+
+## Provenance
+
+- Field-origin transform: `score-to-k8s`
+- Field-origin overlay transform: ``
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `env_var` | 0.90 |
+| `image` | 0.94 |
+| `port` | 0.91 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `apps` | `source_path` | `` | `false` | `metadata.name` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `source_path` | `` | `false` | `containers.{{container_name}}.image` | `false` |
+| `Service` | `{{name}}` | `apps` | `source_path` | `` | `false` | `service.ports.{{service_port_name}}.port` | `false` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `env_var` | `app-team` | 0.90 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `env_var` | `app-team` | 0.90 |
+| `image` | `app-team` | 0.94 |
+| `port` | `app-team` | 0.91 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `env_var` | Score variable maps to a single Kubernetes env var. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `env_var` | Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}. |
+| `image` | Edit the Score container image in {{source_path}}. |
+| `port` | Edit {{service_port_name}} service port in {{source_path}}. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `container_name` | `main` |
+| `service_port_name` | `web` |
+| `source_path` | `score.yaml` |
+| `variable_name` | `LOG_LEVEL` |

--- a/docs/triple-styles/style-b-markdown/springboot.md
+++ b/docs/triple-styles/style-b-markdown/springboot.md
@@ -1,0 +1,110 @@
+# springboot Triple
+
+- Profile: `springboot-paas`
+- Resource: `Kustomization` (`kustomize.toolkit.fluxcd.io/v1/Kustomization`)
+- Capabilities: render-app-config, profile-overrides, inverse-app-config-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `spring-input`
+- Default owner: `platform-engineer`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `build-config` | pom.xml, build.gradle, build.gradle.kts | - | - |
+| `app-config-base` | application.yaml, application.yml | - | - |
+| `app-config-profile` | - | application- | .yaml, .yml |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+| `app-config-base` | `app-team` |
+| `app-config-profile` | `app-team` |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `app-config-base` | `https://json.schemastore.org/spring-configuration-metadata` |
+| `app-config-profile` | `https://json.schemastore.org/spring-configuration-metadata` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Kustomization` | `{{name}}` | `platform-runtime` | `apps` | `` |
+| `Deployment` | `{{name}}` | `platform-runtime` | `apps` | `server.port` |
+| `ConfigMap` | `{{name}}-config` | `platform-runtime` | `apps` | `spring.datasource.url` |
+
+## Provenance
+
+- Field-origin transform: `spring-config-to-manifest`
+- Field-origin overlay transform: `spring-profile-overlay`
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `app_name` | 0.89 |
+| `datasource_url` | 0.78 |
+| `server_port_base` | 0.92 |
+| `server_port_overlay` | 0.88 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Kustomization` | `{{name}}` | `apps` | `build_config_path` | `` | `false` | `build` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `base_config_path` | `` | `false` | `spring.application.name` | `false` |
+| `ConfigMap` | `{{name}}-config` | `apps` | `base_config_path` | `` | `false` | `spring.datasource.url` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `profile_config_path` | `base_config_path` | `false` | `server.port` | `false` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `app_name` | `app-team` | 0.88 | `false` |
+| `datasource_url` | `platform-engineer` | 0.78 | `true` |
+| `server_port` | `app-team` | 0.91 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `app_name` | `app-team` | 0.89 |
+| `datasource_url` | `platform-engineer` | 0.78 |
+| `server_port` | `app-team` | 0.91 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `app_name` | Application identity should be app-editable without platform escalation. |
+| `datasource_url` | Database connectivity impacts shared runtime dependencies. |
+| `server_port` | Application listener port is an app-level configuration concern. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `app_name` | Edit spring.application.name in {{base_config_path}}. |
+| `datasource_url` | Edit spring.datasource.url in {{base_config_path}} and coordinate with platform ownership rules. |
+| `server_port_base` | Edit server.port in {{base_config_path}}. |
+| `server_port_overlay` | Edit server.port in {{profile_config_path}} for environment overrides; use {{base_config_path}} for the default. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `src/main/resources/application.yaml` |
+| `build_config_path` | `pom.xml` |

--- a/docs/triple-styles/style-b-markdown/swamp.md
+++ b/docs/triple-styles/style-b-markdown/swamp.md
@@ -1,0 +1,104 @@
+# swamp Triple
+
+- Profile: `swamp`
+- Resource: `Workflow` (`swamp.dev/v1/Workflow`)
+- Capabilities: workflow-automation, model-orchestration, inverse-workflow-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `swamp-input`
+- Default owner: `app-team`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `swamp-config-base` | .swamp.yaml, .swamp.yml | - | - |
+| `swamp-workflow` | - | workflow- | .yaml, .yml |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `swamp-config-base` | `https://schema.confighub.dev/generators/swamp-v1` |
+| `swamp-workflow` | `https://schema.confighub.dev/generators/swamp-workflow-v1` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `platform-runtime` | `apps` | `jobs[].steps[].task` |
+| `ConfigMap` | `{{name}}-swamp-config` | `platform-runtime` | `apps` | `swamp.version` |
+
+## Provenance
+
+- Field-origin transform: `swamp-workflow-to-execution`
+- Field-origin overlay transform: `swamp-overlay-merge`
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `model_binding_base` | 0.88 |
+| `model_binding_workflow` | 0.84 |
+| `vault_config` | 0.85 |
+| `workflow_definition` | 0.90 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `apps` | `base_config_path` | `` | `false` | `vaults.default.type` | `false` |
+| `ConfigMap` | `{{name}}-swamp-config` | `apps` | `base_config_path` | `` | `false` | `swamp.version` | `false` |
+| `Workflow` | `{{name}}-workflow` | `apps` | `workflow_path` | `` | `false` | `jobs[].steps[].task` | `true` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `model_binding` | `app-team` | 0.88 | `false` |
+| `vault_config` | `platform-engineer` | 0.85 | `true` |
+| `workflow_definition` | `app-team` | 0.90 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `model_binding` | `app-team` | 0.88 |
+| `vault_config` | `platform-engineer` | 0.85 |
+| `workflow_definition` | `app-team` | 0.90 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `model_binding` | Model bindings define which automation models execute in workflows. |
+| `vault_config` | Vault configuration impacts platform credential infrastructure. |
+| `workflow_definition` | Workflow job and step definitions are app-level automation intent. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `model_binding_base` | Edit model references in {{base_config_path}}. |
+| `model_binding_workflow` | Edit model method bindings in {{workflow_path}} for task-specific overrides. |
+| `vault_config` | Edit vaults section in {{base_config_path}} and coordinate with platform secret infrastructure. |
+| `workflow_definition` | Edit jobs and steps in the workflow YAML file. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `.swamp.yaml` |

--- a/docs/triple-styles/style-c-yaml-plus-docs/ably/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/ably/triple.md
@@ -1,0 +1,99 @@
+# ably Triple
+
+- Profile: `ably-config`
+- Resource: `ConfigMap` (`v1/ConfigMap`)
+- Capabilities: app-config-only, provider-config, inverse-provider-config-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `provider-config`
+- Default owner: `app-team`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `provider-config-base` | ably.yaml, ably.yml, ably.json | - | - |
+| `provider-config-overlay` | - | ably- | .yaml, .yml, .json |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `provider-config-base` | `https://schema.confighub.dev/generators/ably-config-v1` |
+| `provider-config-overlay` | `https://schema.confighub.dev/generators/ably-config-v1` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-ably` | `platform-runtime` | `apps` | `app.environment` |
+| `Secret` | `{{name}}-ably-credentials` | `platform-runtime` | `apps` | `credentials.api_key_ref` |
+
+## Provenance
+
+- Field-origin transform: `ably-config-to-runtime`
+- Field-origin overlay transform: `ably-overlay-merge`
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `channels_base` | 0.88 |
+| `channels_overlay` | 0.84 |
+| `environment` | 0.90 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-ably` | `apps` | `base_config_path` | `` | `false` | `app.environment` | `false` |
+| `Secret` | `{{name}}-ably-credentials` | `apps` | `base_config_path` | `` | `false` | `credentials.api_key_ref` | `false` |
+| `ConfigMap` | `{{name}}-ably` | `apps` | `overlay_config_path` | `` | `false` | `channels.inbound` | `true` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `channels` | `app-team` | 0.88 | `false` |
+| `environment` | `app-team` | 0.90 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `channels` | `app-team` | 0.88 |
+| `environment` | `app-team` | 0.90 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `channels` | Channel mapping is app-level runtime behavior. |
+| `environment` | Environment is sourced from {{base_config_path}}. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `channels_base` | Edit channels.inbound in {{base_config_path}}. |
+| `channels_overlay` | Edit channels.inbound in {{overlay_config_path}} for environment-specific behavior; use {{base_config_path}} for defaults. |
+| `environment` | Edit app.environment in {{base_config_path}}. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `ably.yaml` |

--- a/docs/triple-styles/style-c-yaml-plus-docs/ably/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/ably/triple.yaml
@@ -1,0 +1,105 @@
+kind: "ably"
+profile: "ably-config"
+resource_kind: "ConfigMap"
+resource_type: "v1/ConfigMap"
+capabilities:
+  - "app-config-only"
+  - "provider-config"
+  - "inverse-provider-config-patch"
+contract:
+  default_input_role: "provider-config"
+  default_owner: "app-team"
+  input_role_rules:
+    - role: "provider-config-base"
+      exact_basenames:
+        - "ably.yaml"
+        - "ably.yml"
+        - "ably.json"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "provider-config-overlay"
+      exact_basenames:
+        []
+      prefixes:
+        - "ably-"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
+  role_owners:
+    {}
+  role_schema_refs:
+    provider-config-base: "https://schema.confighub.dev/generators/ably-config-v1"
+    provider-config-overlay: "https://schema.confighub.dev/generators/ably-config-v1"
+  wet_targets:
+    - kind: "ConfigMap"
+      name_template: "{{name}}-ably"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "app.environment"
+    - kind: "Secret"
+      name_template: "{{name}}-ably-credentials"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "credentials.api_key_ref"
+provenance:
+  field_origin_transform: "ably-config-to-runtime"
+  field_origin_overlay_transform: "ably-overlay-merge"
+  field_origin_confidences:
+    channels_base: 0.88
+    channels_overlay: 0.84
+    environment: 0.90
+  rendered_lineage_templates:
+    - kind: "ConfigMap"
+      name_template: "{{name}}-ably"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "app.environment"
+      optional: false
+    - kind: "Secret"
+      name_template: "{{name}}-ably-credentials"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "credentials.api_key_ref"
+      optional: false
+    - kind: "ConfigMap"
+      name_template: "{{name}}-ably"
+      namespace: "apps"
+      source_path_hint: "overlay_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "channels.inbound"
+      optional: true
+inverse:
+  inverse_patch_templates:
+    channels:
+      editable_by: "app-team"
+      confidence: 0.88
+      requires_review: false
+    environment:
+      editable_by: "app-team"
+      confidence: 0.90
+      requires_review: false
+  inverse_pointer_templates:
+    channels:
+      owner: "app-team"
+      confidence: 0.88
+    environment:
+      owner: "app-team"
+      confidence: 0.90
+  inverse_patch_reasons:
+    channels: "Channel mapping is app-level runtime behavior."
+    environment: "Environment is sourced from {{base_config_path}}."
+  inverse_edit_hints:
+    channels_base: "Edit channels.inbound in {{base_config_path}}."
+    channels_overlay: "Edit channels.inbound in {{overlay_config_path}} for environment-specific behavior; use {{base_config_path}} for defaults."
+    environment: "Edit app.environment in {{base_config_path}}."
+hints:
+  defaults:
+    base_config_path: "ably.yaml"

--- a/docs/triple-styles/style-c-yaml-plus-docs/backstage/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/backstage/triple.md
@@ -1,0 +1,97 @@
+# backstage Triple
+
+- Profile: `backstage-idp`
+- Resource: `Component` (`backstage.io/v1alpha1/Component`)
+- Capabilities: catalog-metadata, render-manifests, inverse-catalog-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `backstage-input`
+- Default owner: `platform-engineer`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `catalog-spec` | catalog-info.yaml, catalog-info.yml | - | - |
+| `app-config` | app-config.yaml, app-config.yml | - | - |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+| `app-config` | `app-team` |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `app-config` | `https://json.schemastore.org/backstage-app-config` |
+| `catalog-spec` | `https://json.schemastore.org/backstage-catalog-info` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `platform-runtime` | `apps` | `metadata.name` |
+| `ConfigMap` | `{{name}}-catalog` | `platform-runtime` | `apps` | `spec.lifecycle` |
+
+## Provenance
+
+- Field-origin transform: `backstage-component-to-application`
+- Field-origin overlay transform: ``
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `identity` | 0.90 |
+| `lifecycle` | 0.82 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `apps` | `catalog_path` | `` | `false` | `metadata.name` | `false` |
+| `ConfigMap` | `{{name}}-catalog` | `apps` | `catalog_path` | `` | `false` | `spec.lifecycle` | `false` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `identity` | `platform-engineer` | 0.87 | `false` |
+| `lifecycle` | `platform-engineer` | 0.82 | `true` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `lifecycle` | `platform-engineer` | 0.82 |
+| `name` | `platform-engineer` | 0.90 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `identity` | Backstage component identity is sourced from {{catalog_path}}. |
+| `lifecycle` | Lifecycle changes impact platform ownership and support policy. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `lifecycle` | Edit spec.lifecycle in {{catalog_path}} and coordinate rollout policy. |
+| `name` | Edit metadata.name in {{catalog_path}}. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `catalog_path` | `catalog-info.yaml` |

--- a/docs/triple-styles/style-c-yaml-plus-docs/backstage/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/backstage/triple.yaml
@@ -1,0 +1,93 @@
+kind: "backstage"
+profile: "backstage-idp"
+resource_kind: "Component"
+resource_type: "backstage.io/v1alpha1/Component"
+capabilities:
+  - "catalog-metadata"
+  - "render-manifests"
+  - "inverse-catalog-patch"
+contract:
+  default_input_role: "backstage-input"
+  default_owner: "platform-engineer"
+  input_role_rules:
+    - role: "catalog-spec"
+      exact_basenames:
+        - "catalog-info.yaml"
+        - "catalog-info.yml"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "app-config"
+      exact_basenames:
+        - "app-config.yaml"
+        - "app-config.yml"
+      prefixes:
+        []
+      extensions:
+        []
+  role_owners:
+    app-config: "app-team"
+  role_schema_refs:
+    app-config: "https://json.schemastore.org/backstage-app-config"
+    catalog-spec: "https://json.schemastore.org/backstage-catalog-info"
+  wet_targets:
+    - kind: "Application"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "metadata.name"
+    - kind: "ConfigMap"
+      name_template: "{{name}}-catalog"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "spec.lifecycle"
+provenance:
+  field_origin_transform: "backstage-component-to-application"
+  field_origin_overlay_transform: ""
+  field_origin_confidences:
+    identity: 0.90
+    lifecycle: 0.82
+  rendered_lineage_templates:
+    - kind: "Application"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "catalog_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "metadata.name"
+      optional: false
+    - kind: "ConfigMap"
+      name_template: "{{name}}-catalog"
+      namespace: "apps"
+      source_path_hint: "catalog_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "spec.lifecycle"
+      optional: false
+inverse:
+  inverse_patch_templates:
+    identity:
+      editable_by: "platform-engineer"
+      confidence: 0.87
+      requires_review: false
+    lifecycle:
+      editable_by: "platform-engineer"
+      confidence: 0.82
+      requires_review: true
+  inverse_pointer_templates:
+    lifecycle:
+      owner: "platform-engineer"
+      confidence: 0.82
+    name:
+      owner: "platform-engineer"
+      confidence: 0.90
+  inverse_patch_reasons:
+    identity: "Backstage component identity is sourced from {{catalog_path}}."
+    lifecycle: "Lifecycle changes impact platform ownership and support policy."
+  inverse_edit_hints:
+    lifecycle: "Edit spec.lifecycle in {{catalog_path}} and coordinate rollout policy."
+    name: "Edit metadata.name in {{catalog_path}}."
+hints:
+  defaults:
+    catalog_path: "catalog-info.yaml"

--- a/docs/triple-styles/style-c-yaml-plus-docs/c3agent/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/c3agent/triple.md
@@ -1,0 +1,104 @@
+# c3agent Triple
+
+- Profile: `c3agent`
+- Resource: `ConfigMap` (`v1/ConfigMap`)
+- Capabilities: fleet-config, agent-orchestration, inverse-fleet-config-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `fleet-config`
+- Default owner: `app-team`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `fleet-config-base` | c3agent.yaml, c3agent.yml, c3agent.json | - | - |
+| `fleet-config-overlay` | - | c3agent- | .yaml, .yml, .json |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `fleet-config-base` | `https://schema.confighub.dev/generators/c3agent-v1` |
+| `fleet-config-overlay` | `https://schema.confighub.dev/generators/c3agent-v1` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-fleet-config` | `platform-runtime` | `apps` | `fleet.agent_model` |
+| `Secret` | `{{name}}-fleet-credentials` | `platform-runtime` | `apps` | `credentials.anthropic_key_ref` |
+
+## Provenance
+
+- Field-origin transform: `c3agent-config-to-runtime`
+- Field-origin overlay transform: `c3agent-overlay-merge`
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `component_ports_base` | 0.84 |
+| `component_ports_overlay` | 0.80 |
+| `credentials` | 0.86 |
+| `fleet_config` | 0.91 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ConfigMap` | `{{name}}-fleet-config` | `apps` | `base_config_path` | `` | `false` | `fleet.agent_model` | `false` |
+| `Secret` | `{{name}}-fleet-credentials` | `apps` | `base_config_path` | `` | `false` | `credentials.anthropic_key_ref` | `false` |
+| `ConfigMap` | `{{name}}-fleet-config` | `apps` | `overlay_config_path` | `` | `false` | `fleet.max_concurrent_tasks` | `true` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `component_ports` | `platform-engineer` | 0.84 | `true` |
+| `credentials` | `platform-engineer` | 0.86 | `true` |
+| `fleet_config` | `app-team` | 0.91 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `component_ports` | `platform-engineer` | 0.84 |
+| `credentials` | `platform-engineer` | 0.86 |
+| `fleet_config` | `app-team` | 0.91 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `component_ports` | Component port changes affect platform networking and service mesh. |
+| `credentials` | Credential references impact platform secret management. |
+| `fleet_config` | Fleet configuration (model, concurrency) is sourced from {{base_config_path}}. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `component_ports_base` | Edit components.controlplane.grpc_port in {{base_config_path}}. |
+| `component_ports_overlay` | Edit component ports in {{overlay_config_path}} for environment-specific values; use {{base_config_path}} for defaults. |
+| `credentials` | Edit credentials section in {{base_config_path}} and coordinate with platform secret management. |
+| `fleet_config` | Edit fleet.agent_model or fleet.max_concurrent_tasks in {{base_config_path}}. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `c3agent.yaml` |

--- a/docs/triple-styles/style-c-yaml-plus-docs/c3agent/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/c3agent/triple.yaml
@@ -1,0 +1,115 @@
+kind: "c3agent"
+profile: "c3agent"
+resource_kind: "ConfigMap"
+resource_type: "v1/ConfigMap"
+capabilities:
+  - "fleet-config"
+  - "agent-orchestration"
+  - "inverse-fleet-config-patch"
+contract:
+  default_input_role: "fleet-config"
+  default_owner: "app-team"
+  input_role_rules:
+    - role: "fleet-config-base"
+      exact_basenames:
+        - "c3agent.yaml"
+        - "c3agent.yml"
+        - "c3agent.json"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "fleet-config-overlay"
+      exact_basenames:
+        []
+      prefixes:
+        - "c3agent-"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
+  role_owners:
+    {}
+  role_schema_refs:
+    fleet-config-base: "https://schema.confighub.dev/generators/c3agent-v1"
+    fleet-config-overlay: "https://schema.confighub.dev/generators/c3agent-v1"
+  wet_targets:
+    - kind: "ConfigMap"
+      name_template: "{{name}}-fleet-config"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "fleet.agent_model"
+    - kind: "Secret"
+      name_template: "{{name}}-fleet-credentials"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "credentials.anthropic_key_ref"
+provenance:
+  field_origin_transform: "c3agent-config-to-runtime"
+  field_origin_overlay_transform: "c3agent-overlay-merge"
+  field_origin_confidences:
+    component_ports_base: 0.84
+    component_ports_overlay: 0.80
+    credentials: 0.86
+    fleet_config: 0.91
+  rendered_lineage_templates:
+    - kind: "ConfigMap"
+      name_template: "{{name}}-fleet-config"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "fleet.agent_model"
+      optional: false
+    - kind: "Secret"
+      name_template: "{{name}}-fleet-credentials"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "credentials.anthropic_key_ref"
+      optional: false
+    - kind: "ConfigMap"
+      name_template: "{{name}}-fleet-config"
+      namespace: "apps"
+      source_path_hint: "overlay_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "fleet.max_concurrent_tasks"
+      optional: true
+inverse:
+  inverse_patch_templates:
+    component_ports:
+      editable_by: "platform-engineer"
+      confidence: 0.84
+      requires_review: true
+    credentials:
+      editable_by: "platform-engineer"
+      confidence: 0.86
+      requires_review: true
+    fleet_config:
+      editable_by: "app-team"
+      confidence: 0.91
+      requires_review: false
+  inverse_pointer_templates:
+    component_ports:
+      owner: "platform-engineer"
+      confidence: 0.84
+    credentials:
+      owner: "platform-engineer"
+      confidence: 0.86
+    fleet_config:
+      owner: "app-team"
+      confidence: 0.91
+  inverse_patch_reasons:
+    component_ports: "Component port changes affect platform networking and service mesh."
+    credentials: "Credential references impact platform secret management."
+    fleet_config: "Fleet configuration (model, concurrency) is sourced from {{base_config_path}}."
+  inverse_edit_hints:
+    component_ports_base: "Edit components.controlplane.grpc_port in {{base_config_path}}."
+    component_ports_overlay: "Edit component ports in {{overlay_config_path}} for environment-specific values; use {{base_config_path}} for defaults."
+    credentials: "Edit credentials section in {{base_config_path}} and coordinate with platform secret management."
+    fleet_config: "Edit fleet.agent_model or fleet.max_concurrent_tasks in {{base_config_path}}."
+hints:
+  defaults:
+    base_config_path: "c3agent.yaml"

--- a/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.md
@@ -1,0 +1,96 @@
+# helm Triple
+
+- Profile: `helm-paas`
+- Resource: `HelmRelease` (`helm.toolkit.fluxcd.io/v2/HelmRelease`)
+- Capabilities: render-manifests, values-overrides, inverse-values-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `helm-input`
+- Default owner: `platform-engineer`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `chart` | chart.yaml | - | - |
+| `values` | - | values | .yaml, .yml |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+| `values` | `app-team` |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `chart` | `https://json.schemastore.org/chart` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `HelmRelease` | `{{name}}` | `platform-runtime` | `apps` | `` |
+| `Deployment` | `{{name}}` | `platform-runtime` | `apps` | `values.image.tag` |
+| `Service` | `{{name}}` | `platform-runtime` | `apps` | `values.service.port` |
+
+## Provenance
+
+- Field-origin transform: `helm-template`
+- Field-origin overlay transform: ``
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `image_tag` | 0.86 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `HelmRelease` | `{{name}}` | `apps` | `chart_path` | `` | `false` | `Chart.yaml` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `values_paths` | `chart_path` | `true` | `values.image.tag` | `false` |
+| `Service` | `{{name}}` | `apps` | `values_paths` | `chart_path` | `true` | `values.service.port` | `false` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `image_tag` | `app-team` | 0.86 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `image_tag` | `app-team` | 0.86 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `image_tag` | Container image tag maps cleanly to helm values. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `image_tag` | Edit chart values file and keep chart template unchanged. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `chart_path` | `Chart.yaml` |
+| `chart_role` | `chart` |
+| `primary_values_path` | `values.yaml` |
+| `values_role` | `values` |

--- a/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.yaml
@@ -1,0 +1,97 @@
+kind: "helm"
+profile: "helm-paas"
+resource_kind: "HelmRelease"
+resource_type: "helm.toolkit.fluxcd.io/v2/HelmRelease"
+capabilities:
+  - "render-manifests"
+  - "values-overrides"
+  - "inverse-values-patch"
+contract:
+  default_input_role: "helm-input"
+  default_owner: "platform-engineer"
+  input_role_rules:
+    - role: "chart"
+      exact_basenames:
+        - "chart.yaml"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "values"
+      exact_basenames:
+        []
+      prefixes:
+        - "values"
+      extensions:
+        - ".yaml"
+        - ".yml"
+  role_owners:
+    values: "app-team"
+  role_schema_refs:
+    chart: "https://json.schemastore.org/chart"
+  wet_targets:
+    - kind: "HelmRelease"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: ""
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "values.image.tag"
+    - kind: "Service"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "values.service.port"
+provenance:
+  field_origin_transform: "helm-template"
+  field_origin_overlay_transform: ""
+  field_origin_confidences:
+    image_tag: 0.86
+  rendered_lineage_templates:
+    - kind: "HelmRelease"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "chart_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "Chart.yaml"
+      optional: false
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "values_paths"
+      source_path_hint_fallback: "chart_path"
+      source_path_hint_multi: true
+      source_dry_path_template: "values.image.tag"
+      optional: false
+    - kind: "Service"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "values_paths"
+      source_path_hint_fallback: "chart_path"
+      source_path_hint_multi: true
+      source_dry_path_template: "values.service.port"
+      optional: false
+inverse:
+  inverse_patch_templates:
+    image_tag:
+      editable_by: "app-team"
+      confidence: 0.86
+      requires_review: false
+  inverse_pointer_templates:
+    image_tag:
+      owner: "app-team"
+      confidence: 0.86
+  inverse_patch_reasons:
+    image_tag: "Container image tag maps cleanly to helm values."
+  inverse_edit_hints:
+    image_tag: "Edit chart values file and keep chart template unchanged."
+hints:
+  defaults:
+    chart_path: "Chart.yaml"
+    chart_role: "chart"
+    primary_values_path: "values.yaml"
+    values_role: "values"

--- a/docs/triple-styles/style-c-yaml-plus-docs/opsworkflow/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/opsworkflow/triple.md
@@ -1,0 +1,99 @@
+# opsworkflow Triple
+
+- Profile: `ops-workflow`
+- Resource: `Workflow` (`argoproj.io/v1alpha1/Workflow`)
+- Capabilities: workflow-plan, governed-execution-intent, inverse-workflow-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `operations-input`
+- Default owner: `platform-engineer`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `operations-base` | operations.yaml, operations.yml, workflow.yaml, workflow.yml | - | - |
+| `operations-overlay` | - | operations-, workflow- | .yaml, .yml |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `operations-base` | `https://schema.confighub.dev/generators/ops-workflow-v1` |
+| `operations-overlay` | `https://schema.confighub.dev/generators/ops-workflow-v1` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `platform-runtime` | `ops` | `actions.deploy.image_tag` |
+| `Job` | `{{name}}-dry-run` | `platform-runtime` | `ops` | `triggers.schedule` |
+
+## Provenance
+
+- Field-origin transform: `ops-workflow-to-argo-workflow`
+- Field-origin overlay transform: `ops-workflow-overlay-merge`
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `image_tag` | 0.87 |
+| `schedule_base` | 0.84 |
+| `schedule_overlay` | 0.80 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `ops` | `base_spec_path` | `` | `false` | `actions.deploy.image_tag` | `false` |
+| `Job` | `{{name}}-dry-run` | `ops` | `base_spec_path` | `` | `false` | `triggers.schedule` | `false` |
+| `Workflow` | `{{name}}-workflow` | `ops` | `overlay_spec_path` | `` | `false` | `triggers.schedule` | `true` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `image_tag` | `platform-engineer` | 0.87 | `true` |
+| `schedule` | `platform-engineer` | 0.84 | `true` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `image_tag` | `platform-engineer` | 0.87 |
+| `schedule` | `platform-engineer` | 0.84 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `image_tag` | Deployment action image tag is sourced from {{base_spec_path}}. |
+| `schedule` | Schedule changes affect operational execution timing. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `image_tag` | Edit actions.deploy.image_tag in {{base_spec_path}}. |
+| `schedule_base` | Edit triggers.schedule in {{base_spec_path}}. |
+| `schedule_overlay` | Edit triggers.schedule in {{overlay_spec_path}} for environment-specific cadence; use {{base_spec_path}} for defaults. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `base_spec_path` | `operations.yaml` |

--- a/docs/triple-styles/style-c-yaml-plus-docs/opsworkflow/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/opsworkflow/triple.yaml
@@ -1,0 +1,106 @@
+kind: "opsworkflow"
+profile: "ops-workflow"
+resource_kind: "Workflow"
+resource_type: "argoproj.io/v1alpha1/Workflow"
+capabilities:
+  - "workflow-plan"
+  - "governed-execution-intent"
+  - "inverse-workflow-patch"
+contract:
+  default_input_role: "operations-input"
+  default_owner: "platform-engineer"
+  input_role_rules:
+    - role: "operations-base"
+      exact_basenames:
+        - "operations.yaml"
+        - "operations.yml"
+        - "workflow.yaml"
+        - "workflow.yml"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "operations-overlay"
+      exact_basenames:
+        []
+      prefixes:
+        - "operations-"
+        - "workflow-"
+      extensions:
+        - ".yaml"
+        - ".yml"
+  role_owners:
+    {}
+  role_schema_refs:
+    operations-base: "https://schema.confighub.dev/generators/ops-workflow-v1"
+    operations-overlay: "https://schema.confighub.dev/generators/ops-workflow-v1"
+  wet_targets:
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      owner: "platform-runtime"
+      namespace: "ops"
+      source_dry_path_template: "actions.deploy.image_tag"
+    - kind: "Job"
+      name_template: "{{name}}-dry-run"
+      owner: "platform-runtime"
+      namespace: "ops"
+      source_dry_path_template: "triggers.schedule"
+provenance:
+  field_origin_transform: "ops-workflow-to-argo-workflow"
+  field_origin_overlay_transform: "ops-workflow-overlay-merge"
+  field_origin_confidences:
+    image_tag: 0.87
+    schedule_base: 0.84
+    schedule_overlay: 0.80
+  rendered_lineage_templates:
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      namespace: "ops"
+      source_path_hint: "base_spec_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "actions.deploy.image_tag"
+      optional: false
+    - kind: "Job"
+      name_template: "{{name}}-dry-run"
+      namespace: "ops"
+      source_path_hint: "base_spec_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "triggers.schedule"
+      optional: false
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      namespace: "ops"
+      source_path_hint: "overlay_spec_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "triggers.schedule"
+      optional: true
+inverse:
+  inverse_patch_templates:
+    image_tag:
+      editable_by: "platform-engineer"
+      confidence: 0.87
+      requires_review: true
+    schedule:
+      editable_by: "platform-engineer"
+      confidence: 0.84
+      requires_review: true
+  inverse_pointer_templates:
+    image_tag:
+      owner: "platform-engineer"
+      confidence: 0.87
+    schedule:
+      owner: "platform-engineer"
+      confidence: 0.84
+  inverse_patch_reasons:
+    image_tag: "Deployment action image tag is sourced from {{base_spec_path}}."
+    schedule: "Schedule changes affect operational execution timing."
+  inverse_edit_hints:
+    image_tag: "Edit actions.deploy.image_tag in {{base_spec_path}}."
+    schedule_base: "Edit triggers.schedule in {{base_spec_path}}."
+    schedule_overlay: "Edit triggers.schedule in {{overlay_spec_path}} for environment-specific cadence; use {{base_spec_path}} for defaults."
+hints:
+  defaults:
+    base_spec_path: "operations.yaml"

--- a/docs/triple-styles/style-c-yaml-plus-docs/score/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/score/triple.md
@@ -1,0 +1,100 @@
+# score Triple
+
+- Profile: `scoredev-paas`
+- Resource: `Application` (`argoproj.io/v1alpha1/Application`)
+- Capabilities: render-manifests, workload-spec, inverse-score-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `score-input`
+- Default owner: `app-team`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `score-spec` | score.yaml, score.yml | - | - |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `score-spec` | `https://docs.score.dev/schemas/score-v1b1.json` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `platform-runtime` | `apps` | `` |
+| `Deployment` | `{{name}}` | `platform-runtime` | `apps` | `containers.{{container}}.image` |
+| `Service` | `{{name}}` | `platform-runtime` | `apps` | `service.ports.{{service_port}}.port` |
+
+## Provenance
+
+- Field-origin transform: `score-to-k8s`
+- Field-origin overlay transform: ``
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `env_var` | 0.90 |
+| `image` | 0.94 |
+| `port` | 0.91 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Application` | `{{name}}` | `apps` | `source_path` | `` | `false` | `metadata.name` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `source_path` | `` | `false` | `containers.{{container_name}}.image` | `false` |
+| `Service` | `{{name}}` | `apps` | `source_path` | `` | `false` | `service.ports.{{service_port_name}}.port` | `false` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `env_var` | `app-team` | 0.90 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `env_var` | `app-team` | 0.90 |
+| `image` | `app-team` | 0.94 |
+| `port` | `app-team` | 0.91 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `env_var` | Score variable maps to a single Kubernetes env var. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `env_var` | Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}. |
+| `image` | Edit the Score container image in {{source_path}}. |
+| `port` | Edit {{service_port_name}} service port in {{source_path}}. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `container_name` | `main` |
+| `service_port_name` | `web` |
+| `source_path` | `score.yaml` |
+| `variable_name` | `LOG_LEVEL` |

--- a/docs/triple-styles/style-c-yaml-plus-docs/score/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/score/triple.yaml
@@ -1,0 +1,100 @@
+kind: "score"
+profile: "scoredev-paas"
+resource_kind: "Application"
+resource_type: "argoproj.io/v1alpha1/Application"
+capabilities:
+  - "render-manifests"
+  - "workload-spec"
+  - "inverse-score-patch"
+contract:
+  default_input_role: "score-input"
+  default_owner: "app-team"
+  input_role_rules:
+    - role: "score-spec"
+      exact_basenames:
+        - "score.yaml"
+        - "score.yml"
+      prefixes:
+        []
+      extensions:
+        []
+  role_owners:
+    {}
+  role_schema_refs:
+    score-spec: "https://docs.score.dev/schemas/score-v1b1.json"
+  wet_targets:
+    - kind: "Application"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: ""
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "containers.{{container}}.image"
+    - kind: "Service"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "service.ports.{{service_port}}.port"
+provenance:
+  field_origin_transform: "score-to-k8s"
+  field_origin_overlay_transform: ""
+  field_origin_confidences:
+    env_var: 0.90
+    image: 0.94
+    port: 0.91
+  rendered_lineage_templates:
+    - kind: "Application"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "source_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "metadata.name"
+      optional: false
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "source_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "containers.{{container_name}}.image"
+      optional: false
+    - kind: "Service"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "source_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "service.ports.{{service_port_name}}.port"
+      optional: false
+inverse:
+  inverse_patch_templates:
+    env_var:
+      editable_by: "app-team"
+      confidence: 0.90
+      requires_review: false
+  inverse_pointer_templates:
+    env_var:
+      owner: "app-team"
+      confidence: 0.90
+    image:
+      owner: "app-team"
+      confidence: 0.94
+    port:
+      owner: "app-team"
+      confidence: 0.91
+  inverse_patch_reasons:
+    env_var: "Score variable maps to a single Kubernetes env var."
+  inverse_edit_hints:
+    env_var: "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}."
+    image: "Edit the Score container image in {{source_path}}."
+    port: "Edit {{service_port_name}} service port in {{source_path}}."
+hints:
+  defaults:
+    container_name: "main"
+    service_port_name: "web"
+    source_path: "score.yaml"
+    variable_name: "LOG_LEVEL"

--- a/docs/triple-styles/style-c-yaml-plus-docs/springboot/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/springboot/triple.md
@@ -1,0 +1,110 @@
+# springboot Triple
+
+- Profile: `springboot-paas`
+- Resource: `Kustomization` (`kustomize.toolkit.fluxcd.io/v1/Kustomization`)
+- Capabilities: render-app-config, profile-overrides, inverse-app-config-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `spring-input`
+- Default owner: `platform-engineer`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `build-config` | pom.xml, build.gradle, build.gradle.kts | - | - |
+| `app-config-base` | application.yaml, application.yml | - | - |
+| `app-config-profile` | - | application- | .yaml, .yml |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+| `app-config-base` | `app-team` |
+| `app-config-profile` | `app-team` |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `app-config-base` | `https://json.schemastore.org/spring-configuration-metadata` |
+| `app-config-profile` | `https://json.schemastore.org/spring-configuration-metadata` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Kustomization` | `{{name}}` | `platform-runtime` | `apps` | `` |
+| `Deployment` | `{{name}}` | `platform-runtime` | `apps` | `server.port` |
+| `ConfigMap` | `{{name}}-config` | `platform-runtime` | `apps` | `spring.datasource.url` |
+
+## Provenance
+
+- Field-origin transform: `spring-config-to-manifest`
+- Field-origin overlay transform: `spring-profile-overlay`
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `app_name` | 0.89 |
+| `datasource_url` | 0.78 |
+| `server_port_base` | 0.92 |
+| `server_port_overlay` | 0.88 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Kustomization` | `{{name}}` | `apps` | `build_config_path` | `` | `false` | `build` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `base_config_path` | `` | `false` | `spring.application.name` | `false` |
+| `ConfigMap` | `{{name}}-config` | `apps` | `base_config_path` | `` | `false` | `spring.datasource.url` | `false` |
+| `Deployment` | `{{name}}` | `apps` | `profile_config_path` | `base_config_path` | `false` | `server.port` | `false` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `app_name` | `app-team` | 0.88 | `false` |
+| `datasource_url` | `platform-engineer` | 0.78 | `true` |
+| `server_port` | `app-team` | 0.91 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `app_name` | `app-team` | 0.89 |
+| `datasource_url` | `platform-engineer` | 0.78 |
+| `server_port` | `app-team` | 0.91 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `app_name` | Application identity should be app-editable without platform escalation. |
+| `datasource_url` | Database connectivity impacts shared runtime dependencies. |
+| `server_port` | Application listener port is an app-level configuration concern. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `app_name` | Edit spring.application.name in {{base_config_path}}. |
+| `datasource_url` | Edit spring.datasource.url in {{base_config_path}} and coordinate with platform ownership rules. |
+| `server_port_base` | Edit server.port in {{base_config_path}}. |
+| `server_port_overlay` | Edit server.port in {{profile_config_path}} for environment overrides; use {{base_config_path}} for the default. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `src/main/resources/application.yaml` |
+| `build_config_path` | `pom.xml` |

--- a/docs/triple-styles/style-c-yaml-plus-docs/springboot/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/springboot/triple.yaml
@@ -1,0 +1,137 @@
+kind: "springboot"
+profile: "springboot-paas"
+resource_kind: "Kustomization"
+resource_type: "kustomize.toolkit.fluxcd.io/v1/Kustomization"
+capabilities:
+  - "render-app-config"
+  - "profile-overrides"
+  - "inverse-app-config-patch"
+contract:
+  default_input_role: "spring-input"
+  default_owner: "platform-engineer"
+  input_role_rules:
+    - role: "build-config"
+      exact_basenames:
+        - "pom.xml"
+        - "build.gradle"
+        - "build.gradle.kts"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "app-config-base"
+      exact_basenames:
+        - "application.yaml"
+        - "application.yml"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "app-config-profile"
+      exact_basenames:
+        []
+      prefixes:
+        - "application-"
+      extensions:
+        - ".yaml"
+        - ".yml"
+  role_owners:
+    app-config-base: "app-team"
+    app-config-profile: "app-team"
+  role_schema_refs:
+    app-config-base: "https://json.schemastore.org/spring-configuration-metadata"
+    app-config-profile: "https://json.schemastore.org/spring-configuration-metadata"
+  wet_targets:
+    - kind: "Kustomization"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: ""
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "server.port"
+    - kind: "ConfigMap"
+      name_template: "{{name}}-config"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "spring.datasource.url"
+provenance:
+  field_origin_transform: "spring-config-to-manifest"
+  field_origin_overlay_transform: "spring-profile-overlay"
+  field_origin_confidences:
+    app_name: 0.89
+    datasource_url: 0.78
+    server_port_base: 0.92
+    server_port_overlay: 0.88
+  rendered_lineage_templates:
+    - kind: "Kustomization"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "build_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "build"
+      optional: false
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "spring.application.name"
+      optional: false
+    - kind: "ConfigMap"
+      name_template: "{{name}}-config"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "spring.datasource.url"
+      optional: false
+    - kind: "Deployment"
+      name_template: "{{name}}"
+      namespace: "apps"
+      source_path_hint: "profile_config_path"
+      source_path_hint_fallback: "base_config_path"
+      source_path_hint_multi: false
+      source_dry_path_template: "server.port"
+      optional: false
+inverse:
+  inverse_patch_templates:
+    app_name:
+      editable_by: "app-team"
+      confidence: 0.88
+      requires_review: false
+    datasource_url:
+      editable_by: "platform-engineer"
+      confidence: 0.78
+      requires_review: true
+    server_port:
+      editable_by: "app-team"
+      confidence: 0.91
+      requires_review: false
+  inverse_pointer_templates:
+    app_name:
+      owner: "app-team"
+      confidence: 0.89
+    datasource_url:
+      owner: "platform-engineer"
+      confidence: 0.78
+    server_port:
+      owner: "app-team"
+      confidence: 0.91
+  inverse_patch_reasons:
+    app_name: "Application identity should be app-editable without platform escalation."
+    datasource_url: "Database connectivity impacts shared runtime dependencies."
+    server_port: "Application listener port is an app-level configuration concern."
+  inverse_edit_hints:
+    app_name: "Edit spring.application.name in {{base_config_path}}."
+    datasource_url: "Edit spring.datasource.url in {{base_config_path}} and coordinate with platform ownership rules."
+    server_port_base: "Edit server.port in {{base_config_path}}."
+    server_port_overlay: "Edit server.port in {{profile_config_path}} for environment overrides; use {{base_config_path}} for the default."
+hints:
+  defaults:
+    base_config_path: "src/main/resources/application.yaml"
+    build_config_path: "pom.xml"

--- a/docs/triple-styles/style-c-yaml-plus-docs/swamp/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/swamp/triple.md
@@ -1,0 +1,104 @@
+# swamp Triple
+
+- Profile: `swamp`
+- Resource: `Workflow` (`swamp.dev/v1/Workflow`)
+- Capabilities: workflow-automation, model-orchestration, inverse-workflow-patch
+
+```mermaid
+flowchart LR
+  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+```
+
+## Contract
+
+- Default input role: `swamp-input`
+- Default owner: `app-team`
+
+### Input role rules
+
+| Role | Exact basenames | Prefixes | Extensions |
+| --- | --- | --- | --- |
+| `swamp-config-base` | .swamp.yaml, .swamp.yml | - | - |
+| `swamp-workflow` | - | workflow- | .yaml, .yml |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `swamp-config-base` | `https://schema.confighub.dev/generators/swamp-v1` |
+| `swamp-workflow` | `https://schema.confighub.dev/generators/swamp-workflow-v1` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `platform-runtime` | `apps` | `jobs[].steps[].task` |
+| `ConfigMap` | `{{name}}-swamp-config` | `platform-runtime` | `apps` | `swamp.version` |
+
+## Provenance
+
+- Field-origin transform: `swamp-workflow-to-execution`
+- Field-origin overlay transform: `swamp-overlay-merge`
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `model_binding_base` | 0.88 |
+| `model_binding_workflow` | 0.84 |
+| `vault_config` | 0.85 |
+| `workflow_definition` | 0.90 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Workflow` | `{{name}}-workflow` | `apps` | `base_config_path` | `` | `false` | `vaults.default.type` | `false` |
+| `ConfigMap` | `{{name}}-swamp-config` | `apps` | `base_config_path` | `` | `false` | `swamp.version` | `false` |
+| `Workflow` | `{{name}}-workflow` | `apps` | `workflow_path` | `` | `false` | `jobs[].steps[].task` | `true` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `model_binding` | `app-team` | 0.88 | `false` |
+| `vault_config` | `platform-engineer` | 0.85 | `true` |
+| `workflow_definition` | `app-team` | 0.90 | `false` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `model_binding` | `app-team` | 0.88 |
+| `vault_config` | `platform-engineer` | 0.85 |
+| `workflow_definition` | `app-team` | 0.90 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `model_binding` | Model bindings define which automation models execute in workflows. |
+| `vault_config` | Vault configuration impacts platform credential infrastructure. |
+| `workflow_definition` | Workflow job and step definitions are app-level automation intent. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `model_binding_base` | Edit model references in {{base_config_path}}. |
+| `model_binding_workflow` | Edit model method bindings in {{workflow_path}} for task-specific overrides. |
+| `vault_config` | Edit vaults section in {{base_config_path}} and coordinate with platform secret infrastructure. |
+| `workflow_definition` | Edit jobs and steps in the workflow YAML file. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `base_config_path` | `.swamp.yaml` |

--- a/docs/triple-styles/style-c-yaml-plus-docs/swamp/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/swamp/triple.yaml
@@ -1,0 +1,113 @@
+kind: "swamp"
+profile: "swamp"
+resource_kind: "Workflow"
+resource_type: "swamp.dev/v1/Workflow"
+capabilities:
+  - "workflow-automation"
+  - "model-orchestration"
+  - "inverse-workflow-patch"
+contract:
+  default_input_role: "swamp-input"
+  default_owner: "app-team"
+  input_role_rules:
+    - role: "swamp-config-base"
+      exact_basenames:
+        - ".swamp.yaml"
+        - ".swamp.yml"
+      prefixes:
+        []
+      extensions:
+        []
+    - role: "swamp-workflow"
+      exact_basenames:
+        []
+      prefixes:
+        - "workflow-"
+      extensions:
+        - ".yaml"
+        - ".yml"
+  role_owners:
+    {}
+  role_schema_refs:
+    swamp-config-base: "https://schema.confighub.dev/generators/swamp-v1"
+    swamp-workflow: "https://schema.confighub.dev/generators/swamp-workflow-v1"
+  wet_targets:
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "jobs[].steps[].task"
+    - kind: "ConfigMap"
+      name_template: "{{name}}-swamp-config"
+      owner: "platform-runtime"
+      namespace: "apps"
+      source_dry_path_template: "swamp.version"
+provenance:
+  field_origin_transform: "swamp-workflow-to-execution"
+  field_origin_overlay_transform: "swamp-overlay-merge"
+  field_origin_confidences:
+    model_binding_base: 0.88
+    model_binding_workflow: 0.84
+    vault_config: 0.85
+    workflow_definition: 0.90
+  rendered_lineage_templates:
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "vaults.default.type"
+      optional: false
+    - kind: "ConfigMap"
+      name_template: "{{name}}-swamp-config"
+      namespace: "apps"
+      source_path_hint: "base_config_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "swamp.version"
+      optional: false
+    - kind: "Workflow"
+      name_template: "{{name}}-workflow"
+      namespace: "apps"
+      source_path_hint: "workflow_path"
+      source_path_hint_fallback: ""
+      source_path_hint_multi: false
+      source_dry_path_template: "jobs[].steps[].task"
+      optional: true
+inverse:
+  inverse_patch_templates:
+    model_binding:
+      editable_by: "app-team"
+      confidence: 0.88
+      requires_review: false
+    vault_config:
+      editable_by: "platform-engineer"
+      confidence: 0.85
+      requires_review: true
+    workflow_definition:
+      editable_by: "app-team"
+      confidence: 0.90
+      requires_review: false
+  inverse_pointer_templates:
+    model_binding:
+      owner: "app-team"
+      confidence: 0.88
+    vault_config:
+      owner: "platform-engineer"
+      confidence: 0.85
+    workflow_definition:
+      owner: "app-team"
+      confidence: 0.90
+  inverse_patch_reasons:
+    model_binding: "Model bindings define which automation models execute in workflows."
+    vault_config: "Vault configuration impacts platform credential infrastructure."
+    workflow_definition: "Workflow job and step definitions are app-level automation intent."
+  inverse_edit_hints:
+    model_binding_base: "Edit model references in {{base_config_path}}."
+    model_binding_workflow: "Edit model method bindings in {{workflow_path}} for task-specific overrides."
+    vault_config: "Edit vaults section in {{base_config_path}} and coordinate with platform secret infrastructure."
+    workflow_definition: "Edit jobs and steps in the workflow YAML file."
+hints:
+  defaults:
+    base_config_path: ".swamp.yaml"


### PR DESCRIPTION
## Summary

Implements all three requested triple expression styles across every supported generator kind (8 total), with deterministic regeneration and sync tests.

## Delivered

1. Style A (YAML-first projection) for all 8 kinds
   - `docs/triple-styles/style-a-yaml/*.yaml`
2. Style B (Markdown projection) for all 8 kinds
   - `docs/triple-styles/style-b-markdown/*.md`
3. Style C (YAML + Markdown pair per kind) for all 8 kinds
   - `docs/triple-styles/style-c-yaml-plus-docs/<kind>/triple.yaml`
   - `docs/triple-styles/style-c-yaml-plus-docs/<kind>/triple.md`
4. Comparison index
   - `docs/triple-styles/README.md`

## Tooling

- Added sync command:
  - `go run ./cmd/cub-gen-style-sync`
  - source: `cmd/cub-gen-style-sync/main.go`
- Added deterministic sync tests:
  - `cmd/cub-gen-style-sync/main_test.go`
  - validates all 8 kinds exist in all 3 styles
  - validates checked-in style files are in sync with generator output
- Added make target:
  - `make sync-triple-styles`

## Docs

- Added README section with style-comparison paths and regeneration commands.

## Validation

- `go test ./cmd/cub-gen-style-sync -count=1`
- `make ci`

