### PR TITLE
ci: enforce operation registry discoverability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-troubleshoot docs docs-serve
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -62,15 +62,18 @@ check-no-legacy-provider-terms:
 check-connected-auth-contract:
 	./test/checks/check-connected-auth-contract.sh
 
+check-registry-discoverability:
+	./test/checks/check-registry-discoverability.sh
+
 update-goldens:
 	UPDATE_GOLDEN=1 go test ./cmd/cub-gen -run 'Golden' -count=1 -v
 
 sync-triple-styles:
 	go run ./cmd/cub-gen-style-sync
 
-ci-local: build test test-contracts test-bridge-symmetry test-examples lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract
+ci-local: build test test-contracts test-bridge-symmetry test-examples lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 
-ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract
+ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 
 ci-connected-troubleshoot:
 	CONNECTED_FALLBACK_MODE=changeset ALLOW_FALLBACK_INGEST=1 ALLOW_STORY_10_SKIP=1 $(MAKE) ci-connected

--- a/test/checks/check-registry-discoverability.sh
+++ b/test/checks/check-registry-discoverability.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+USE_RG=0
+if command -v rg >/dev/null 2>&1; then
+  USE_RG=1
+fi
+
+file_has_pattern() {
+  local pattern="$1"
+  local file="$2"
+  if [ "$USE_RG" -eq 1 ]; then
+    rg -q -- "$pattern" "$file"
+  else
+    grep -Eq -- "$pattern" "$file"
+  fi
+}
+
+guide="docs/workflows/operation-registry-real-apps.md"
+if [ ! -f "$guide" ]; then
+  echo "error: missing operation-registry guide: $guide" >&2
+  exit 1
+fi
+
+declare -a failures=()
+while IFS= read -r registry; do
+  example_dir="$(dirname "$(dirname "$registry")")"
+  example_name="$(basename "$example_dir")"
+  readme="$example_dir/README.md"
+  rel_registry="${registry#$ROOT_DIR/}"
+
+  if [ ! -f "$readme" ]; then
+    failures+=("$example_name: missing README.md for registry-bearing example")
+    continue
+  fi
+
+  if ! file_has_pattern 'platform/registry\.yaml' "$readme"; then
+    failures+=("$example_name: README missing platform/registry.yaml discoverability")
+  fi
+
+  if ! file_has_pattern "$rel_registry" "$guide"; then
+    failures+=("$example_name: operation-registry guide missing $rel_registry")
+  fi
+done < <(find "$ROOT_DIR/examples" -mindepth 3 -maxdepth 3 -type f -path '*/platform/registry.yaml' | sort)
+
+if [ "${#failures[@]}" -gt 0 ]; then
+  echo "error: registry discoverability check failed:" >&2
+  for failure in "${failures[@]}"; do
+    echo "  - $failure" >&2
+  done
+  exit 1
+fi
+
+echo "ok: registry-bearing examples are discoverable in example READMEs and central guide"


### PR DESCRIPTION
## Summary
- add `test/checks/check-registry-discoverability.sh`
- enforce that every example with `platform/registry.yaml` is discoverable in:
  - its own example README (`platform/registry.yaml` mention)
  - the central guide `docs/workflows/operation-registry-real-apps.md`
- wire the gate into both `ci-local` and `ci-connected`

## Validation
- `make ci-local`
