### PR TITLE
fix: remove FIXME marker and duplicate doc links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,12 @@ Fast demo entry points:
 - Works standalone (no backend required) and produces [ConfigHub-ready change bundles](https://confighub.github.io/cub-gen/platform/) for governed execution when connected.
 - Exposes supported generator families via `cub-gen generators`.
 
-## Documentation - FIXME **
+## Documentation
 
 Full documentation is published at **https://confighub.github.io/cub-gen/**
 
 - [Getting Started](https://confighub.github.io/cub-gen/getting-started/) — build and run your first import in 10 minutes
 - [The ConfigHub Platform](https://confighub.github.io/cub-gen/platform/) — how cub-gen connects to ConfigHub, bridge workers, and Flux/ArgoCD
-- [Architecture](https://confighub.github.io/cub-gen/architecture/) — DRY/WET model, field-origin maps, governed execution
-- [Generator Reference](https://confighub.github.io/cub-gen/generators/) — contract triples for all 8 generator kinds
 - [Architecture](https://confighub.github.io/cub-gen/agentic-gitops/02-design/00-agentic-gitops-design/) — DRY/WET model, field-origin maps, governed execution
 - [Generator Reference](https://confighub.github.io/cub-gen/triple-styles/) — contract triples for all 8 generator kinds
 - [CLI Reference](https://confighub.github.io/cub-gen/cli-reference/) — full command and flag documentation


### PR DESCRIPTION
## Summary
- Remove leftover `- FIXME **` from Documentation heading
- Remove duplicate Architecture and Generator Reference links (first pair had wrong URLs)

## Test plan
- [x] Visual inspection of README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)