### PR TITLE
chore(plan): close remaining hardening gap with docs-sync gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ sync-triple-styles:
 
 ci-local: build test test-contracts test-bridge-symmetry test-examples lint-dual-mode check-story-status check-ai-only-scope
 
-ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence
+ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-ai-only-scope
 
 ci-connected-troubleshoot:
 	CONNECTED_FALLBACK_MODE=changeset ALLOW_FALLBACK_INGEST=1 ALLOW_STORY_10_SKIP=1 $(MAKE) ci-connected

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ This shows structural change governance first: actions/schedules/approval gates 
 
 ```bash
 make ci-local       # build + tests + parity + docs/coverage gates
-make ci-connected   # connected entrypoints + lifecycle + phase-3/4 stories + connected full-loop helm e2e + flux/argo live reconcile gates
+make ci-connected   # connected entrypoints + lifecycle + phase-3/4 stories + connected full-loop helm e2e + flux/argo live reconcile gates + ai-only scope gate
 make ci-connected-troubleshoot # non-release diagnostics (changeset fallback + Story 10 skip allowed)
 make ci             # alias of ci-local
 ```

--- a/docs/plans/2026-03-11-action-plan-v01-execution-checklist.md
+++ b/docs/plans/2026-03-11-action-plan-v01-execution-checklist.md
@@ -42,9 +42,11 @@ Goal: make `DRY -> WET -> LIVE` feel native for app/AI developers, with verifica
 
 5. `docs(workflows): add AI-only guardrails section to prompt-as-dry and user-story acceptance`
 - Why: keep docs synchronized with safety policy.
-- Done when: both docs reference the same enforcement matrix and failure behavior.
+- Status: done; enforced by `test/checks/check-ai-only-scope.sh` (requires both docs to reference `ai-only-guardrails.md`).
 
 ## PR sequence (recommended)
+
+Completed:
 
 1. PR-A: `feat(cli): add change explain --change-id mode`
 2. PR-B: `examples(agent): add tool-call lifecycle proof script + summary artifact`

--- a/test/checks/check-ai-only-scope.sh
+++ b/test/checks/check-ai-only-scope.sh
@@ -9,6 +9,8 @@ if [ ! -f "$DOC" ]; then
   echo "error: missing AI-only guardrails doc: $DOC" >&2
   exit 1
 fi
+PROMPT_DOC="docs/workflows/prompt-as-dry.md"
+STORY_DOC="docs/workflows/user-story-acceptance.md"
 
 has_pattern() {
   local pattern="$1"
@@ -32,6 +34,23 @@ require_doc_text() {
 require_doc_text "Allowed Scope Matrix" "Allowed Scope Matrix section"
 require_doc_text "Hard Deny List" "Hard Deny List section"
 require_doc_text "Mandatory Rollback Hooks" "Mandatory Rollback Hooks section"
+
+if [ ! -f "$PROMPT_DOC" ]; then
+  echo "error: missing prompt-as-dry doc: $PROMPT_DOC" >&2
+  exit 1
+fi
+if [ ! -f "$STORY_DOC" ]; then
+  echo "error: missing user-story acceptance doc: $STORY_DOC" >&2
+  exit 1
+fi
+if ! has_pattern "ai-only-guardrails\\.md" "$PROMPT_DOC"; then
+  echo "error: prompt-as-dry doc missing AI-only guardrails reference" >&2
+  exit 1
+fi
+if ! has_pattern "ai-only-guardrails\\.md" "$STORY_DOC"; then
+  echo "error: user-story acceptance doc missing AI-only guardrails reference" >&2
+  exit 1
+fi
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT


### PR DESCRIPTION
## Summary
- close remaining P1 hardening line in action-plan checklist with explicit done status
- enforce docs-sync behavior in `check-ai-only-scope.sh` (requires `prompt-as-dry.md` and `user-story-acceptance.md` to reference `ai-only-guardrails.md`)
- include AI-only scope gate in `make ci-connected`
- update README CI target description accordingly

## Validation
- `make ci-local`
