### PR TITLE
feat(cli): add first-class change explain command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Flux/Argo still reconcile to LIVE. `cub-gen` adds governance before deploy and t
 - `change run`: execute the full governed flow (local or connected).
 - `change explain`: answer "what should I edit and why?" for a specific field.
 
-`change preview` and `change run` are available as first-class CLI commands.
-`change explain` is mapped through the demo wrappers until its native subcommand lands.
+`change preview`, `change run`, and `change explain` are available as first-class CLI commands.
 
 ## Core Value in 10 Seconds
 

--- a/cmd/cub-gen/change_command_test.go
+++ b/cmd/cub-gen/change_command_test.go
@@ -113,6 +113,90 @@ func TestChangeRunConnectedMissingBaseURL(t *testing.T) {
 	}
 }
 
+func TestChangeExplainJSON(t *testing.T) {
+	setupAliases(t)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		"score",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, out)
+	}
+
+	explanation, ok := got["explanation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected explanation object, got %T", got["explanation"])
+	}
+	if owner, ok := explanation["owner"].(string); !ok || strings.TrimSpace(owner) == "" {
+		t.Fatalf("expected non-empty owner, got %v", explanation["owner"])
+	}
+	if wetPath, ok := explanation["wet_path"].(string); !ok || strings.TrimSpace(wetPath) == "" {
+		t.Fatalf("expected non-empty wet_path, got %v", explanation["wet_path"])
+	}
+	if dryPath, ok := explanation["dry_path"].(string); !ok || strings.TrimSpace(dryPath) == "" {
+		t.Fatalf("expected non-empty dry_path, got %v", explanation["dry_path"])
+	}
+}
+
+func TestChangeExplainWetPathFilter(t *testing.T) {
+	setupAliases(t)
+
+	previewOut, _, err := runWithCapturedIO([]string{
+		"change", "preview",
+		"--space", "platform",
+		"score",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("change preview returned error: %v", err)
+	}
+	var preview map[string]any
+	if err := json.Unmarshal([]byte(previewOut), &preview); err != nil {
+		t.Fatalf("unmarshal change preview output: %v", err)
+	}
+	recommendation, ok := preview["edit_recommendation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected edit_recommendation object, got %T", preview["edit_recommendation"])
+	}
+	wetPath, ok := recommendation["wet_path"].(string)
+	if !ok || strings.TrimSpace(wetPath) == "" {
+		t.Fatalf("expected wet_path recommendation, got %v", recommendation["wet_path"])
+	}
+
+	explainOut, _, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		"--wet-path", wetPath,
+		"score",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v", err)
+	}
+	var explain map[string]any
+	if err := json.Unmarshal([]byte(explainOut), &explain); err != nil {
+		t.Fatalf("unmarshal change explain output: %v", err)
+	}
+	query, ok := explain["query"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected query object, got %T", explain["query"])
+	}
+	if got, ok := query["wet_path_filter"].(string); !ok || got != wetPath {
+		t.Fatalf("expected wet_path_filter=%q, got %v", wetPath, query["wet_path_filter"])
+	}
+}
+
 func TestChangeCommandErrorModes(t *testing.T) {
 	tests := []struct {
 		name string
@@ -126,7 +210,7 @@ func TestChangeCommandErrorModes(t *testing.T) {
 		},
 		{
 			name: "unknown-subcommand",
-			args: []string{"change", "explain"},
+			args: []string{"change", "unknown"},
 			sub:  "unknown change subcommand",
 		},
 		{
@@ -138,6 +222,11 @@ func TestChangeCommandErrorModes(t *testing.T) {
 			name: "run-missing-targets",
 			args: []string{"change", "run"},
 			sub:  "usage: cub-gen change run",
+		},
+		{
+			name: "explain-missing-targets",
+			args: []string{"change", "explain"},
+			sub:  "usage: cub-gen change explain",
 		},
 	}
 

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -1011,6 +1011,32 @@ type changeRunResult struct {
 	PromotionReady bool                `json:"promotion_ready"`
 }
 
+type changeExplainQuery struct {
+	WetPathFilter string `json:"wet_path_filter,omitempty"`
+	DryPathFilter string `json:"dry_path_filter,omitempty"`
+	OwnerFilter   string `json:"owner_filter,omitempty"`
+	MatchCount    int    `json:"match_count"`
+}
+
+type changeExplainSuggestion struct {
+	Owner            string  `json:"owner"`
+	WetPath          string  `json:"wet_path"`
+	DryPath          string  `json:"dry_path"`
+	EditHint         string  `json:"edit_hint"`
+	Confidence       float64 `json:"confidence"`
+	SourcePath       string  `json:"source_path,omitempty"`
+	SourceTransform  string  `json:"source_transform,omitempty"`
+	GeneratorName    string  `json:"generator_name,omitempty"`
+	GeneratorProfile string  `json:"generator_profile,omitempty"`
+}
+
+type changeExplainResult struct {
+	Input       changePreviewInput      `json:"input"`
+	Change      changePreviewSummary    `json:"change"`
+	Query       changeExplainQuery      `json:"query"`
+	Explanation changeExplainSuggestion `json:"explanation"`
+}
+
 func runChange(args []string) error {
 	if len(args) == 0 {
 		printChangeUsage(os.Stderr)
@@ -1025,6 +1051,8 @@ func runChange(args []string) error {
 		return runChangePreview(args[1:])
 	case "run":
 		return runChangeRun(args[1:])
+	case "explain":
+		return runChangeExplain(args[1:])
 	default:
 		printChangeUsage(os.Stderr)
 		return fmt.Errorf("unknown change subcommand: %s", args[0])
@@ -1055,7 +1083,7 @@ func runChangePreview(args []string) error {
 	targetSlug := fs.Arg(0)
 	renderTargetSlug := fs.Arg(1)
 
-	result, _, err := buildChangePreviewResult(
+	result, _, _, err := buildChangePreviewResult(
 		targetSlug,
 		renderTargetSlug,
 		*space,
@@ -1114,7 +1142,7 @@ func runChangeRun(args []string) error {
 		return errors.New("change run --mode must be local|connected")
 	}
 
-	preview, bundle, err := buildChangePreviewResult(
+	preview, bundle, _, err := buildChangePreviewResult(
 		targetSlug,
 		renderTargetSlug,
 		*space,
@@ -1207,25 +1235,98 @@ func runChangeRun(args []string) error {
 	return writeJSON(f, result, *pretty)
 }
 
+func runChangeExplain(args []string) error {
+	fs := flag.NewFlagSet("change explain", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	space := fs.String("space", "default", "ConfigHub space label")
+	ref := fs.String("ref", "HEAD", "Git ref label to include in output")
+	whereResource := fs.String("where-resource", "", "Additional resource filter expression")
+	wetPath := fs.String("wet-path", "", "Filter explanations to a specific WET path")
+	dryPath := fs.String("dry-path", "", "Filter explanations to a specific DRY path")
+	owner := fs.String("owner", "", "Filter explanations to a specific owner")
+	out := fs.String("out", "-", "Output file path, or '-' for stdout")
+	jsonOut := fs.Bool("json", true, "Output JSON")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	_ = jsonOut
+
+	if fs.NArg() != 2 {
+		return errors.New("usage: cub-gen change explain [flags] <target-slug> <render-target-slug>")
+	}
+	targetSlug := fs.Arg(0)
+	renderTargetSlug := fs.Arg(1)
+
+	preview, _, imported, err := buildChangePreviewResult(
+		targetSlug,
+		renderTargetSlug,
+		*space,
+		*ref,
+		*whereResource,
+		"cub-gen",
+	)
+	if err != nil {
+		return err
+	}
+
+	wetFilter := strings.TrimSpace(*wetPath)
+	dryFilter := strings.TrimSpace(*dryPath)
+	ownerFilter := strings.TrimSpace(*owner)
+
+	suggestion, matchCount, ok := pickInverseSuggestion(imported.Provenance, wetFilter, dryFilter, ownerFilter)
+	if !ok {
+		return fmt.Errorf("no inverse edit explanation matched filters (wet_path=%q dry_path=%q owner=%q)", wetFilter, dryFilter, ownerFilter)
+	}
+
+	result := changeExplainResult{
+		Input:  preview.Input,
+		Change: preview.Change,
+		Query: changeExplainQuery{
+			WetPathFilter: wetFilter,
+			DryPathFilter: dryFilter,
+			OwnerFilter:   ownerFilter,
+			MatchCount:    matchCount,
+		},
+		Explanation: suggestion,
+	}
+
+	if *out == "-" {
+		return writeJSON(os.Stdout, result, *pretty)
+	}
+
+	f, err := os.Create(*out)
+	if err != nil {
+		return fmt.Errorf("create output file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	return writeJSON(f, result, *pretty)
+}
+
 func buildChangePreviewResult(
 	targetSlug, renderTargetSlug, space, ref, whereResource, verifier string,
-) (changePreviewResult, publish.ChangeBundle, error) {
+) (changePreviewResult, publish.ChangeBundle, gitopsflow.ImportFlowResult, error) {
 	imported, err := gitopsflow.Import(targetSlug, renderTargetSlug, ref, space, whereResource)
 	if err != nil {
-		return changePreviewResult{}, publish.ChangeBundle{}, err
+		return changePreviewResult{}, publish.ChangeBundle{}, gitopsflow.ImportFlowResult{}, err
 	}
 
 	bundle := publish.BuildBundle(imported)
 	if err := publish.VerifyBundle(bundle); err != nil {
-		return changePreviewResult{}, publish.ChangeBundle{}, fmt.Errorf("verify generated bundle: %w", err)
+		return changePreviewResult{}, publish.ChangeBundle{}, gitopsflow.ImportFlowResult{}, fmt.Errorf("verify generated bundle: %w", err)
 	}
 
 	attestationRecord, err := attest.Build(bundle, verifier)
 	if err != nil {
-		return changePreviewResult{}, publish.ChangeBundle{}, fmt.Errorf("build attestation: %w", err)
+		return changePreviewResult{}, publish.ChangeBundle{}, gitopsflow.ImportFlowResult{}, fmt.Errorf("build attestation: %w", err)
 	}
 	if err := attest.VerifyRecordAgainstBundle(attestationRecord, bundle); err != nil {
-		return changePreviewResult{}, publish.ChangeBundle{}, fmt.Errorf("verify generated attestation: %w", err)
+		return changePreviewResult{}, publish.ChangeBundle{}, gitopsflow.ImportFlowResult{}, fmt.Errorf("verify generated attestation: %w", err)
 	}
 
 	topEdit, ok := bestInverseEditPointer(imported.Provenance)
@@ -1264,7 +1365,7 @@ func buildChangePreviewResult(
 		},
 	}
 
-	return result, bundle, nil
+	return result, bundle, imported, nil
 }
 
 func bestInverseEditPointer(provenance []model.ProvenanceRecord) (model.InverseEditPointer, bool) {
@@ -1279,6 +1380,106 @@ func bestInverseEditPointer(provenance []model.ProvenanceRecord) (model.InverseE
 		}
 	}
 	return best, found
+}
+
+func pickInverseSuggestion(
+	provenance []model.ProvenanceRecord,
+	wetFilter, dryFilter, ownerFilter string,
+) (changeExplainSuggestion, int, bool) {
+	matchCount := 0
+	best := changeExplainSuggestion{}
+	bestConfidence := -1.0
+
+	for _, record := range provenance {
+		for _, pointer := range record.InverseEditPointers {
+			if wetFilter != "" && pointer.WetPath != wetFilter {
+				continue
+			}
+			if dryFilter != "" && pointer.DryPath != dryFilter {
+				continue
+			}
+			if ownerFilter != "" && pointer.Owner != ownerFilter {
+				continue
+			}
+			matchCount++
+
+			sourcePath := ""
+			sourceTransform := ""
+			if source, ok := bestFieldOrigin(record.FieldOriginMap, pointer.WetPath, pointer.DryPath); ok {
+				sourcePath = source.SourcePath
+				sourceTransform = source.Transform
+			}
+
+			candidate := changeExplainSuggestion{
+				Owner:            pointer.Owner,
+				WetPath:          pointer.WetPath,
+				DryPath:          pointer.DryPath,
+				EditHint:         pointer.EditHint,
+				Confidence:       pointer.Confidence,
+				SourcePath:       sourcePath,
+				SourceTransform:  sourceTransform,
+				GeneratorName:    record.GeneratorName,
+				GeneratorProfile: record.GeneratorProfile,
+			}
+			if candidate.Confidence > bestConfidence {
+				best = candidate
+				bestConfidence = candidate.Confidence
+			}
+		}
+	}
+
+	if bestConfidence < 0 {
+		return changeExplainSuggestion{}, 0, false
+	}
+	return best, matchCount, true
+}
+
+func bestFieldOrigin(origins []model.FieldOrigin, wetPath, dryPath string) (model.FieldOrigin, bool) {
+	best := model.FieldOrigin{}
+	bestConfidence := -1.0
+
+	for _, origin := range origins {
+		if wetPath != "" && origin.WetPath != wetPath {
+			continue
+		}
+		if dryPath != "" && origin.DryPath != dryPath {
+			continue
+		}
+		if origin.Confidence > bestConfidence {
+			best = origin
+			bestConfidence = origin.Confidence
+		}
+	}
+	if bestConfidence >= 0 {
+		return best, true
+	}
+
+	for _, origin := range origins {
+		if dryPath != "" && origin.DryPath != dryPath {
+			continue
+		}
+		if origin.Confidence > bestConfidence {
+			best = origin
+			bestConfidence = origin.Confidence
+		}
+	}
+	if bestConfidence >= 0 {
+		return best, true
+	}
+
+	for _, origin := range origins {
+		if wetPath != "" && origin.WetPath != wetPath {
+			continue
+		}
+		if origin.Confidence > bestConfidence {
+			best = origin
+			bestConfidence = origin.Confidence
+		}
+	}
+	if bestConfidence < 0 {
+		return model.FieldOrigin{}, false
+	}
+	return best, true
 }
 
 func discoveredProfiles(discovered []gitopsflow.DiscoveredResource) []string {
@@ -1761,6 +1962,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
+	fmt.Fprintln(out, "  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out, "  cub-gen bridge <ingest|decision|promote> [flags]")
@@ -1791,6 +1993,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen verify-attestation --in attestation.json --bundle bundle.json")
 	fmt.Fprintln(out, "  cub-gen change preview --space my-space ./examples/scoredev-paas ./examples/scoredev-paas")
 	fmt.Fprintln(out, "  cub-gen change run --mode local --space my-space ./examples/scoredev-paas ./examples/scoredev-paas")
+	fmt.Fprintln(out, "  cub-gen change explain --space my-space --wet-path \"Deployment/spec/template/spec/containers[name=main]/image\" ./examples/scoredev-paas ./examples/scoredev-paas")
 	fmt.Fprintln(out, "  cub-gen bridge ingest --in bundle.json --base-url https://confighub.example")
 	fmt.Fprintln(out, "  cub-gen bridge decision query --change-id chg_123 --base-url https://confighub.example")
 	fmt.Fprintln(out, "  cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123")
@@ -1808,11 +2011,13 @@ func printChangeUsage(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
+	fmt.Fprintln(out, "  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")
 	fmt.Fprintln(out, "  cub-gen change preview --space my-space ./examples/helm-paas ./examples/helm-paas")
 	fmt.Fprintln(out, "  cub-gen change preview --space my-space ./examples/swamp-automation ./examples/swamp-automation")
 	fmt.Fprintln(out, "  cub-gen change run --mode local --space my-space ./examples/scoredev-paas ./examples/scoredev-paas")
+	fmt.Fprintln(out, "  cub-gen change explain --space my-space --owner app-team ./examples/scoredev-paas ./examples/scoredev-paas")
 }
 
 func printGitOpsUsage(out io.Writer) {

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -10,6 +10,7 @@ Usage:
   cub-gen verify-attestation [--in FILE|-] [--bundle FILE] [--json] [--pretty]
   cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>
   cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>
+  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-slug> <render-target-slug>
   cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]
   cub-gen gitops <discover|import|cleanup> [flags]
   cub-gen bridge <ingest|decision|promote> [flags]
@@ -40,6 +41,7 @@ GitOps parity examples:
   cub-gen verify-attestation --in attestation.json --bundle bundle.json
   cub-gen change preview --space my-space ./examples/scoredev-paas ./examples/scoredev-paas
   cub-gen change run --mode local --space my-space ./examples/scoredev-paas ./examples/scoredev-paas
+  cub-gen change explain --space my-space --wet-path "Deployment/spec/template/spec/containers[name=main]/image" ./examples/scoredev-paas ./examples/scoredev-paas
   cub-gen bridge ingest --in bundle.json --base-url https://confighub.example
   cub-gen bridge decision query --change-id chg_123 --base-url https://confighub.example
   cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123

--- a/docs/contracts/change-cli-v1.md
+++ b/docs/contracts/change-cli-v1.md
@@ -100,20 +100,18 @@ Expected output fields (`ChangeExplainResult`):
 - `7`: contract/triple validation failed
 - `8`: internal execution error
 
-## MVP compatibility mapping (today)
+## MVP implementation status (today)
 
-Until native `cub-gen change` subcommands are implemented, wrappers map to existing commands:
+Native subcommands are implemented for:
 
 - `change preview`
-  - `cub-gen gitops import --json ...`
-  - `cub-gen publish --in ...`
-  - extract mutation card fields from import/provenance
-- `change run (local)`
-  - `examples/demo/app-ai-change-run.sh`
-- `change run (connected)`
-  - `examples/demo/run-confighub-lifecycle-connected.sh`
+- `change run (local|connected)`
 - `change explain`
-  - read `inverse_edit_pointers` from import output or mutation card projection
+
+Compatibility wrappers remain useful for demo packaging and story scripts:
+
+- `examples/demo/app-ai-change-run.sh`
+- `examples/demo/run-confighub-lifecycle-connected.sh`
 
 ## Determinism requirements
 

--- a/docs/workflows/prompt-as-dry.md
+++ b/docs/workflows/prompt-as-dry.md
@@ -88,13 +88,13 @@ This path performs real backend ingest/query and writes per-phase summaries:
 
 Each summary includes the governed decision state for the same `change_id` lifecycle.
 
-## Where "preview / run / explain" fits today
+## Where "preview / run / explain" fits
 
-Until first-class `cub-gen change ...` commands land, use this mapping:
+Use the first-class commands directly:
 
-- `change preview` -> `cub-gen gitops import --json ...` (look at provenance + inverse pointers)
-- `change run` -> `app-ai-change-run.sh` (local) or `run-confighub-lifecycle-connected.sh` (connected)
-- `change explain` -> inspect `inverse_edit_pointers` / `mutation-card.json` edit recommendation
+- `change preview` -> compact mutation card and evidence summary
+- `change run` -> local or connected governed execution in one command
+- `change explain` -> direct inverse-edit answer for a selected field/owner filter
 
 ## Why this is compelling
 


### PR DESCRIPTION
## Summary
- add native `change explain` subcommand for inverse-edit drilldown
- support filters: `--wet-path`, `--dry-path`, `--owner`
- return explanation payload with owner, edit hint, confidence, source path/transform, and generator metadata
- update `change` help/usage and top-level golden help output
- expand `change_command_test.go` with explain success and filter coverage
- update README + prompt-as-dry + change-cli contract docs to reflect preview/run/explain as first-class

## Validation
- gofmt on touched files
- make ci-local
