### PR TITLE
feat(api): add /v1/changes compatibility HTTP lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-troubleshoot docs docs-serve
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -19,6 +19,9 @@ test-bridge-symmetry:
 
 test-examples:
 	go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$$' -count=1 -v
+
+test-change-api-http:
+	./examples/demo/change-api-http-e2e.sh
 
 test-connected-entrypoints:
 	CONNECTED_FALLBACK_MODE=off ./examples/demo/run-all-connected-entrypoints.sh
@@ -71,7 +74,7 @@ update-goldens:
 sync-triple-styles:
 	go run ./cmd/cub-gen-style-sync
 
-ci-local: build test test-contracts test-bridge-symmetry test-examples lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
+ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 
 ci-connected: build test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-ai-only-scope check-docs-entrypoints check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 

--- a/cmd/cub-gen/change_api.go
+++ b/cmd/cub-gen/change_api.go
@@ -1,0 +1,516 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	bridgeflow "github.com/confighub/cub-gen/internal/bridge"
+	"github.com/confighub/cub-gen/internal/model"
+)
+
+type changeRunOptions struct {
+	Space            string
+	Ref              string
+	WhereResource    string
+	Mode             string
+	BaseURL          string
+	Token            string
+	IngestEndpoint   string
+	DecisionEndpoint string
+	Verifier         string
+}
+
+func executeChangeRun(targetSlug, renderTargetSlug string, opts changeRunOptions) (changeRunResult, []model.ProvenanceRecord, error) {
+	runMode := strings.ToLower(strings.TrimSpace(opts.Mode))
+	if runMode != "local" && runMode != "connected" {
+		return changeRunResult{}, nil, errors.New("change run --mode must be local|connected")
+	}
+	verifier := strings.TrimSpace(opts.Verifier)
+	if verifier == "" {
+		verifier = "cub-gen"
+	}
+
+	preview, bundle, imported, err := buildChangePreviewResult(
+		targetSlug,
+		renderTargetSlug,
+		opts.Space,
+		opts.Ref,
+		opts.WhereResource,
+		verifier,
+	)
+	if err != nil {
+		return changeRunResult{}, nil, err
+	}
+
+	decision := changeRunDecision{
+		State:     "ALLOW",
+		Authority: verifier,
+		Source:    "local-preview",
+	}
+	promotionReady := true
+
+	if runMode == "connected" {
+		resolvedBaseURL := strings.TrimSpace(opts.BaseURL)
+		if resolvedBaseURL == "" {
+			resolvedBaseURL = strings.TrimSpace(os.Getenv("CONFIGHUB_BASE_URL"))
+		}
+		if resolvedBaseURL == "" {
+			return changeRunResult{}, nil, errors.New("change run --mode connected requires --base-url or CONFIGHUB_BASE_URL")
+		}
+
+		resolvedToken := strings.TrimSpace(opts.Token)
+		if resolvedToken == "" {
+			resolvedToken = strings.TrimSpace(os.Getenv("CONFIGHUB_TOKEN"))
+		}
+
+		ingestRes, err := bridgeflow.IngestBundle(context.Background(), bridgeflow.Client{
+			BaseURL:      resolvedBaseURL,
+			BearerToken:  resolvedToken,
+			EndpointPath: strings.TrimSpace(opts.IngestEndpoint),
+		}, bundle)
+		if err != nil {
+			return changeRunResult{}, nil, fmt.Errorf("connected ingest: %w", err)
+		}
+
+		decisionRec, err := bridgeflow.QueryDecisionByChangeID(context.Background(), bridgeflow.DecisionClient{
+			BaseURL:      resolvedBaseURL,
+			BearerToken:  resolvedToken,
+			EndpointPath: strings.TrimSpace(opts.DecisionEndpoint),
+		}, preview.Change.ChangeID)
+		if err != nil {
+			return changeRunResult{}, nil, fmt.Errorf("connected decision query: %w", err)
+		}
+
+		authority := strings.TrimSpace(decisionRec.ApprovedBy)
+		if authority == "" {
+			authority = strings.TrimSpace(decisionRec.PolicyDecisionRef)
+		}
+		if authority == "" {
+			authority = "confighub-policy"
+		}
+
+		decision = changeRunDecision{
+			State:     string(decisionRec.State),
+			Authority: authority,
+			Source:    "confighub-backend",
+		}
+		if decision.State != "ALLOW" {
+			promotionReady = false
+		}
+		if strings.TrimSpace(ingestRes.ChangeID) == "" {
+			promotionReady = false
+		}
+	}
+
+	result := changeRunResult{
+		Mode:           runMode,
+		Preview:        preview,
+		Decision:       decision,
+		PromotionReady: promotionReady,
+	}
+	return result, imported.Provenance, nil
+}
+
+type changeAPIInput struct {
+	TargetSlug       string `json:"target_slug"`
+	RenderTargetSlug string `json:"render_target_slug"`
+	Space            string `json:"space,omitempty"`
+	Ref              string `json:"ref,omitempty"`
+	WhereResource    string `json:"where_resource,omitempty"`
+}
+
+type changeAPIConnected struct {
+	BaseURL          string `json:"base_url,omitempty"`
+	Token            string `json:"token,omitempty"`
+	IngestEndpoint   string `json:"ingest_endpoint,omitempty"`
+	DecisionEndpoint string `json:"decision_endpoint,omitempty"`
+}
+
+type changeAPIRequest struct {
+	Action    string             `json:"action"`
+	Mode      string             `json:"mode,omitempty"`
+	Input     changeAPIInput     `json:"input"`
+	Connected changeAPIConnected `json:"connected,omitempty"`
+}
+
+type changeAPIResponse struct {
+	Change             changePreviewSummary      `json:"change"`
+	Decision           *changeRunDecision        `json:"decision,omitempty"`
+	PromotionReady     *bool                     `json:"promotion_ready,omitempty"`
+	Verification       changePreviewVerification `json:"verification"`
+	EditRecommendation model.InverseEditPointer  `json:"edit_recommendation"`
+	Artifacts          map[string]string         `json:"artifacts"`
+}
+
+type apiErrorBody struct {
+	Error struct {
+		Code    string         `json:"code"`
+		Message string         `json:"message"`
+		Details map[string]any `json:"details,omitempty"`
+	} `json:"error"`
+}
+
+type changeRecord struct {
+	Input              changePreviewInput
+	Change             changePreviewSummary
+	Verification       changePreviewVerification
+	EditRecommendation model.InverseEditPointer
+	Decision           *changeRunDecision
+	PromotionReady     *bool
+	Artifacts          map[string]string
+	Provenance         []model.ProvenanceRecord
+}
+
+type changeAPIServer struct {
+	defaultSpace    string
+	defaultRef      string
+	defaultVerifier string
+
+	mu      sync.RWMutex
+	records map[string]changeRecord
+}
+
+func runChangeAPI(args []string) error {
+	if len(args) == 0 {
+		printChangeAPIUsage(os.Stderr)
+		return errors.New("change api subcommand required")
+	}
+
+	switch args[0] {
+	case "help", "-h", "--help":
+		printChangeAPIUsage(os.Stdout)
+		return nil
+	case "serve":
+		return runChangeAPIServe(args[1:])
+	default:
+		printChangeAPIUsage(os.Stderr)
+		return fmt.Errorf("unknown change api subcommand: %s", args[0])
+	}
+}
+
+func runChangeAPIServe(args []string) error {
+	fs := flag.NewFlagSet("change api serve", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	listen := fs.String("listen", "127.0.0.1:8787", "Listen address for compatibility API")
+	space := fs.String("space", "default", "Default ConfigHub space label")
+	ref := fs.String("ref", "HEAD", "Default git ref label")
+	verifier := fs.String("verifier", "cub-gen", "Default verifier identity label")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: cub-gen change api serve [--listen ADDR] [--space SPACE] [--ref REF] [--verifier NAME]")
+	}
+
+	handler := newChangeAPIHandler(strings.TrimSpace(*space), strings.TrimSpace(*ref), strings.TrimSpace(*verifier))
+	fmt.Fprintf(os.Stderr, "change api listening on http://%s\n", strings.TrimSpace(*listen))
+	return http.ListenAndServe(strings.TrimSpace(*listen), handler)
+}
+
+func newChangeAPIHandler(defaultSpace, defaultRef, defaultVerifier string) http.Handler {
+	space := strings.TrimSpace(defaultSpace)
+	if space == "" {
+		space = "default"
+	}
+	ref := strings.TrimSpace(defaultRef)
+	if ref == "" {
+		ref = "HEAD"
+	}
+	verifier := strings.TrimSpace(defaultVerifier)
+	if verifier == "" {
+		verifier = "cub-gen"
+	}
+
+	return &changeAPIServer{
+		defaultSpace:    space,
+		defaultRef:      ref,
+		defaultVerifier: verifier,
+		records:         map[string]changeRecord{},
+	}
+}
+
+func (s *changeAPIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/v1/changes" && r.Method == http.MethodPost:
+		s.handlePostChanges(w, r)
+		return
+	case strings.HasPrefix(r.URL.Path, "/v1/changes/"):
+		s.handleChangeByID(w, r)
+		return
+	case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+		writeJSONResponse(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	default:
+		writeAPIError(w, http.StatusNotFound, "NOT_FOUND", "endpoint not found", nil)
+		return
+	}
+}
+
+func (s *changeAPIServer) handlePostChanges(w http.ResponseWriter, r *http.Request) {
+	var req changeAPIRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_REQUEST", "invalid JSON body", map[string]any{"error": err.Error()})
+		return
+	}
+	if dec.More() {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_REQUEST", "invalid JSON body", map[string]any{"error": "multiple JSON values"})
+		return
+	}
+
+	action := strings.ToLower(strings.TrimSpace(req.Action))
+	if action == "" {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_REQUEST", "action is required", map[string]any{"field": "action"})
+		return
+	}
+	if action != "preview" && action != "run" {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_REQUEST", "action must be preview|run", map[string]any{"field": "action"})
+		return
+	}
+
+	targetSlug := strings.TrimSpace(req.Input.TargetSlug)
+	renderTargetSlug := strings.TrimSpace(req.Input.RenderTargetSlug)
+	if targetSlug == "" || renderTargetSlug == "" {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_REQUEST", "input.target_slug and input.render_target_slug are required", map[string]any{"field": "input"})
+		return
+	}
+
+	space := strings.TrimSpace(req.Input.Space)
+	if space == "" {
+		space = s.defaultSpace
+	}
+	ref := strings.TrimSpace(req.Input.Ref)
+	if ref == "" {
+		ref = s.defaultRef
+	}
+	whereResource := strings.TrimSpace(req.Input.WhereResource)
+
+	if action == "preview" {
+		preview, _, imported, err := buildChangePreviewResult(targetSlug, renderTargetSlug, space, ref, whereResource, s.defaultVerifier)
+		if err != nil {
+			writeAPIError(w, http.StatusUnprocessableEntity, "CHANGE_FAILED", err.Error(), nil)
+			return
+		}
+		record := changeRecord{
+			Input:              preview.Input,
+			Change:             preview.Change,
+			Verification:       preview.Verification,
+			EditRecommendation: preview.EditRecommendation,
+			Artifacts:          defaultArtifactRefs(preview.Change.ChangeID),
+			Provenance:         imported.Provenance,
+		}
+		s.upsertRecord(record)
+		writeJSONResponse(w, http.StatusOK, changeAPIResponse{
+			Change:             record.Change,
+			Verification:       record.Verification,
+			EditRecommendation: record.EditRecommendation,
+			Artifacts:          cloneStringMap(record.Artifacts),
+		})
+		return
+	}
+
+	runMode := strings.ToLower(strings.TrimSpace(req.Mode))
+	if runMode == "" {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_REQUEST", "mode is required for action=run", map[string]any{"field": "mode"})
+		return
+	}
+
+	runResult, provenance, err := executeChangeRun(targetSlug, renderTargetSlug, changeRunOptions{
+		Space:            space,
+		Ref:              ref,
+		WhereResource:    whereResource,
+		Mode:             runMode,
+		BaseURL:          strings.TrimSpace(req.Connected.BaseURL),
+		Token:            strings.TrimSpace(req.Connected.Token),
+		IngestEndpoint:   strings.TrimSpace(req.Connected.IngestEndpoint),
+		DecisionEndpoint: strings.TrimSpace(req.Connected.DecisionEndpoint),
+		Verifier:         s.defaultVerifier,
+	})
+	if err != nil {
+		status := http.StatusUnprocessableEntity
+		if strings.Contains(err.Error(), "requires --base-url") || strings.Contains(err.Error(), "mode must be") {
+			status = http.StatusBadRequest
+		}
+		writeAPIError(w, status, "CHANGE_FAILED", err.Error(), nil)
+		return
+	}
+
+	promotion := runResult.PromotionReady
+	record := changeRecord{
+		Input:              runResult.Preview.Input,
+		Change:             runResult.Preview.Change,
+		Verification:       runResult.Preview.Verification,
+		EditRecommendation: runResult.Preview.EditRecommendation,
+		Decision: &changeRunDecision{
+			State:     runResult.Decision.State,
+			Authority: runResult.Decision.Authority,
+			Source:    runResult.Decision.Source,
+		},
+		PromotionReady: &promotion,
+		Artifacts:      defaultArtifactRefs(runResult.Preview.Change.ChangeID),
+		Provenance:     provenance,
+	}
+	s.upsertRecord(record)
+
+	writeJSONResponse(w, http.StatusOK, changeAPIResponse{
+		Change:             record.Change,
+		Decision:           record.Decision,
+		PromotionReady:     record.PromotionReady,
+		Verification:       record.Verification,
+		EditRecommendation: record.EditRecommendation,
+		Artifacts:          cloneStringMap(record.Artifacts),
+	})
+}
+
+func (s *changeAPIServer) handleChangeByID(w http.ResponseWriter, r *http.Request) {
+	trimmed := strings.TrimPrefix(r.URL.Path, "/v1/changes/")
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" {
+		writeAPIError(w, http.StatusNotFound, "NOT_FOUND", "endpoint not found", nil)
+		return
+	}
+	parts := strings.Split(trimmed, "/")
+	changeID, err := url.PathUnescape(parts[0])
+	if err != nil || strings.TrimSpace(changeID) == "" {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_REQUEST", "invalid change_id path segment", nil)
+		return
+	}
+
+	record, ok := s.getRecord(changeID)
+	if !ok {
+		writeAPIError(w, http.StatusNotFound, "NOT_FOUND", "change_id not found", map[string]any{"change_id": changeID})
+		return
+	}
+
+	if len(parts) == 1 {
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed", nil)
+			return
+		}
+		writeJSONResponse(w, http.StatusOK, changeAPIResponse{
+			Change:             record.Change,
+			Decision:           record.Decision,
+			PromotionReady:     record.PromotionReady,
+			Verification:       record.Verification,
+			EditRecommendation: record.EditRecommendation,
+			Artifacts:          cloneStringMap(record.Artifacts),
+		})
+		return
+	}
+
+	if len(parts) == 2 && parts[1] == "explanations" {
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed", nil)
+			return
+		}
+		wetFilter := strings.TrimSpace(r.URL.Query().Get("wet_path"))
+		dryFilter := strings.TrimSpace(r.URL.Query().Get("dry_path"))
+		ownerFilter := strings.TrimSpace(r.URL.Query().Get("owner"))
+		suggestion, matchCount, ok := pickInverseSuggestion(record.Provenance, wetFilter, dryFilter, ownerFilter)
+		if !ok {
+			writeAPIError(w, http.StatusNotFound, "NOT_FOUND", "no matching explanations", map[string]any{"change_id": changeID})
+			return
+		}
+		resp := changeExplainResult{
+			Input:  record.Input,
+			Change: record.Change,
+			Query: changeExplainQuery{
+				WetPathFilter: wetFilter,
+				DryPathFilter: dryFilter,
+				OwnerFilter:   ownerFilter,
+				MatchCount:    matchCount,
+			},
+			Explanation: suggestion,
+		}
+		writeJSONResponse(w, http.StatusOK, resp)
+		return
+	}
+
+	writeAPIError(w, http.StatusNotFound, "NOT_FOUND", "endpoint not found", nil)
+}
+
+func (s *changeAPIServer) upsertRecord(record changeRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[record.Change.ChangeID] = record
+}
+
+func (s *changeAPIServer) getRecord(changeID string) (changeRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	record, ok := s.records[changeID]
+	if !ok {
+		return changeRecord{}, false
+	}
+	return record, true
+}
+
+func defaultArtifactRefs(changeID string) map[string]string {
+	items := map[string]string{
+		"bundle":      fmt.Sprintf("change://%s/bundle", changeID),
+		"attestation": fmt.Sprintf("change://%s/attestation", changeID),
+		"provenance":  fmt.Sprintf("change://%s/provenance", changeID),
+	}
+	keys := make([]string, 0, len(items))
+	for k := range items {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	ordered := make(map[string]string, len(items))
+	for _, k := range keys {
+		ordered[k] = items[k]
+	}
+	return ordered
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func writeAPIError(w http.ResponseWriter, status int, code, message string, details map[string]any) {
+	resp := apiErrorBody{}
+	resp.Error.Code = code
+	resp.Error.Message = message
+	if len(details) > 0 {
+		resp.Error.Details = details
+	}
+	writeJSONResponse(w, status, resp)
+}
+
+func writeJSONResponse(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(payload)
+}
+
+func printChangeAPIUsage(out *os.File) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  cub-gen change api serve [--listen ADDR] [--space SPACE] [--ref REF] [--verifier NAME]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Compatibility HTTP endpoints:")
+	fmt.Fprintln(out, "  POST /v1/changes")
+	fmt.Fprintln(out, "  GET  /v1/changes/{change_id}")
+	fmt.Fprintln(out, "  GET  /v1/changes/{change_id}/explanations")
+}

--- a/cmd/cub-gen/change_api_server_test.go
+++ b/cmd/cub-gen/change_api_server_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestChangeAPIHTTPRunLifecycleGolden(t *testing.T) {
+	setupAliases(t)
+
+	srv := httptest.NewServer(newChangeAPIHandler("platform", "HEAD", "ci-bot"))
+	defer srv.Close()
+
+	postReq := map[string]any{
+		"action": "run",
+		"mode":   "local",
+		"input": map[string]any{
+			"target_slug":        "score",
+			"render_target_slug": "render-target",
+			"space":              "platform",
+			"ref":                "HEAD",
+		},
+	}
+	status, postResp := mustJSONRequest(t, http.MethodPost, srv.URL+"/v1/changes", postReq)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 from POST /v1/changes, got %d body=%v", status, postResp)
+	}
+
+	changeID := nestedString(t, postResp, "change", "change_id")
+	if !strings.HasPrefix(changeID, "chg_") {
+		t.Fatalf("expected change_id prefix chg_, got %q", changeID)
+	}
+
+	status, getResp := mustJSONRequest(t, http.MethodGet, srv.URL+"/v1/changes/"+changeID, nil)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 from GET /v1/changes/{id}, got %d body=%v", status, getResp)
+	}
+
+	status, explainResp := mustJSONRequest(t, http.MethodGet, srv.URL+"/v1/changes/"+changeID+"/explanations?owner=app-team", nil)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 from GET /v1/changes/{id}/explanations, got %d body=%v", status, explainResp)
+	}
+
+	snapshot := map[string]any{
+		"post":    postResp,
+		"get":     getResp,
+		"explain": explainResp,
+	}
+	normalizeChangeAPIHTTPRunSnapshot(snapshot)
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "change-api-http-run.golden.json"), snapshot)
+}
+
+func TestChangeAPIHTTPErrorGolden(t *testing.T) {
+	setupAliases(t)
+
+	srv := httptest.NewServer(newChangeAPIHandler("platform", "HEAD", "ci-bot"))
+	defer srv.Close()
+
+	badReq := map[string]any{
+		"action": "run",
+		"input": map[string]any{
+			"target_slug":        "score",
+			"render_target_slug": "render-target",
+		},
+	}
+	status, body := mustJSONRequest(t, http.MethodPost, srv.URL+"/v1/changes", badReq)
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected 400 from invalid run request, got %d body=%v", status, body)
+	}
+
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "change-api-http-error.golden.json"), body)
+}
+
+func mustJSONRequest(t *testing.T, method, url string, payload any) (int, map[string]any) {
+	t.Helper()
+
+	var body io.Reader
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal request payload: %v", err)
+		}
+		body = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("perform request: %v", err)
+	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode response JSON: %v\nbody=%s", err, string(data))
+	}
+	return res.StatusCode, decoded
+}
+
+func nestedString(t *testing.T, root map[string]any, path ...string) string {
+	t.Helper()
+
+	var cur any = root
+	for _, segment := range path {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			t.Fatalf("expected map at %q, got %T", segment, cur)
+		}
+		cur = m[segment]
+	}
+	s, ok := cur.(string)
+	if !ok {
+		t.Fatalf("expected string at %v, got %T", path, cur)
+	}
+	return s
+}
+
+func normalizeChangeAPIHTTPRunSnapshot(snapshot map[string]any) {
+	for _, key := range []string{"post", "get", "explain"} {
+		obj, ok := snapshot[key].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if change, ok := obj["change"].(map[string]any); ok {
+			if id, ok := change["change_id"].(string); ok && strings.HasPrefix(id, "chg_") {
+				change["change_id"] = "chg_REDACTED"
+			}
+			if digest, ok := change["bundle_digest"].(string); ok && strings.HasPrefix(digest, "sha256:") {
+				change["bundle_digest"] = "sha256:REDACTED"
+			}
+			if digest, ok := change["attestation_digest"].(string); ok && strings.HasPrefix(digest, "sha256:") {
+				change["attestation_digest"] = "sha256:REDACTED"
+			}
+		}
+
+		if artifacts, ok := obj["artifacts"].(map[string]any); ok {
+			for artifactKey := range artifacts {
+				artifacts[artifactKey] = "change://chg_REDACTED/" + artifactKey
+			}
+		}
+	}
+}

--- a/cmd/cub-gen/change_command_test.go
+++ b/cmd/cub-gen/change_command_test.go
@@ -315,6 +315,16 @@ func TestChangeCommandErrorModes(t *testing.T) {
 			args: []string{"change", "explain", "--change-id", "chg_123"},
 			sub:  "requires --bundle FILE",
 		},
+		{
+			name: "api-missing-subcommand",
+			args: []string{"change", "api"},
+			sub:  "change api subcommand required",
+		},
+		{
+			name: "api-unknown-subcommand",
+			args: []string{"change", "api", "unknown"},
+			sub:  "unknown change api subcommand",
+		},
 	}
 
 	for _, tc := range tests {

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -12,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/confighub/cub-gen/internal/attest"
-	bridgeflow "github.com/confighub/cub-gen/internal/bridge"
 	"github.com/confighub/cub-gen/internal/detect"
 	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
 	"github.com/confighub/cub-gen/internal/importer"
@@ -1053,6 +1051,8 @@ func runChange(args []string) error {
 		return runChangeRun(args[1:])
 	case "explain":
 		return runChangeExplain(args[1:])
+	case "api":
+		return runChangeAPI(args[1:])
 	default:
 		printChangeUsage(os.Stderr)
 		return fmt.Errorf("unknown change subcommand: %s", args[0])
@@ -1142,83 +1142,19 @@ func runChangeRun(args []string) error {
 		return errors.New("change run --mode must be local|connected")
 	}
 
-	preview, bundle, _, err := buildChangePreviewResult(
-		targetSlug,
-		renderTargetSlug,
-		*space,
-		*ref,
-		*whereResource,
-		*verifier,
-	)
+	result, _, err := executeChangeRun(targetSlug, renderTargetSlug, changeRunOptions{
+		Space:            *space,
+		Ref:              *ref,
+		WhereResource:    *whereResource,
+		Mode:             runMode,
+		BaseURL:          *baseURL,
+		Token:            *token,
+		IngestEndpoint:   *ingestEndpoint,
+		DecisionEndpoint: *decisionEndpoint,
+		Verifier:         *verifier,
+	})
 	if err != nil {
 		return err
-	}
-
-	decision := changeRunDecision{
-		State:     "ALLOW",
-		Authority: *verifier,
-		Source:    "local-preview",
-	}
-	promotionReady := true
-
-	if runMode == "connected" {
-		resolvedBaseURL := strings.TrimSpace(*baseURL)
-		if resolvedBaseURL == "" {
-			resolvedBaseURL = strings.TrimSpace(os.Getenv("CONFIGHUB_BASE_URL"))
-		}
-		if resolvedBaseURL == "" {
-			return errors.New("change run --mode connected requires --base-url or CONFIGHUB_BASE_URL")
-		}
-
-		resolvedToken := strings.TrimSpace(*token)
-		if resolvedToken == "" {
-			resolvedToken = strings.TrimSpace(os.Getenv("CONFIGHUB_TOKEN"))
-		}
-
-		ingestRes, err := bridgeflow.IngestBundle(context.Background(), bridgeflow.Client{
-			BaseURL:      resolvedBaseURL,
-			BearerToken:  resolvedToken,
-			EndpointPath: strings.TrimSpace(*ingestEndpoint),
-		}, bundle)
-		if err != nil {
-			return fmt.Errorf("connected ingest: %w", err)
-		}
-
-		decisionRec, err := bridgeflow.QueryDecisionByChangeID(context.Background(), bridgeflow.DecisionClient{
-			BaseURL:      resolvedBaseURL,
-			BearerToken:  resolvedToken,
-			EndpointPath: strings.TrimSpace(*decisionEndpoint),
-		}, preview.Change.ChangeID)
-		if err != nil {
-			return fmt.Errorf("connected decision query: %w", err)
-		}
-
-		authority := strings.TrimSpace(decisionRec.ApprovedBy)
-		if authority == "" {
-			authority = strings.TrimSpace(decisionRec.PolicyDecisionRef)
-		}
-		if authority == "" {
-			authority = "confighub-policy"
-		}
-
-		decision = changeRunDecision{
-			State:     string(decisionRec.State),
-			Authority: authority,
-			Source:    "confighub-backend",
-		}
-		if decision.State != "ALLOW" {
-			promotionReady = false
-		}
-		if ingestRes.ChangeID == "" {
-			promotionReady = false
-		}
-	}
-
-	result := changeRunResult{
-		Mode:           runMode,
-		Preview:        preview,
-		Decision:       decision,
-		PromotionReady: promotionReady,
 	}
 
 	if *out == "-" {
@@ -2017,6 +1953,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen change explain --change-id ID --bundle FILE [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen change api serve [--listen ADDR] [--space SPACE] [--ref REF] [--verifier NAME]")
 	fmt.Fprintln(out, "  cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]")
 	fmt.Fprintln(out, "  cub-gen gitops <discover|import|cleanup> [flags]")
 	fmt.Fprintln(out, "  cub-gen bridge <ingest|decision|promote> [flags]")
@@ -2049,6 +1986,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen change run --mode local --space my-space ./examples/scoredev-paas ./examples/scoredev-paas")
 	fmt.Fprintln(out, "  cub-gen change explain --space my-space --wet-path \"Deployment/spec/template/spec/containers[name=main]/image\" ./examples/scoredev-paas ./examples/scoredev-paas")
 	fmt.Fprintln(out, "  cub-gen change explain --change-id chg_123 --bundle bundle.json --owner app-team")
+	fmt.Fprintln(out, "  cub-gen change api serve --listen 127.0.0.1:8787 --space my-space")
 	fmt.Fprintln(out, "  cub-gen bridge ingest --in bundle.json --base-url https://confighub.example")
 	fmt.Fprintln(out, "  cub-gen bridge decision query --change-id chg_123 --base-url https://confighub.example")
 	fmt.Fprintln(out, "  cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123")
@@ -2068,6 +2006,7 @@ func printChangeUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-slug> <render-target-slug>")
 	fmt.Fprintln(out, "  cub-gen change explain --change-id ID --bundle FILE [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty]")
+	fmt.Fprintln(out, "  cub-gen change api serve [--listen ADDR] [--space SPACE] [--ref REF] [--verifier NAME]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")
 	fmt.Fprintln(out, "  cub-gen change preview --space my-space ./examples/helm-paas ./examples/helm-paas")
@@ -2075,6 +2014,7 @@ func printChangeUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cub-gen change run --mode local --space my-space ./examples/scoredev-paas ./examples/scoredev-paas")
 	fmt.Fprintln(out, "  cub-gen change explain --space my-space --owner app-team ./examples/scoredev-paas ./examples/scoredev-paas")
 	fmt.Fprintln(out, "  cub-gen change explain --change-id chg_123 --bundle bundle.json --wet-path \"Deployment/spec/template/spec/containers[name=main]/image\"")
+	fmt.Fprintln(out, "  cub-gen change api serve --listen 127.0.0.1:8787 --space my-space")
 }
 
 func printGitOpsUsage(out io.Writer) {

--- a/cmd/cub-gen/testdata/parity/change-api-http-error.golden.json
+++ b/cmd/cub-gen/testdata/parity/change-api-http-error.golden.json
@@ -1,0 +1,9 @@
+{
+  "error": {
+    "code": "INVALID_REQUEST",
+    "details": {
+      "field": "mode"
+    },
+    "message": "mode is required for action=run"
+  }
+}

--- a/cmd/cub-gen/testdata/parity/change-api-http-run.golden.json
+++ b/cmd/cub-gen/testdata/parity/change-api-http-run.golden.json
@@ -1,0 +1,90 @@
+{
+  "explain": {
+    "change": {
+      "attestation_digest": "sha256:REDACTED",
+      "bundle_digest": "sha256:REDACTED",
+      "change_id": "chg_REDACTED"
+    },
+    "explanation": {
+      "confidence": 0.94,
+      "dry_path": "containers.main.image",
+      "edit_hint": "Edit the Score container image in score.yaml.",
+      "generator_name": "scoredev-paas",
+      "generator_profile": "scoredev-paas",
+      "owner": "app-team",
+      "source_path": "score.yaml",
+      "source_transform": "score-to-k8s",
+      "wet_path": "Deployment/spec/template/spec/containers[name=main]/image"
+    },
+    "input": {
+      "ref": "HEAD",
+      "render_target_slug": "render-target",
+      "space": "platform",
+      "target_slug": "score"
+    },
+    "query": {
+      "match_count": 3,
+      "owner_filter": "app-team"
+    }
+  },
+  "get": {
+    "artifacts": {
+      "attestation": "change://chg_REDACTED/attestation",
+      "bundle": "change://chg_REDACTED/bundle",
+      "provenance": "change://chg_REDACTED/provenance"
+    },
+    "change": {
+      "attestation_digest": "sha256:REDACTED",
+      "bundle_digest": "sha256:REDACTED",
+      "change_id": "chg_REDACTED"
+    },
+    "decision": {
+      "authority": "ci-bot",
+      "source": "local-preview",
+      "state": "ALLOW"
+    },
+    "edit_recommendation": {
+      "confidence": 0.94,
+      "dry_path": "containers.main.image",
+      "edit_hint": "Edit the Score container image in score.yaml.",
+      "owner": "app-team",
+      "wet_path": "Deployment/spec/template/spec/containers[name=main]/image"
+    },
+    "promotion_ready": true,
+    "verification": {
+      "attestation_valid": true,
+      "bundle_valid": true,
+      "verifier": "ci-bot"
+    }
+  },
+  "post": {
+    "artifacts": {
+      "attestation": "change://chg_REDACTED/attestation",
+      "bundle": "change://chg_REDACTED/bundle",
+      "provenance": "change://chg_REDACTED/provenance"
+    },
+    "change": {
+      "attestation_digest": "sha256:REDACTED",
+      "bundle_digest": "sha256:REDACTED",
+      "change_id": "chg_REDACTED"
+    },
+    "decision": {
+      "authority": "ci-bot",
+      "source": "local-preview",
+      "state": "ALLOW"
+    },
+    "edit_recommendation": {
+      "confidence": 0.94,
+      "dry_path": "containers.main.image",
+      "edit_hint": "Edit the Score container image in score.yaml.",
+      "owner": "app-team",
+      "wet_path": "Deployment/spec/template/spec/containers[name=main]/image"
+    },
+    "promotion_ready": true,
+    "verification": {
+      "attestation_valid": true,
+      "bundle_valid": true,
+      "verifier": "ci-bot"
+    }
+  }
+}

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -12,6 +12,7 @@ Usage:
   cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-slug> <render-target-slug>
   cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-slug> <render-target-slug>
   cub-gen change explain --change-id ID --bundle FILE [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty]
+  cub-gen change api serve [--listen ADDR] [--space SPACE] [--ref REF] [--verifier NAME]
   cub-gen generators [--kind KIND] [--profile PROFILE] [--capability CAPABILITY] [--strict-filters] [--json|--markdown] [--details] [--pretty]
   cub-gen gitops <discover|import|cleanup> [flags]
   cub-gen bridge <ingest|decision|promote> [flags]
@@ -44,6 +45,7 @@ GitOps parity examples:
   cub-gen change run --mode local --space my-space ./examples/scoredev-paas ./examples/scoredev-paas
   cub-gen change explain --space my-space --wet-path "Deployment/spec/template/spec/containers[name=main]/image" ./examples/scoredev-paas ./examples/scoredev-paas
   cub-gen change explain --change-id chg_123 --bundle bundle.json --owner app-team
+  cub-gen change api serve --listen 127.0.0.1:8787 --space my-space
   cub-gen bridge ingest --in bundle.json --base-url https://confighub.example
   cub-gen bridge decision query --change-id chg_123 --base-url https://confighub.example
   cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123

--- a/docs/contracts/change-api-v1.md
+++ b/docs/contracts/change-api-v1.md
@@ -7,6 +7,12 @@ This contract defines the HTTP API surface that mirrors `cub-gen change preview|
 
 Goal: CI systems, agents, and UIs can consume one JSON contract without shelling across multiple files.
 
+Run the compatibility server locally:
+
+```bash
+./cub-gen change api serve --listen 127.0.0.1:8787 --space platform --ref HEAD --verifier ci-bot
+```
+
 ## Endpoints
 
 ### 1) Create or execute a change
@@ -100,6 +106,20 @@ Schema:
 }
 ```
 
+### `POST /v1/changes` (run local)
+
+```json
+{
+  "action": "run",
+  "mode": "local",
+  "input": {
+    "target_slug": "./examples/scoredev-paas",
+    "render_target_slug": "./examples/scoredev-paas",
+    "space": "platform"
+  }
+}
+```
+
 ### `GET /v1/changes/{change_id}/explanations?wet_path=...`
 
 ```json
@@ -159,7 +179,8 @@ Error body shape:
 
 Compatibility adapter in this repo:
 
-- `examples/demo/change-api-adapter.sh`
+- Native HTTP server: `cub-gen change api serve ...`
+- CI sample using direct HTTP calls: `examples/demo/change-api-http-e2e.sh`
 
 ## See also
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -52,6 +52,7 @@ If your platform is workflow-heavy, start here before app-manifest demos:
 | Script | What it demonstrates |
 |--------|---------------------|
 | `change-api-adapter.sh --request <json> [--out <json>]` | Thin compatibility adapter mapping API-style JSON requests to `change preview|run|explain` (including explain by `change_id + bundle`) |
+| `change-api-http-e2e.sh [repo] [target]` | Native HTTP compatibility flow using `POST /v1/changes`, `GET /v1/changes/{change_id}`, and `GET /v1/changes/{change_id}/explanations` |
 | `app-ai-change-run.sh <repo> [target]` | One-command app/AI path: import + publish + verify + attest + mutation card output |
 | `prompt-as-dry-local.sh [repo]` | Canonical prompt-as-DRY local path with AI-only scope guardrails (Swamp workflow intent -> governed mutation card) |
 | `prompt-as-dry-connected.sh [repo] [target] [slug]` | Canonical prompt-as-DRY connected path with AI-only scope guardrails (`cub auth login` + backend ingest/query lifecycle) |

--- a/examples/demo/change-api-http-e2e.sh
+++ b/examples/demo/change-api-http-e2e.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  ./examples/demo/change-api-http-e2e.sh [target-slug] [render-target-slug]
+
+Default:
+  target-slug: ./examples/scoredev-paas
+  render-target-slug: ./examples/scoredev-paas
+USAGE
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+TARGET_SLUG="${1:-./examples/scoredev-paas}"
+RENDER_TARGET_SLUG="${2:-$TARGET_SLUG}"
+LISTEN_ADDR="${CHANGE_API_LISTEN_ADDR:-127.0.0.1:18787}"
+BASE_URL="http://${LISTEN_ADDR}"
+
+for cmd in curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: required command not found: $cmd" >&2
+    exit 1
+  fi
+done
+
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  go build -o ./cub-gen ./cmd/cub-gen
+fi
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  if [ -n "${api_pid:-}" ]; then
+    kill "$api_pid" >/dev/null 2>&1 || true
+    wait "$api_pid" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+./cub-gen change api serve --listen "$LISTEN_ADDR" --space platform --ref HEAD --verifier ci-bot >"$tmpdir/server.log" 2>&1 &
+api_pid=$!
+
+for _ in {1..40}; do
+  if curl -fsS "$BASE_URL/healthz" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+
+if ! curl -fsS "$BASE_URL/healthz" >/dev/null 2>&1; then
+  echo "error: API server did not become ready" >&2
+  echo "--- server log ---" >&2
+  sed -n '1,120p' "$tmpdir/server.log" >&2
+  exit 1
+fi
+
+cat > "$tmpdir/run-request.json" <<JSON
+{
+  "action": "run",
+  "mode": "local",
+  "input": {
+    "target_slug": "${TARGET_SLUG}",
+    "render_target_slug": "${RENDER_TARGET_SLUG}",
+    "space": "platform",
+    "ref": "HEAD"
+  }
+}
+JSON
+
+curl -fsS \
+  -H 'Content-Type: application/json' \
+  -X POST \
+  --data-binary "@$tmpdir/run-request.json" \
+  "$BASE_URL/v1/changes" > "$tmpdir/run-response.json"
+
+change_id="$(jq -r '.change.change_id // empty' "$tmpdir/run-response.json")"
+if [ -z "$change_id" ]; then
+  echo "error: missing change_id in run response" >&2
+  cat "$tmpdir/run-response.json" >&2
+  exit 1
+fi
+
+curl -fsS "$BASE_URL/v1/changes/$change_id" > "$tmpdir/get-response.json"
+curl -fsS "$BASE_URL/v1/changes/$change_id/explanations?owner=app-team" > "$tmpdir/explain-response.json"
+
+jq -e '.decision.state == "ALLOW" and .promotion_ready == true and (.verification.bundle_valid == true) and (.verification.attestation_valid == true)' "$tmpdir/run-response.json" >/dev/null
+jq -e --arg id "$change_id" '.change.change_id == $id and .decision.state == "ALLOW"' "$tmpdir/get-response.json" >/dev/null
+jq -e --arg id "$change_id" '.change.change_id == $id and .query.match_count >= 1 and (.explanation.owner == "app-team")' "$tmpdir/explain-response.json" >/dev/null
+
+jq -n \
+  --arg change_id "$change_id" \
+  --arg decision_state "$(jq -r '.decision.state' "$tmpdir/run-response.json")" \
+  --arg decision_source "$(jq -r '.decision.source' "$tmpdir/run-response.json")" \
+  --arg dry_path "$(jq -r '.explanation.dry_path' "$tmpdir/explain-response.json")" \
+  --arg wet_path "$(jq -r '.explanation.wet_path' "$tmpdir/explain-response.json")" \
+  '{
+    status: "ok",
+    endpoint_contract: [
+      "POST /v1/changes",
+      "GET /v1/changes/{change_id}",
+      "GET /v1/changes/{change_id}/explanations"
+    ],
+    change_id: $change_id,
+    decision: {
+      state: $decision_state,
+      source: $decision_source
+    },
+    explanation: {
+      dry_path: $dry_path,
+      wet_path: $wet_path
+    }
+  }'


### PR DESCRIPTION
## Summary
- add native compatibility HTTP surface inside `cub-gen` via `cub-gen change api serve`
- implement endpoints backed by existing lifecycle internals (no logic fork):
  - `POST /v1/changes`
  - `GET /v1/changes/{change_id}`
  - `GET /v1/changes/{change_id}/explanations`
- add in-memory change records that preserve `change_id`, decision source/state, verification, and artifact references
- add golden-backed endpoint contract tests
- add direct HTTP e2e sample script (`examples/demo/change-api-http-e2e.sh`) and wire it into `make ci-local`
- document local + connected request shapes in `docs/contracts/change-api-v1.md`

## Validation
- `go test ./...`
- `make ci-local`
- `./examples/demo/change-api-http-e2e.sh`

Closes #161
