### PR TITLE
feat(adapter): add change API compatibility adapter

### DIFF
--- a/.github/workflows/connected-story7.yml
+++ b/.github/workflows/connected-story7.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           name: story-7-summary-${{ inputs.example_slug }}
           path: |
+            ${{ env.OUT_DIR }}/change-run-request.json
             ${{ env.OUT_DIR }}/change-run.json
+            ${{ env.OUT_DIR }}/change-explain-request.json
             ${{ env.OUT_DIR }}/change-explain.json
             ${{ env.OUT_DIR }}/story-7-summary.json

--- a/docs/contracts/change-api-v1.md
+++ b/docs/contracts/change-api-v1.md
@@ -157,6 +157,10 @@ Error body shape:
 - `POST /v1/changes {action:"run"}` ↔ `cub-gen change run ...`
 - `GET /v1/changes/{change_id}/explanations` ↔ `cub-gen change explain ...`
 
+Compatibility adapter in this repo:
+
+- `examples/demo/change-api-adapter.sh`
+
 ## See also
 
 - `docs/contracts/change-cli-v1.md`

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -51,6 +51,7 @@ If your platform is workflow-heavy, start here before app-manifest demos:
 
 | Script | What it demonstrates |
 |--------|---------------------|
+| `change-api-adapter.sh --request <json> [--out <json>]` | Thin compatibility adapter mapping API-style JSON requests to `change preview|run|explain` |
 | `app-ai-change-run.sh <repo> [target]` | One-command app/AI path: import + publish + verify + attest + mutation card output |
 | `prompt-as-dry-local.sh [repo]` | Canonical prompt-as-DRY local path (Swamp workflow intent -> governed mutation card) |
 | `prompt-as-dry-connected.sh [repo] [target] [slug]` | Canonical prompt-as-DRY connected path (`cub auth login` + backend ingest/query lifecycle) |

--- a/examples/demo/change-api-adapter.sh
+++ b/examples/demo/change-api-adapter.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  ./examples/demo/change-api-adapter.sh --request <request.json> [--out <response.json>]
+
+Request shape (see docs/contracts/change-api-v1.md):
+  {
+    "action": "preview" | "run" | "explain",
+    "mode": "local" | "connected",          # required for run
+    "input": {
+      "target_slug": "./examples/scoredev-paas",
+      "render_target_slug": "./examples/scoredev-paas",
+      "space": "platform",
+      "ref": "HEAD",
+      "where_resource": "..."
+    },
+    "connected": {
+      "base_url": "https://confighub.example",
+      "token": "...",
+      "ingest_endpoint": "/api/v1/...",
+      "decision_endpoint": "/api/v1/..."
+    },
+    "filters": {
+      "wet_path": "...",
+      "dry_path": "...",
+      "owner": "..."
+    }
+  }
+USAGE
+}
+
+REQUEST=""
+OUT="-"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --request)
+      REQUEST="${2:-}"
+      shift 2
+      ;;
+    --out)
+      OUT="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown arg: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$REQUEST" ] || [ ! -f "$REQUEST" ]; then
+  echo "error: --request <file> is required" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 1
+fi
+
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  go build -o ./cub-gen ./cmd/cub-gen
+fi
+
+action="$(jq -r '.action // empty' "$REQUEST")"
+target_slug="$(jq -r '.input.target_slug // empty' "$REQUEST")"
+render_target_slug="$(jq -r '.input.render_target_slug // empty' "$REQUEST")"
+space="$(jq -r '.input.space // "platform"' "$REQUEST")"
+ref="$(jq -r '.input.ref // "HEAD"' "$REQUEST")"
+where_resource="$(jq -r '.input.where_resource // empty' "$REQUEST")"
+
+if [ -z "$action" ] || [ -z "$target_slug" ] || [ -z "$render_target_slug" ]; then
+  echo "error: request must include action + input.target_slug + input.render_target_slug" >&2
+  exit 1
+fi
+
+cmd=(./cub-gen change)
+
+case "$action" in
+  preview)
+    cmd+=(preview --space "$space" --ref "$ref")
+    if [ -n "$where_resource" ]; then
+      cmd+=(--where-resource "$where_resource")
+    fi
+    cmd+=("$target_slug" "$render_target_slug")
+    ;;
+  run)
+    mode="$(jq -r '.mode // empty' "$REQUEST")"
+    if [ -z "$mode" ]; then
+      echo "error: action=run requires mode" >&2
+      exit 1
+    fi
+    cmd+=(run --mode "$mode" --space "$space" --ref "$ref")
+    if [ -n "$where_resource" ]; then
+      cmd+=(--where-resource "$where_resource")
+    fi
+    if [ "$mode" = "connected" ]; then
+      base_url="$(jq -r '.connected.base_url // env.CONFIGHUB_BASE_URL // empty' "$REQUEST")"
+      token="$(jq -r '.connected.token // env.CONFIGHUB_TOKEN // empty' "$REQUEST")"
+      ingest_endpoint="$(jq -r '.connected.ingest_endpoint // empty' "$REQUEST")"
+      decision_endpoint="$(jq -r '.connected.decision_endpoint // empty' "$REQUEST")"
+      if [ -n "$base_url" ]; then
+        cmd+=(--base-url "$base_url")
+      fi
+      if [ -n "$token" ]; then
+        cmd+=(--token "$token")
+      fi
+      if [ -n "$ingest_endpoint" ]; then
+        cmd+=(--ingest-endpoint "$ingest_endpoint")
+      fi
+      if [ -n "$decision_endpoint" ]; then
+        cmd+=(--decision-endpoint "$decision_endpoint")
+      fi
+    fi
+    cmd+=("$target_slug" "$render_target_slug")
+    ;;
+  explain)
+    wet_path="$(jq -r '.filters.wet_path // empty' "$REQUEST")"
+    dry_path="$(jq -r '.filters.dry_path // empty' "$REQUEST")"
+    owner="$(jq -r '.filters.owner // empty' "$REQUEST")"
+    cmd+=(explain --space "$space" --ref "$ref")
+    if [ -n "$where_resource" ]; then
+      cmd+=(--where-resource "$where_resource")
+    fi
+    if [ -n "$wet_path" ]; then
+      cmd+=(--wet-path "$wet_path")
+    fi
+    if [ -n "$dry_path" ]; then
+      cmd+=(--dry-path "$dry_path")
+    fi
+    if [ -n "$owner" ]; then
+      cmd+=(--owner "$owner")
+    fi
+    cmd+=("$target_slug" "$render_target_slug")
+    ;;
+  *)
+    echo "error: unsupported action: $action" >&2
+    exit 1
+    ;;
+esac
+
+if [ "$OUT" = "-" ]; then
+  "${cmd[@]}"
+else
+  mkdir -p "$(dirname "$OUT")"
+  "${cmd[@]}" > "$OUT"
+  echo "[change-api-adapter] wrote response: $OUT"
+fi

--- a/examples/demo/story-7-ci-api-flow-connected.sh
+++ b/examples/demo/story-7-ci-api-flow-connected.sh
@@ -30,20 +30,55 @@ if [ "${SKIP_BUILD:-0}" != "1" ]; then
   go build -o ./cub-gen ./cmd/cub-gen
 fi
 
-./cub-gen change run \
-  --mode connected \
-  --space "$SPACE" \
-  --base-url "$CONFIGHUB_BASE_URL" \
-  --token "$CONFIGHUB_TOKEN" \
-  --verifier "$VERIFIER" \
-  "$REPO_PATH" "$RENDER_TARGET" > "$OUT_DIR/change-run.json"
+jq -n \
+  --arg action "run" \
+  --arg mode "connected" \
+  --arg target_slug "$REPO_PATH" \
+  --arg render_target_slug "$RENDER_TARGET" \
+  --arg space "$SPACE" \
+  --arg base_url "$CONFIGHUB_BASE_URL" \
+  --arg token "$CONFIGHUB_TOKEN" \
+  '{
+    action: $action,
+    mode: $mode,
+    input: {
+      target_slug: $target_slug,
+      render_target_slug: $render_target_slug,
+      space: $space
+    },
+    connected: {
+      base_url: $base_url,
+      token: $token
+    }
+  }' > "$OUT_DIR/change-run-request.json"
+
+./examples/demo/change-api-adapter.sh \
+  --request "$OUT_DIR/change-run-request.json" \
+  --out "$OUT_DIR/change-run.json"
 
 WET_PATH="$(jq -r '.preview.edit_recommendation.wet_path // empty' "$OUT_DIR/change-run.json")"
 if [ -n "$WET_PATH" ]; then
-  ./cub-gen change explain \
-    --space "$SPACE" \
-    --wet-path "$WET_PATH" \
-    "$REPO_PATH" "$RENDER_TARGET" > "$OUT_DIR/change-explain.json"
+  jq -n \
+    --arg action "explain" \
+    --arg target_slug "$REPO_PATH" \
+    --arg render_target_slug "$RENDER_TARGET" \
+    --arg space "$SPACE" \
+    --arg wet_path "$WET_PATH" \
+    '{
+      action: $action,
+      input: {
+        target_slug: $target_slug,
+        render_target_slug: $render_target_slug,
+        space: $space
+      },
+      filters: {
+        wet_path: $wet_path
+      }
+    }' > "$OUT_DIR/change-explain-request.json"
+
+  ./examples/demo/change-api-adapter.sh \
+    --request "$OUT_DIR/change-explain-request.json" \
+    --out "$OUT_DIR/change-explain.json"
 fi
 
 jq -n \


### PR DESCRIPTION
## Summary
- add `examples/demo/change-api-adapter.sh` to map API-style JSON requests to `change preview|run|explain`
- update Story 7 connected script to call adapter with single request/response JSON files
- include request/response artifacts in connected Story 7 workflow upload
- document adapter in demo README and change API contract

## Validation
- bash -n examples/demo/change-api-adapter.sh examples/demo/story-7-ci-api-flow-connected.sh
- make ci-local
