### PR TITLE
docs: link filed follow-up issues in change-surface pack

### DIFF
--- a/docs/plans/2026-03-11-change-surface-issue-pack.md
+++ b/docs/plans/2026-03-11-change-surface-issue-pack.md
@@ -30,6 +30,12 @@ New hardening delivered after initial pack:
 - Connected auth contract gate.
 - Legacy naming gate (`no-config-platform` consistency).
 
+## Filed follow-up issues
+
+- #160 feat(ci): enforce DRY ownership with PR gate for WET edits
+- #161 feat(api): add compatibility `/v1/changes` surface for change lifecycle
+- #162 feat(connected): enforce strict backend-authoritative mode for release paths
+
 ## Product posture (applies to every issue)
 
 - Lead with developer outcomes, not framework jargon.


### PR DESCRIPTION
## Summary
- update `docs/plans/2026-03-11-change-surface-issue-pack.md` to link newly filed follow-up issues:
  - #160 PR gate for WET edits
  - #161 compatibility `/v1/changes` API surface
  - #162 strict backend-authoritative connected release mode

## Validation
- `make ci-local`
