### PR TITLE
docs: surface operation registry real-app examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ If your platform is workflow-heavy (operations workflows or agent-authored workf
   | jq '.provenance[0].swamp_workflow_analysis'
 ```
 
+## Operation Registry Examples (Not AI-Ops Only)
+
+`FrameworkRegistry` is used across multiple example types:
+
+- AI Ops platform: `examples/ai-ops-paas/platform/registry.yaml`
+- Ops workflow platform: `examples/ops-workflow/platform/registry.yaml`
+- Swamp workflow platform: `examples/swamp-automation/platform/registry.yaml`
+
+Guide: [docs/workflows/operation-registry-real-apps.md](docs/workflows/operation-registry-real-apps.md)
+
 This shows structural change governance first: actions/schedules/approval gates for Ops, and models/methods/required steps for Swamp.
 
 ## Which Story Should You Read First?

--- a/docs/workflows/operation-registry-real-apps.md
+++ b/docs/workflows/operation-registry-real-apps.md
@@ -1,0 +1,61 @@
+# Operation Registry in Real Apps
+
+`FrameworkRegistry` is not limited to the AI Ops example.
+This repo includes three runnable platform patterns using registry-driven operations.
+
+## Where it is used
+
+| Example | Registry file | What it models |
+|---|---|---|
+| AI Ops PaaS | `examples/ai-ops-paas/platform/registry.yaml` | Agent fleet platform operations (fleet config, runtime, credentials, RBAC). |
+| Ops Workflow Platform | `examples/ops-workflow/platform/registry.yaml` | Operational workflows (deploy/restart/scale/rollback) with schedule and policy checks. |
+| Swamp Workflow Platform | `examples/swamp-automation/platform/registry.yaml` | Agent-authored workflow graph changes with model/method and required-step constraints. |
+
+## Why this helps
+
+`FrameworkRegistry` gives one typed surface for:
+
+1. operation discovery (`what can this platform do?`)
+2. input validation (`is this change allowed for this environment?`)
+3. governance/audit (`which operation and policy produced this outcome?`)
+
+This works for app workloads and ops/workflow workloads.
+
+## Quick run paths
+
+```bash
+# AI Ops registry-backed platform
+./examples/ai-ops-paas/demo-local.sh
+
+# Ops workflow registry-backed platform
+./examples/ops-workflow/demo-local.sh
+
+# Swamp workflow registry-backed platform
+./examples/swamp-automation/demo-local.sh
+```
+
+Connected mode for any of the above:
+
+```bash
+cub auth login
+./examples/<example>/demo-connected.sh
+```
+
+## Practical "real app" shape
+
+For a typical Spring/Helm app platform, registry operations usually look like:
+
+- route/expose app
+- scale app
+- bind database
+- upgrade image
+
+For ops/workflow platforms, operations usually look like:
+
+- define workflow
+- schedule workflow
+- add action/model-method step
+- enforce required validation/approval step
+
+The same cub-gen flow applies to both:
+`discover -> import -> publish -> verify -> attest -> (connected) decision/query`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -128,6 +128,9 @@ If your users mostly run workflows (not app manifests), start with these two:
   | jq '.provenance[0].swamp_workflow_analysis'
 ```
 
+Operation-registry walkthrough (AI Ops + Ops Workflow + Swamp):
+- [docs/workflows/operation-registry-real-apps.md](../docs/workflows/operation-registry-real-apps.md)
+
 ## Platform + app patterns (Kubernetes workloads)
 
 | Example | You use... | cub-gen shows you... |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - "CLI Reference": cli-reference.md
       - "The ConfigHub Platform": platform.md
       - "Confidence Scores": workflows/confidence-scores.md
+      - "Operation Registry in Real Apps": workflows/operation-registry-real-apps.md
       - "Adoption Path & FAQ": agentic-gitops/05-rollout/40-adoption-and-reference.md
 
   - Architecture:

--- a/test/checks/check-docs-entrypoints.sh
+++ b/test/checks/check-docs-entrypoints.sh
@@ -38,6 +38,7 @@ require_file_pattern "README.md" "cub auth login" "connected auth step (cub auth
 require_file_pattern "README.md" "confighubai/confighub" "ConfigHub OSS backend link"
 require_file_pattern "README.md" "Use Your Repo in 3 Commands" "own-repo quickstart section"
 require_file_pattern "README.md" "confidence-scores\\.md" "confidence interpretation link"
+require_file_pattern "README.md" "operation-registry-real-apps\\.md" "operation registry real-apps guide link"
 
 # Docs-site landing pages must preserve the same message.
 require_file_pattern "docs/index.md" "cub auth login" "connected auth step (cub auth login)"
@@ -48,5 +49,6 @@ require_file_pattern "docs/platform.md" "confighubai/confighub" "ConfigHub OSS b
 # Examples landing page must keep own-repo entry and confidence guidance.
 require_file_pattern "examples/README.md" "Use your own repo quickly" "own-repo quickstart section"
 require_file_pattern "examples/README.md" "confidence-scores\\.md" "confidence interpretation link"
+require_file_pattern "examples/README.md" "operation-registry-real-apps\\.md" "operation registry real-apps guide link"
 
-echo "ok: core docs keep local-vs-connected onboarding, backend availability, own-repo quickstart, and confidence guidance"
+echo "ok: core docs keep local-vs-connected onboarding, backend availability, own-repo quickstart, confidence guidance, and operation-registry discoverability"


### PR DESCRIPTION
## Summary
- add a focused guide showing where `FrameworkRegistry` is used in real examples (AI Ops, Ops Workflow, Swamp)
- link the guide from `README.md` and `examples/README.md`
- add the guide to docs navigation (`mkdocs.yml`)
- extend docs entrypoint CI checks so operation-registry discoverability stays enforced

## Validation
- `make ci-local`
