### PR TITLE
ci: enforce no legacy provider naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-ai-only-scope check-docs-entrypoints update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-troubleshoot docs docs-serve
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -56,15 +56,18 @@ check-ai-only-scope:
 check-docs-entrypoints:
 	./test/checks/check-docs-entrypoints.sh
 
+check-no-legacy-provider-terms:
+	./test/checks/check-no-legacy-provider-terms.sh
+
 update-goldens:
 	UPDATE_GOLDEN=1 go test ./cmd/cub-gen -run 'Golden' -count=1 -v
 
 sync-triple-styles:
 	go run ./cmd/cub-gen-style-sync
 
-ci-local: build test test-contracts test-bridge-symmetry test-examples lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints
+ci-local: build test test-contracts test-bridge-symmetry test-examples lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms
 
-ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-ai-only-scope check-docs-entrypoints
+ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms
 
 ci-connected-troubleshoot:
 	CONNECTED_FALLBACK_MODE=changeset ALLOW_FALLBACK_INGEST=1 ALLOW_STORY_10_SKIP=1 $(MAKE) ci-connected

--- a/test/checks/check-no-legacy-provider-terms.sh
+++ b/test/checks/check-no-legacy-provider-terms.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+USE_RG=0
+if command -v rg >/dev/null 2>&1; then
+  USE_RG=1
+fi
+
+search_pattern='\\bA[b]ly\\b|\\ba[b]ly\\b'
+exclude_globs=(
+  --glob '!.git/**'
+  --glob '!**/*.png'
+  --glob '!**/*.jpg'
+  --glob '!**/*.jpeg'
+  --glob '!**/*.gif'
+  --glob '!**/*.svg'
+)
+
+if [ "$USE_RG" -eq 1 ]; then
+  if rg -n -S --pcre2 "$search_pattern" "${exclude_globs[@]}" \
+    README.md docs examples cmd internal .github mkdocs.yml; then
+    echo "error: found legacy provider terminology. Use no-config-platform naming instead." >&2
+    exit 1
+  fi
+else
+  if grep -RInE '\bA[b]ly\b|\ba[b]ly\b' README.md docs examples cmd internal .github mkdocs.yml; then
+    echo "error: found legacy provider terminology. Use no-config-platform naming instead." >&2
+    exit 1
+  fi
+fi
+
+echo "ok: no legacy provider terminology found; naming is consistently no-config-platform"


### PR DESCRIPTION
## Summary
- add a new CI/docs gate to prevent reintroduction of legacy provider naming
- enforce this in both `ci-local` and `ci-connected`
- use a neutral check name (`check-no-legacy-provider-terms`) and avoid self-matching regex issues

## Validation
- `make ci-local`
