### PR TITLE
docs: clarify examples/demo onboarding with local vs connected modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,107 @@
 # cub-gen
 
-`cub-gen` is the local-first entry point to the [ConfigHub](https://github.com/confighubai/confighub) platform — a deterministic DRY → WET generator importer with command-shape parity to `cub gitops`.
+`cub-gen` tells you where deployed fields came from in your existing GitOps repo, and what file to edit safely.
 
-## Start here (intro + demos)
+It works on config you already have (Helm, Score, Spring Boot, Backstage, ops workflows, c3agent, and more) and emits:
 
-If you are new, use this path first:
+1. provenance ("what generated this")
+2. field-origin maps ("which source field controls this deployed field")
+3. inverse-edit guidance ("edit this path in this file")
+
+## What It Is, What It Is Not
+
+`cub-gen` is:
+
+- A local-first analysis and import CLI for platform/app config.
+- An on-ramp to governed execution in ConfigHub.
+
+`cub-gen` is not:
+
+- A reconciler replacement (Flux/Argo still reconcile WET -> LIVE).
+- A Kubernetes controller that enforces policy by itself.
+
+## The Core Value In 10 Seconds
+
+You can take a deployed field and trace it back to the right source edit:
+
+```json
+{
+  "wet_path": "Deployment/spec/template/spec/containers[name=main]/image",
+  "dry_path": "containers.main.image",
+  "owner": "app-team",
+  "edit_hint": "Edit the Score container image in score.yaml.",
+  "confidence": 0.94
+}
+```
+
+That is the day-to-day problem `cub-gen` solves.
+
+## ConfigHub Exists Today
+
+ConfigHub is not hypothetical. The backend/control plane exists and is open source at:
+[https://github.com/confighubai/confighub](https://github.com/confighubai/confighub)
+
+`cub-gen` is the local-first front door to that platform.
+
+## Start Here
+
+If you are new, use this path:
 
 1. Plain-English platform story:
    [`docs/workflows/build-your-own-heroku-in-a-weekend.md`](docs/workflows/build-your-own-heroku-in-a-weekend.md)
-2. Example catalog and narratives:
+2. Example catalog:
    [`examples/README.md`](examples/README.md)
 3. Demo track index:
    [`examples/demo/README.md`](examples/demo/README.md)
 
-Fast demo entry points:
+## Quickstart: Local Mode (No Login Required)
 
-- Core module walkthrough (all modules): `./examples/demo/run-all-modules.sh`
-- AI work platform scenarios: `./examples/demo/ai-work-platform/run-all.sh`
-- AI Ops PaaS narrative demo: `./examples/ai-ops-paas/demo.sh`
-- Full lifecycle matrix (create -> govern -> update): `./examples/demo/run-all-confighub-lifecycles.sh`
-- Live Flux reconciliation proof (kind + Flux): `./examples/demo/e2e-live-reconcile-flux.sh`
+```bash
+go build -o ./cub-gen ./cmd/cub-gen
+./cub-gen gitops discover --space platform ./examples/scoredev-paas
+./cub-gen gitops import --space platform --json ./examples/scoredev-paas ./examples/scoredev-paas \
+  | jq '.provenance[0].inverse_edit_pointers[:2]'
+```
 
-## What cub-gen does today
+Use this mode when you want immediate value from existing repos without backend setup.
 
-- Detects generator-style app sources in Git repos (`helm`, `score.dev`, `springboot`, `backstage`, `ably-config`, `ops-workflow`, `c3agent`, `swamp`).
-- Runs the same staged flow shape as `cub gitops`:
-  - `gitops discover`
-  - `gitops import`
-  - `gitops cleanup`
-- Emits provenance and inverse-edit guidance ("what rendered field came from which DRY field").
-- Works standalone (no backend required) and produces [ConfigHub-ready change bundles](https://confighub.github.io/cub-gen/platform/) for governed execution when connected.
-- Exposes supported generator families via `cub-gen generators`.
+## Quickstart: Connected Mode (ConfigHub)
+
+```bash
+# 1) Log into ConfigHub with cub
+cub auth login
+
+# 2) Build a governed change bundle from your repo
+./cub-gen publish --space platform ./examples/scoredev-paas ./examples/scoredev-paas > bundle.json
+./cub-gen verify --in bundle.json
+./cub-gen attest --in bundle.json --verifier ci-bot > attestation.json
+
+# 3) Submit to ConfigHub
+./cub-gen bridge ingest --in bundle.json --base-url https://confighub.example > ingest.json
+```
+
+If your ConfigHub endpoint requires bearer auth for bridge calls, pass `--token`.
 
 ## Documentation
 
-Full documentation is published at **https://confighub.github.io/cub-gen/**
+Full docs are published at **https://confighub.github.io/cub-gen/**.
 
-- [Getting Started](https://confighub.github.io/cub-gen/getting-started/) — build and run your first import in 10 minutes
-- [The ConfigHub Platform](https://confighub.github.io/cub-gen/platform/) — how cub-gen connects to ConfigHub, bridge workers, and Flux/ArgoCD
-- [Architecture](https://confighub.github.io/cub-gen/agentic-gitops/02-design/00-agentic-gitops-design/) — DRY/WET model, field-origin maps, governed execution
-- [Generator Reference](https://confighub.github.io/cub-gen/triple-styles/) — contract triples for all 8 generator kinds
-- [CLI Reference](https://confighub.github.io/cub-gen/cli-reference/) — full command and flag documentation
-- [Contributing](https://confighub.github.io/cub-gen/contributing-guide/) — proof-first delivery, test-backed PRs
+- [Getting Started](https://confighub.github.io/cub-gen/getting-started/)
+- [The ConfigHub Platform](https://confighub.github.io/cub-gen/platform/)
+- [CLI Reference](https://confighub.github.io/cub-gen/cli-reference/)
+- [Examples](examples/README.md)
+- [Contributing](https://confighub.github.io/cub-gen/contributing-guide/)
 
-## Part of the ConfigHub platform
+## One Platform, Multiple Workload Adapters
 
-`cub-gen` is the local-first on-ramp. The full stack:
+This is one model with different adapters:
 
-1. **DRY** app intent lives in Git (`Chart.yaml`, `score.yaml`, `application.yaml`, etc.)
-2. **cub-gen** classifies DRY inputs + WET targets and emits provenance with field-origin tracing
-3. **cub-gen publish** produces change bundles with SHA-256 digest verification
-4. **[ConfigHub](https://github.com/confighubai/confighub)** ingests bundles, enforces governed decision state (ALLOW | ESCALATE | BLOCK), manages units with revision history
-5. **Bridge workers** connect ConfigHub to clusters via HTTP/2 SSE (Kubernetes, Flux, ArgoCD)
-6. **Flux/Argo** continue to reconcile WET → LIVE — unchanged
+- Spring Boot (`application.yaml`)
+- Helm (`Chart.yaml` + `values.yaml`)
+- score.dev (`score.yaml`)
+- c3agent (`c3agent.yaml`)
 
-Teams can start with `cub-gen` locally today and connect to ConfigHub when they need cross-repo queries, policy at write time, and governed execution. See the [platform docs](https://confighub.github.io/cub-gen/platform/) for the full story.
-
-## One platform, different workload adapters
-
-`cub-gen` models one platform pattern that supports many workload types.
-
-It is not "one PaaS for Spring Boot" and a different one for Helm or AI agents.
-It is one governance layer with workload adapters:
-
-- Spring Boot adapter reads `application.yaml` conventions.
-- Helm adapter reads `Chart.yaml` + `values.yaml`.
-- score.dev adapter reads `score.yaml`.
-- c3agent adapter reads `c3agent.yaml`.
-
-Same flow every time:
-
-1. Team pushes workload config to Git.
-2. `cub-gen` discovers/imports and emits provenance + inverse edit guidance.
-3. Flux/Argo reconciles rendered manifests.
-
-### Who does what
-
-- Platform team: defines adapters, defaults, and guardrails once.
-- App team: writes app config and code (the files they already use).
-
-### Which comes first in practice
-
-Most orgs start with existing repos and drifted manifests.
-
-1. Path 1 (most common): import what already exists to get visibility and governance first.
-2. Path 2 (next step): standardize clean self-service contracts after visibility is in place.
-
-For a plain-English narrative and team responsibilities, see
-[`docs/workflows/build-your-own-heroku-in-a-weekend.md`](docs/workflows/build-your-own-heroku-in-a-weekend.md).
+Platform team defines adapters/guardrails once. App teams keep writing the files they already use.
 
 ## Jump-in demo modules
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,142 +1,110 @@
 # Examples — Governed Config for Every Stack
 
-You already have a deployment pipeline. Git, Helm, Flux, Argo, Spring Boot, Score —
-whatever you use to get code running in production. That pipeline works.
+You already have a deployment pipeline: Git, Helm, Flux, Argo, Spring Boot, Score, or internal workflows.
 
-What it can't answer: *who changed this field, what generator produced it,
-why was it allowed, and what would break if I change it back?*
+`cub-gen` adds the missing answers:
 
-**cub-gen** is a local CLI that scans your existing repo, classifies every config
-file by owner and purpose, and produces a traceable evidence chain — without
-changing your workflow.
+- who changed this field,
+- what source produced this deployed value,
+- who owns it,
+- what file to edit safely.
 
-Each example in this directory is a complete, runnable scenario for a specific
-technology stack. Pick the one closest to your world and try it.
+Each example in this directory is runnable and maps to a real platform/app pattern.
 
-## What is cub-gen?
+## What `cub-gen` does
 
-`cub-gen` is a deterministic, Git-native generator importer. It reads your
-existing config files (Helm charts, Spring Boot properties, Score workloads,
-AI agent fleet configs, operational workflows) and produces:
+`cub-gen` is a deterministic, Git-native generator importer. It reads existing config and emits:
 
-1. **Generator detection** — recognizes what kind of project you have
-2. **DRY/WET classification** — separates human-authored intent (DRY) from
-   rendered deployment artifacts (WET)
-3. **Field-origin tracing** — maps every deployed field back to its source file,
-   line, and owner
-4. **Inverse-edit guidance** — tells you *where to edit* to change a deployed value
-5. **Evidence bundles** — publish, verify, and attest changes for governance
+1. generator detection (what type of project this is),
+2. DRY/WET classification (authoring intent vs rendered targets),
+3. field-origin tracing (WET field -> DRY source path),
+4. inverse-edit guidance (where to edit),
+5. evidence bundles (`publish`, `verify`, `attest`).
 
-It runs locally. No server required. No vendor lock-in at the CLI layer.
-When you're ready for cross-repo queries, policy evaluation, and governed
-decisions, connect to [ConfigHub](https://confighub.com).
+## Run modes
 
-## How DRY → WET → LIVE works
+## Local mode (fastest, no login required)
 
-```
- YOU EDIT (DRY)              cub-gen TRACES (WET)           RECONCILER DEPLOYS (LIVE)
-┌──────────────┐           ┌───────────────────┐          ┌──────────────────┐
-│ values.yaml  │──detect──▶│ Deployment.yaml   │──Flux───▶│ Running pod      │
-│ score.yaml   │  import   │ Service.yaml      │  Argo    │ Live config      │
-│ app.yaml     │  publish  │ ConfigMap.yaml     │          │ Cluster state    │
-│ c3agent.yaml │           │ HelmRelease.yaml  │          │                  │
-└──────────────┘           └───────────────────┘          └──────────────────┘
-       │                          │                              │
-   Your files.               What generators               What's actually
-   You own these.            produce from them.             running.
+```bash
+go build -o ./cub-gen ./cmd/cub-gen
+./examples/demo/run-all-modules.sh
+./examples/demo/run-all-confighub-lifecycles.sh
 ```
 
-- **DRY** = the files you edit in Git. Human-authored intent.
-- **WET** = rendered manifests that generators produce from DRY. Machine-readable,
-  queryable, governable.
-- **LIVE** = what's actually running in your cluster. Reconciled by Flux/Argo.
+## Connected mode (ConfigHub)
 
-cub-gen works at the DRY→WET boundary. It doesn't replace your reconciler — it
-makes the link between "what you wrote" and "what got deployed" explicit and
-traceable.
+```bash
+cub auth login
+TOKEN="$(cub auth get-token)"
+BASE_URL="https://confighub.example"
+
+./cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas > /tmp/bundle.json
+./cub-gen verify --in /tmp/bundle.json
+./cub-gen attest --in /tmp/bundle.json --verifier ci-bot > /tmp/attestation.json
+./cub-gen bridge ingest --in /tmp/bundle.json --base-url "$BASE_URL" --token "$TOKEN" > /tmp/ingest.json
+```
+
+Use local mode for first value. Use connected mode for centralized governance state and cross-repo visibility.
 
 ## Verifier identity
 
-When you run `cub-gen attest --verifier <name>`, the verifier name identifies
-*who or what* vouches for the evidence bundle. Common verifier identities:
+When you run `cub-gen attest --verifier <name>`, the verifier name records who/what attested the bundle.
 
 | Verifier | When to use |
 |----------|-------------|
-| `ci-bot` | CI pipeline attestation (GitHub Actions, GitLab CI, Jenkins) |
-| `platform-lead` | Human platform engineer sign-off |
-| `security-review` | Security team review attestation |
+| `ci-bot` | CI pipeline attestation |
+| `platform-lead` | Human platform sign-off |
+| `security-review` | Security approval |
 | `deploy-agent` | Automated deployment agent |
-
-The verifier is a string label — not a cryptographic identity (yet). It records
-*intent*: "this actor reviewed and approved this evidence bundle." Future versions
-will support signature-based verification.
 
 ## Pick your starting point
 
-### Platform + App patterns (Kubernetes workloads)
+## Platform + app patterns (Kubernetes workloads)
 
 | Example | You use... | cub-gen shows you... |
 |---------|-----------|---------------------|
 | [**helm-paas**](helm-paas/) | Helm charts + values overlays | Chart contract tracing, values ownership, ALLOW/BLOCK governance |
-| [**scoredev-paas**](scoredev-paas/) | Score.dev workload specs | Platform-agnostic DRY with full field-origin mapping |
-| [**springboot-paas**](springboot-paas/) | Spring Boot + application.yaml | Framework config ownership, datasource vs app-config boundaries |
+| [**scoredev-paas**](scoredev-paas/) | Score.dev workload specs | DRY intent with field-origin mapping |
+| [**springboot-paas**](springboot-paas/) | Spring Boot + `application.yaml` | App/platform ownership boundaries |
 
-### Integration patterns (external services + developer portals)
-
-| Example | You use... | cub-gen shows you... |
-|---------|-----------|---------------------|
-| [**backstage-idp**](backstage-idp/) | Backstage software catalog | Catalog entity governance with ownership standards |
-| [**just-apps-no-platform-config**](just-apps-no-platform-config/) | SaaS provider config (Ably, etc.) | App-only config without platform layer — simplest possible example |
-
-### AI + automation patterns
+## Integration patterns (external services + developer portals)
 
 | Example | You use... | cub-gen shows you... |
 |---------|-----------|---------------------|
-| [**c3agent**](c3agent/) | AI agent fleets (Claude, GPT) | Fleet config governance, model policy, token budgets |
-| [**ai-ops-paas**](ai-ops-paas/) | Full AI platform with registry + constraints | Enterprise AI fleet with constraint enforcement |
-| [**swamp-automation**](swamp-automation/) | Swamp AI workflow orchestration | DAG workflows with model binding governance |
-| [**swamp-project**](swamp-project/) | Helm chart for AI runtime | Helm-based Swamp deployment with model gateway policy |
+| [**backstage-idp**](backstage-idp/) | Backstage software catalog | Catalog governance with ownership standards |
+| [**just-apps-no-platform-config**](just-apps-no-platform-config/) | SaaS provider config | App-only config governance without platform layer |
 
-### Operations patterns
+## AI + automation patterns
 
 | Example | You use... | cub-gen shows you... |
 |---------|-----------|---------------------|
-| [**ops-workflow**](ops-workflow/) | Scheduled maintenance + rollouts | Execution policy, approval gates, deploy windows |
-| [**confighub-actions**](confighub-actions/) | ConfigHub lifecycle automation | Recursive governance — ConfigHub governing itself |
+| [**c3agent**](c3agent/) | AI agent fleets | Fleet config governance, model policy, budget controls |
+| [**ai-ops-paas**](ai-ops-paas/) | Full AI platform + constraints | Registry + constraints + governed lifecycle |
+| [**swamp-automation**](swamp-automation/) | Swamp workflow orchestration | DAG/model binding governance |
+| [**swamp-project**](swamp-project/) | Helm chart for AI runtime | Helm-based runtime policy mapping |
 
-### Infrastructure
+## Operations patterns
+
+| Example | You use... | cub-gen shows you... |
+|---------|-----------|---------------------|
+| [**ops-workflow**](ops-workflow/) | Scheduled maintenance workflows | Approval and execution policy mapping |
+| [**confighub-actions**](confighub-actions/) | ConfigHub lifecycle automation | Recursive governance (ConfigHub governing itself) |
+
+## Infrastructure
 
 | Example | Purpose |
 |---------|---------|
-| [**live-reconcile**](live-reconcile/) | Flux e2e test fixture — proves WET→LIVE reconciliation |
-| [**demo**](demo/) | Runnable demo scripts for all examples |
+| [**live-reconcile**](live-reconcile/) | Flux e2e fixture proving WET->LIVE reconciliation |
+| [**demo**](demo/) | Runnable demo script index |
 
-## Quick start
+## How to read each example
 
-```bash
-# Build once
-go build -o ./cub-gen ./cmd/cub-gen
+Every example README should answer:
 
-# Pick any example — here's helm-paas
-./cub-gen gitops discover --space platform ./examples/helm-paas
-./cub-gen gitops import --space platform --json ./examples/helm-paas ./examples/helm-paas
+1. What scenario it models.
+2. Who owns which fields.
+3. How to run local mode.
+4. How to run connected mode.
+5. What proof artifacts to inspect.
 
-# Full evidence chain (works with any example)
-./cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas > bundle.json
-./cub-gen verify --in bundle.json
-./cub-gen attest --in bundle.json --verifier ci-bot > attestation.json
-./cub-gen verify-attestation --in attestation.json --bundle bundle.json
-
-# Bridge to ConfigHub (governance decisions)
-./cub-gen bridge ingest --in bundle.json --base-url https://confighub.example > ingest.json
-./cub-gen bridge decision create --ingest ingest.json > decision.json
-./cub-gen bridge decision apply --decision decision.json --state ALLOW \
-  --approved-by platform-lead --reason "reviewed and approved"
-```
-
-## Next steps
-
-- **Run the E2E demo**: `./examples/demo/run-all-modules.sh`
-- **Try the AI work platform demos**: `./examples/demo/ai-work-platform/run-all.sh`
-- **Read the design docs**: `docs/agentic-gitops/`
-- **Contribute a new generator**: see [CONTRIBUTING.md](../CONTRIBUTING.md)
+For acceptance criteria across examples, see [Example Checklist](../docs/workflows/example-checklist.md).

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -1,72 +1,98 @@
 # Demo Scripts
 
-Runnable demo scripts for every cub-gen example. Each script demonstrates the
-full flow: detect → import → publish → verify → attest → bridge.
+Runnable demo scripts for every `cub-gen` example.
+
+Each script demonstrates part of the flow:
+
+```
+detect -> import -> publish -> verify -> attest -> (optional) bridge ingest/query
+```
+
+## Local mode (no ConfigHub login required)
 
 ## Core platform/app track
 
 | Script | Example | What it demonstrates |
 |--------|---------|---------------------|
-| `module-1-helm-import.sh` | [`helm-paas`](../helm-paas/) | Helm chart detection, values ownership, field-origin tracing |
-| `module-2-score-field-map.sh` | [`scoredev-paas`](../scoredev-paas/) | Score workload spec with full field-origin mapping |
-| `module-3-spring-ownership.sh` | [`springboot-paas`](../springboot-paas/) | Spring Boot ownership boundaries (app vs platform fields) |
-| `module-4-bridge-governance.sh` | All examples | Bridge flow: ingest → decision → ALLOW/BLOCK |
+| `module-1-helm-import.sh` | [`helm-paas`](../helm-paas/) | Helm detection, values ownership, field-origin tracing |
+| `module-2-score-field-map.sh` | [`scoredev-paas`](../scoredev-paas/) | Score field-origin and inverse edit mapping |
+| `module-3-spring-ownership.sh` | [`springboot-paas`](../springboot-paas/) | Spring ownership boundaries (app vs platform) |
+| `module-4-bridge-governance.sh` | Multiple | Local bridge contract simulation |
 | `module-5-ably-platform.sh` | [`just-apps-no-platform-config`](../just-apps-no-platform-config/) | Provider config governance without platform layer |
-| `run-all-modules.sh` | All above | Run all core modules in sequence |
+| `run-all-modules.sh` | All above | Run all core modules |
 
 ## AI work platform track
 
 | Script | Example | What it demonstrates |
 |--------|---------|---------------------|
-| `ai-work-platform/scenario-1-c3agent.sh` | [`c3agent`](../c3agent/) + [`ai-ops-paas`](../ai-ops-paas/) | 11-target c3agent metadata coverage |
-| `ai-work-platform/scenario-2-swamp.sh` | [`swamp-automation`](../swamp-automation/) | Swamp workflow governance with model bindings |
-| `ai-work-platform/scenario-3-confighub-actions.sh` | [`confighub-actions`](../confighub-actions/) | Recursive governance — ConfigHub governing itself |
-| `ai-work-platform/scenario-4-operations.sh` | [`ops-workflow`](../ops-workflow/) | Operations workflow with execution policy |
+| `ai-work-platform/scenario-1-c3agent.sh` | [`c3agent`](../c3agent/) + [`ai-ops-paas`](../ai-ops-paas/) | c3agent 11-target coverage |
+| `ai-work-platform/scenario-2-swamp.sh` | [`swamp-automation`](../swamp-automation/) | Swamp workflow/model governance |
+| `ai-work-platform/scenario-3-confighub-actions.sh` | [`confighub-actions`](../confighub-actions/) | Recursive governance |
+| `ai-work-platform/scenario-4-operations.sh` | [`ops-workflow`](../ops-workflow/) | Operations workflow governance |
 | `ai-work-platform/run-all.sh` | All above | Run all AI platform scenarios |
 
-## ConfigHub lifecycle simulation
+## Lifecycle simulation scripts
 
 | Script | What it demonstrates |
 |--------|---------------------|
-| `simulate-confighub-lifecycle.sh <repo> <target> [slug]` | Full lifecycle: create → govern → update |
-| `run-all-confighub-lifecycles.sh` | Run lifecycle sim for every example |
-| `simulate-repo-wizard.sh <repo> <target> [hint]` | GUI-wizard simulation |
+| `simulate-confighub-lifecycle.sh <repo> <target> [slug]` | Full local lifecycle simulation |
+| `run-all-confighub-lifecycles.sh` | Lifecycle simulation across current fixtures |
+| `simulate-repo-wizard.sh <repo> <target> [hint]` | GUI wizard simulation path |
+
+## Connected mode (ConfigHub)
+
+Start with authentication:
+
+```bash
+cub auth login
+TOKEN="$(cub auth get-token)"
+```
+
+Then run bridge calls with `--token "$TOKEN"` and your `--base-url`.
+
+Connected flow shape:
+
+```
+publish -> verify -> attest -> bridge ingest -> decision query
+```
+
+Connected ingest/query are real ConfigHub API calls. Some decision/promotion steps in current demo scripts are still local contract simulation.
 
 ## Live reconciler e2e (Flux + kind)
 
 | Script | What it demonstrates |
 |--------|---------------------|
-| `e2e-live-reconcile-flux.sh` | Real WET→LIVE reconciliation with Flux on a local kind cluster |
+| `e2e-live-reconcile-flux.sh` | Real WET->LIVE reconciliation with Flux on local kind cluster |
 
-This script creates a local `kind` cluster, installs Flux, and proves:
-1. Create reconciliation (v1 applied to LIVE)
-2. Update reconciliation (v2 rolled out)
-3. Drift correction (manual drift reverted by Flux)
+This script proves:
+
+1. Create reconciliation (v1 to LIVE).
+2. Update reconciliation (v2 rollout).
+3. Drift correction (manual drift reverted).
 
 Uses fixtures from [`live-reconcile`](../live-reconcile/).
 
 ## Quick start
 
 ```bash
-# Build cub-gen first
 go build -o ./cub-gen ./cmd/cub-gen
-
-# Run all core demos
 ./examples/demo/run-all-modules.sh
-
-# Run all AI platform demos
 ./examples/demo/ai-work-platform/run-all.sh
-
-# Run a single module
-./examples/demo/module-1-helm-import.sh
 ```
 
-## Persona value bundles
+## Qualification caveat
 
-`persona-value-bundles.sh` generates output organized by persona:
+Without a live `WET -> LIVE` reconciler loop shown end-to-end, classify the flow as `governed config automation`, not full `Agentic GitOps`.
 
-- **App team**: field-edit maps for Score and Spring Boot
-- **GitOps team**: Helm bundles, attestations, verification
-- **Platform engineer**: generator details, import summaries
+References:
 
-Output goes to `output/persona-value/`.
+- `docs/agentic-gitops/03-worked-examples/04-eight-example-story-cards.md`
+- `docs/agentic-gitops/02-design/10-generators-prd.md`
+
+## PRD user-story coverage snapshot
+
+| Status | User stories |
+|---|---|
+| Met/strong in current demos | 2, 3, 4, 5, 6, 13 |
+| Partial (simulated/local-first, not full backend/runtime integration) | 1, 7, 9, 12 |
+| Deferred | 8, 10, 11 |


### PR DESCRIPTION
## Summary
- rewrites `examples/README.md` with explicit local vs connected run modes
- rewrites `examples/demo/README.md` with clearer script index and connected auth path
- keeps the new top-level README intro clarifications and aligns example entrypoints

## Key UX updates
- connected paths now start with `cub auth login`
- connected snippets use `cub auth get-token` + `--token` on bridge ingest
- stronger upfront explanation of what `cub-gen` is and where ConfigHub fits

## Validation
- `make ci` passes
