### PR TITLE
feat(gitops): richer discover/import text + cleaner style projections

### DIFF
--- a/cmd/cub-gen-style-sync/main.go
+++ b/cmd/cub-gen-style-sync/main.go
@@ -184,77 +184,131 @@ func renderYAML(entry styleModel) string {
 	}
 
 	w.line(0, "contract:")
-	w.line(1, "default_input_role: %s", yamlQuote(entry.Contract.DefaultInputRole))
-	w.line(1, "default_owner: %s", yamlQuote(entry.Contract.DefaultOwner))
-
-	w.line(1, "input_role_rules:")
-	for _, rule := range entry.Contract.InputRoleRules {
-		w.line(2, "- role: %s", yamlQuote(rule.Role))
-		w.stringSlice(3, "exact_basenames", rule.ExactBasenames)
-		w.stringSlice(3, "prefixes", rule.Prefixes)
-		w.stringSlice(3, "extensions", rule.Extensions)
+	if strings.TrimSpace(entry.Contract.DefaultInputRole) != "" {
+		w.line(1, "default_input_role: %s", yamlQuote(entry.Contract.DefaultInputRole))
+	}
+	if strings.TrimSpace(entry.Contract.DefaultOwner) != "" {
+		w.line(1, "default_owner: %s", yamlQuote(entry.Contract.DefaultOwner))
 	}
 
-	w.line(1, "role_owners:")
-	writeMapStringString(&w, 2, entry.Contract.RoleOwners)
+	if len(entry.Contract.InputRoleRules) > 0 {
+		w.line(1, "input_role_rules:")
+		for _, rule := range entry.Contract.InputRoleRules {
+			w.line(2, "- role: %s", yamlQuote(rule.Role))
+			if len(rule.ExactBasenames) > 0 {
+				w.stringSlice(3, "exact_basenames", rule.ExactBasenames)
+			}
+			if len(rule.Prefixes) > 0 {
+				w.stringSlice(3, "prefixes", rule.Prefixes)
+			}
+			if len(rule.Extensions) > 0 {
+				w.stringSlice(3, "extensions", rule.Extensions)
+			}
+		}
+	}
 
-	w.line(1, "role_schema_refs:")
-	writeMapStringString(&w, 2, entry.Contract.RoleSchemaRefs)
+	if len(entry.Contract.RoleOwners) > 0 {
+		w.line(1, "role_owners:")
+		writeMapStringString(&w, 2, entry.Contract.RoleOwners)
+	}
 
-	w.line(1, "wet_targets:")
-	for _, target := range entry.Contract.WetTargets {
-		w.line(2, "- kind: %s", yamlQuote(target.Kind))
-		w.line(3, "name_template: %s", yamlQuote(target.NameTemplate))
-		w.line(3, "owner: %s", yamlQuote(target.Owner))
-		w.line(3, "namespace: %s", yamlQuote(target.Namespace))
-		w.line(3, "source_dry_path_template: %s", yamlQuote(target.SourceDryPathTemplate))
+	if len(entry.Contract.RoleSchemaRefs) > 0 {
+		w.line(1, "role_schema_refs:")
+		writeMapStringString(&w, 2, entry.Contract.RoleSchemaRefs)
+	}
+
+	if len(entry.Contract.WetTargets) > 0 {
+		w.line(1, "wet_targets:")
+		for _, target := range entry.Contract.WetTargets {
+			w.line(2, "- kind: %s", yamlQuote(target.Kind))
+			w.line(3, "name_template: %s", yamlQuote(target.NameTemplate))
+			w.line(3, "owner: %s", yamlQuote(target.Owner))
+			if strings.TrimSpace(target.Namespace) != "" {
+				w.line(3, "namespace: %s", yamlQuote(target.Namespace))
+			}
+			if strings.TrimSpace(target.SourceDryPathTemplate) != "" {
+				w.line(3, "source_dry_path_template: %s", yamlQuote(target.SourceDryPathTemplate))
+			}
+		}
 	}
 
 	w.line(0, "provenance:")
-	w.line(1, "field_origin_transform: %s", yamlQuote(entry.Provenance.FieldOriginTransform))
-	w.line(1, "field_origin_overlay_transform: %s", yamlQuote(entry.Provenance.FieldOriginOverlayTransform))
-	w.line(1, "field_origin_confidences:")
-	writeMapStringFloat(&w, 2, entry.Provenance.FieldOriginConfidences)
+	if strings.TrimSpace(entry.Provenance.FieldOriginTransform) != "" {
+		w.line(1, "field_origin_transform: %s", yamlQuote(entry.Provenance.FieldOriginTransform))
+	}
+	if strings.TrimSpace(entry.Provenance.FieldOriginOverlayTransform) != "" {
+		w.line(1, "field_origin_overlay_transform: %s", yamlQuote(entry.Provenance.FieldOriginOverlayTransform))
+	}
+	if len(entry.Provenance.FieldOriginConfidences) > 0 {
+		w.line(1, "field_origin_confidences:")
+		writeMapStringFloat(&w, 2, entry.Provenance.FieldOriginConfidences)
+	}
 
-	w.line(1, "rendered_lineage_templates:")
-	for _, tpl := range entry.Provenance.RenderedLineageTemplates {
-		w.line(2, "- kind: %s", yamlQuote(tpl.Kind))
-		w.line(3, "name_template: %s", yamlQuote(tpl.NameTemplate))
-		w.line(3, "namespace: %s", yamlQuote(tpl.Namespace))
-		w.line(3, "source_path_hint: %s", yamlQuote(tpl.SourcePathHint))
-		w.line(3, "source_path_hint_fallback: %s", yamlQuote(tpl.SourcePathHintFallback))
-		w.line(3, "source_path_hint_multi: %t", tpl.SourcePathHintMulti)
-		w.line(3, "source_dry_path_template: %s", yamlQuote(tpl.SourceDryPathTemplate))
-		w.line(3, "optional: %t", tpl.Optional)
+	if len(entry.Provenance.RenderedLineageTemplates) > 0 {
+		w.line(1, "rendered_lineage_templates:")
+		for _, tpl := range entry.Provenance.RenderedLineageTemplates {
+			w.line(2, "- kind: %s", yamlQuote(tpl.Kind))
+			w.line(3, "name_template: %s", yamlQuote(tpl.NameTemplate))
+			if strings.TrimSpace(tpl.Namespace) != "" {
+				w.line(3, "namespace: %s", yamlQuote(tpl.Namespace))
+			}
+			if strings.TrimSpace(tpl.SourcePathHint) != "" {
+				w.line(3, "source_path_hint: %s", yamlQuote(tpl.SourcePathHint))
+			}
+			if strings.TrimSpace(tpl.SourcePathHintFallback) != "" {
+				w.line(3, "source_path_hint_fallback: %s", yamlQuote(tpl.SourcePathHintFallback))
+			}
+			if tpl.SourcePathHintMulti {
+				w.line(3, "source_path_hint_multi: true")
+			}
+			if strings.TrimSpace(tpl.SourceDryPathTemplate) != "" {
+				w.line(3, "source_dry_path_template: %s", yamlQuote(tpl.SourceDryPathTemplate))
+			}
+			if tpl.Optional {
+				w.line(3, "optional: true")
+			}
+		}
 	}
 
 	w.line(0, "inverse:")
-	w.line(1, "inverse_patch_templates:")
-	for _, key := range sortedKeysPatch(entry.Inverse.InversePatchTemplates) {
-		tpl := entry.Inverse.InversePatchTemplates[key]
-		w.line(2, "%s:", key)
-		w.line(3, "editable_by: %s", yamlQuote(tpl.EditableBy))
-		w.line(3, "confidence: %.2f", tpl.Confidence)
-		w.line(3, "requires_review: %t", tpl.RequiresReview)
+	if len(entry.Inverse.InversePatchTemplates) > 0 {
+		w.line(1, "inverse_patch_templates:")
+		for _, key := range sortedKeysPatch(entry.Inverse.InversePatchTemplates) {
+			tpl := entry.Inverse.InversePatchTemplates[key]
+			w.line(2, "%s:", key)
+			w.line(3, "editable_by: %s", yamlQuote(tpl.EditableBy))
+			w.line(3, "confidence: %.2f", tpl.Confidence)
+			if tpl.RequiresReview {
+				w.line(3, "requires_review: true")
+			}
+		}
 	}
 
-	w.line(1, "inverse_pointer_templates:")
-	for _, key := range sortedKeysPointer(entry.Inverse.InversePointerTemplates) {
-		tpl := entry.Inverse.InversePointerTemplates[key]
-		w.line(2, "%s:", key)
-		w.line(3, "owner: %s", yamlQuote(tpl.Owner))
-		w.line(3, "confidence: %.2f", tpl.Confidence)
+	if len(entry.Inverse.InversePointerTemplates) > 0 {
+		w.line(1, "inverse_pointer_templates:")
+		for _, key := range sortedKeysPointer(entry.Inverse.InversePointerTemplates) {
+			tpl := entry.Inverse.InversePointerTemplates[key]
+			w.line(2, "%s:", key)
+			w.line(3, "owner: %s", yamlQuote(tpl.Owner))
+			w.line(3, "confidence: %.2f", tpl.Confidence)
+		}
 	}
 
-	w.line(1, "inverse_patch_reasons:")
-	writeMapStringString(&w, 2, entry.Inverse.InversePatchReasons)
+	if len(entry.Inverse.InversePatchReasons) > 0 {
+		w.line(1, "inverse_patch_reasons:")
+		writeMapStringString(&w, 2, entry.Inverse.InversePatchReasons)
+	}
 
-	w.line(1, "inverse_edit_hints:")
-	writeMapStringString(&w, 2, entry.Inverse.InverseEditHints)
+	if len(entry.Inverse.InverseEditHints) > 0 {
+		w.line(1, "inverse_edit_hints:")
+		writeMapStringString(&w, 2, entry.Inverse.InverseEditHints)
+	}
 
-	w.line(0, "hints:")
-	w.line(1, "defaults:")
-	writeMapStringString(&w, 2, entry.Hints)
+	if len(entry.Hints) > 0 {
+		w.line(0, "hints:")
+		w.line(1, "defaults:")
+		writeMapStringString(&w, 2, entry.Hints)
+	}
 
 	return b.String()
 }
@@ -266,10 +320,7 @@ func renderMarkdown(entry styleModel) string {
 	fmt.Fprintf(&b, "- Resource: `%s` (`%s`)\n", entry.ResourceKind, entry.ResourceType)
 	fmt.Fprintf(&b, "- Capabilities: %s\n\n", strings.Join(entry.Capabilities, ", "))
 
-	b.WriteString("```mermaid\n")
-	b.WriteString("flowchart LR\n")
-	b.WriteString("  dry[\"DRY Inputs\"] --> gen[\"Generator\"] --> wet[\"WET Targets\"]\n")
-	b.WriteString("```\n\n")
+	b.WriteString(renderMermaid(entry))
 
 	b.WriteString("## Contract\n\n")
 	fmt.Fprintf(&b, "- Default input role: `%s`\n", entry.Contract.DefaultInputRole)
@@ -379,6 +430,102 @@ func renderMarkdown(entry styleModel) string {
 	return b.String()
 }
 
+func renderMermaid(entry styleModel) string {
+	var b strings.Builder
+	b.WriteString("```mermaid\n")
+	b.WriteString("flowchart LR\n")
+	b.WriteString("  subgraph DRY[\"DRY Inputs\"]\n")
+	if len(entry.Contract.InputRoleRules) == 0 {
+		b.WriteString("    d0[\"No explicit DRY input rules\"]\n")
+	} else {
+		for i, rule := range entry.Contract.InputRoleRules {
+			roleOwner := ownerForRole(entry, rule.Role)
+			label := fmt.Sprintf("%s: %s", rule.Role, inputRulePattern(rule))
+			if roleOwner != "" {
+				label += fmt.Sprintf("<br/>owner: %s", roleOwner)
+			}
+			fmt.Fprintf(&b, "    d%d[\"%s\"]\n", i+1, mermaidLabel(label))
+		}
+	}
+	b.WriteString("  end\n")
+
+	genLabel := fmt.Sprintf("%s (%s)<br/>capabilities: %s", entry.Kind, entry.Profile, strings.Join(entry.Capabilities, ", "))
+	fmt.Fprintf(&b, "  gen[\"%s\"]\n", mermaidLabel(genLabel))
+
+	b.WriteString("  subgraph WET[\"WET Targets\"]\n")
+	if len(entry.Contract.WetTargets) == 0 {
+		b.WriteString("    w0[\"No explicit WET targets\"]\n")
+	} else {
+		for i, target := range entry.Contract.WetTargets {
+			label := fmt.Sprintf("%s %s<br/>owner: %s", target.Kind, target.NameTemplate, target.Owner)
+			if target.Namespace != "" {
+				label += fmt.Sprintf("<br/>namespace: %s", target.Namespace)
+			}
+			if target.SourceDryPathTemplate != "" {
+				label += fmt.Sprintf("<br/>source: %s", target.SourceDryPathTemplate)
+			}
+			fmt.Fprintf(&b, "    w%d[\"%s\"]\n", i+1, mermaidLabel(label))
+		}
+	}
+	b.WriteString("  end\n")
+
+	if len(entry.Contract.InputRoleRules) == 0 {
+		b.WriteString("  d0 --> gen\n")
+	} else {
+		for i := range entry.Contract.InputRoleRules {
+			fmt.Fprintf(&b, "  d%d --> gen\n", i+1)
+		}
+	}
+	if len(entry.Contract.WetTargets) == 0 {
+		b.WriteString("  gen --> w0\n")
+	} else {
+		for i := range entry.Contract.WetTargets {
+			fmt.Fprintf(&b, "  gen --> w%d\n", i+1)
+		}
+	}
+	b.WriteString("```\n\n")
+	return b.String()
+}
+
+func ownerForRole(entry styleModel, role string) string {
+	if owner, ok := entry.Contract.RoleOwners[role]; ok && strings.TrimSpace(owner) != "" {
+		return owner
+	}
+	return entry.Contract.DefaultOwner
+}
+
+func inputRulePattern(rule registry.InputRoleRule) string {
+	parts := make([]string, 0, len(rule.ExactBasenames)+len(rule.Prefixes))
+	if len(rule.ExactBasenames) > 0 {
+		parts = append(parts, strings.Join(rule.ExactBasenames, ", "))
+	}
+	if len(rule.Prefixes) > 0 && len(rule.Extensions) > 0 {
+		for _, prefix := range rule.Prefixes {
+			for _, ext := range rule.Extensions {
+				parts = append(parts, prefix+"*"+ext)
+			}
+		}
+	} else if len(rule.Prefixes) > 0 {
+		for _, prefix := range rule.Prefixes {
+			parts = append(parts, prefix+"*")
+		}
+	} else if len(rule.Extensions) > 0 {
+		for _, ext := range rule.Extensions {
+			parts = append(parts, "*"+ext)
+		}
+	}
+	if len(parts) == 0 {
+		return "pattern unspecified"
+	}
+	return strings.Join(parts, " | ")
+}
+
+func mermaidLabel(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	return value
+}
+
 type yamlWriter struct {
 	b *strings.Builder
 }
@@ -390,11 +537,10 @@ func (w yamlWriter) line(indent int, format string, args ...any) {
 }
 
 func (w yamlWriter) stringSlice(indent int, key string, values []string) {
-	w.line(indent, "%s:", key)
 	if len(values) == 0 {
-		w.line(indent+1, "[]")
 		return
 	}
+	w.line(indent, "%s:", key)
 	for _, value := range values {
 		w.line(indent+1, "- %s", yamlQuote(value))
 	}
@@ -402,10 +548,6 @@ func (w yamlWriter) stringSlice(indent int, key string, values []string) {
 
 func writeMapStringString(w *yamlWriter, indent int, values map[string]string) {
 	keys := sortedKeysString(values)
-	if len(keys) == 0 {
-		w.line(indent, "{}")
-		return
-	}
 	for _, key := range keys {
 		w.line(indent, "%s: %s", key, yamlQuote(values[key]))
 	}
@@ -413,10 +555,6 @@ func writeMapStringString(w *yamlWriter, indent int, values map[string]string) {
 
 func writeMapStringFloat(w *yamlWriter, indent int, values map[string]float64) {
 	keys := sortedKeysFloat(values)
-	if len(keys) == 0 {
-		w.line(indent, "{}")
-		return
-	}
 	for _, key := range keys {
 		w.line(indent, "%s: %.2f", key, values[key])
 	}

--- a/cmd/cub-gen-style-sync/main_test.go
+++ b/cmd/cub-gen-style-sync/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -76,6 +77,36 @@ func TestCheckedInTripleStylesAreInSync(t *testing.T) {
 		if got != want {
 			t.Fatalf("checked-in triple styles content drift at %s\nrun: go run ./cmd/cub-gen-style-sync", rel)
 		}
+	}
+}
+
+func TestGeneratedStylesAreReadable(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "triple-styles")
+	if err := syncStyles(root); err != nil {
+		t.Fatalf("syncStyles: %v", err)
+	}
+
+	kinds := registry.Kinds()
+	emptyListLineRe := regexp.MustCompile(`(?m)^\s*\[\]\s*$`)
+	for _, kind := range kinds {
+		name := string(kind)
+		t.Run(name+"-yaml-clean", func(t *testing.T) {
+			yaml := mustReadFile(t, filepath.Join(root, "style-a-yaml", name+".yaml"))
+			if emptyListLineRe.MatchString(yaml) {
+				t.Fatalf("yaml contains empty list placeholder for %s", name)
+			}
+			if strings.Contains(yaml, `: ""`) {
+				t.Fatalf("yaml contains empty quoted value for %s", name)
+			}
+		})
+		t.Run(name+"-markdown-mermaid", func(t *testing.T) {
+			md := mustReadFile(t, filepath.Join(root, "style-b-markdown", name+".md"))
+			if strings.Contains(md, `dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]`) {
+				t.Fatalf("markdown contains generic mermaid stub for %s", name)
+			}
+			assertFileContains(t, filepath.Join(root, "style-b-markdown", name+".md"), "subgraph DRY")
+			assertFileContains(t, filepath.Join(root, "style-b-markdown", name+".md"), "subgraph WET")
+		})
 	}
 }
 

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/confighub/cub-gen/internal/detect"
 	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
 	"github.com/confighub/cub-gen/internal/importer"
+	"github.com/confighub/cub-gen/internal/model"
 	"github.com/confighub/cub-gen/internal/publish"
 	"github.com/confighub/cub-gen/internal/registry"
 )
@@ -1056,12 +1057,7 @@ func runGitOpsImport(args []string) error {
 		return nil
 	}
 
-	fmt.Printf("Discovered %d GitOps resources, creating renderer units...\n", len(result.Discovered))
-	fmt.Printf("Created renderer units: %d\n", len(result.DryUnits))
-	fmt.Println("Rendering discovered resources...")
-	fmt.Printf("Created wet units: %d\n", len(result.WetUnits))
-	fmt.Printf("Created links: %d\n", len(result.Links))
-	fmt.Println("GitOps import complete")
+	printImportTable(result)
 	return nil
 }
 
@@ -1109,9 +1105,38 @@ func runGitOpsCleanup(args []string) error {
 }
 
 func printDiscoverTable(result gitopsflow.DiscoverResult) {
-	rows := make([][2]string, 0, len(result.Resources))
+	kindCapabilities := map[string]string{}
+	for _, kind := range registry.Kinds() {
+		spec, ok := registry.Spec(kind)
+		if !ok {
+			continue
+		}
+		kindCapabilities[string(kind)] = strings.Join(spec.Capabilities, ",")
+	}
+
+	confidenceByGeneratorID := map[string]float64{}
+	for _, d := range result.Detections {
+		confidenceByGeneratorID[d.ID] = d.Confidence
+	}
+
+	rows := make([][6]string, 0, len(result.Resources))
 	for _, r := range result.Resources {
-		rows = append(rows, [2]string{r.ResourceType, r.ResourceName})
+		confidence := "-"
+		if v, ok := confidenceByGeneratorID[r.GeneratorID]; ok {
+			confidence = fmt.Sprintf("%.2f", v)
+		}
+		capabilities := kindCapabilities[r.GeneratorKind]
+		if strings.TrimSpace(capabilities) == "" {
+			capabilities = "-"
+		}
+		rows = append(rows, [6]string{
+			r.ResourceType,
+			r.ResourceName,
+			r.GeneratorKind,
+			r.GeneratorProfile,
+			capabilities,
+			confidence,
+		})
 	}
 	sort.Slice(rows, func(i, j int) bool {
 		if rows[i][0] != rows[j][0] {
@@ -1120,9 +1145,132 @@ func printDiscoverTable(result gitopsflow.DiscoverResult) {
 		return rows[i][1] < rows[j][1]
 	})
 
-	fmt.Println("Resource Type\tResource Name")
+	fmt.Println("Resource Type\tResource Name\tGenerator Kind\tProfile\tCapabilities\tConfidence")
 	for _, row := range rows {
-		fmt.Printf("%s\t%s\n", row[0], row[1])
+		fmt.Printf("%s\t%s\t%s\t%s\t%s\t%s\n", row[0], row[1], row[2], row[3], row[4], row[5])
+	}
+}
+
+func printImportTable(result gitopsflow.ImportFlowResult) {
+	fmt.Printf("Discovered %d GitOps resources, creating renderer units...\n", len(result.Discovered))
+	printImportDiscoveredTable(result)
+	fmt.Printf("Created renderer units: %d\n", len(result.DryUnits))
+	fmt.Println("Rendering discovered resources...")
+	fmt.Printf("Created wet units: %d\n", len(result.WetUnits))
+	fmt.Printf("Created links: %d\n", len(result.Links))
+	fmt.Printf("Generated contracts: %d\n", len(result.Contracts))
+	fmt.Printf("Generated provenance records: %d\n", len(result.Provenance))
+	fmt.Printf("Generated inverse transform plans: %d\n", len(result.InversePlans))
+	printImportTripleSummary(result)
+	fmt.Println("GitOps import complete")
+}
+
+func printImportDiscoveredTable(result gitopsflow.ImportFlowResult) {
+	kindCapabilities := map[string]string{}
+	for _, kind := range registry.Kinds() {
+		spec, ok := registry.Spec(kind)
+		if !ok {
+			continue
+		}
+		kindCapabilities[string(kind)] = strings.Join(spec.Capabilities, ",")
+	}
+
+	rows := make([][5]string, 0, len(result.Discovered))
+	for _, r := range result.Discovered {
+		capabilities := kindCapabilities[r.GeneratorKind]
+		if strings.TrimSpace(capabilities) == "" {
+			capabilities = "-"
+		}
+		rows = append(rows, [5]string{
+			r.ResourceType,
+			r.ResourceName,
+			r.GeneratorKind,
+			r.GeneratorProfile,
+			capabilities,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i][0] != rows[j][0] {
+			return rows[i][0] < rows[j][0]
+		}
+		return rows[i][1] < rows[j][1]
+	})
+
+	fmt.Println("Resource Type\tResource Name\tGenerator Kind\tProfile\tCapabilities")
+	for _, row := range rows {
+		fmt.Printf("%s\t%s\t%s\t%s\t%s\n", row[0], row[1], row[2], row[3], row[4])
+	}
+}
+
+func printImportTripleSummary(result gitopsflow.ImportFlowResult) {
+	if len(result.Contracts) == 0 {
+		return
+	}
+
+	dryInputsByGeneratorID := map[string]int{}
+	for _, dry := range result.DryInputs {
+		dryInputsByGeneratorID[dry.GeneratorID]++
+	}
+
+	wetTargetsByGeneratorID := map[string]int{}
+	for _, wet := range result.WetManifestTargets {
+		wetTargetsByGeneratorID[wet.GeneratorID]++
+	}
+
+	inversePatchesBySourceRef := map[string]int{}
+	reviewRequiredBySourceRef := map[string]int{}
+	editableByTotals := map[string]int{}
+	for _, plan := range result.InversePlans {
+		for _, patch := range plan.Patches {
+			inversePatchesBySourceRef[plan.SourceRef]++
+			if patch.RequiresReview {
+				reviewRequiredBySourceRef[plan.SourceRef]++
+			}
+			if owner := strings.TrimSpace(patch.EditableBy); owner != "" {
+				editableByTotals[owner]++
+			}
+		}
+	}
+
+	totalReviewRequired := 0
+	for _, v := range reviewRequiredBySourceRef {
+		totalReviewRequired += v
+	}
+
+	contracts := append([]model.GeneratorContract(nil), result.Contracts...)
+	sort.Slice(contracts, func(i, j int) bool {
+		if contracts[i].Kind != contracts[j].Kind {
+			return contracts[i].Kind < contracts[j].Kind
+		}
+		return contracts[i].GeneratorID < contracts[j].GeneratorID
+	})
+
+	fmt.Println("Generator Kind\tProfile\tCapabilities\tDry Inputs\tWet Targets\tInverse Patches\tReview Required")
+	for _, c := range contracts {
+		fmt.Printf("%s\t%s\t%s\t%d\t%d\t%d\t%d\n",
+			c.Kind,
+			c.Profile,
+			strings.Join(c.Capabilities, ","),
+			dryInputsByGeneratorID[c.GeneratorID],
+			wetTargetsByGeneratorID[c.GeneratorID],
+			inversePatchesBySourceRef[c.SourcePath],
+			reviewRequiredBySourceRef[c.SourcePath],
+		)
+	}
+
+	if len(editableByTotals) == 0 {
+		return
+	}
+	owners := make([]string, 0, len(editableByTotals))
+	for owner := range editableByTotals {
+		owners = append(owners, owner)
+	}
+	sort.Strings(owners)
+
+	fmt.Printf("Review required patches: %d\n", totalReviewRequired)
+	fmt.Println("Patch owner\tCount")
+	for _, owner := range owners {
+		fmt.Printf("%s\t%d\n", owner, editableByTotals[owner])
 	}
 }
 

--- a/cmd/cub-gen/testdata/parity/gitops-discover.table.golden.txt
+++ b/cmd/cub-gen/testdata/parity/gitops-discover.table.golden.txt
@@ -1,2 +1,2 @@
-Resource Type	Resource Name
-helm.toolkit.fluxcd.io/v2/HelmRelease	helm-paas
+Resource Type	Resource Name	Generator Kind	Profile	Capabilities	Confidence
+helm.toolkit.fluxcd.io/v2/HelmRelease	helm-paas	helm	helm-paas	render-manifests,values-overrides,inverse-values-patch	0.98

--- a/cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt
+++ b/cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt
@@ -1,6 +1,16 @@
 Discovered 1 GitOps resources, creating renderer units...
+Resource Type	Resource Name	Generator Kind	Profile	Capabilities
+helm.toolkit.fluxcd.io/v2/HelmRelease	helm-paas	helm	helm-paas	render-manifests,values-overrides,inverse-values-patch
 Created renderer units: 1
 Rendering discovered resources...
 Created wet units: 1
 Created links: 1
+Generated contracts: 1
+Generated provenance records: 1
+Generated inverse transform plans: 1
+Generator Kind	Profile	Capabilities	Dry Inputs	Wet Targets	Inverse Patches	Review Required
+helm	helm-paas	render-manifests,values-overrides,inverse-values-patch	3	3	1	0
+Review required patches: 0
+Patch owner	Count
+app-team	1
 GitOps import complete

--- a/docs/decisions/2026-03-08-go-canonical-generator-triples.md
+++ b/docs/decisions/2026-03-08-go-canonical-generator-triples.md
@@ -1,0 +1,31 @@
+# Decision: Keep Go Registry as Canonical Generator Triple Source
+
+Date: 2026-03-08
+Status: accepted
+
+## Decision
+
+Keep `internal/registry/registry.go` as the canonical source of truth for generator triples.
+
+## Rationale
+
+1. Runtime behavior is already contract-tested against the Go registry.
+2. Existing import/discover/generator parity suites are stable and green.
+3. We can still provide platform-readable projections (YAML + Markdown) without introducing dual-write drift risk.
+
+## Consequence
+
+1. `docs/triple-styles/style-a-yaml/*.yaml` are read-only projections, not runtime-loaded specs.
+2. `docs/triple-styles/style-b-markdown/*.md` and style-C pairs are documentation projections.
+3. New/changed generator behavior is implemented in Go first, then projected via:
+   - `go run ./cmd/cub-gen-style-sync`
+   - `make sync-triple-styles`
+
+## Guardrails
+
+1. `cmd/cub-gen-style-sync/main_test.go` enforces checked-in projection sync.
+2. CI fails on projection drift.
+
+## Future Review Trigger
+
+Revisit YAML-as-runtime only if platform-owner authoring in Go becomes a sustained adoption blocker.

--- a/docs/triple-styles/style-a-yaml/ably.yaml
+++ b/docs/triple-styles/style-a-yaml/ably.yaml
@@ -15,21 +15,13 @@ contract:
         - "ably.yaml"
         - "ably.yml"
         - "ably.json"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "provider-config-overlay"
-      exact_basenames:
-        []
       prefixes:
         - "ably-"
       extensions:
         - ".yaml"
         - ".yml"
         - ".json"
-  role_owners:
-    {}
   role_schema_refs:
     provider-config-base: "https://schema.confighub.dev/generators/ably-config-v1"
     provider-config-overlay: "https://schema.confighub.dev/generators/ably-config-v1"
@@ -56,24 +48,16 @@ provenance:
       name_template: "{{name}}-ably"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "app.environment"
-      optional: false
     - kind: "Secret"
       name_template: "{{name}}-ably-credentials"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "credentials.api_key_ref"
-      optional: false
     - kind: "ConfigMap"
       name_template: "{{name}}-ably"
       namespace: "apps"
       source_path_hint: "overlay_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "channels.inbound"
       optional: true
 inverse:
@@ -81,11 +65,9 @@ inverse:
     channels:
       editable_by: "app-team"
       confidence: 0.88
-      requires_review: false
     environment:
       editable_by: "app-team"
       confidence: 0.90
-      requires_review: false
   inverse_pointer_templates:
     channels:
       owner: "app-team"

--- a/docs/triple-styles/style-a-yaml/backstage.yaml
+++ b/docs/triple-styles/style-a-yaml/backstage.yaml
@@ -14,18 +14,10 @@ contract:
       exact_basenames:
         - "catalog-info.yaml"
         - "catalog-info.yml"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "app-config"
       exact_basenames:
         - "app-config.yaml"
         - "app-config.yml"
-      prefixes:
-        []
-      extensions:
-        []
   role_owners:
     app-config: "app-team"
   role_schema_refs:
@@ -44,7 +36,6 @@ contract:
       source_dry_path_template: "spec.lifecycle"
 provenance:
   field_origin_transform: "backstage-component-to-application"
-  field_origin_overlay_transform: ""
   field_origin_confidences:
     identity: 0.90
     lifecycle: 0.82
@@ -53,24 +44,17 @@ provenance:
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "catalog_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "metadata.name"
-      optional: false
     - kind: "ConfigMap"
       name_template: "{{name}}-catalog"
       namespace: "apps"
       source_path_hint: "catalog_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "spec.lifecycle"
-      optional: false
 inverse:
   inverse_patch_templates:
     identity:
       editable_by: "platform-engineer"
       confidence: 0.87
-      requires_review: false
     lifecycle:
       editable_by: "platform-engineer"
       confidence: 0.82

--- a/docs/triple-styles/style-a-yaml/c3agent.yaml
+++ b/docs/triple-styles/style-a-yaml/c3agent.yaml
@@ -15,21 +15,13 @@ contract:
         - "c3agent.yaml"
         - "c3agent.yml"
         - "c3agent.json"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "fleet-config-overlay"
-      exact_basenames:
-        []
       prefixes:
         - "c3agent-"
       extensions:
         - ".yaml"
         - ".yml"
         - ".json"
-  role_owners:
-    {}
   role_schema_refs:
     fleet-config-base: "https://schema.confighub.dev/generators/c3agent-v1"
     fleet-config-overlay: "https://schema.confighub.dev/generators/c3agent-v1"
@@ -57,24 +49,16 @@ provenance:
       name_template: "{{name}}-fleet-config"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "fleet.agent_model"
-      optional: false
     - kind: "Secret"
       name_template: "{{name}}-fleet-credentials"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "credentials.anthropic_key_ref"
-      optional: false
     - kind: "ConfigMap"
       name_template: "{{name}}-fleet-config"
       namespace: "apps"
       source_path_hint: "overlay_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "fleet.max_concurrent_tasks"
       optional: true
 inverse:
@@ -90,7 +74,6 @@ inverse:
     fleet_config:
       editable_by: "app-team"
       confidence: 0.91
-      requires_review: false
   inverse_pointer_templates:
     component_ports:
       owner: "platform-engineer"

--- a/docs/triple-styles/style-a-yaml/helm.yaml
+++ b/docs/triple-styles/style-a-yaml/helm.yaml
@@ -13,13 +13,7 @@ contract:
     - role: "chart"
       exact_basenames:
         - "chart.yaml"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "values"
-      exact_basenames:
-        []
       prefixes:
         - "values"
       extensions:
@@ -34,7 +28,6 @@ contract:
       name_template: "{{name}}"
       owner: "platform-runtime"
       namespace: "apps"
-      source_dry_path_template: ""
     - kind: "Deployment"
       name_template: "{{name}}"
       owner: "platform-runtime"
@@ -47,7 +40,6 @@ contract:
       source_dry_path_template: "values.service.port"
 provenance:
   field_origin_transform: "helm-template"
-  field_origin_overlay_transform: ""
   field_origin_confidences:
     image_tag: 0.86
   rendered_lineage_templates:
@@ -55,10 +47,7 @@ provenance:
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "chart_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "Chart.yaml"
-      optional: false
     - kind: "Deployment"
       name_template: "{{name}}"
       namespace: "apps"
@@ -66,7 +55,6 @@ provenance:
       source_path_hint_fallback: "chart_path"
       source_path_hint_multi: true
       source_dry_path_template: "values.image.tag"
-      optional: false
     - kind: "Service"
       name_template: "{{name}}"
       namespace: "apps"
@@ -74,13 +62,11 @@ provenance:
       source_path_hint_fallback: "chart_path"
       source_path_hint_multi: true
       source_dry_path_template: "values.service.port"
-      optional: false
 inverse:
   inverse_patch_templates:
     image_tag:
       editable_by: "app-team"
       confidence: 0.86
-      requires_review: false
   inverse_pointer_templates:
     image_tag:
       owner: "app-team"

--- a/docs/triple-styles/style-a-yaml/opsworkflow.yaml
+++ b/docs/triple-styles/style-a-yaml/opsworkflow.yaml
@@ -16,21 +16,13 @@ contract:
         - "operations.yml"
         - "workflow.yaml"
         - "workflow.yml"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "operations-overlay"
-      exact_basenames:
-        []
       prefixes:
         - "operations-"
         - "workflow-"
       extensions:
         - ".yaml"
         - ".yml"
-  role_owners:
-    {}
   role_schema_refs:
     operations-base: "https://schema.confighub.dev/generators/ops-workflow-v1"
     operations-overlay: "https://schema.confighub.dev/generators/ops-workflow-v1"
@@ -57,24 +49,16 @@ provenance:
       name_template: "{{name}}-workflow"
       namespace: "ops"
       source_path_hint: "base_spec_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "actions.deploy.image_tag"
-      optional: false
     - kind: "Job"
       name_template: "{{name}}-dry-run"
       namespace: "ops"
       source_path_hint: "base_spec_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "triggers.schedule"
-      optional: false
     - kind: "Workflow"
       name_template: "{{name}}-workflow"
       namespace: "ops"
       source_path_hint: "overlay_spec_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "triggers.schedule"
       optional: true
 inverse:

--- a/docs/triple-styles/style-a-yaml/score.yaml
+++ b/docs/triple-styles/style-a-yaml/score.yaml
@@ -14,12 +14,6 @@ contract:
       exact_basenames:
         - "score.yaml"
         - "score.yml"
-      prefixes:
-        []
-      extensions:
-        []
-  role_owners:
-    {}
   role_schema_refs:
     score-spec: "https://docs.score.dev/schemas/score-v1b1.json"
   wet_targets:
@@ -27,7 +21,6 @@ contract:
       name_template: "{{name}}"
       owner: "platform-runtime"
       namespace: "apps"
-      source_dry_path_template: ""
     - kind: "Deployment"
       name_template: "{{name}}"
       owner: "platform-runtime"
@@ -40,7 +33,6 @@ contract:
       source_dry_path_template: "service.ports.{{service_port}}.port"
 provenance:
   field_origin_transform: "score-to-k8s"
-  field_origin_overlay_transform: ""
   field_origin_confidences:
     env_var: 0.90
     image: 0.94
@@ -50,32 +42,22 @@ provenance:
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "source_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "metadata.name"
-      optional: false
     - kind: "Deployment"
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "source_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "containers.{{container_name}}.image"
-      optional: false
     - kind: "Service"
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "source_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "service.ports.{{service_port_name}}.port"
-      optional: false
 inverse:
   inverse_patch_templates:
     env_var:
       editable_by: "app-team"
       confidence: 0.90
-      requires_review: false
   inverse_pointer_templates:
     env_var:
       owner: "app-team"

--- a/docs/triple-styles/style-a-yaml/springboot.yaml
+++ b/docs/triple-styles/style-a-yaml/springboot.yaml
@@ -15,21 +15,11 @@ contract:
         - "pom.xml"
         - "build.gradle"
         - "build.gradle.kts"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "app-config-base"
       exact_basenames:
         - "application.yaml"
         - "application.yml"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "app-config-profile"
-      exact_basenames:
-        []
       prefixes:
         - "application-"
       extensions:
@@ -46,7 +36,6 @@ contract:
       name_template: "{{name}}"
       owner: "platform-runtime"
       namespace: "apps"
-      source_dry_path_template: ""
     - kind: "Deployment"
       name_template: "{{name}}"
       owner: "platform-runtime"
@@ -70,40 +59,28 @@ provenance:
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "build_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "build"
-      optional: false
     - kind: "Deployment"
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "spring.application.name"
-      optional: false
     - kind: "ConfigMap"
       name_template: "{{name}}-config"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "spring.datasource.url"
-      optional: false
     - kind: "Deployment"
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "profile_config_path"
       source_path_hint_fallback: "base_config_path"
-      source_path_hint_multi: false
       source_dry_path_template: "server.port"
-      optional: false
 inverse:
   inverse_patch_templates:
     app_name:
       editable_by: "app-team"
       confidence: 0.88
-      requires_review: false
     datasource_url:
       editable_by: "platform-engineer"
       confidence: 0.78
@@ -111,7 +88,6 @@ inverse:
     server_port:
       editable_by: "app-team"
       confidence: 0.91
-      requires_review: false
   inverse_pointer_templates:
     app_name:
       owner: "app-team"

--- a/docs/triple-styles/style-a-yaml/swamp.yaml
+++ b/docs/triple-styles/style-a-yaml/swamp.yaml
@@ -14,20 +14,12 @@ contract:
       exact_basenames:
         - ".swamp.yaml"
         - ".swamp.yml"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "swamp-workflow"
-      exact_basenames:
-        []
       prefixes:
         - "workflow-"
       extensions:
         - ".yaml"
         - ".yml"
-  role_owners:
-    {}
   role_schema_refs:
     swamp-config-base: "https://schema.confighub.dev/generators/swamp-v1"
     swamp-workflow: "https://schema.confighub.dev/generators/swamp-workflow-v1"
@@ -55,24 +47,16 @@ provenance:
       name_template: "{{name}}-workflow"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "vaults.default.type"
-      optional: false
     - kind: "ConfigMap"
       name_template: "{{name}}-swamp-config"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "swamp.version"
-      optional: false
     - kind: "Workflow"
       name_template: "{{name}}-workflow"
       namespace: "apps"
       source_path_hint: "workflow_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "jobs[].steps[].task"
       optional: true
 inverse:
@@ -80,7 +64,6 @@ inverse:
     model_binding:
       editable_by: "app-team"
       confidence: 0.88
-      requires_review: false
     vault_config:
       editable_by: "platform-engineer"
       confidence: 0.85
@@ -88,7 +71,6 @@ inverse:
     workflow_definition:
       editable_by: "app-team"
       confidence: 0.90
-      requires_review: false
   inverse_pointer_templates:
     model_binding:
       owner: "app-team"

--- a/docs/triple-styles/style-b-markdown/ably.md
+++ b/docs/triple-styles/style-b-markdown/ably.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["provider-config-base: ably.yaml, ably.yml, ably.json<br/>owner: app-team"]
+    d2["provider-config-overlay: ably-*.yaml | ably-*.yml | ably-*.json<br/>owner: app-team"]
+  end
+  gen["ably (ably-config)<br/>capabilities: app-config-only, provider-config, inverse-provider-config-patch"]
+  subgraph WET["WET Targets"]
+    w1["ConfigMap {{name}}-ably<br/>owner: platform-runtime<br/>namespace: apps<br/>source: app.environment"]
+    w2["Secret {{name}}-ably-credentials<br/>owner: platform-runtime<br/>namespace: apps<br/>source: credentials.api_key_ref"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
 ```
 
 ## Contract

--- a/docs/triple-styles/style-b-markdown/backstage.md
+++ b/docs/triple-styles/style-b-markdown/backstage.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["catalog-spec: catalog-info.yaml, catalog-info.yml<br/>owner: platform-engineer"]
+    d2["app-config: app-config.yaml, app-config.yml<br/>owner: app-team"]
+  end
+  gen["backstage (backstage-idp)<br/>capabilities: catalog-metadata, render-manifests, inverse-catalog-patch"]
+  subgraph WET["WET Targets"]
+    w1["Application {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: metadata.name"]
+    w2["ConfigMap {{name}}-catalog<br/>owner: platform-runtime<br/>namespace: apps<br/>source: spec.lifecycle"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
 ```
 
 ## Contract

--- a/docs/triple-styles/style-b-markdown/c3agent.md
+++ b/docs/triple-styles/style-b-markdown/c3agent.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["fleet-config-base: c3agent.yaml, c3agent.yml, c3agent.json<br/>owner: app-team"]
+    d2["fleet-config-overlay: c3agent-*.yaml | c3agent-*.yml | c3agent-*.json<br/>owner: app-team"]
+  end
+  gen["c3agent (c3agent)<br/>capabilities: fleet-config, agent-orchestration, inverse-fleet-config-patch"]
+  subgraph WET["WET Targets"]
+    w1["ConfigMap {{name}}-fleet-config<br/>owner: platform-runtime<br/>namespace: apps<br/>source: fleet.agent_model"]
+    w2["Secret {{name}}-fleet-credentials<br/>owner: platform-runtime<br/>namespace: apps<br/>source: credentials.anthropic_key_ref"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
 ```
 
 ## Contract

--- a/docs/triple-styles/style-b-markdown/helm.md
+++ b/docs/triple-styles/style-b-markdown/helm.md
@@ -6,7 +6,21 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["chart: chart.yaml<br/>owner: platform-engineer"]
+    d2["values: values*.yaml | values*.yml<br/>owner: app-team"]
+  end
+  gen["helm (helm-paas)<br/>capabilities: render-manifests, values-overrides, inverse-values-patch"]
+  subgraph WET["WET Targets"]
+    w1["HelmRelease {{name}}<br/>owner: platform-runtime<br/>namespace: apps"]
+    w2["Deployment {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: values.image.tag"]
+    w3["Service {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: values.service.port"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
+  gen --> w3
 ```
 
 ## Contract

--- a/docs/triple-styles/style-b-markdown/opsworkflow.md
+++ b/docs/triple-styles/style-b-markdown/opsworkflow.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["operations-base: operations.yaml, operations.yml, workflow.yaml, workflow.yml<br/>owner: platform-engineer"]
+    d2["operations-overlay: operations-*.yaml | operations-*.yml | workflow-*.yaml | workflow-*.yml<br/>owner: platform-engineer"]
+  end
+  gen["opsworkflow (ops-workflow)<br/>capabilities: workflow-plan, governed-execution-intent, inverse-workflow-patch"]
+  subgraph WET["WET Targets"]
+    w1["Workflow {{name}}-workflow<br/>owner: platform-runtime<br/>namespace: ops<br/>source: actions.deploy.image_tag"]
+    w2["Job {{name}}-dry-run<br/>owner: platform-runtime<br/>namespace: ops<br/>source: triggers.schedule"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
 ```
 
 ## Contract

--- a/docs/triple-styles/style-b-markdown/score.md
+++ b/docs/triple-styles/style-b-markdown/score.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["score-spec: score.yaml, score.yml<br/>owner: app-team"]
+  end
+  gen["score (scoredev-paas)<br/>capabilities: render-manifests, workload-spec, inverse-score-patch"]
+  subgraph WET["WET Targets"]
+    w1["Application {{name}}<br/>owner: platform-runtime<br/>namespace: apps"]
+    w2["Deployment {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: containers.{{container}}.image"]
+    w3["Service {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: service.ports.{{service_port}}.port"]
+  end
+  d1 --> gen
+  gen --> w1
+  gen --> w2
+  gen --> w3
 ```
 
 ## Contract

--- a/docs/triple-styles/style-b-markdown/springboot.md
+++ b/docs/triple-styles/style-b-markdown/springboot.md
@@ -6,7 +6,23 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["build-config: pom.xml, build.gradle, build.gradle.kts<br/>owner: platform-engineer"]
+    d2["app-config-base: application.yaml, application.yml<br/>owner: app-team"]
+    d3["app-config-profile: application-*.yaml | application-*.yml<br/>owner: app-team"]
+  end
+  gen["springboot (springboot-paas)<br/>capabilities: render-app-config, profile-overrides, inverse-app-config-patch"]
+  subgraph WET["WET Targets"]
+    w1["Kustomization {{name}}<br/>owner: platform-runtime<br/>namespace: apps"]
+    w2["Deployment {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: server.port"]
+    w3["ConfigMap {{name}}-config<br/>owner: platform-runtime<br/>namespace: apps<br/>source: spring.datasource.url"]
+  end
+  d1 --> gen
+  d2 --> gen
+  d3 --> gen
+  gen --> w1
+  gen --> w2
+  gen --> w3
 ```
 
 ## Contract

--- a/docs/triple-styles/style-b-markdown/swamp.md
+++ b/docs/triple-styles/style-b-markdown/swamp.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["swamp-config-base: .swamp.yaml, .swamp.yml<br/>owner: app-team"]
+    d2["swamp-workflow: workflow-*.yaml | workflow-*.yml<br/>owner: app-team"]
+  end
+  gen["swamp (swamp)<br/>capabilities: workflow-automation, model-orchestration, inverse-workflow-patch"]
+  subgraph WET["WET Targets"]
+    w1["Workflow {{name}}-workflow<br/>owner: platform-runtime<br/>namespace: apps<br/>source: jobs[].steps[].task"]
+    w2["ConfigMap {{name}}-swamp-config<br/>owner: platform-runtime<br/>namespace: apps<br/>source: swamp.version"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
 ```
 
 ## Contract

--- a/docs/triple-styles/style-c-yaml-plus-docs/ably/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/ably/triple.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["provider-config-base: ably.yaml, ably.yml, ably.json<br/>owner: app-team"]
+    d2["provider-config-overlay: ably-*.yaml | ably-*.yml | ably-*.json<br/>owner: app-team"]
+  end
+  gen["ably (ably-config)<br/>capabilities: app-config-only, provider-config, inverse-provider-config-patch"]
+  subgraph WET["WET Targets"]
+    w1["ConfigMap {{name}}-ably<br/>owner: platform-runtime<br/>namespace: apps<br/>source: app.environment"]
+    w2["Secret {{name}}-ably-credentials<br/>owner: platform-runtime<br/>namespace: apps<br/>source: credentials.api_key_ref"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
 ```
 
 ## Contract

--- a/docs/triple-styles/style-c-yaml-plus-docs/ably/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/ably/triple.yaml
@@ -15,21 +15,13 @@ contract:
         - "ably.yaml"
         - "ably.yml"
         - "ably.json"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "provider-config-overlay"
-      exact_basenames:
-        []
       prefixes:
         - "ably-"
       extensions:
         - ".yaml"
         - ".yml"
         - ".json"
-  role_owners:
-    {}
   role_schema_refs:
     provider-config-base: "https://schema.confighub.dev/generators/ably-config-v1"
     provider-config-overlay: "https://schema.confighub.dev/generators/ably-config-v1"
@@ -56,24 +48,16 @@ provenance:
       name_template: "{{name}}-ably"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "app.environment"
-      optional: false
     - kind: "Secret"
       name_template: "{{name}}-ably-credentials"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "credentials.api_key_ref"
-      optional: false
     - kind: "ConfigMap"
       name_template: "{{name}}-ably"
       namespace: "apps"
       source_path_hint: "overlay_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "channels.inbound"
       optional: true
 inverse:
@@ -81,11 +65,9 @@ inverse:
     channels:
       editable_by: "app-team"
       confidence: 0.88
-      requires_review: false
     environment:
       editable_by: "app-team"
       confidence: 0.90
-      requires_review: false
   inverse_pointer_templates:
     channels:
       owner: "app-team"

--- a/docs/triple-styles/style-c-yaml-plus-docs/backstage/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/backstage/triple.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["catalog-spec: catalog-info.yaml, catalog-info.yml<br/>owner: platform-engineer"]
+    d2["app-config: app-config.yaml, app-config.yml<br/>owner: app-team"]
+  end
+  gen["backstage (backstage-idp)<br/>capabilities: catalog-metadata, render-manifests, inverse-catalog-patch"]
+  subgraph WET["WET Targets"]
+    w1["Application {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: metadata.name"]
+    w2["ConfigMap {{name}}-catalog<br/>owner: platform-runtime<br/>namespace: apps<br/>source: spec.lifecycle"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
 ```
 
 ## Contract

--- a/docs/triple-styles/style-c-yaml-plus-docs/backstage/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/backstage/triple.yaml
@@ -14,18 +14,10 @@ contract:
       exact_basenames:
         - "catalog-info.yaml"
         - "catalog-info.yml"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "app-config"
       exact_basenames:
         - "app-config.yaml"
         - "app-config.yml"
-      prefixes:
-        []
-      extensions:
-        []
   role_owners:
     app-config: "app-team"
   role_schema_refs:
@@ -44,7 +36,6 @@ contract:
       source_dry_path_template: "spec.lifecycle"
 provenance:
   field_origin_transform: "backstage-component-to-application"
-  field_origin_overlay_transform: ""
   field_origin_confidences:
     identity: 0.90
     lifecycle: 0.82
@@ -53,24 +44,17 @@ provenance:
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "catalog_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "metadata.name"
-      optional: false
     - kind: "ConfigMap"
       name_template: "{{name}}-catalog"
       namespace: "apps"
       source_path_hint: "catalog_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "spec.lifecycle"
-      optional: false
 inverse:
   inverse_patch_templates:
     identity:
       editable_by: "platform-engineer"
       confidence: 0.87
-      requires_review: false
     lifecycle:
       editable_by: "platform-engineer"
       confidence: 0.82

--- a/docs/triple-styles/style-c-yaml-plus-docs/c3agent/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/c3agent/triple.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["fleet-config-base: c3agent.yaml, c3agent.yml, c3agent.json<br/>owner: app-team"]
+    d2["fleet-config-overlay: c3agent-*.yaml | c3agent-*.yml | c3agent-*.json<br/>owner: app-team"]
+  end
+  gen["c3agent (c3agent)<br/>capabilities: fleet-config, agent-orchestration, inverse-fleet-config-patch"]
+  subgraph WET["WET Targets"]
+    w1["ConfigMap {{name}}-fleet-config<br/>owner: platform-runtime<br/>namespace: apps<br/>source: fleet.agent_model"]
+    w2["Secret {{name}}-fleet-credentials<br/>owner: platform-runtime<br/>namespace: apps<br/>source: credentials.anthropic_key_ref"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
 ```
 
 ## Contract

--- a/docs/triple-styles/style-c-yaml-plus-docs/c3agent/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/c3agent/triple.yaml
@@ -15,21 +15,13 @@ contract:
         - "c3agent.yaml"
         - "c3agent.yml"
         - "c3agent.json"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "fleet-config-overlay"
-      exact_basenames:
-        []
       prefixes:
         - "c3agent-"
       extensions:
         - ".yaml"
         - ".yml"
         - ".json"
-  role_owners:
-    {}
   role_schema_refs:
     fleet-config-base: "https://schema.confighub.dev/generators/c3agent-v1"
     fleet-config-overlay: "https://schema.confighub.dev/generators/c3agent-v1"
@@ -57,24 +49,16 @@ provenance:
       name_template: "{{name}}-fleet-config"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "fleet.agent_model"
-      optional: false
     - kind: "Secret"
       name_template: "{{name}}-fleet-credentials"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "credentials.anthropic_key_ref"
-      optional: false
     - kind: "ConfigMap"
       name_template: "{{name}}-fleet-config"
       namespace: "apps"
       source_path_hint: "overlay_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "fleet.max_concurrent_tasks"
       optional: true
 inverse:
@@ -90,7 +74,6 @@ inverse:
     fleet_config:
       editable_by: "app-team"
       confidence: 0.91
-      requires_review: false
   inverse_pointer_templates:
     component_ports:
       owner: "platform-engineer"

--- a/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.md
@@ -6,7 +6,21 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["chart: chart.yaml<br/>owner: platform-engineer"]
+    d2["values: values*.yaml | values*.yml<br/>owner: app-team"]
+  end
+  gen["helm (helm-paas)<br/>capabilities: render-manifests, values-overrides, inverse-values-patch"]
+  subgraph WET["WET Targets"]
+    w1["HelmRelease {{name}}<br/>owner: platform-runtime<br/>namespace: apps"]
+    w2["Deployment {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: values.image.tag"]
+    w3["Service {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: values.service.port"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
+  gen --> w3
 ```
 
 ## Contract

--- a/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.yaml
@@ -13,13 +13,7 @@ contract:
     - role: "chart"
       exact_basenames:
         - "chart.yaml"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "values"
-      exact_basenames:
-        []
       prefixes:
         - "values"
       extensions:
@@ -34,7 +28,6 @@ contract:
       name_template: "{{name}}"
       owner: "platform-runtime"
       namespace: "apps"
-      source_dry_path_template: ""
     - kind: "Deployment"
       name_template: "{{name}}"
       owner: "platform-runtime"
@@ -47,7 +40,6 @@ contract:
       source_dry_path_template: "values.service.port"
 provenance:
   field_origin_transform: "helm-template"
-  field_origin_overlay_transform: ""
   field_origin_confidences:
     image_tag: 0.86
   rendered_lineage_templates:
@@ -55,10 +47,7 @@ provenance:
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "chart_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "Chart.yaml"
-      optional: false
     - kind: "Deployment"
       name_template: "{{name}}"
       namespace: "apps"
@@ -66,7 +55,6 @@ provenance:
       source_path_hint_fallback: "chart_path"
       source_path_hint_multi: true
       source_dry_path_template: "values.image.tag"
-      optional: false
     - kind: "Service"
       name_template: "{{name}}"
       namespace: "apps"
@@ -74,13 +62,11 @@ provenance:
       source_path_hint_fallback: "chart_path"
       source_path_hint_multi: true
       source_dry_path_template: "values.service.port"
-      optional: false
 inverse:
   inverse_patch_templates:
     image_tag:
       editable_by: "app-team"
       confidence: 0.86
-      requires_review: false
   inverse_pointer_templates:
     image_tag:
       owner: "app-team"

--- a/docs/triple-styles/style-c-yaml-plus-docs/opsworkflow/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/opsworkflow/triple.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["operations-base: operations.yaml, operations.yml, workflow.yaml, workflow.yml<br/>owner: platform-engineer"]
+    d2["operations-overlay: operations-*.yaml | operations-*.yml | workflow-*.yaml | workflow-*.yml<br/>owner: platform-engineer"]
+  end
+  gen["opsworkflow (ops-workflow)<br/>capabilities: workflow-plan, governed-execution-intent, inverse-workflow-patch"]
+  subgraph WET["WET Targets"]
+    w1["Workflow {{name}}-workflow<br/>owner: platform-runtime<br/>namespace: ops<br/>source: actions.deploy.image_tag"]
+    w2["Job {{name}}-dry-run<br/>owner: platform-runtime<br/>namespace: ops<br/>source: triggers.schedule"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
 ```
 
 ## Contract

--- a/docs/triple-styles/style-c-yaml-plus-docs/opsworkflow/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/opsworkflow/triple.yaml
@@ -16,21 +16,13 @@ contract:
         - "operations.yml"
         - "workflow.yaml"
         - "workflow.yml"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "operations-overlay"
-      exact_basenames:
-        []
       prefixes:
         - "operations-"
         - "workflow-"
       extensions:
         - ".yaml"
         - ".yml"
-  role_owners:
-    {}
   role_schema_refs:
     operations-base: "https://schema.confighub.dev/generators/ops-workflow-v1"
     operations-overlay: "https://schema.confighub.dev/generators/ops-workflow-v1"
@@ -57,24 +49,16 @@ provenance:
       name_template: "{{name}}-workflow"
       namespace: "ops"
       source_path_hint: "base_spec_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "actions.deploy.image_tag"
-      optional: false
     - kind: "Job"
       name_template: "{{name}}-dry-run"
       namespace: "ops"
       source_path_hint: "base_spec_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "triggers.schedule"
-      optional: false
     - kind: "Workflow"
       name_template: "{{name}}-workflow"
       namespace: "ops"
       source_path_hint: "overlay_spec_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "triggers.schedule"
       optional: true
 inverse:

--- a/docs/triple-styles/style-c-yaml-plus-docs/score/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/score/triple.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["score-spec: score.yaml, score.yml<br/>owner: app-team"]
+  end
+  gen["score (scoredev-paas)<br/>capabilities: render-manifests, workload-spec, inverse-score-patch"]
+  subgraph WET["WET Targets"]
+    w1["Application {{name}}<br/>owner: platform-runtime<br/>namespace: apps"]
+    w2["Deployment {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: containers.{{container}}.image"]
+    w3["Service {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: service.ports.{{service_port}}.port"]
+  end
+  d1 --> gen
+  gen --> w1
+  gen --> w2
+  gen --> w3
 ```
 
 ## Contract

--- a/docs/triple-styles/style-c-yaml-plus-docs/score/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/score/triple.yaml
@@ -14,12 +14,6 @@ contract:
       exact_basenames:
         - "score.yaml"
         - "score.yml"
-      prefixes:
-        []
-      extensions:
-        []
-  role_owners:
-    {}
   role_schema_refs:
     score-spec: "https://docs.score.dev/schemas/score-v1b1.json"
   wet_targets:
@@ -27,7 +21,6 @@ contract:
       name_template: "{{name}}"
       owner: "platform-runtime"
       namespace: "apps"
-      source_dry_path_template: ""
     - kind: "Deployment"
       name_template: "{{name}}"
       owner: "platform-runtime"
@@ -40,7 +33,6 @@ contract:
       source_dry_path_template: "service.ports.{{service_port}}.port"
 provenance:
   field_origin_transform: "score-to-k8s"
-  field_origin_overlay_transform: ""
   field_origin_confidences:
     env_var: 0.90
     image: 0.94
@@ -50,32 +42,22 @@ provenance:
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "source_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "metadata.name"
-      optional: false
     - kind: "Deployment"
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "source_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "containers.{{container_name}}.image"
-      optional: false
     - kind: "Service"
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "source_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "service.ports.{{service_port_name}}.port"
-      optional: false
 inverse:
   inverse_patch_templates:
     env_var:
       editable_by: "app-team"
       confidence: 0.90
-      requires_review: false
   inverse_pointer_templates:
     env_var:
       owner: "app-team"

--- a/docs/triple-styles/style-c-yaml-plus-docs/springboot/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/springboot/triple.md
@@ -6,7 +6,23 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["build-config: pom.xml, build.gradle, build.gradle.kts<br/>owner: platform-engineer"]
+    d2["app-config-base: application.yaml, application.yml<br/>owner: app-team"]
+    d3["app-config-profile: application-*.yaml | application-*.yml<br/>owner: app-team"]
+  end
+  gen["springboot (springboot-paas)<br/>capabilities: render-app-config, profile-overrides, inverse-app-config-patch"]
+  subgraph WET["WET Targets"]
+    w1["Kustomization {{name}}<br/>owner: platform-runtime<br/>namespace: apps"]
+    w2["Deployment {{name}}<br/>owner: platform-runtime<br/>namespace: apps<br/>source: server.port"]
+    w3["ConfigMap {{name}}-config<br/>owner: platform-runtime<br/>namespace: apps<br/>source: spring.datasource.url"]
+  end
+  d1 --> gen
+  d2 --> gen
+  d3 --> gen
+  gen --> w1
+  gen --> w2
+  gen --> w3
 ```
 
 ## Contract

--- a/docs/triple-styles/style-c-yaml-plus-docs/springboot/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/springboot/triple.yaml
@@ -15,21 +15,11 @@ contract:
         - "pom.xml"
         - "build.gradle"
         - "build.gradle.kts"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "app-config-base"
       exact_basenames:
         - "application.yaml"
         - "application.yml"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "app-config-profile"
-      exact_basenames:
-        []
       prefixes:
         - "application-"
       extensions:
@@ -46,7 +36,6 @@ contract:
       name_template: "{{name}}"
       owner: "platform-runtime"
       namespace: "apps"
-      source_dry_path_template: ""
     - kind: "Deployment"
       name_template: "{{name}}"
       owner: "platform-runtime"
@@ -70,40 +59,28 @@ provenance:
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "build_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "build"
-      optional: false
     - kind: "Deployment"
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "spring.application.name"
-      optional: false
     - kind: "ConfigMap"
       name_template: "{{name}}-config"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "spring.datasource.url"
-      optional: false
     - kind: "Deployment"
       name_template: "{{name}}"
       namespace: "apps"
       source_path_hint: "profile_config_path"
       source_path_hint_fallback: "base_config_path"
-      source_path_hint_multi: false
       source_dry_path_template: "server.port"
-      optional: false
 inverse:
   inverse_patch_templates:
     app_name:
       editable_by: "app-team"
       confidence: 0.88
-      requires_review: false
     datasource_url:
       editable_by: "platform-engineer"
       confidence: 0.78
@@ -111,7 +88,6 @@ inverse:
     server_port:
       editable_by: "app-team"
       confidence: 0.91
-      requires_review: false
   inverse_pointer_templates:
     app_name:
       owner: "app-team"

--- a/docs/triple-styles/style-c-yaml-plus-docs/swamp/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/swamp/triple.md
@@ -6,7 +6,19 @@
 
 ```mermaid
 flowchart LR
-  dry["DRY Inputs"] --> gen["Generator"] --> wet["WET Targets"]
+  subgraph DRY["DRY Inputs"]
+    d1["swamp-config-base: .swamp.yaml, .swamp.yml<br/>owner: app-team"]
+    d2["swamp-workflow: workflow-*.yaml | workflow-*.yml<br/>owner: app-team"]
+  end
+  gen["swamp (swamp)<br/>capabilities: workflow-automation, model-orchestration, inverse-workflow-patch"]
+  subgraph WET["WET Targets"]
+    w1["Workflow {{name}}-workflow<br/>owner: platform-runtime<br/>namespace: apps<br/>source: jobs[].steps[].task"]
+    w2["ConfigMap {{name}}-swamp-config<br/>owner: platform-runtime<br/>namespace: apps<br/>source: swamp.version"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+  gen --> w2
 ```
 
 ## Contract

--- a/docs/triple-styles/style-c-yaml-plus-docs/swamp/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/swamp/triple.yaml
@@ -14,20 +14,12 @@ contract:
       exact_basenames:
         - ".swamp.yaml"
         - ".swamp.yml"
-      prefixes:
-        []
-      extensions:
-        []
     - role: "swamp-workflow"
-      exact_basenames:
-        []
       prefixes:
         - "workflow-"
       extensions:
         - ".yaml"
         - ".yml"
-  role_owners:
-    {}
   role_schema_refs:
     swamp-config-base: "https://schema.confighub.dev/generators/swamp-v1"
     swamp-workflow: "https://schema.confighub.dev/generators/swamp-workflow-v1"
@@ -55,24 +47,16 @@ provenance:
       name_template: "{{name}}-workflow"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "vaults.default.type"
-      optional: false
     - kind: "ConfigMap"
       name_template: "{{name}}-swamp-config"
       namespace: "apps"
       source_path_hint: "base_config_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "swamp.version"
-      optional: false
     - kind: "Workflow"
       name_template: "{{name}}-workflow"
       namespace: "apps"
       source_path_hint: "workflow_path"
-      source_path_hint_fallback: ""
-      source_path_hint_multi: false
       source_dry_path_template: "jobs[].steps[].task"
       optional: true
 inverse:
@@ -80,7 +64,6 @@ inverse:
     model_binding:
       editable_by: "app-team"
       confidence: 0.88
-      requires_review: false
     vault_config:
       editable_by: "platform-engineer"
       confidence: 0.85
@@ -88,7 +71,6 @@ inverse:
     workflow_definition:
       editable_by: "app-team"
       confidence: 0.90
-      requires_review: false
   inverse_pointer_templates:
     model_binding:
       owner: "app-team"


### PR DESCRIPTION
## Summary

Implements both requested slices while keeping Go canonical:

1. Richer `gitops discover/import` text output for fast operator comprehension.
2. Better style projections (`docs/triple-styles`) with non-generic Mermaid and cleaner YAML.

## 1) GitOps text UX (discover/import)

### `gitops discover` text mode

Adds columns:
- `Resource Type`
- `Resource Name`
- `Generator Kind`
- `Profile`
- `Capabilities`
- `Confidence`

### `gitops import` text mode

Adds:
- discovered resource table (type/name/generator/profile/capabilities)
- generated triple counts (contracts/provenance/inverse plans)
- per-generator triple summary table:
  - capabilities
  - dry input count
  - wet target count
  - inverse patch count
  - review-required count
- patch owner summary

Parity goldens updated:
- `cmd/cub-gen/testdata/parity/gitops-discover.table.golden.txt`
- `cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt`

## 2) Style projection quality

### Mermaid improvements

`cmd/cub-gen-style-sync` now generates per-generator Mermaid diagrams with:
- concrete DRY input patterns by role
- role ownership labels
- generator kind/profile/capabilities
- explicit WET targets with owner/namespace/source path

### YAML readability improvements

Projection YAML now omits empty placeholders:
- no empty `[]` list stubs
- no empty quoted scalar values
- optional fields omitted when empty/false

### New readability guard tests

`cmd/cub-gen-style-sync/main_test.go` now enforces:
- no generic Mermaid stub output
- no empty placeholder lines in generated YAML

## Canonical source decision

Added explicit decision note that Go remains canonical:
- `docs/decisions/2026-03-08-go-canonical-generator-triples.md`

## Validation

- `go run ./cmd/cub-gen-style-sync`
- `go test ./cmd/cub-gen-style-sync -count=1`
- `make ci`

