### PR TITLE
test(docs): enforce connected onboarding + backend clarity in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-ai-only-scope update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-troubleshoot docs docs-serve
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-ai-only-scope check-docs-entrypoints update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -53,15 +53,18 @@ check-story-evidence:
 check-ai-only-scope:
 	./test/checks/check-ai-only-scope.sh
 
+check-docs-entrypoints:
+	./test/checks/check-docs-entrypoints.sh
+
 update-goldens:
 	UPDATE_GOLDEN=1 go test ./cmd/cub-gen -run 'Golden' -count=1 -v
 
 sync-triple-styles:
 	go run ./cmd/cub-gen-style-sync
 
-ci-local: build test test-contracts test-bridge-symmetry test-examples lint-dual-mode check-story-status check-ai-only-scope
+ci-local: build test test-contracts test-bridge-symmetry test-examples lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints
 
-ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-ai-only-scope
+ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-ai-only-scope check-docs-entrypoints
 
 ci-connected-troubleshoot:
 	CONNECTED_FALLBACK_MODE=changeset ALLOW_FALLBACK_INGEST=1 ALLOW_STORY_10_SKIP=1 $(MAKE) ci-connected

--- a/test/checks/check-docs-entrypoints.sh
+++ b/test/checks/check-docs-entrypoints.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+USE_RG=0
+if command -v rg >/dev/null 2>&1; then
+  USE_RG=1
+fi
+
+has_pattern() {
+  local pattern="$1"
+  local file="$2"
+  if [ "$USE_RG" -eq 1 ]; then
+    rg -q -- "$pattern" "$file"
+  else
+    grep -Eq -- "$pattern" "$file"
+  fi
+}
+
+require_file_pattern() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if [ ! -f "$file" ]; then
+    echo "error: missing file: $file" >&2
+    exit 1
+  fi
+  if ! has_pattern "$pattern" "$file"; then
+    echo "error: $file missing $label" >&2
+    exit 1
+  fi
+}
+
+# Main README must keep clear connected onboarding and backend reality.
+require_file_pattern "README.md" "cub auth login" "connected auth step (cub auth login)"
+require_file_pattern "README.md" "confighubai/confighub" "ConfigHub OSS backend link"
+
+# Docs-site landing pages must preserve the same message.
+require_file_pattern "docs/index.md" "cub auth login" "connected auth step (cub auth login)"
+require_file_pattern "docs/index.md" "confighubai/confighub" "ConfigHub OSS backend link"
+require_file_pattern "docs/platform.md" "cub auth login" "connected auth step (cub auth login)"
+require_file_pattern "docs/platform.md" "confighubai/confighub" "ConfigHub OSS backend link"
+
+echo "ok: core docs keep explicit local-vs-connected onboarding and backend availability"


### PR DESCRIPTION
## Summary
- add `test/checks/check-docs-entrypoints.sh` to enforce core onboarding clarity in docs
- require explicit `cub auth login` and `confighubai/confighub` backend link in key entry docs
- wire the check into both `ci-local` and `ci-connected`

## Validation
- `make ci-local`
