### PR TITLE
docs: explain confidence scores and enforce entrypoint links

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Take a deployed field and trace it to the exact source edit path:
 
 That is the day-to-day workflow this tool optimizes.
 
+## Confidence Guide
+
+Use confidence to decide routing speed:
+
+- `>= 0.90`: proceed with normal app/team edit flow.
+- `0.75 - 0.89`: run `change preview` and `change explain` before merge.
+- `< 0.75`: escalate for platform review.
+
+Full interpretation guide: [docs/workflows/confidence-scores.md](docs/workflows/confidence-scores.md)
+
 ## ConfigHub Is Real (Today)
 
 Connected mode targets a live ConfigHub backend. Backend OSS repo:

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,12 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 
     [Getting Started](getting-started.md)
 
+-   **Interpret confidence quickly**
+
+    Understand when to auto-route edits and when to escalate for review.
+
+    [Confidence Scores](workflows/confidence-scores.md)
+
 -   **Start with workflows (Ops + Swamp)**
 
     See structural workflow governance first: actions, schedules, approval gates, model/method bindings, and required-step checks.

--- a/docs/workflows/confidence-scores.md
+++ b/docs/workflows/confidence-scores.md
@@ -1,0 +1,41 @@
+# Confidence Scores (How to Read Them)
+
+`cub-gen` emits confidence on field-origin mappings and inverse-edit guidance.
+Use confidence as an execution hint, not as a replacement for review.
+
+## Quick interpretation
+
+| Confidence range | Meaning | Recommended action |
+|---|---|---|
+| `>= 0.90` | Strong mapping confidence | Safe default for direct DRY edits in normal app-team flow. |
+| `0.75 - 0.89` | Likely correct, some ambiguity | Use `change preview` + `change explain` before merge. |
+| `< 0.75` | Ambiguous mapping | Escalate to platform owner or reviewer before applying. |
+
+## Why confidence varies
+
+Confidence depends on generator structure:
+
+- High confidence: explicit schema and stable transforms.
+- Medium confidence: overlays and inferred ownership.
+- Lower confidence: multiple possible source paths for one WET field.
+
+## Operational rule of thumb
+
+1. Treat confidence as a routing signal.
+2. Low confidence means "human review required", not "mapping is wrong".
+3. Keep ownership and policy gates authoritative in connected mode.
+
+## Commands to inspect confidence directly
+
+```bash
+# Top recommendations with confidence
+./cub-gen change explain --space platform --owner app-team ./examples/helm-paas ./examples/helm-paas
+
+# Raw provenance data (includes confidence fields)
+./cub-gen gitops import --space platform --json ./examples/helm-paas ./examples/helm-paas
+```
+
+## Related
+
+- [User story acceptance](user-story-acceptance.md)
+- [Prompt as DRY](prompt-as-dry.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,9 @@ Each example in this directory is runnable and maps to a real platform/app patte
 4. inverse-edit guidance (where to edit),
 5. evidence bundles (`publish`, `verify`, `attest`).
 
+If confidence scores are new to your team, use:
+- [Confidence score guide](../docs/workflows/confidence-scores.md)
+
 ## Run modes
 
 ## Local mode (fastest, no login required)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - getting-started.md
       - "CLI Reference": cli-reference.md
       - "The ConfigHub Platform": platform.md
+      - "Confidence Scores": workflows/confidence-scores.md
       - "Adoption Path & FAQ": agentic-gitops/05-rollout/40-adoption-and-reference.md
 
   - Architecture:

--- a/test/checks/check-docs-entrypoints.sh
+++ b/test/checks/check-docs-entrypoints.sh
@@ -36,6 +36,8 @@ require_file_pattern() {
 # Main README must keep clear connected onboarding and backend reality.
 require_file_pattern "README.md" "cub auth login" "connected auth step (cub auth login)"
 require_file_pattern "README.md" "confighubai/confighub" "ConfigHub OSS backend link"
+require_file_pattern "README.md" "Use Your Repo in 3 Commands" "own-repo quickstart section"
+require_file_pattern "README.md" "confidence-scores\\.md" "confidence interpretation link"
 
 # Docs-site landing pages must preserve the same message.
 require_file_pattern "docs/index.md" "cub auth login" "connected auth step (cub auth login)"
@@ -43,4 +45,8 @@ require_file_pattern "docs/index.md" "confighubai/confighub" "ConfigHub OSS back
 require_file_pattern "docs/platform.md" "cub auth login" "connected auth step (cub auth login)"
 require_file_pattern "docs/platform.md" "confighubai/confighub" "ConfigHub OSS backend link"
 
-echo "ok: core docs keep explicit local-vs-connected onboarding and backend availability"
+# Examples landing page must keep own-repo entry and confidence guidance.
+require_file_pattern "examples/README.md" "Use your own repo quickly" "own-repo quickstart section"
+require_file_pattern "examples/README.md" "confidence-scores\\.md" "confidence interpretation link"
+
+echo "ok: core docs keep local-vs-connected onboarding, backend availability, own-repo quickstart, and confidence guidance"


### PR DESCRIPTION
## Summary
- add a confidence score interpretation guide for field-origin mappings
- link confidence guidance from core entry docs: `README.md`, `examples/README.md`, and `docs/index.md`
- add the confidence guide to docs navigation in `mkdocs.yml`
- extend docs entrypoint CI checks to enforce:
  - connected auth + backend OSS link
  - own-repo quickstart section
  - confidence guide linkage

## Validation
- `make ci-local`

## Notes
- `mkdocs build --strict` could not be run locally in this environment (`mkdocs` not installed).
