### PR TITLE
docs(contract): add change API v1 spec and schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Workflow template for non-interactive CI auth:
 - Example suites: `examples/*`
 - Demo runners: `examples/demo/*`
 - Contracts and decisions: `docs/contracts`, `docs/decisions`
+- Change API contract: `docs/contracts/change-api-v1.md`
 - Workflow docs: `docs/workflows`
 
 ## Development

--- a/docs/contracts/change-api-v1.md
+++ b/docs/contracts/change-api-v1.md
@@ -1,0 +1,163 @@
+# Change API Contract v1 (Draft)
+
+Status: Draft
+Version: `1.0.0-draft`
+
+This contract defines the HTTP API surface that mirrors `cub-gen change preview|run|explain`.
+
+Goal: CI systems, agents, and UIs can consume one JSON contract without shelling across multiple files.
+
+## Endpoints
+
+### 1) Create or execute a change
+
+`POST /v1/changes`
+
+Request fields:
+
+- `action`: `preview` or `run`
+- `mode`: `local` or `connected` (required for `action=run`)
+- `input`: target/render target + labels (`space`, `ref`, `where_resource`)
+- `connected`: optional backend connection fields (`base_url`, `token`, endpoint overrides)
+
+Response:
+
+- `change` (`change_id`, `bundle_digest`, `attestation_digest`)
+- `edit_recommendation` (owner, paths, hint, confidence)
+- `verification` (bundle/attestation validity)
+- `decision` and `promotion_ready` when `action=run`
+- `artifacts` references for audit/debug
+
+Schema:
+
+- `docs/contracts/schemas/change-request.v1.schema.json`
+
+### 2) Get change status
+
+`GET /v1/changes/{change_id}`
+
+Response:
+
+- `change`
+- `decision`
+- `verification`
+- `artifacts`
+
+Schema:
+
+- `docs/contracts/schemas/change-decision.v1.schema.json`
+
+### 3) Explain what to edit
+
+`GET /v1/changes/{change_id}/explanations`
+
+Query params:
+
+- `wet_path` (optional)
+- `dry_path` (optional)
+- `owner` (optional)
+
+Response:
+
+- `query` (filters + match count)
+- `explanation` (owner, source path, dry/wet path, edit hint, confidence)
+
+Schema:
+
+- `docs/contracts/schemas/change-explanation.v1.schema.json`
+
+## Example requests
+
+### `POST /v1/changes` (preview)
+
+```json
+{
+  "action": "preview",
+  "input": {
+    "target_slug": "./examples/scoredev-paas",
+    "render_target_slug": "./examples/scoredev-paas",
+    "space": "platform",
+    "ref": "HEAD"
+  }
+}
+```
+
+### `POST /v1/changes` (run connected)
+
+```json
+{
+  "action": "run",
+  "mode": "connected",
+  "input": {
+    "target_slug": "./examples/helm-paas",
+    "render_target_slug": "./examples/helm-paas",
+    "space": "platform"
+  },
+  "connected": {
+    "base_url": "https://confighub.example",
+    "token": "${CONFIGHUB_TOKEN}"
+  }
+}
+```
+
+### `GET /v1/changes/{change_id}/explanations?wet_path=...`
+
+```json
+{
+  "change": {
+    "change_id": "chg_01J...",
+    "bundle_digest": "sha256:...",
+    "attestation_digest": "sha256:..."
+  },
+  "query": {
+    "wet_path_filter": "Deployment/spec/template/spec/containers[name=main]/image",
+    "match_count": 1
+  },
+  "explanation": {
+    "owner": "app-team",
+    "wet_path": "Deployment/spec/template/spec/containers[name=main]/image",
+    "dry_path": "containers.main.image",
+    "edit_hint": "Edit the Score container image in score.yaml.",
+    "confidence": 0.94,
+    "source_path": "score.yaml",
+    "source_transform": "score-container-to-deployment"
+  }
+}
+```
+
+## Error contract
+
+HTTP status guidance:
+
+- `200`: success
+- `400`: invalid request payload or missing required filters
+- `401`: auth missing/invalid for connected mode
+- `404`: `change_id` not found
+- `409`: policy conflict or non-terminal decision constraints
+- `422`: contract/triple validation failure
+- `503`: backend dependency unavailable
+
+Error body shape:
+
+```json
+{
+  "error": {
+    "code": "INVALID_REQUEST",
+    "message": "change run requires mode=local|connected",
+    "details": {
+      "field": "mode"
+    }
+  }
+}
+```
+
+## Mapping to CLI
+
+- `POST /v1/changes {action:"preview"}` ↔ `cub-gen change preview ...`
+- `POST /v1/changes {action:"run"}` ↔ `cub-gen change run ...`
+- `GET /v1/changes/{change_id}/explanations` ↔ `cub-gen change explain ...`
+
+## See also
+
+- `docs/contracts/change-cli-v1.md`
+- `docs/contracts/decision-and-attestation-state.md`

--- a/docs/contracts/change-cli-v1.md
+++ b/docs/contracts/change-cli-v1.md
@@ -125,3 +125,7 @@ Compatibility wrappers remain useful for demo packaging and story scripts:
 1. Replacing Flux/Argo reconciliation.
 2. Defining backend HTTP API schemas (handled in API contract doc).
 3. Hiding policy outcomes (`BLOCK`/`ESCALATE` remain explicit).
+
+## See also
+
+- `docs/contracts/change-api-v1.md`

--- a/docs/contracts/schemas/change-decision.v1.schema.json
+++ b/docs/contracts/schemas/change-decision.v1.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.confighub.dev/contracts/change-decision-v1",
+  "title": "ChangeDecisionV1",
+  "type": "object",
+  "required": ["change", "verification"],
+  "additionalProperties": false,
+  "properties": {
+    "change": {
+      "type": "object",
+      "required": ["change_id", "bundle_digest", "attestation_digest"],
+      "additionalProperties": false,
+      "properties": {
+        "change_id": {"type": "string", "pattern": "^chg_"},
+        "bundle_digest": {"type": "string", "pattern": "^sha256:"},
+        "attestation_digest": {"type": "string", "pattern": "^sha256:"}
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "state": {"type": "string", "enum": ["INGESTED", "ATTESTED", "ALLOW", "ESCALATE", "BLOCK"]},
+        "authority": {"type": "string"},
+        "source": {"type": "string"}
+      }
+    },
+    "promotion_ready": {"type": "boolean"},
+    "verification": {
+      "type": "object",
+      "required": ["bundle_valid", "attestation_valid"],
+      "additionalProperties": false,
+      "properties": {
+        "bundle_valid": {"type": "boolean"},
+        "attestation_valid": {"type": "boolean"},
+        "verifier": {"type": "string"}
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/docs/contracts/schemas/change-explanation.v1.schema.json
+++ b/docs/contracts/schemas/change-explanation.v1.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.confighub.dev/contracts/change-explanation-v1",
+  "title": "ChangeExplanationV1",
+  "type": "object",
+  "required": ["change", "query", "explanation"],
+  "additionalProperties": false,
+  "properties": {
+    "change": {
+      "type": "object",
+      "required": ["change_id"],
+      "additionalProperties": false,
+      "properties": {
+        "change_id": {"type": "string", "pattern": "^chg_"},
+        "bundle_digest": {"type": "string", "pattern": "^sha256:"},
+        "attestation_digest": {"type": "string", "pattern": "^sha256:"}
+      }
+    },
+    "query": {
+      "type": "object",
+      "required": ["match_count"],
+      "additionalProperties": false,
+      "properties": {
+        "wet_path_filter": {"type": "string"},
+        "dry_path_filter": {"type": "string"},
+        "owner_filter": {"type": "string"},
+        "match_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "explanation": {
+      "type": "object",
+      "required": ["owner", "wet_path", "dry_path", "edit_hint", "confidence"],
+      "additionalProperties": false,
+      "properties": {
+        "owner": {"type": "string"},
+        "wet_path": {"type": "string"},
+        "dry_path": {"type": "string"},
+        "edit_hint": {"type": "string"},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "source_path": {"type": "string"},
+        "source_transform": {"type": "string"},
+        "generator_name": {"type": "string"},
+        "generator_profile": {"type": "string"}
+      }
+    }
+  }
+}

--- a/docs/contracts/schemas/change-request.v1.schema.json
+++ b/docs/contracts/schemas/change-request.v1.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.confighub.dev/contracts/change-request-v1",
+  "title": "ChangeRequestV1",
+  "type": "object",
+  "required": ["action", "input"],
+  "additionalProperties": false,
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["preview", "run"]
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["local", "connected"]
+    },
+    "input": {
+      "type": "object",
+      "required": ["target_slug", "render_target_slug"],
+      "additionalProperties": false,
+      "properties": {
+        "target_slug": {"type": "string", "minLength": 1},
+        "render_target_slug": {"type": "string", "minLength": 1},
+        "space": {"type": "string"},
+        "ref": {"type": "string"},
+        "where_resource": {"type": "string"}
+      }
+    },
+    "connected": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "base_url": {"type": "string", "format": "uri"},
+        "token": {"type": "string"},
+        "ingest_endpoint": {"type": "string"},
+        "decision_endpoint": {"type": "string"}
+      }
+    },
+    "filters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "wet_path": {"type": "string"},
+        "dry_path": {"type": "string"},
+        "owner": {"type": "string"}
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "action": {"const": "run"}
+        }
+      },
+      "then": {
+        "required": ["mode"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add new API contract doc: docs/contracts/change-api-v1.md
- define `POST/GET /v1/changes*` endpoint semantics aligned to `change preview|run|explain`
- add JSON schemas:
  - change-request.v1.schema.json
  - change-decision.v1.schema.json
  - change-explanation.v1.schema.json
- link API contract from README repo map and change-cli contract

## Validation
- make ci-local
