### PR TITLE
ci(actions): bump checkout/setup-go to node24-ready versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     name: Build + Unit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -51,7 +51,7 @@ jobs:
       PROMOTION_PR_NUMBER: ${{ vars.PROMOTION_PR_NUMBER || secrets.PROMOTION_PR_NUMBER }}
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Determine connected prerequisites
         id: connected-preflight
@@ -99,7 +99,7 @@ jobs:
 
       - name: Set up Go
         if: steps.connected-preflight.outputs.can_run == 'true'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/connected-story7.yml
+++ b/.github/workflows/connected-story7.yml
@@ -22,7 +22,7 @@ jobs:
       RUN_ID: ${{ github.run_id }}
       VERIFIER: ci-bot
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required secrets
         run: |
@@ -31,7 +31,7 @@ jobs:
           test -n "$CONFIGHUB_TOKEN"
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- upgrade GitHub Actions versions to node24-ready majors:
  - `actions/checkout@v5`
  - `actions/setup-go@v6`
- apply across CI, connected-story7, and docs workflows

## Why
- removes current Node.js 20 deprecation warnings in CI logs
- keeps workflow runtime aligned with upcoming GitHub Actions defaults

## Validation
- make ci-local
