### PR TITLE
docs: add own-repo quickstart to getting started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,24 @@ cd cub-gen
 go build -o cub-gen ./cmd/cub-gen
 ```
 
+## Use your own repo in 3 commands
+
+```bash
+REPO=/path/to/your/repo
+./cub-gen change preview --space platform "$REPO" "$REPO"
+./cub-gen change run --mode local --space platform "$REPO" "$REPO"
+./cub-gen change explain --space platform --owner app-team "$REPO" "$REPO"
+```
+
+Connected mode for the same repo:
+
+```bash
+cub auth login
+BASE_URL="${CONFIGHUB_BASE_URL:-$(cub context get --json | jq -r '.coordinate.serverURL')}"
+TOKEN="$(cub auth get-token)"
+./cub-gen change run --mode connected --base-url "$BASE_URL" --token "$TOKEN" --space platform "$REPO" "$REPO"
+```
+
 ## Your first import (Helm)
 
 The three core commands mirror `cub gitops`:

--- a/test/checks/check-docs-entrypoints.sh
+++ b/test/checks/check-docs-entrypoints.sh
@@ -45,6 +45,8 @@ require_file_pattern "docs/index.md" "cub auth login" "connected auth step (cub 
 require_file_pattern "docs/index.md" "confighubai/confighub" "ConfigHub OSS backend link"
 require_file_pattern "docs/platform.md" "cub auth login" "connected auth step (cub auth login)"
 require_file_pattern "docs/platform.md" "confighubai/confighub" "ConfigHub OSS backend link"
+require_file_pattern "docs/getting-started.md" "Use your own repo in 3 commands" "own-repo quickstart section"
+require_file_pattern "docs/getting-started.md" "cub auth login" "connected auth step (cub auth login)"
 
 # Examples landing page must keep own-repo entry and confidence guidance.
 require_file_pattern "examples/README.md" "Use your own repo quickly" "own-repo quickstart section"


### PR DESCRIPTION
## Summary
- add "Use your own repo in 3 commands" to docs-site `docs/getting-started.md`
- add connected mode variant starting with `cub auth login`
- extend docs entrypoint gate to enforce own-repo + auth guidance in getting-started

## Validation
- `make ci-local`
