### PR TITLE
feat(demo): add runnable prompt-as-dry local/connected scripts

### DIFF
--- a/docs/workflows/prompt-as-dry.md
+++ b/docs/workflows/prompt-as-dry.md
@@ -33,7 +33,7 @@ Together, these represent "prompt as DRY": intent captured as a short workflow s
 Run one command:
 
 ```bash
-./examples/demo/app-ai-change-run.sh ./examples/swamp-automation
+./examples/demo/prompt-as-dry-local.sh
 ```
 
 This executes:
@@ -78,10 +78,7 @@ cub auth login
 Then run a connected lifecycle for the same DRY artifact:
 
 ```bash
-./examples/demo/run-confighub-lifecycle-connected.sh \
-  ./examples/swamp-automation \
-  ./examples/swamp-automation \
-  prompt-dry-swamp
+./examples/demo/prompt-as-dry-connected.sh
 ```
 
 This path performs real backend ingest/query and writes per-phase summaries:

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -52,6 +52,8 @@ If your platform is workflow-heavy, start here before app-manifest demos:
 | Script | What it demonstrates |
 |--------|---------------------|
 | `app-ai-change-run.sh <repo> [target]` | One-command app/AI path: import + publish + verify + attest + mutation card output |
+| `prompt-as-dry-local.sh [repo]` | Canonical prompt-as-DRY local path (Swamp workflow intent -> governed mutation card) |
+| `prompt-as-dry-connected.sh [repo] [target] [slug]` | Canonical prompt-as-DRY connected path (`cub auth login` + backend ingest/query lifecycle) |
 | `simulate-confighub-lifecycle.sh <repo> <target> [slug]` | Full local lifecycle simulation |
 | `run-all-confighub-lifecycles.sh` | Lifecycle simulation across current fixtures |
 | `run-confighub-lifecycle-connected.sh <repo> <target> [slug]` | Connected lifecycle: real ConfigHub ingest/query when bridge endpoints are available, with backend `changeset` fallback when they are not |
@@ -172,6 +174,7 @@ Connected CI bootstrap/runbook:
 ```bash
 go build -o ./cub-gen ./cmd/cub-gen
 ./examples/demo/app-ai-change-run.sh ./examples/scoredev-paas
+./examples/demo/prompt-as-dry-local.sh
 ./examples/demo/run-all-modules.sh
 ./examples/demo/ai-work-platform/run-all.sh
 ```

--- a/examples/demo/prompt-as-dry-connected.sh
+++ b/examples/demo/prompt-as-dry-connected.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/examples/demo/lib/connected-preflight.sh"
+
+REPO_PATH="${1:-./examples/swamp-automation}"
+RENDER_TARGET="${2:-$REPO_PATH}"
+SLUG="${3:-prompt-dry-swamp}"
+
+if [ ! -d "$REPO_PATH" ]; then
+  echo "error: repo path not found: $REPO_PATH" >&2
+  exit 1
+fi
+if [ ! -d "$RENDER_TARGET" ]; then
+  echo "error: render target path not found: $RENDER_TARGET" >&2
+  exit 1
+fi
+
+require_connected_preflight
+print_connected_context
+
+echo "[prompt-as-dry][connected] intent artifact: $REPO_PATH/workflow-deploy.yaml"
+./examples/demo/run-confighub-lifecycle-connected.sh "$REPO_PATH" "$RENDER_TARGET" "$SLUG"

--- a/examples/demo/prompt-as-dry-local.sh
+++ b/examples/demo/prompt-as-dry-local.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+REPO_PATH="${1:-./examples/swamp-automation}"
+
+if [ ! -d "$REPO_PATH" ]; then
+  echo "error: repo path not found: $REPO_PATH" >&2
+  exit 1
+fi
+
+echo "[prompt-as-dry][local] intent artifact: $REPO_PATH/workflow-deploy.yaml"
+./examples/demo/app-ai-change-run.sh "$REPO_PATH" "$REPO_PATH"


### PR DESCRIPTION
## Summary
- add dedicated prompt-as-DRY demo scripts:
  - `examples/demo/prompt-as-dry-local.sh`
  - `examples/demo/prompt-as-dry-connected.sh`
- update `prompt-as-dry.md` to use the runnable script entrypoints
- index these scripts in `examples/demo/README.md`

## Validation
- make ci-local
