### PR TITLE
docs: add helm and spring operation registry examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ If your platform is workflow-heavy (operations workflows or agent-authored workf
 
 `FrameworkRegistry` is used across multiple example types:
 
+- Helm platform: `examples/helm-paas/platform/registry.yaml`
+- Spring Boot platform: `examples/springboot-paas/platform/registry.yaml`
 - AI Ops platform: `examples/ai-ops-paas/platform/registry.yaml`
 - Ops workflow platform: `examples/ops-workflow/platform/registry.yaml`
 - Swamp workflow platform: `examples/swamp-automation/platform/registry.yaml`

--- a/docs/workflows/operation-registry-real-apps.md
+++ b/docs/workflows/operation-registry-real-apps.md
@@ -7,6 +7,8 @@ This repo includes three runnable platform patterns using registry-driven operat
 
 | Example | Registry file | What it models |
 |---|---|---|
+| Helm PaaS | `examples/helm-paas/platform/registry.yaml` | Helm app lifecycle operations (image tag, scaling, ingress, chart upgrade). |
+| Spring Boot PaaS | `examples/springboot-paas/platform/registry.yaml` | Spring service operations (runtime config, actuator health, datasource, scaling). |
 | AI Ops PaaS | `examples/ai-ops-paas/platform/registry.yaml` | Agent fleet platform operations (fleet config, runtime, credentials, RBAC). |
 | Ops Workflow Platform | `examples/ops-workflow/platform/registry.yaml` | Operational workflows (deploy/restart/scale/rollback) with schedule and policy checks. |
 | Swamp Workflow Platform | `examples/swamp-automation/platform/registry.yaml` | Agent-authored workflow graph changes with model/method and required-step constraints. |
@@ -24,6 +26,12 @@ This works for app workloads and ops/workflow workloads.
 ## Quick run paths
 
 ```bash
+# Helm registry-backed platform
+./examples/helm-paas/demo-local.sh
+
+# Spring Boot registry-backed platform
+./examples/springboot-paas/demo-local.sh
+
 # AI Ops registry-backed platform
 ./examples/ai-ops-paas/demo-local.sh
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -130,6 +130,7 @@ If your users mostly run workflows (not app manifests), start with these two:
 
 Operation-registry walkthrough (AI Ops + Ops Workflow + Swamp):
 - [docs/workflows/operation-registry-real-apps.md](../docs/workflows/operation-registry-real-apps.md)
+Now includes Helm + Spring Boot registry-backed platform examples too.
 
 ## Platform + app patterns (Kubernetes workloads)
 

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -50,6 +50,7 @@ cub-gen doesn't touch this layer — your existing reconciler stays in control.
 | `platform/base/runtime-policy.yaml` | Platform team | Required probes and resource limits |
 | `platform/base/network-policy.yaml` | Platform team | Egress rules and namespace boundaries |
 | `platform/overlays/prod/resource-baseline.yaml` | Platform team | Production resource floors |
+| `platform/registry.yaml` | Platform team | FrameworkRegistry typed operations + constraints for Helm platform APIs |
 | `gitops/flux/helmrelease.yaml` | Platform team | Flux HelmRelease transport |
 | `gitops/argo/application.yaml` | Platform team | ArgoCD Application transport |
 
@@ -229,6 +230,7 @@ WET:  Deployment/spec/template/spec/containers[0]/image = "ghcr.io/example/payme
 | `platform/base/runtime-policy.yaml` | Platform | Required probes, resource limits |
 | `platform/base/network-policy.yaml` | Platform | Egress rules |
 | `platform/overlays/prod/resource-baseline.yaml` | Platform | Prod resource floors |
+| `platform/registry.yaml` | Platform | FrameworkRegistry for Helm operations/constraints |
 | `gitops/flux/helmrelease.yaml` | Platform | Flux v2 HelmRelease transport |
 | `gitops/argo/application.yaml` | Platform | ArgoCD Application transport |
 | `docs/user-stories.md` | — | Narrative user stories |

--- a/examples/helm-paas/platform/registry.yaml
+++ b/examples/helm-paas/platform/registry.yaml
@@ -1,0 +1,122 @@
+# NOTE: This registry is illustrative. ConfigHub evaluates policy decisions server-side.
+# cub-gen imports this operation contract so teams can trace ownership and intent.
+
+apiVersion: confighub.io/v1
+kind: FrameworkRegistry
+
+metadata:
+  name: helm-platform
+  version: 1.0.0
+
+spec:
+  description: "Typed platform operations for Helm-based application delivery"
+  homepage: "https://docs.acme-corp.com/platforms/helm"
+
+  operations:
+    - name: setImageTag
+      description: "Update release image tag in values overlays"
+      inputs:
+        type: object
+        properties:
+          image_tag:
+            type: string
+            required: true
+          environment:
+            type: string
+            enum: [dev, staging, prod]
+            required: true
+      outputs:
+        resources: [Deployment]
+      constraints:
+        - semver-image-tags
+      validation:
+        rules:
+          - condition: "inputs.image_tag == 'latest'"
+            message: "latest image tag is not allowed"
+            severity: error
+
+    - name: scaleRelease
+      description: "Set replica targets by environment"
+      inputs:
+        type: object
+        properties:
+          replicas:
+            type: integer
+            required: true
+          environment:
+            type: string
+            enum: [dev, staging, prod]
+            required: true
+      outputs:
+        resources: [Deployment]
+      constraints:
+        - min-2-replicas-prod
+      validation:
+        rules:
+          - condition: "inputs.environment == 'prod' && inputs.replicas < 2"
+            message: "Production releases require at least 2 replicas"
+            severity: error
+
+    - name: configureIngress
+      description: "Expose app routes using ingress configuration"
+      inputs:
+        type: object
+        properties:
+          host:
+            type: string
+            required: true
+          tls:
+            type: boolean
+            default: true
+      outputs:
+        resources: [Ingress, Service]
+      constraints:
+        - tls-required-prod
+      validation:
+        rules:
+          - condition: "inputs.tls == false && labels.variant == 'prod'"
+            message: "TLS is required for production ingress"
+            severity: error
+
+    - name: setValuesOverlay
+      description: "Apply environment-specific values override source"
+      inputs:
+        type: object
+        properties:
+          values_file:
+            type: string
+            required: true
+          owner_team:
+            type: string
+            required: true
+      outputs:
+        resources: [ConfigMap]
+
+    - name: upgradeChartVersion
+      description: "Promote chart version within approved registries"
+      inputs:
+        type: object
+        properties:
+          chart_version:
+            type: string
+            required: true
+          registry:
+            type: string
+            required: true
+      outputs:
+        resources: [HelmRelease]
+      constraints:
+        - approved-chart-registries
+
+  constraints:
+    - semver-image-tags
+    - min-2-replicas-prod
+    - tls-required-prod
+    - approved-chart-registries
+
+  produces:
+    - Deployment
+    - Service
+    - Ingress
+    - ConfigMap
+    - HelmRelease

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -54,6 +54,7 @@ manifests to LIVE state. cub-gen doesn't touch your reconciler.
 | `src/main/java/.../InventoryApplication.java` | App team | Service implementation |
 | `platform/base/runtime-policy.yaml` | Platform | Required actuator health, managed datasource |
 | `platform/overlays/prod/slo-policy.yaml` | Platform | Production SLO targets (99.9%, p95 250ms) |
+| `platform/registry.yaml` | Platform | FrameworkRegistry typed operations + constraints for Spring platform APIs |
 | `gitops/flux/kustomization.yaml` | Platform | Flux Kustomization transport |
 | `gitops/argo/application.yaml` | Platform | ArgoCD Application transport |
 
@@ -234,6 +235,7 @@ WET:  Deployment/spec/template/spec/containers[0]/env[name=SERVER_PORT]/value = 
 | `application-prod.yaml` | Shared | Prod overrides — port (app), datasource (platform) |
 | `platform/base/runtime-policy.yaml` | Platform | Required actuator, managed datasource |
 | `platform/overlays/prod/slo-policy.yaml` | Platform | SLO targets — 99.9%, p95 250ms |
+| `platform/registry.yaml` | Platform | FrameworkRegistry for Spring operations/constraints |
 | `gitops/flux/kustomization.yaml` | Platform | Flux Kustomization transport |
 | `gitops/argo/application.yaml` | Platform | ArgoCD Application transport |
 

--- a/examples/springboot-paas/platform/registry.yaml
+++ b/examples/springboot-paas/platform/registry.yaml
@@ -1,0 +1,120 @@
+# NOTE: This registry is illustrative. ConfigHub evaluates constraints server-side.
+# cub-gen imports and traces these operation contracts for governance visibility.
+
+apiVersion: confighub.io/v1
+kind: FrameworkRegistry
+
+metadata:
+  name: springboot-platform
+  version: 1.0.0
+
+spec:
+  description: "Typed platform operations for Spring Boot services on Kubernetes"
+  homepage: "https://docs.acme-corp.com/platforms/springboot"
+
+  operations:
+    - name: configureRuntime
+      description: "Set Spring runtime identity and profile-level defaults"
+      inputs:
+        type: object
+        properties:
+          app_name:
+            type: string
+            required: true
+          server_port:
+            type: integer
+            required: true
+          profile:
+            type: string
+            enum: [dev, staging, prod]
+            required: true
+      outputs:
+        resources: [ConfigMap]
+
+    - name: configureActuatorHealth
+      description: "Require health endpoints and readiness/liveness checks"
+      inputs:
+        type: object
+        properties:
+          health_path:
+            type: string
+            default: /actuator/health
+          readiness_path:
+            type: string
+            default: /actuator/health/readiness
+          liveness_path:
+            type: string
+            default: /actuator/health/liveness
+      outputs:
+        resources: [Deployment]
+      constraints:
+        - actuator-required-prod
+
+    - name: bindDatasource
+      description: "Bind datasource secret refs and enforce managed datasource policy"
+      inputs:
+        type: object
+        properties:
+          datasource_secret_ref:
+            type: string
+            required: true
+          max_pool_size:
+            type: integer
+            required: false
+            default: 20
+      outputs:
+        resources: [Secret, ConfigMap]
+      constraints:
+        - managed-datasource-policy
+      validation:
+        rules:
+          - condition: "inputs.max_pool_size > 50"
+            message: "Pool sizes above 50 require platform-dba review"
+            severity: error
+
+    - name: scaleService
+      description: "Set deployment replicas per environment tier"
+      inputs:
+        type: object
+        properties:
+          replicas:
+            type: integer
+            required: true
+          environment:
+            type: string
+            enum: [dev, staging, prod]
+            required: true
+      outputs:
+        resources: [Deployment]
+      constraints:
+        - min-2-replicas-prod
+      validation:
+        rules:
+          - condition: "inputs.environment == 'prod' && inputs.replicas < 2"
+            message: "Production requires at least 2 replicas"
+            severity: error
+
+    - name: exposeService
+      description: "Expose Spring service with stable service contract"
+      inputs:
+        type: object
+        properties:
+          service_port:
+            type: integer
+            default: 80
+          target_port:
+            type: integer
+            required: true
+      outputs:
+        resources: [Service]
+
+  constraints:
+    - actuator-required-prod
+    - managed-datasource-policy
+    - min-2-replicas-prod
+
+  produces:
+    - Deployment
+    - Service
+    - ConfigMap
+    - Secret


### PR DESCRIPTION
## Summary
- add concrete `FrameworkRegistry` examples for:
  - `examples/helm-paas/platform/registry.yaml`
  - `examples/springboot-paas/platform/registry.yaml`
- extend the operation-registry real-app guide to include Helm and Spring paths
- update root/examples entry docs to surface these new registry-backed app platform examples
- update Helm and Spring example READMEs to include `platform/registry.yaml` in key-file ownership tables

## Validation
- `make ci-local`
