### PR TITLE
feat(change): explain existing change by bundle

### DIFF
--- a/cmd/cub-gen/change_command_test.go
+++ b/cmd/cub-gen/change_command_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -197,6 +199,86 @@ func TestChangeExplainWetPathFilter(t *testing.T) {
 	}
 }
 
+func TestChangeExplainByChangeIDFromBundle(t *testing.T) {
+	setupAliases(t)
+
+	publishOut, stderr, err := runWithCapturedIO([]string{
+		"publish",
+		"--space", "platform",
+		"score",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("publish returned error: %v\nstderr=%s", err, stderr)
+	}
+
+	var bundle map[string]any
+	if err := json.Unmarshal([]byte(publishOut), &bundle); err != nil {
+		t.Fatalf("unmarshal publish output: %v", err)
+	}
+	changeID, ok := bundle["change_id"].(string)
+	if !ok || strings.TrimSpace(changeID) == "" {
+		t.Fatalf("missing change_id in bundle: %v", bundle["change_id"])
+	}
+
+	bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(bundlePath, []byte(publishOut), 0o600); err != nil {
+		t.Fatalf("write bundle file: %v", err)
+	}
+
+	out, explainErr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--change-id", changeID,
+		"--bundle", bundlePath,
+		"--owner", "app-team",
+	})
+	if err != nil {
+		t.Fatalf("change explain by change-id returned error: %v\nstderr=%s", err, explainErr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, out)
+	}
+	change, ok := got["change"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected change object, got %T", got["change"])
+	}
+	if gotID, ok := change["change_id"].(string); !ok || gotID != changeID {
+		t.Fatalf("expected change_id=%q, got %v", changeID, change["change_id"])
+	}
+}
+
+func TestChangeExplainByChangeIDMismatch(t *testing.T) {
+	setupAliases(t)
+
+	publishOut, stderr, err := runWithCapturedIO([]string{
+		"publish",
+		"--space", "platform",
+		"score",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("publish returned error: %v\nstderr=%s", err, stderr)
+	}
+	bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(bundlePath, []byte(publishOut), 0o600); err != nil {
+		t.Fatalf("write bundle file: %v", err)
+	}
+
+	_, _, err = runWithCapturedIO([]string{
+		"change", "explain",
+		"--change-id", "chg_mismatch",
+		"--bundle", bundlePath,
+	})
+	if err == nil {
+		t.Fatal("expected mismatch error")
+	}
+	if !strings.Contains(err.Error(), "bundle change_id mismatch") {
+		t.Fatalf("unexpected error: %q", err.Error())
+	}
+}
+
 func TestChangeCommandErrorModes(t *testing.T) {
 	tests := []struct {
 		name string
@@ -227,6 +309,11 @@ func TestChangeCommandErrorModes(t *testing.T) {
 			name: "explain-missing-targets",
 			args: []string{"change", "explain"},
 			sub:  "usage: cub-gen change explain",
+		},
+		{
+			name: "explain-change-id-missing-bundle",
+			args: []string{"change", "explain", "--change-id", "chg_123"},
+			sub:  "requires --bundle FILE",
 		},
 	}
 

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -1241,6 +1241,8 @@ func runChangeExplain(args []string) error {
 	space := fs.String("space", "default", "ConfigHub space label")
 	ref := fs.String("ref", "HEAD", "Git ref label to include in output")
 	whereResource := fs.String("where-resource", "", "Additional resource filter expression")
+	changeID := fs.String("change-id", "", "Existing change ID to explain without creating a new lifecycle")
+	bundlePath := fs.String("bundle", "", "Existing change bundle JSON file to use with --change-id")
 	wetPath := fs.String("wet-path", "", "Filter explanations to a specific WET path")
 	dryPath := fs.String("dry-path", "", "Filter explanations to a specific DRY path")
 	owner := fs.String("owner", "", "Filter explanations to a specific owner")
@@ -1255,36 +1257,87 @@ func runChangeExplain(args []string) error {
 	}
 	_ = jsonOut
 
-	if fs.NArg() != 2 {
-		return errors.New("usage: cub-gen change explain [flags] <target-slug> <render-target-slug>")
-	}
-	targetSlug := fs.Arg(0)
-	renderTargetSlug := fs.Arg(1)
-
-	preview, _, imported, err := buildChangePreviewResult(
-		targetSlug,
-		renderTargetSlug,
-		*space,
-		*ref,
-		*whereResource,
-		"cub-gen",
-	)
-	if err != nil {
-		return err
-	}
-
 	wetFilter := strings.TrimSpace(*wetPath)
 	dryFilter := strings.TrimSpace(*dryPath)
 	ownerFilter := strings.TrimSpace(*owner)
+	changeIDFilter := strings.TrimSpace(*changeID)
 
-	suggestion, matchCount, ok := pickInverseSuggestion(imported.Provenance, wetFilter, dryFilter, ownerFilter)
+	var (
+		input      changePreviewInput
+		change     changePreviewSummary
+		provenance []model.ProvenanceRecord
+		err        error
+	)
+
+	if changeIDFilter != "" {
+		if fs.NArg() != 0 {
+			return errors.New("usage: cub-gen change explain --change-id ID --bundle FILE [flags]")
+		}
+		bundleRaw := strings.TrimSpace(*bundlePath)
+		if bundleRaw == "" {
+			return errors.New("change explain --change-id requires --bundle FILE")
+		}
+		var bundle publish.ChangeBundle
+		if err := readJSONInput(bundleRaw, &bundle); err != nil {
+			return fmt.Errorf("read bundle json: %w", err)
+		}
+		if err := publish.VerifyBundle(bundle); err != nil {
+			return fmt.Errorf("verify bundle before explain: %w", err)
+		}
+		if bundle.ChangeID == "" {
+			return errors.New("bundle does not contain change_id")
+		}
+		if bundle.ChangeID != changeIDFilter {
+			return fmt.Errorf("bundle change_id mismatch: expected %s, got %s", changeIDFilter, bundle.ChangeID)
+		}
+		input = changePreviewInput{
+			TargetSlug:       bundle.TargetSlug,
+			RenderTargetSlug: bundle.RenderTargetSlug,
+			Space:            bundle.Space,
+			Ref:              bundle.Ref,
+		}
+		change = changePreviewSummary{
+			ChangeID:          bundle.ChangeID,
+			BundleDigest:      bundle.BundleDigest,
+			AttestationDigest: "",
+		}
+		provenance = bundle.Provenance
+	} else {
+		if strings.TrimSpace(*bundlePath) != "" {
+			return errors.New("change explain --bundle requires --change-id")
+		}
+		if fs.NArg() != 2 {
+			return errors.New("usage: cub-gen change explain [flags] <target-slug> <render-target-slug>")
+		}
+		targetSlug := fs.Arg(0)
+		renderTargetSlug := fs.Arg(1)
+
+		var preview changePreviewResult
+		var imported gitopsflow.ImportFlowResult
+		preview, _, imported, err = buildChangePreviewResult(
+			targetSlug,
+			renderTargetSlug,
+			*space,
+			*ref,
+			*whereResource,
+			"cub-gen",
+		)
+		if err != nil {
+			return err
+		}
+		input = preview.Input
+		change = preview.Change
+		provenance = imported.Provenance
+	}
+
+	suggestion, matchCount, ok := pickInverseSuggestion(provenance, wetFilter, dryFilter, ownerFilter)
 	if !ok {
 		return fmt.Errorf("no inverse edit explanation matched filters (wet_path=%q dry_path=%q owner=%q)", wetFilter, dryFilter, ownerFilter)
 	}
 
 	result := changeExplainResult{
-		Input:  preview.Input,
-		Change: preview.Change,
+		Input:  input,
+		Change: change,
 		Query: changeExplainQuery{
 			WetPathFilter: wetFilter,
 			DryPathFilter: dryFilter,
@@ -1963,6 +2016,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-slug> <render-target-slug>")
+	fmt.Fprintln(out, "  cub-gen change explain --change-id ID --bundle FILE [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out, "  cub-gen bridge <ingest|decision|promote> [flags]")
@@ -1994,6 +2048,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen change preview --space my-space ./examples/scoredev-paas ./examples/scoredev-paas")
 	fmt.Fprintln(out, "  cub-gen change run --mode local --space my-space ./examples/scoredev-paas ./examples/scoredev-paas")
 	fmt.Fprintln(out, "  cub-gen change explain --space my-space --wet-path \"Deployment/spec/template/spec/containers[name=main]/image\" ./examples/scoredev-paas ./examples/scoredev-paas")
+	fmt.Fprintln(out, "  cub-gen change explain --change-id chg_123 --bundle bundle.json --owner app-team")
 	fmt.Fprintln(out, "  cub-gen bridge ingest --in bundle.json --base-url https://confighub.example")
 	fmt.Fprintln(out, "  cub-gen bridge decision query --change-id chg_123 --base-url https://confighub.example")
 	fmt.Fprintln(out, "  cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123")
@@ -2012,12 +2067,14 @@ func printChangeUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-slug> <render-target-slug>")
+	fmt.Fprintln(out, "  cub-gen change explain --change-id ID --bundle FILE [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")
 	fmt.Fprintln(out, "  cub-gen change preview --space my-space ./examples/helm-paas ./examples/helm-paas")
 	fmt.Fprintln(out, "  cub-gen change preview --space my-space ./examples/swamp-automation ./examples/swamp-automation")
 	fmt.Fprintln(out, "  cub-gen change run --mode local --space my-space ./examples/scoredev-paas ./examples/scoredev-paas")
 	fmt.Fprintln(out, "  cub-gen change explain --space my-space --owner app-team ./examples/scoredev-paas ./examples/scoredev-paas")
+	fmt.Fprintln(out, "  cub-gen change explain --change-id chg_123 --bundle bundle.json --wet-path \"Deployment/spec/template/spec/containers[name=main]/image\"")
 }
 
 func printGitOpsUsage(out io.Writer) {

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -11,6 +11,7 @@ Usage:
   cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>
   cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>
   cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-slug> <render-target-slug>
+  cub-gen change explain --change-id ID --bundle FILE [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty]
   cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]
   cub-gen gitops <discover|import|cleanup> [flags]
   cub-gen bridge <ingest|decision|promote> [flags]
@@ -42,6 +43,7 @@ GitOps parity examples:
   cub-gen change preview --space my-space ./examples/scoredev-paas ./examples/scoredev-paas
   cub-gen change run --mode local --space my-space ./examples/scoredev-paas ./examples/scoredev-paas
   cub-gen change explain --space my-space --wet-path "Deployment/spec/template/spec/containers[name=main]/image" ./examples/scoredev-paas ./examples/scoredev-paas
+  cub-gen change explain --change-id chg_123 --bundle bundle.json --owner app-team
   cub-gen bridge ingest --in bundle.json --base-url https://confighub.example
   cub-gen bridge decision query --change-id chg_123 --base-url https://confighub.example
   cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123

--- a/docs/contracts/change-cli-v1.md
+++ b/docs/contracts/change-cli-v1.md
@@ -69,25 +69,26 @@ Expected output fields (`ChangeRunResult`):
 Purpose:
 - Explain exactly what to edit for a specific field/resource.
 
-Proposed flags:
+Supported invocation modes:
 
-- `--change-id <id>` (required)
-- `--wet-path <path>` (optional, one of `--wet-path` or `--resource` required)
-- `--resource <kind/name>` (optional)
-- `--mode <local|connected>` (required)
-- `--base-url <url>` (required for `connected` unless resolved from context)
-- `--token <token>` (required for `connected` unless resolved from auth)
+1. Fresh analysis mode (mints a new lifecycle):
+- `cub-gen change explain [filters] <target-slug> <render-target-slug>`
+
+2. Existing lifecycle mode (no new lifecycle minted):
+- `cub-gen change explain --change-id <id> --bundle <bundle.json> [filters]`
+
+Filters:
+
+- `--wet-path <path>` (optional)
+- `--dry-path <path>` (optional)
+- `--owner <owner>` (optional)
 - `--json` (default output format)
 
 Expected output fields (`ChangeExplainResult`):
 
-- `change_id`
-- `query.{wet_path,resource}`
-- `owner`
-- `source.{file,path,line}`
-- `confidence`
-- `edit_hint`
-- `evidence_refs[]`
+- `change.{change_id,bundle_digest,attestation_digest}`
+- `query.{wet_path_filter,dry_path_filter,owner_filter,match_count}`
+- `explanation.{owner,wet_path,dry_path,edit_hint,confidence,source_path,source_transform,generator_name,generator_profile}`
 
 ## Exit code contract
 


### PR DESCRIPTION
## Summary
- add `cub-gen change explain --change-id ID --bundle FILE` mode
- validate and verify the provided bundle before explanation lookup
- enforce strict mode semantics (`--change-id` requires `--bundle`, `--bundle` requires `--change-id`)
- keep existing positional explain flow unchanged
- update help text, parity golden output, and change CLI contract docs

## Tests
- `make ci-local`
- `go test ./cmd/cub-gen -run '^(TestChangePreviewJSON|TestChangeRunLocalJSON|TestChangeRunConnectedMissingBaseURL|TestChangeExplainJSON|TestChangeExplainWetPathFilter|TestChangeExplainByChangeIDFromBundle|TestChangeExplainByChangeIDMismatch|TestChangeCommandErrorModes|TestTopLevelCommandGoldenHelp)$' -count=1`
