### PR TITLE
feat(ci): enforce DRY ownership in PRs for Helm + Spring

### DIFF
--- a/.github/workflows/pr-dry-ownership-gate.yml
+++ b/.github/workflows/pr-dry-ownership-gate.yml
@@ -1,0 +1,161 @@
+name: PR DRY Ownership Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'examples/helm-paas/**'
+      - 'examples/springboot-paas/**'
+      - 'test/checks/pr-dry-ownership-gate.sh'
+      - '.github/workflows/pr-dry-ownership-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - slug: helm
+            repo_path: ./examples/helm-paas
+            actor_role: app-team
+          - slug: springboot
+            repo_path: ./examples/springboot-paas
+            actor_role: app-team
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Resolve base/head refs
+        id: refs
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ -n "$PR_BASE_SHA" ] && [ -n "$PR_HEAD_SHA" ]; then
+            echo "base_ref=$PR_BASE_SHA" >> "$GITHUB_OUTPUT"
+            echo "head_ref=$PR_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          else
+            # workflow_dispatch fallback
+            echo "base_ref=HEAD~1" >> "$GITHUB_OUTPUT"
+            echo "head_ref=HEAD" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run DRY ownership gate
+        id: gate
+        continue-on-error: true
+        env:
+          REPO_PATH: ${{ matrix.repo_path }}
+          ACTOR_ROLE: ${{ matrix.actor_role }}
+          BASE_REF: ${{ steps.refs.outputs.base_ref }}
+          HEAD_REF: ${{ steps.refs.outputs.head_ref }}
+        run: |
+          out_dir=".tmp/pr-gate/${{ matrix.slug }}"
+          mkdir -p "$out_dir"
+          report="$out_dir/report.json"
+          log="$out_dir/gate.log"
+
+          set +e
+          ./test/checks/pr-dry-ownership-gate.sh "$REPO_PATH" "$BASE_REF" "$HEAD_REF" "$ACTOR_ROLE" --report-json "$report" >"$log" 2>&1
+          exit_code=$?
+          set -e
+
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          echo "report=$report" >> "$GITHUB_OUTPUT"
+          echo "log=$log" >> "$GITHUB_OUTPUT"
+
+          cat "$log"
+
+      - name: Build failure comment payload
+        if: steps.gate.outputs.exit_code != '0' && github.event_name == 'pull_request'
+        id: comment
+        env:
+          REPORT_PATH: ${{ steps.gate.outputs.report }}
+        run: |
+          out_dir=".tmp/pr-gate/${{ matrix.slug }}"
+          comment_file="$out_dir/comment.md"
+          marker="<!-- cub-gen-dry-ownership:${{ matrix.slug }} -->"
+
+          {
+            echo "$marker"
+            echo "### cub-gen DRY ownership gate failed (${{ matrix.slug }})"
+            echo
+            echo "Repository path: \`${{ matrix.repo_path }}\`"
+            echo "Actor role: \`${{ matrix.actor_role }}\`"
+            echo
+            echo "Detected violations:"
+            jq -r '.failures[]? | "- \(.)"' "$REPORT_PATH"
+            echo
+            echo "Suggested DRY edit guidance:"
+            echo
+            echo "| Wet path | Suggested DRY path | Suggested DRY file(s) | Owner | Confidence |"
+            echo "|---|---|---|---|---|"
+            jq -r '.suggestions[]? | "| `\(.wet_path)` | `\(.dry_path)` | `\((.dry_files // []) | join(", "))` | `\(.owner)` | \((.confidence // 0) | tostring) |"' "$REPORT_PATH"
+          } > "$comment_file"
+
+          echo "comment_file=$comment_file" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert PR comment
+        if: steps.gate.outputs.exit_code != '0' && github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        env:
+          COMMENT_FILE: ${{ steps.comment.outputs.comment_file }}
+          COMMENT_MARKER: "<!-- cub-gen-dry-ownership:${{ matrix.slug }} -->"
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = process.env.COMMENT_MARKER;
+            const body = fs.readFileSync(process.env.COMMENT_FILE, 'utf8');
+            const issue_number = context.issue.number;
+            const { owner, repo } = context.repo;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            for (const c of comments) {
+              if (c.user?.type === 'Bot' && c.body?.includes(marker)) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id });
+              }
+            }
+
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+
+      - name: Build success summary
+        if: steps.gate.outputs.exit_code == '0'
+        env:
+          REPORT_PATH: ${{ steps.gate.outputs.report }}
+        run: |
+          {
+            echo "### DRY ownership gate passed (${{ matrix.slug }})"
+            echo
+            echo "Checked files:"
+            jq -r '.changed_files[]? | "- \(.)"' "$REPORT_PATH"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload gate artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dry-ownership-gate-${{ matrix.slug }}
+          path: |
+            ${{ steps.gate.outputs.report }}
+            ${{ steps.gate.outputs.log }}
+
+      - name: Fail job on BLOCK
+        if: steps.gate.outputs.exit_code != '0'
+        run: exit 1

--- a/docs/workflows/connected-ci-bootstrap.md
+++ b/docs/workflows/connected-ci-bootstrap.md
@@ -59,3 +59,30 @@ This explicitly enables:
 - `CONNECTED_FALLBACK_MODE=changeset`
 - `ALLOW_FALLBACK_INGEST=1`
 - `ALLOW_STORY_10_SKIP=1`
+
+## 5) PR DRY ownership gate (WET edit blocker)
+
+Use the dedicated workflow:
+
+- `.github/workflows/pr-dry-ownership-gate.yml`
+
+What it does:
+
+- Runs `test/checks/pr-dry-ownership-gate.sh` for:
+  - `examples/helm-paas`
+  - `examples/springboot-paas`
+- Compares PR-changed YAML/JSON files to recognized DRY inputs.
+- Blocks merge if a PR edits non-DRY/WET paths (or wrong-owner DRY paths when actor role is enforced).
+- Posts an actionable PR comment with:
+  - `wet_path`
+  - suggested `dry_path`
+  - suggested DRY file candidates
+  - owner
+  - confidence
+
+Manual run (local against refs):
+
+```bash
+./test/checks/pr-dry-ownership-gate.sh ./examples/helm-paas origin/main HEAD app-team --report-json .tmp/pr-gate/helm.json
+./test/checks/pr-dry-ownership-gate.sh ./examples/springboot-paas origin/main HEAD app-team --report-json .tmp/pr-gate/spring.json
+```

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -62,6 +62,17 @@ If your platform is workflow-heavy, start here before app-manifest demos:
 | `run-all-connected-entrypoints.sh` | Runs every `examples/*/demo-connected.sh` entrypoint (all examples, optional `live-reconcile`) |
 | `simulate-repo-wizard.sh <repo> <target> [hint]` | GUI wizard simulation path |
 
+## CI policy gates (PR path)
+
+Use these when you want merge-blocking enforcement, not just local guidance:
+
+- `test/checks/pr-dry-ownership-gate.sh <repo-path> <base-ref> <head-ref> [actor-role] --report-json <path>`
+  - Blocks direct WET edits by requiring recognized DRY input files.
+  - Emits JSON with failures plus inverse-edit suggestions (`wet_path`, `dry_path`, owner, confidence).
+- `.github/workflows/pr-dry-ownership-gate.yml`
+  - Runs the gate for Helm + Spring examples.
+  - Posts a PR comment with actionable DRY edit guidance and fails status on BLOCK.
+
 ## Phase 3 connected story scripts
 
 | Script | User story | What it demonstrates |

--- a/test/checks/pr-dry-ownership-gate.sh
+++ b/test/checks/pr-dry-ownership-gate.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  ./test/checks/pr-dry-ownership-gate.sh <repo-path> <base-ref> <head-ref> [actor-role] [--report-json <path>]
+
+Example:
+  ./test/checks/pr-dry-ownership-gate.sh ./examples/helm-paas origin/main HEAD app-team
+  ./test/checks/pr-dry-ownership-gate.sh ./examples/helm-paas origin/main HEAD app-team --report-json .tmp/pr-gate/report.json
+
+Behavior:
+  - Loads DRY inputs via `cub-gen gitops import`.
+  - Scans changed YAML/JSON files in <repo-path> between refs.
+  - Fails if a changed file is not a recognized DRY input.
+  - Optionally enforces owner role match for DRY files unless actor-role is `any`.
+  - Optionally writes a JSON report with failures + inverse-edit suggestions.
+USAGE
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+REPO_PATH="${1:-}"
+BASE_REF="${2:-}"
+HEAD_REF="${3:-}"
+ACTOR_ROLE="${4:-any}"
+SPACE="${SPACE:-platform}"
+REPORT_JSON="${REPORT_JSON:-}"
+
+if [ "${5:-}" = "--report-json" ]; then
+  REPORT_JSON="${6:-}"
+elif [ -n "${5:-}" ]; then
+  echo "error: unsupported argument: ${5:-}" >&2
+  usage >&2
+  exit 1
+fi
+
+if [ "${5:-}" = "--report-json" ] && [ -z "$REPORT_JSON" ]; then
+  echo "error: --report-json requires a path" >&2
+  usage >&2
+  exit 1
+fi
+
+if [ -z "$REPO_PATH" ] || [ -z "$BASE_REF" ] || [ -z "$HEAD_REF" ]; then
+  usage >&2
+  exit 1
+fi
+
+if [ ! -d "$REPO_PATH" ]; then
+  echo "error: repo path not found: $REPO_PATH" >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "error: base ref not found: $BASE_REF" >&2
+  exit 1
+fi
+if ! git rev-parse --verify "$HEAD_REF" >/dev/null 2>&1; then
+  echo "error: head ref not found: $HEAD_REF" >&2
+  exit 1
+fi
+
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  go build -o ./cub-gen ./cmd/cub-gen
+fi
+
+repo_norm="${REPO_PATH#./}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+./cub-gen gitops import --space "$SPACE" --json "$REPO_PATH" "$REPO_PATH" > "$tmpdir/import.json"
+
+jq -r '.dry_inputs[]? | "\(.path)\t\(.owner)"' "$tmpdir/import.json" > "$tmpdir/dry-inputs.tsv"
+jq '[.dry_inputs[]? | {path, owner, role}]' "$tmpdir/import.json" > "$tmpdir/dry-inputs.json"
+jq '
+  (.dry_inputs // []) as $inputs
+  |
+  [.provenance[]?.inverse_edit_pointers[]? as $ptr
+   | {
+       wet_path: $ptr.wet_path,
+       dry_path: $ptr.dry_path,
+       dry_files: ($inputs | map(select(.owner == $ptr.owner) | .path) | unique),
+       owner: $ptr.owner,
+       confidence: $ptr.confidence,
+       edit_hint: $ptr.edit_hint
+     }]
+  | sort_by(-(.confidence // 0))
+  | .[:10]
+' "$tmpdir/import.json" > "$tmpdir/inverse-pointers.json"
+
+write_report() {
+  local status="$1"
+
+  : > "$tmpdir/checked-files.txt"
+  for file in "${checked_files[@]:-}"; do
+    [ -n "$file" ] || continue
+    printf '%s\n' "$file" >> "$tmpdir/checked-files.txt"
+  done
+
+  : > "$tmpdir/failures.txt"
+  for failure in "${failures[@]:-}"; do
+    [ -n "$failure" ] || continue
+    printf '%s\n' "$failure" >> "$tmpdir/failures.txt"
+  done
+
+  jq -Rs 'split("\n") | map(select(length > 0))' "$tmpdir/checked-files.txt" > "$tmpdir/checked-files.json"
+  jq -Rs 'split("\n") | map(select(length > 0))' "$tmpdir/failures.txt" > "$tmpdir/failures.json"
+
+  if [ -n "$REPORT_JSON" ]; then
+    mkdir -p "$(dirname "$REPORT_JSON")"
+    jq -n \
+      --arg status "$status" \
+      --arg repo_path "$repo_norm" \
+      --arg base_ref "$BASE_REF" \
+      --arg head_ref "$HEAD_REF" \
+      --arg actor_role "$ACTOR_ROLE" \
+      --arg space "$SPACE" \
+      --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --argjson changed_files "$(cat "$tmpdir/checked-files.json")" \
+      --argjson failures "$(cat "$tmpdir/failures.json")" \
+      --argjson dry_inputs "$(cat "$tmpdir/dry-inputs.json")" \
+      --argjson suggestions "$(cat "$tmpdir/inverse-pointers.json")" \
+      '{
+        status: $status,
+        repo_path: $repo_path,
+        base_ref: $base_ref,
+        head_ref: $head_ref,
+        actor_role: $actor_role,
+        space: $space,
+        generated_at: $generated_at,
+        changed_files: $changed_files,
+        failures: $failures,
+        dry_inputs: $dry_inputs,
+        suggestions: $suggestions
+      }' > "$REPORT_JSON"
+  fi
+}
+
+declare -a changed_files=()
+while IFS= read -r changed; do
+  changed_files+=("$changed")
+done < <(git diff --name-only "$BASE_REF" "$HEAD_REF" -- "$repo_norm")
+
+declare -a checked_files=()
+declare -a failures=()
+
+if [ "${#changed_files[@]}" -eq 0 ]; then
+  write_report "pass"
+  echo "ok: no changed files under $repo_norm"
+  exit 0
+fi
+
+for changed in "${changed_files[@]}"; do
+  case "$changed" in
+    *.yaml|*.yml|*.json) ;;
+    *) continue ;;
+  esac
+  checked_files+=("$changed")
+
+  rel="$changed"
+  if [[ "$rel" == "$repo_norm/"* ]]; then
+    rel="${rel#"$repo_norm/"}"
+  fi
+
+  dry_line="$(awk -F'\t' -v path="$rel" '$1 == path {print $0}' "$tmpdir/dry-inputs.tsv" || true)"
+  if [ -z "$dry_line" ]; then
+    failures+=("$changed: changed file is not a recognized DRY input for this generator")
+    continue
+  fi
+
+  owner="$(printf '%s' "$dry_line" | cut -f2)"
+  if [ "$ACTOR_ROLE" != "any" ] && [ "$owner" != "$ACTOR_ROLE" ]; then
+    failures+=("$changed: owner mismatch (file owner=$owner, actor role=$ACTOR_ROLE)")
+  fi
+done
+
+if [ "${#failures[@]}" -gt 0 ]; then
+  write_report "fail"
+  echo "error: PR dry-ownership gate failed for $repo_norm" >&2
+  for failure in "${failures[@]}"; do
+    echo "  - $failure" >&2
+  done
+
+  top_hint="$(jq -r '
+    [.provenance[]?.inverse_edit_pointers[]?]
+    | sort_by(-(.confidence // 0))
+    | .[0].edit_hint // "Use `cub-gen change explain` to locate correct DRY edit path."
+  ' "$tmpdir/import.json")"
+  echo "hint: $top_hint" >&2
+  exit 2
+fi
+
+write_report "pass"
+echo "ok: changed YAML/JSON files are DRY inputs and pass ownership role check"


### PR DESCRIPTION
## Summary
- add a Bash-3-compatible `test/checks/pr-dry-ownership-gate.sh` that compares PR YAML/JSON edits against recognized DRY inputs
- emit optional structured JSON reports with failures and inverse-edit suggestions (`wet_path`, `dry_path`, DRY file candidates, owner, confidence)
- add `.github/workflows/pr-dry-ownership-gate.yml` to run gate checks on Helm + Spring example PR paths, upload artifacts, and upsert actionable PR comments on BLOCK
- document gate usage in `docs/workflows/connected-ci-bootstrap.md` and `examples/demo/README.md`

## Validation
- `make ci-local`
- `./test/checks/pr-dry-ownership-gate.sh ./examples/helm-paas HEAD HEAD any --report-json .tmp/pr-gate/pass.json`
- `./test/checks/pr-dry-ownership-gate.sh ./examples/helm-paas 9784e69 HEAD app-team --report-json .tmp/pr-gate/fail.json`
- `./test/checks/pr-dry-ownership-gate.sh ./examples/springboot-paas 9784e69 HEAD app-team --report-json .tmp/pr-gate/spring-fail.json`

Closes #160
