### PR TITLE
ci: enforce connected auth contract for scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-troubleshoot docs docs-serve
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -59,15 +59,18 @@ check-docs-entrypoints:
 check-no-legacy-provider-terms:
 	./test/checks/check-no-legacy-provider-terms.sh
 
+check-connected-auth-contract:
+	./test/checks/check-connected-auth-contract.sh
+
 update-goldens:
 	UPDATE_GOLDEN=1 go test ./cmd/cub-gen -run 'Golden' -count=1 -v
 
 sync-triple-styles:
 	go run ./cmd/cub-gen-style-sync
 
-ci-local: build test test-contracts test-bridge-symmetry test-examples lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms
+ci-local: build test test-contracts test-bridge-symmetry test-examples lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract
 
-ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms
+ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract
 
 ci-connected-troubleshoot:
 	CONNECTED_FALLBACK_MODE=changeset ALLOW_FALLBACK_INGEST=1 ALLOW_STORY_10_SKIP=1 $(MAKE) ci-connected

--- a/test/checks/check-connected-auth-contract.sh
+++ b/test/checks/check-connected-auth-contract.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+USE_RG=0
+if command -v rg >/dev/null 2>&1; then
+  USE_RG=1
+fi
+
+file_has_pattern() {
+  local pattern="$1"
+  local file="$2"
+  if [ "$USE_RG" -eq 1 ]; then
+    rg -q -- "$pattern" "$file"
+  else
+    grep -Eq -- "$pattern" "$file"
+  fi
+}
+
+declare -a scripts=()
+while IFS= read -r script; do
+  scripts+=("$script")
+done < <(
+  {
+    find "$ROOT_DIR/examples/demo" -maxdepth 1 -type f -name '*connected*.sh'
+    find "$ROOT_DIR/examples" -mindepth 2 -maxdepth 2 -type f -name 'demo-connected.sh'
+  } | sort
+)
+
+declare -a failures=()
+for script in "${scripts[@]}"; do
+  # Accept either:
+  # 1) shared connected preflight path, or
+  # 2) call into connected lifecycle wrapper that enforces preflight, or
+  # 3) explicit CI non-interactive auth contract.
+  if file_has_pattern 'connected-preflight\.sh|require_connected_preflight|run-confighub-lifecycle-connected\.sh' "$script"; then
+    continue
+  fi
+
+  if file_has_pattern 'CONFIGHUB_TOKEN.*required|non-interactive CI mode|--mode connected' "$script"; then
+    continue
+  fi
+
+  failures+=("${script#$ROOT_DIR/}: missing connected auth/preflight contract")
+done
+
+if [ "${#failures[@]}" -gt 0 ]; then
+  echo "error: connected auth contract check failed:" >&2
+  for failure in "${failures[@]}"; do
+    echo "  - $failure" >&2
+  done
+  exit 1
+fi
+
+echo "ok: all connected scripts use shared preflight/lifecycle or explicit CI auth contract"


### PR DESCRIPTION
## Summary
- add a new gate: `test/checks/check-connected-auth-contract.sh`
- enforce connected-script auth contract across:
  - `examples/demo/*connected*.sh`
  - `examples/*/demo-connected.sh`
- accepted contracts:
  1) shared connected preflight (`connected-preflight.sh` / `require_connected_preflight`)
  2) connected lifecycle wrapper (`run-confighub-lifecycle-connected.sh`)
  3) explicit CI non-interactive auth contract (`CONFIGHUB_TOKEN` required)
- wire the gate into both `ci-local` and `ci-connected`

## Validation
- `make ci-local`
