### PR TITLE
ci(story7): use change run in connected workflow

### DIFF
--- a/.github/workflows/connected-story7.yml
+++ b/.github/workflows/connected-story7.yml
@@ -21,6 +21,7 @@ jobs:
       EXAMPLE_SLUG: ${{ inputs.example_slug }}
       RUN_ID: ${{ github.run_id }}
       VERIFIER: ci-bot
+      OUT_DIR: .tmp/ci-connected/${{ github.run_id }}/${{ inputs.example_slug }}
     steps:
       - uses: actions/checkout@v5
 
@@ -43,3 +44,12 @@ jobs:
 
       - name: Run story 7 connected CI flow
         run: ./examples/demo/story-7-ci-api-flow-connected.sh
+
+      - name: Upload story 7 summary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: story-7-summary-${{ inputs.example_slug }}
+          path: |
+            ${{ env.OUT_DIR }}/change-run.json
+            ${{ env.OUT_DIR }}/change-explain.json
+            ${{ env.OUT_DIR }}/story-7-summary.json

--- a/examples/demo/story-7-ci-api-flow-connected.sh
+++ b/examples/demo/story-7-ci-api-flow-connected.sh
@@ -10,6 +10,8 @@ REPO_PATH="${REPO_PATH:-./examples/$EXAMPLE_SLUG}"
 RENDER_TARGET="${RENDER_TARGET:-$REPO_PATH}"
 RUN_ID="${RUN_ID:-${GITHUB_RUN_ID:-local}}"
 OUT_DIR="${OUT_DIR:-$ROOT_DIR/.tmp/ci-connected/$RUN_ID/$EXAMPLE_SLUG}"
+SPACE="${SPACE:-${CONFIGHUB_SPACE:-platform}}"
+VERIFIER="${VERIFIER:-ci-bot}"
 
 if [ -z "${CONFIGHUB_TOKEN:-}" ]; then
   echo "error: CONFIGHUB_TOKEN is required for non-interactive CI mode." >&2
@@ -22,26 +24,56 @@ mkdir -p "$OUT_DIR"
 echo "[story-7] CI-centric connected flow"
 echo "[story-7] example: $EXAMPLE_SLUG"
 echo "[story-7] output: $OUT_DIR"
+echo "[story-7] mode: cub-gen change run --mode connected"
 
-VERIFIER="${VERIFIER:-ci-bot}" \
-./examples/demo/run-confighub-lifecycle-connected.sh "$REPO_PATH" "$RENDER_TARGET" "$EXAMPLE_SLUG" "$OUT_DIR"
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  go build -o ./cub-gen ./cmd/cub-gen
+fi
+
+./cub-gen change run \
+  --mode connected \
+  --space "$SPACE" \
+  --base-url "$CONFIGHUB_BASE_URL" \
+  --token "$CONFIGHUB_TOKEN" \
+  --verifier "$VERIFIER" \
+  "$REPO_PATH" "$RENDER_TARGET" > "$OUT_DIR/change-run.json"
+
+WET_PATH="$(jq -r '.preview.edit_recommendation.wet_path // empty' "$OUT_DIR/change-run.json")"
+if [ -n "$WET_PATH" ]; then
+  ./cub-gen change explain \
+    --space "$SPACE" \
+    --wet-path "$WET_PATH" \
+    "$REPO_PATH" "$RENDER_TARGET" > "$OUT_DIR/change-explain.json"
+fi
 
 jq -n \
   --arg story "7-ci-centric-api-flow" \
   --arg run_id "$RUN_ID" \
   --arg example "$EXAMPLE_SLUG" \
-  --arg change_id "$(jq -r .change_id "$OUT_DIR/update/bundle.json")" \
-  --arg decision_state "$(jq -r '.state // "UNKNOWN"' "$OUT_DIR/update/decision-final.json")" \
-  --arg policy_ref "$(jq -r '.policy_decision_ref // ""' "$OUT_DIR/update/decision-final.json")" \
-  --arg verifier "${VERIFIER:-ci-bot}" \
-  --arg ingest_status "$(jq -r '.status // "unknown"' "$OUT_DIR/update/ingest.json")" \
+  --arg change_id "$(jq -r '.preview.change.change_id' "$OUT_DIR/change-run.json")" \
+  --arg decision_state "$(jq -r '.decision.state // "UNKNOWN"' "$OUT_DIR/change-run.json")" \
+  --arg decision_authority "$(jq -r '.decision.authority // ""' "$OUT_DIR/change-run.json")" \
+  --arg decision_source "$(jq -r '.decision.source // ""' "$OUT_DIR/change-run.json")" \
+  --argjson promotion_ready "$(jq '.promotion_ready // false' "$OUT_DIR/change-run.json")" \
+  --arg verifier "$VERIFIER" \
+  --arg wet_path "$(jq -r '.preview.edit_recommendation.wet_path // ""' "$OUT_DIR/change-run.json")" \
+  --arg dry_path "$(jq -r '.preview.edit_recommendation.dry_path // ""' "$OUT_DIR/change-run.json")" \
+  --arg edit_hint "$(jq -r '.preview.edit_recommendation.edit_hint // ""' "$OUT_DIR/change-run.json")" \
+  --argjson wet_targets "$(jq '.preview.counts.wet_targets // 0' "$OUT_DIR/change-run.json")" \
   '{
     story: $story,
     run_id: $run_id,
     example: $example,
     change_id: $change_id,
     decision_state: $decision_state,
-    policy_decision_ref: $policy_ref,
+    decision_authority: $decision_authority,
+    decision_source: $decision_source,
+    promotion_ready: $promotion_ready,
     verifier: $verifier,
-    ingest_status: $ingest_status
+    wet_targets: $wet_targets,
+    top_edit_recommendation: {
+      wet_path: $wet_path,
+      dry_path: $dry_path,
+      edit_hint: $edit_hint
+    }
   }' | tee "$OUT_DIR/story-7-summary.json"


### PR DESCRIPTION
## Summary
- update story 7 connected script to use first-class `cub-gen change run --mode connected`
- add optional follow-up `change explain` output for top recommended wet path
- emit story-7 summary directly from change-run contract fields
- update connected-story7 workflow to upload change-run/explain/summary artifacts

## Validation
- bash -n examples/demo/story-7-ci-api-flow-connected.sh
- make ci-local
