### PR TITLE
feat(cli): add first-class change preview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Flux/Argo still reconcile to LIVE. `cub-gen` adds governance before deploy and t
 - `change run`: execute the full governed flow (local or connected).
 - `change explain`: answer "what should I edit and why?" for a specific field.
 
-Today these are exposed via demo wrappers while the first-class CLI surface lands.
+`change preview` is available as a first-class CLI command.
+`change run` and `change explain` are mapped through the demo wrappers until their native subcommands land.
 
 ## Core Value in 10 Seconds
 
@@ -78,6 +79,7 @@ This gives immediate value with local evidence and lifecycle outputs.
 If you want one command that returns the edit recommendation plus evidence artifacts:
 
 ```bash
+./cub-gen change preview --space platform ./examples/scoredev-paas ./examples/scoredev-paas
 ./examples/demo/app-ai-change-run.sh ./examples/scoredev-paas
 ```
 

--- a/cmd/cub-gen/change_command_test.go
+++ b/cmd/cub-gen/change_command_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestChangePreviewJSON(t *testing.T) {
+	setupAliases(t)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "preview",
+		"--space", "platform",
+		"score",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("change preview returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change preview output: %v\noutput=%s", err, out)
+	}
+
+	change, ok := got["change"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected change object, got %T", got["change"])
+	}
+	if changeID, ok := change["change_id"].(string); !ok || !strings.HasPrefix(changeID, "chg_") {
+		t.Fatalf("unexpected change_id: %v", change["change_id"])
+	}
+	if digest, ok := change["bundle_digest"].(string); !ok || !strings.HasPrefix(digest, "sha256:") {
+		t.Fatalf("unexpected bundle_digest: %v", change["bundle_digest"])
+	}
+
+	verification, ok := got["verification"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected verification object, got %T", got["verification"])
+	}
+	if valid, ok := verification["bundle_valid"].(bool); !ok || !valid {
+		t.Fatalf("expected bundle_valid=true, got %v", verification["bundle_valid"])
+	}
+	if valid, ok := verification["attestation_valid"].(bool); !ok || !valid {
+		t.Fatalf("expected attestation_valid=true, got %v", verification["attestation_valid"])
+	}
+
+	recommendation, ok := got["edit_recommendation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected edit_recommendation object, got %T", got["edit_recommendation"])
+	}
+	if owner, ok := recommendation["owner"].(string); !ok || strings.TrimSpace(owner) == "" {
+		t.Fatalf("expected non-empty owner, got %v", recommendation["owner"])
+	}
+}
+
+func TestChangeCommandErrorModes(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		sub  string
+	}{
+		{
+			name: "missing-subcommand",
+			args: []string{"change"},
+			sub:  "change subcommand required",
+		},
+		{
+			name: "unknown-subcommand",
+			args: []string{"change", "run"},
+			sub:  "unknown change subcommand",
+		},
+		{
+			name: "preview-missing-targets",
+			args: []string{"change", "preview"},
+			sub:  "usage: cub-gen change preview",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := runWithCapturedIO(tc.args)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.sub) {
+				t.Fatalf("expected error containing %q, got %q", tc.sub, err.Error())
+			}
+		})
+	}
+}

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -48,6 +48,8 @@ func run(args []string) error {
 		return runAttest(args[1:])
 	case "verify-attestation":
 		return runVerifyAttestation(args[1:])
+	case "change":
+		return runChange(args[1:])
 	case "generators":
 		return runGenerators(args[1:])
 	case "gitops":
@@ -958,6 +960,191 @@ func runVerifyAttestation(args []string) error {
 	return nil
 }
 
+type changePreviewInput struct {
+	TargetSlug       string `json:"target_slug"`
+	RenderTargetSlug string `json:"render_target_slug"`
+	Space            string `json:"space"`
+	Ref              string `json:"ref"`
+	WhereResource    string `json:"where_resource,omitempty"`
+}
+
+type changePreviewSummary struct {
+	ChangeID          string `json:"change_id"`
+	BundleDigest      string `json:"bundle_digest"`
+	AttestationDigest string `json:"attestation_digest"`
+}
+
+type changePreviewCounts struct {
+	DiscoveredResources int `json:"discovered_resources"`
+	DryInputs           int `json:"dry_inputs"`
+	WetTargets          int `json:"wet_targets"`
+	InversePatches      int `json:"inverse_patches"`
+}
+
+type changePreviewVerification struct {
+	BundleValid      bool   `json:"bundle_valid"`
+	AttestationValid bool   `json:"attestation_valid"`
+	Verifier         string `json:"verifier"`
+}
+
+type changePreviewResult struct {
+	Input              changePreviewInput        `json:"input"`
+	Change             changePreviewSummary      `json:"change"`
+	DiscoveredProfile  []string                  `json:"discovered_profiles"`
+	Counts             changePreviewCounts       `json:"counts"`
+	EditRecommendation model.InverseEditPointer  `json:"edit_recommendation"`
+	Verification       changePreviewVerification `json:"verification"`
+}
+
+func runChange(args []string) error {
+	if len(args) == 0 {
+		printChangeUsage(os.Stderr)
+		return errors.New("change subcommand required")
+	}
+
+	switch args[0] {
+	case "help", "-h", "--help":
+		printChangeUsage(os.Stdout)
+		return nil
+	case "preview":
+		return runChangePreview(args[1:])
+	default:
+		printChangeUsage(os.Stderr)
+		return fmt.Errorf("unknown change subcommand: %s", args[0])
+	}
+}
+
+func runChangePreview(args []string) error {
+	fs := flag.NewFlagSet("change preview", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	space := fs.String("space", "default", "ConfigHub space label")
+	ref := fs.String("ref", "HEAD", "Git ref label to include in output")
+	whereResource := fs.String("where-resource", "", "Additional resource filter expression")
+	out := fs.String("out", "-", "Output file path, or '-' for stdout")
+	verifier := fs.String("verifier", "cub-gen", "Verifier identity label")
+	jsonOut := fs.Bool("json", true, "Output JSON")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	_ = jsonOut
+
+	if fs.NArg() != 2 {
+		return errors.New("usage: cub-gen change preview [flags] <target-slug> <render-target-slug>")
+	}
+	targetSlug := fs.Arg(0)
+	renderTargetSlug := fs.Arg(1)
+
+	imported, err := gitopsflow.Import(targetSlug, renderTargetSlug, *ref, *space, *whereResource)
+	if err != nil {
+		return err
+	}
+
+	bundle := publish.BuildBundle(imported)
+	if err := publish.VerifyBundle(bundle); err != nil {
+		return fmt.Errorf("verify generated bundle: %w", err)
+	}
+
+	attestationRecord, err := attest.Build(bundle, *verifier)
+	if err != nil {
+		return fmt.Errorf("build attestation: %w", err)
+	}
+	if err := attest.VerifyRecordAgainstBundle(attestationRecord, bundle); err != nil {
+		return fmt.Errorf("verify generated attestation: %w", err)
+	}
+
+	topEdit, ok := bestInverseEditPointer(imported.Provenance)
+	if !ok {
+		topEdit = model.InverseEditPointer{
+			Owner:    "unknown",
+			EditHint: "No inverse edit hint produced.",
+		}
+	}
+
+	result := changePreviewResult{
+		Input: changePreviewInput{
+			TargetSlug:       targetSlug,
+			RenderTargetSlug: renderTargetSlug,
+			Space:            *space,
+			Ref:              *ref,
+			WhereResource:    strings.TrimSpace(*whereResource),
+		},
+		Change: changePreviewSummary{
+			ChangeID:          bundle.ChangeID,
+			BundleDigest:      bundle.BundleDigest,
+			AttestationDigest: attestationRecord.AttestationDigest,
+		},
+		DiscoveredProfile: discoveredProfiles(imported.Discovered),
+		Counts: changePreviewCounts{
+			DiscoveredResources: len(imported.Discovered),
+			DryInputs:           len(imported.DryInputs),
+			WetTargets:          len(imported.WetManifestTargets),
+			InversePatches:      countInversePatches(imported.InversePlans),
+		},
+		EditRecommendation: topEdit,
+		Verification: changePreviewVerification{
+			BundleValid:      true,
+			AttestationValid: true,
+			Verifier:         *verifier,
+		},
+	}
+
+	if *out == "-" {
+		return writeJSON(os.Stdout, result, *pretty)
+	}
+
+	f, err := os.Create(*out)
+	if err != nil {
+		return fmt.Errorf("create output file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	return writeJSON(f, result, *pretty)
+}
+
+func bestInverseEditPointer(provenance []model.ProvenanceRecord) (model.InverseEditPointer, bool) {
+	best := model.InverseEditPointer{}
+	found := false
+	for _, record := range provenance {
+		for _, pointer := range record.InverseEditPointers {
+			if !found || pointer.Confidence > best.Confidence {
+				best = pointer
+				found = true
+			}
+		}
+	}
+	return best, found
+}
+
+func discoveredProfiles(discovered []gitopsflow.DiscoveredResource) []string {
+	set := map[string]struct{}{}
+	for _, resource := range discovered {
+		profile := strings.TrimSpace(resource.GeneratorProfile)
+		if profile == "" {
+			continue
+		}
+		set[profile] = struct{}{}
+	}
+	profiles := make([]string, 0, len(set))
+	for profile := range set {
+		profiles = append(profiles, profile)
+	}
+	sort.Strings(profiles)
+	return profiles
+}
+
+func countInversePatches(plans []model.InverseTransformPlan) int {
+	total := 0
+	for _, plan := range plans {
+		total += len(plan.Patches)
+	}
+	return total
+}
+
 func runGitOps(args []string) error {
 	if len(args) == 0 {
 		printGitOpsUsage(os.Stderr)
@@ -1411,6 +1598,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen verify [--in FILE|-] [--json] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out, "  cub-gen bridge <ingest|decision|promote> [flags]")
@@ -1439,6 +1627,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/just-apps-no-platform-config ./examples/just-apps-no-platform-config | cub-gen attest --in - --verifier ci-bot")
 	fmt.Fprintln(out, "  cub-gen publish --space my-space ./examples/ops-workflow ./examples/ops-workflow | cub-gen attest --in - --verifier ci-bot")
 	fmt.Fprintln(out, "  cub-gen verify-attestation --in attestation.json --bundle bundle.json")
+	fmt.Fprintln(out, "  cub-gen change preview --space my-space ./examples/scoredev-paas ./examples/scoredev-paas")
 	fmt.Fprintln(out, "  cub-gen bridge ingest --in bundle.json --base-url https://confighub.example")
 	fmt.Fprintln(out, "  cub-gen bridge decision query --change-id chg_123 --base-url https://confighub.example")
 	fmt.Fprintln(out, "  cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123")
@@ -1448,6 +1637,17 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen generators --capability render-manifests")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Note: gitops commands are local-only prototypes that mirror cub gitops stages.")
+}
+
+func printChangeUsage(out io.Writer) {
+	fmt.Fprintln(out, "cub-gen change: developer-facing change workflow commands")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Examples:")
+	fmt.Fprintln(out, "  cub-gen change preview --space my-space ./examples/helm-paas ./examples/helm-paas")
+	fmt.Fprintln(out, "  cub-gen change preview --space my-space ./examples/swamp-automation ./examples/swamp-automation")
 }
 
 func printGitOpsUsage(out io.Writer) {

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -8,6 +8,7 @@ Usage:
   cub-gen verify [--in FILE|-] [--json] [--pretty]
   cub-gen attest [--in FILE|-] [--out FILE|-] [--verifier NAME] [--pretty]
   cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]
+  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>
   cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]
   cub-gen gitops <discover|import|cleanup> [flags]
   cub-gen bridge <ingest|decision|promote> [flags]
@@ -36,6 +37,7 @@ GitOps parity examples:
   cub-gen publish --space my-space ./examples/just-apps-no-platform-config ./examples/just-apps-no-platform-config | cub-gen attest --in - --verifier ci-bot
   cub-gen publish --space my-space ./examples/ops-workflow ./examples/ops-workflow | cub-gen attest --in - --verifier ci-bot
   cub-gen verify-attestation --in attestation.json --bundle bundle.json
+  cub-gen change preview --space my-space ./examples/scoredev-paas ./examples/scoredev-paas
   cub-gen bridge ingest --in bundle.json --base-url https://confighub.example
   cub-gen bridge decision query --change-id chg_123 --base-url https://confighub.example
   cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123


### PR DESCRIPTION
## Summary
- add `cub-gen change preview` as a first-class CLI subcommand
- wire it to existing `gitops import -> publish -> verify -> attest` internals
- output a compact mutation summary with `change_id`, digest, top inverse-edit hint, and verification status
- add change command tests and update top-help parity golden
- update README to reflect `change preview` availability

## Validation
- make ci-local
