### PR TITLE
ci/docs: enforce strict connected mode in release lanes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,19 +21,19 @@ test-examples:
 	go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$$' -count=1 -v
 
 test-connected-entrypoints:
-	./examples/demo/run-all-connected-entrypoints.sh
+	CONNECTED_FALLBACK_MODE=off ./examples/demo/run-all-connected-entrypoints.sh
 
 test-connected-lifecycles:
-	./examples/demo/run-all-connected-lifecycles.sh
+	CONNECTED_FALLBACK_MODE=off ./examples/demo/run-all-connected-lifecycles.sh
 
 test-phase-3-stories:
-	./examples/demo/run-phase-3-connected-stories.sh
+	CONNECTED_FALLBACK_MODE=off ./examples/demo/run-phase-3-connected-stories.sh
 
 test-phase-4-stories:
-	./examples/demo/run-phase-4-connected-stories.sh
+	CONNECTED_FALLBACK_MODE=off ./examples/demo/run-phase-4-connected-stories.sh
 
 test-connected-governed-reconcile-helm:
-	RECONCILER=both ./examples/demo/e2e-connected-governed-reconcile-helm.sh
+	CONNECTED_FALLBACK_MODE=off RECONCILER=both ./examples/demo/e2e-connected-governed-reconcile-helm.sh
 
 test-live-reconcile-flux:
 	./examples/demo/e2e-live-reconcile-flux.sh

--- a/README.md
+++ b/README.md
@@ -230,4 +230,7 @@ make ci-connected
 make ci-connected-troubleshoot
 ```
 
+`make ci-connected` enforces strict backend-authoritative mode (`CONNECTED_FALLBACK_MODE=off`).
+Use `make ci-connected-troubleshoot` only for fallback diagnostics.
+
 Contributing guide: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -128,6 +128,11 @@ Bridge endpoint behavior:
 - Forced fallback (`CONNECTED_FALLBACK_MODE=changeset`): always use backend `changeset` fallback (troubleshooting only).
 - Release qualification policy: keep `ALLOW_FALLBACK_INGEST=0` and `ALLOW_STORY_10_SKIP=0` (strict mode).
 
+CI behavior:
+
+- `make ci-connected` enforces strict mode (`CONNECTED_FALLBACK_MODE=off`).
+- `make ci-connected-troubleshoot` is the only fallback-enabled lane.
+
 Fallback mode records `ingest.json`/`decision-final.json` in the standard contract shape with `source=confighub-backend-changeset-fallback`, so story scripts and CI gates remain deterministic.
 
 If your backend exposes non-default paths, set `BRIDGE_INGEST_ENDPOINT` and `BRIDGE_DECISION_ENDPOINT`.


### PR DESCRIPTION
## Summary
- enforce strict connected behavior in release lanes by pinning:
  - `CONNECTED_FALLBACK_MODE=off` for all canonical connected test targets
- keep fallback mode isolated to `ci-connected-troubleshoot`
- update docs (`README.md`, `examples/demo/README.md`) to clearly separate strict release mode vs troubleshoot lane

## Validation
- `make ci-local`

## Related
- closes #162
