### PR TITLE
docs: clarify cub-gen value and align examples to domain POVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,24 @@
 
 See where every deployed config value came from.
 
-`cub-gen` is a local CLI that scans your repo, classifies config files by generator type, and traces every rendered field back to the source file, line, and owner that produced it.
+`cub-gen` is a governance + traceability sidecar for GitOps.
+
+If you already run app/config in Git, OCI artifacts, and Flux/Argo reconciliation, `cub-gen` answers:
+
+- Which source file/path controls this live field?
+- Did the right team edit the right thing?
+- Can we block unsafe edits before they hit cluster?
+
+It does this by classifying your existing repo and mapping rendered fields back
+to source file, line, and owner.
+
+## What it is not
+
+- Not a Kubernetes reconciler
+- Not a Flux/Argo replacement
+- Not an OCI replacement
+
+Flux/Argo still reconcile to LIVE. `cub-gen` adds governance before deploy and traceability after deploy.
 
 ## What it looks like
 

--- a/docs/agentic-gitops/00-index/00-gitops7-index.md
+++ b/docs/agentic-gitops/00-index/00-gitops7-index.md
@@ -137,6 +137,7 @@ ConfigHub (dry+wet Units; WET deployment contract) ----------+
 |----------------|----------|
 | Store dry+wet Units, keep WET authoritative for deployment, publish, resolve field-origin maps, route editing to DRY ingress | **ConfigHub** |
 | Detect stale renders (inputs changed, output not re-rendered) | **ConfigHub** (publishing pipeline) |
+| Import generator-style DRY inputs, produce field-origin maps + inverse-edit guidance, and emit governed change bundles | **cub-gen** |
 | Reconcile runtime from published artifacts | **Flux / Argo** (inner loop) |
 | Observe cluster, capture evidence, detect drift from intended state | **cub-scout** |
 | Record governed mutation history; redirect WET edits to DRY sources | **cub-track** |
@@ -145,11 +146,17 @@ ConfigHub (dry+wet Units; WET deployment contract) ----------+
 
 **Never cross these boundaries:**
 - cub-scout observes the CLUSTER, not the generator pipeline
+- cub-gen analyzes/imports DRY->WET intent, not LIVE runtime state
 - cub-track records MUTATIONS, not runtime state
 - ConfigHub STORES and GOVERNS, it does not reconcile
 - Flux/Argo RECONCILE, they are not replaced
 - Staleness (DRY changed, WET not re-rendered) is ConfigHub's concern, not cub-scout's
 - Drift (cluster differs from intended state) is cub-scout's concern, not ConfigHub's
+
+**Clarity check (not one tool in disguise):**
+- `cub-gen` + `cub-scout` are complementary surfaces in one operating model, not duplicates.
+- `cub-track` is a separate mutation-ledger surface (Labs/planned), not a hidden rename of either tool.
+- Packaging may converge later (`cub track`), but the responsibilities stay separate.
 
 ---
 

--- a/docs/agentic-gitops/05-rollout/10-cub-track.md
+++ b/docs/agentic-gitops/05-rollout/10-cub-track.md
@@ -50,6 +50,18 @@ governed execution (Stages 1-3).
 
 In governed mode, verification evidence and attestation are required before and after execution; they are core to the model, not add-ons.
 
+### Relationship to cub-gen and cub-scout
+
+These tools are complementary and intentionally separate:
+
+| Tool | Primary job | Does not do |
+|------|-------------|-------------|
+| `cub-gen` | DRY -> WET import/provenance, field-origin maps, inverse-edit guidance, governed bundle emission | Observe cluster runtime; reconcile |
+| `cub-scout` | Observe LIVE runtime, capture drift/evidence | Infer generator provenance from DRY inputs; reconcile |
+| `cub-track` | Record mutation intent/decision/outcome in Git, explain/search mutation history | Reconcile; replace ConfigHub governance authority |
+
+They are not one tool in disguise. Packaging may converge later (`cub track`), but boundaries stay fixed.
+
 ---
 
 ## Motivation

--- a/docs/agentic-gitops/05-rollout/20-cub-track-internal-decision-memo.md
+++ b/docs/agentic-gitops/05-rollout/20-cub-track-internal-decision-memo.md
@@ -45,6 +45,14 @@ It is explicitly positioned as:
 3. Not writing full WET telemetry/transcripts to Git by default.
 4. Not forcing product coupling in MVP.
 
+## Relationship Clarification (Tool Boundaries)
+
+1. `cub-gen` is the DRY->WET import/provenance surface (field-origin + inverse-edit).
+2. `cub-scout` is the LIVE observation/evidence surface.
+3. `cub-track` is the mutation ledger surface (intent/decision/outcome in Git).
+4. These are complementary, not duplicates or hidden rebrands.
+5. Packaging may converge later under `cub track`, but boundaries must remain explicit.
+
 ## Architecture Boundary (DRY vs WET)
 
 1. **Git (DRY):** immutable linkage + compact receipts.

--- a/docs/agentic-gitops/cub-track-internal-decision-memo.md
+++ b/docs/agentic-gitops/cub-track-internal-decision-memo.md
@@ -45,6 +45,14 @@ It is explicitly positioned as:
 3. Not writing full WET telemetry/transcripts to Git by default.
 4. Not forcing product coupling in MVP.
 
+## Relationship Clarification (Tool Boundaries)
+
+1. `cub-gen` is the DRY->WET import/provenance surface (field-origin + inverse-edit).
+2. `cub-scout` is the LIVE observation/evidence surface.
+3. `cub-track` is the mutation ledger surface (intent/decision/outcome in Git).
+4. These are complementary, not duplicates or hidden rebrands.
+5. Packaging may converge later under `cub track`, but boundaries must remain explicit.
+
 ## Architecture Boundary (DRY vs WET)
 
 1. **Git (DRY):** immutable linkage + compact receipts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,23 +1,40 @@
 # cub-gen
 
-**Deterministic Git-native generator importer with command-shape parity to `cub gitops`.**
+**Governance + traceability sidecar for GitOps.**
 
-cub-gen detects generator-style app sources in Git repos, classifies DRY inputs and WET targets, and emits provenance with field-origin tracing and inverse-edit guidance — all without touching your runtime controllers.
+cub-gen works with what teams already run today:
+
+- app/config in Git
+- OCI artifacts
+- Flux/Argo reconciliation to cluster
+
+It adds what those layers do not provide by default:
+
+- source-to-live field traceability (`which file/path controls this field?`)
+- ownership-aware edit routing (`who should edit this?`)
+- governed safety decisions before deploy (`ALLOW/ESCALATE/BLOCK`)
 
 ---
 
 ## Why cub-gen exists
 
-Classical GitOps answers *"what changed?"* and *"did it sync?"*
+Classical GitOps is strong at applying changes.
 
 Teams still struggle to answer:
 
-- Why was this change proposed?
-- Who authorized it?
-- What checks ran before execution?
-- Was the real outcome verified afterward?
+- Which source file/path controls this live field?
+- Did the right team edit the right thing?
+- Can we block unsafe edits before they hit cluster?
 
-AI-assisted changes make this gap wider because more changes happen faster. cub-gen adds the **import and provenance layer** that answers these questions, while keeping Flux/Argo as the reconciler.
+AI-assisted changes make this gap wider because more changes happen faster.
+
+cub-gen adds the import/provenance layer that answers these questions while keeping Flux/Argo as reconciler.
+
+## What cub-gen is not
+
+- Not a Kubernetes reconciler
+- Not a Flux/Argo replacement
+- Not an OCI replacement
 
 ---
 

--- a/docs/workflows/domain-pov-matrix.md
+++ b/docs/workflows/domain-pov-matrix.md
@@ -1,0 +1,62 @@
+# Domain POV Matrix
+
+This matrix captures how different domain users evaluate `cub-gen` and which
+message should lead each example.
+
+## 1. Spring Boot shops
+
+- Primary user: app teams + platform DBA/ops boundaries.
+- First pain: "Which Spring property changed, and who owns it?"
+- Best first value: ALLOW/BLOCK feedback in Spring property terms.
+- Avoid leading with: Kubernetes internals and long bridge mechanics.
+
+## 2. Helm platform teams (IITS-style environments)
+
+- Primary user: platform consultants/engineers with umbrella charts, overlays,
+  and Flux/Argo transport layers.
+- First pain: value precedence and ownership archaeology during incidents.
+- Best first value: inventory + ownership map + inverse edit path.
+- Avoid leading with: full attestation pipeline before visibility is proven.
+
+## 3. Score.dev platform teams
+
+- Primary user: platform team maintaining Score render/provisioning contracts.
+- First pain: no clear trace from `score.yaml` intent to runtime fields.
+- Best first value: post-render provenance + ownership boundaries.
+- Avoid leading with: generic Kubernetes authoring concepts (developers do not
+  author Kubernetes directly).
+
+## 4. Swamp / workflow-native teams
+
+- Primary user: workflow maintainers and security/compliance leads.
+- First pain: structural workflow mutation risk (models/methods/required steps).
+- Best first value: workflow change classification and policy-ready metadata.
+- Avoid leading with: Helm-style DRY->WET rendering assumptions.
+
+## 5. Ops workflow teams
+
+- Primary user: SRE/operations automation owners.
+- First pain: schedule/action changes are high impact but weakly governed.
+- Best first value: explicit ownership and decision state on workflow changes.
+- Avoid leading with: app deployment narratives not relevant to operations flow.
+
+## 6. Backstage catalog owners
+
+- Primary user: IDP/catalog admins and service owners.
+- First pain: ownership/lifecycle churn during reorg/compliance updates.
+- Best first value: catalog change provenance and policy checks by field.
+- Avoid leading with: cluster reconciliation details.
+
+## 7. AI fleet/platform teams
+
+- Primary user: AI platform owners balancing speed and safety.
+- First pain: model/budget/credential changes fan out quickly.
+- Best first value: short fleet intent with traceable, governed runtime output.
+- Avoid leading with: tool replacement narratives (Flux/Argo remain).
+
+## Cross-domain messaging rules
+
+- Lead with existing workflow compatibility.
+- Explain "what changes for me tomorrow morning" before architecture terms.
+- Keep WET details primarily for platform/operator readers.
+- Treat verification + attestation as trust boundary, not as optional garnish.

--- a/docs/workflows/persona-5-minute-runbooks.md
+++ b/docs/workflows/persona-5-minute-runbooks.md
@@ -7,6 +7,13 @@ Each runbook has two paths:
 - `Local mode`: offline, no login required.
 - `Connected mode`: real ConfigHub round-trip, starts with `cub auth login`.
 
+Persona principles used here (from field feedback):
+
+- Start with the user's existing authoring model (`application.yaml`, `values.yaml`, `score.yaml`, workflow YAML).
+- Lead with visibility and edit guidance first; layer governance complexity second.
+- Keep reconciler/runtime unchanged (Flux/Argo stay in place).
+- Describe value in domain language, not platform jargon.
+
 Build once before local runs:
 
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,25 @@ locally with no backend. Generator detection, field-origin tracing, and evidence
 bundles work offline. Cross-repo queries, policy enforcement, and governed decisions
 require [ConfigHub](https://confighub.github.io/cub-gen/platform/).
 
+## Pick your domain POV first
+
+Start with the example that matches how your team already thinks:
+
+| If you are... | Start here | First value you should see |
+|---|---|---|
+| Spring Boot platform or app lead | [`springboot-paas`](./springboot-paas/) | "Which Spring property changed, who owns it, and what file do I edit?" |
+| Helm/Flux/Argo platform team (umbrella charts, overlays) | [`helm-paas`](./helm-paas/) | Ownership + field trace map without chart archaeology |
+| Score.dev platform team | [`scoredev-paas`](./scoredev-paas/) | Visibility from `score.yaml` intent to rendered runtime fields |
+| Ops/SRE workflow owner | [`ops-workflow`](./ops-workflow/) | Governed schedule/action changes with explicit ALLOW/BLOCK outcomes |
+| AI workflow / Swamp-style team | [`swamp-automation`](./swamp-automation/) | Structural workflow-change classification and policy-ready evidence |
+| AI fleet platform owner | [`c3agent`](./c3agent/) or [`ai-ops-paas`](./ai-ops-paas/) | Model/budget/credential governance over fleet config changes |
+| Backstage catalog owner | [`backstage-idp`](./backstage-idp/) | Catalog ownership/lifecycle changes become traceable and reviewable |
+| Reconciler reliability owner | [`live-reconcile`](./live-reconcile/) | Real Flux+Argo create/update/drift-correction proof harness |
+
+If you are unsure, start with `helm-paas` (platform POV) or `springboot-paas` (app-team POV).
+
+Deeper persona framing (from domain feedback): [Domain POV Matrix](../docs/workflows/domain-pov-matrix.md)
+
 ## What `cub-gen` does
 
 `cub-gen` is a deterministic, Git-native generator importer. It reads existing config and emits:

--- a/examples/ai-ops-paas/README.md
+++ b/examples/ai-ops-paas/README.md
@@ -11,6 +11,17 @@ guidance.
 This is the full platform version of the c3agent story. For the standalone
 fleet config (without registry and constraints), see [`c3agent`](../c3agent/).
 
+## Domain POV (platform teams launching AI-ops PaaS)
+
+Use this when you are building a "Heroku for AI operations" internally:
+
+- app/AI teams should author short fleet intent, not Kubernetes objects,
+- platform teams must enforce model, budget, credential, and RBAC guardrails,
+- runtime should still flow through existing Flux/Argo + OCI operations.
+
+The first value is platform clarity: one contract for teams, one governance
+surface for platform owners.
+
 ## What you get
 
 - **Self-service provisioning**: teams author `c3agent.yaml`, platform provides

--- a/examples/backstage-idp/README.md
+++ b/examples/backstage-idp/README.md
@@ -10,6 +10,17 @@ governance over *what* changed. When 50 teams rename owners during a reorg,
 you need traceability — not just commit history. ConfigHub makes every catalog
 change traceable, auditable, and queryable across repos.
 
+## Domain POV (Backstage/catalog admins)
+
+Use this example if your catalog is operationally critical:
+
+- `catalog-info.yaml` drives ownership, lifecycle, and service discoverability,
+- high-volume metadata edits happen during reorgs or compliance updates,
+- you need policy checks and provenance without changing Backstage workflows.
+
+The first value is catalog trust: owner/lifecycle edits become explicit,
+reviewable, and queryable across repos.
+
 ## What you get
 
 - **Catalog entity governance**: ownership, lifecycle, and type changes are

--- a/examples/c3agent/README.md
+++ b/examples/c3agent/README.md
@@ -13,6 +13,17 @@ properly isolated? ConfigHub makes AI fleet governance explicit and traceable.
 > For the full platform story with registry and constraint enforcement, see
 > [`ai-ops-paas`](../ai-ops-paas/).
 
+## Domain POV (AI fleet operators)
+
+This example is for teams already operating autonomous agent fleets:
+
+- model/budget/credential changes happen frequently,
+- one config change can fan out into many runtime resources,
+- platform teams need clear policy boundaries without slowing app teams.
+
+The first value is controlled speed: fast fleet edits with explicit ownership,
+traceability, and safe escalation paths.
+
 ## What you get
 
 - **Fleet config governance**: 30 lines of DRY config → 11 governed WET

--- a/examples/confighub-actions/README.md
+++ b/examples/confighub-actions/README.md
@@ -10,6 +10,17 @@ This is governance governing itself. The lifecycle definition is configuration,
 and configuration gets governed. The same provenance, ownership, and decision
 pipeline that governs your app changes also governs the governance rules.
 
+## Domain POV (platform control-plane operators)
+
+This example is for teams operating policy-driven platform lifecycles:
+
+- release/verification/apply stages are already encoded as workflow config,
+- production controls (approvals, windows, break-glass) evolve frequently,
+- governance changes themselves need auditable governance.
+
+The first value is recursive safety: lifecycle policy edits are treated with the
+same rigor as app/runtime changes.
+
 ## What you get
 
 - **Recursive governance**: changes to lifecycle rules go through the same

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -8,6 +8,19 @@ Each script demonstrates part of the flow:
 detect -> import -> publish -> verify -> attest -> (optional) bridge ingest/query
 ```
 
+## Pick your first demo by persona
+
+| Persona | Start here | Why |
+|---|---|---|
+| Spring app/platform team | `module-3-spring-ownership.sh` | Fast app-vs-platform ownership proof in Spring terms |
+| Helm platform engineer | `module-1-helm-import.sh` | Immediate DRY source mapping for chart/value changes |
+| Score platform team | `module-2-score-field-map.sh` | `score.yaml` -> runtime field trace in one command |
+| Ops/SRE workflow owner | `ai-work-platform/scenario-4-operations.sh` | Governed workflow mutation path, not just manifests |
+| Swamp/workflow maintainer | `ai-work-platform/scenario-2-swamp.sh` | Structural workflow-change classification path |
+| Reliability/reconciler owner | `e2e-live-reconcile-flux.sh` and `e2e-live-reconcile-argo.sh` | Real create/update/drift correction loops |
+
+See also: [Domain POV Matrix](../../docs/workflows/domain-pov-matrix.md)
+
 ## Workflow-first start (Ops + Swamp)
 
 If your platform is workflow-heavy, start here before app-manifest demos:

--- a/examples/demo/ai-work-platform/README.md
+++ b/examples/demo/ai-work-platform/README.md
@@ -2,6 +2,17 @@
 
 These demos simulate AI-work platform use cases while keeping the same local-first `cub-gen` import model.
 
+## Domain POV
+
+This track is for teams combining:
+
+- app or prompt-level intent authored by humans/agents,
+- workflow-style execution models (Swamp/ops actions),
+- Kubernetes GitOps runtime (Flux/Argo) where needed.
+
+Use this track to validate the closed loop:
+intent -> governed change bundle -> decision -> runtime outcome -> next edit guidance.
+
 Scenarios:
 
 1. C3 Agent (`c3agent`)

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -5,6 +5,17 @@ The platform owns the chart structure; app teams own their values overlays.
 ConfigHub makes that contract explicit, traceable, and auditable — without
 changing how you use Helm.
 
+## Domain POV (Helm platform teams)
+
+This example is written for teams like IITS customer environments:
+
+- umbrella charts + subcharts + environment overlays,
+- Flux/Argo reconciliation from Git/OCI,
+- repeated incidents caused by unclear value precedence and ownership.
+
+The first win is visibility, not policy complexity: who owns each value, which
+source won, and what to edit next.
+
 ## What you get
 
 - **Field-origin tracing**: every deployed field maps back to `values.yaml`,

--- a/examples/just-apps-no-platform-config/README.md
+++ b/examples/just-apps-no-platform-config/README.md
@@ -9,6 +9,17 @@ This is the simplest cub-gen example: app-only configuration with no platform
 contracts. It proves the governance model works for *any* configuration, not
 just Kubernetes workloads.
 
+## Domain POV (app teams without a formal platform)
+
+This example is for teams that manage provider config directly today:
+
+- no full platform contract yet,
+- app teams still need safe change flow and traceability,
+- platform policy may be added later without breaking existing authoring.
+
+The first value is immediate visibility on plain config files, before any major
+platform rollout.
+
 ## What you get
 
 - **Field-origin tracing**: every channel, credential ref, and setting maps

--- a/examples/live-reconcile/README.md
+++ b/examples/live-reconcile/README.md
@@ -2,6 +2,18 @@
 
 This example proves LIVE reconciliation loops with both Flux and Argo CD using a real `kind` cluster.
 
+## Domain POV (reconciler reliability owners)
+
+Use this harness if your team already trusts GitOps reconcilers and wants
+repeatable proof of behavior:
+
+- create/update/drift-correction in one script,
+- side-by-side Flux vs Argo verification,
+- connected governed path from `helm-paas` artifacts to LIVE correction.
+
+The first value is confidence that governance tooling remains additive to real
+reconciler behavior.
+
 ## What You Get
 
 - `flux/manifests-v1`: initial desired state (`replicas=1`, revision `v1`)

--- a/examples/ops-workflow/README.md
+++ b/examples/ops-workflow/README.md
@@ -10,6 +10,18 @@ workflow definition gets the same field-origin tracing, ownership mapping,
 and decision pipeline as a Helm chart. Nothing executes without an explicit
 ALLOW decision.
 
+## Domain POV (SRE and operations workflow teams)
+
+This example fits teams that already run scheduled/triggered operational
+actions (deploy, restart, scale) through scripts, CI jobs, or runbooks:
+
+- changes to schedules/actions are high impact,
+- approvals and safe windows are often tribal knowledge,
+- post-incident review needs traceable "who changed what and why."
+
+The first value is operational clarity: workflows are governed config artifacts,
+not opaque automation scripts.
+
 ## What you get
 
 - **Workflow-as-config governance**: schedule changes, action parameters, and

--- a/examples/scoredev-paas/README.md
+++ b/examples/scoredev-paas/README.md
@@ -10,6 +10,17 @@ ConfigHub adds the missing piece: traceable provenance from Score workload spec
 through to governed Kubernetes manifests, with field-level ownership and
 inverse-edit guidance.
 
+## Domain POV (Score platform teams)
+
+This example is for organizations already using Score at scale:
+
+- developers author `score.yaml` and do not touch Kubernetes YAML,
+- platform teams own provisioners, workload classes, and policy defaults,
+- incidents still require tracing "what happened between Score and runtime."
+
+The first value is post-render clarity: which runtime fields came from Score
+intent vs platform defaults, and who should edit each one.
+
 ## What you get
 
 - **Full field-origin mapping**: every rendered Kubernetes field traces back to

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -10,6 +10,18 @@ When someone changes `spring.datasource.hikari.maximum-pool-size`, is that an
 app change or a platform change? Today, your PR reviewer has to know. With
 ConfigHub, the ownership boundary is explicit and enforced.
 
+## Domain POV (Spring Boot shops)
+
+This example targets Spring-heavy teams where developers know Spring, not
+Kubernetes:
+
+- app teams edit `application*.yaml` and ship features,
+- platform teams own datasource/SLO/secrets boundaries,
+- reviews fail when ownership is implicit ("is this app config or platform config?").
+
+The goal is invisible governance for app developers: they get a clear ALLOW or
+BLOCK in PR terms they understand, without learning manifest internals.
+
 ## What you get
 
 - **Ownership-aware field tracing**: `server.port` is app-team owned;

--- a/examples/swamp-automation/README.md
+++ b/examples/swamp-automation/README.md
@@ -11,6 +11,18 @@ For this pattern, `cub-gen` is most useful as a **workflow change classifier and
 
 > For deploying the Swamp runtime itself on Kubernetes, see [`swamp-project`](../swamp-project/).
 
+## Domain POV (Swamp/workflow maintainers)
+
+This example is tuned for local-first workflow teams:
+
+- AI agents compose workflow steps from typed models,
+- teams review workflow diffs in Git,
+- safety hinges on structural checks (models/methods/required steps), not
+  Helm-style template rendering.
+
+The first value is structural governance: classify workflow mutations quickly
+and gate risky changes before execution.
+
 ## What you get
 
 - **Structural workflow diffing**: step graph and model-method changes are visible in one governed bundle.

--- a/examples/swamp-project/README.md
+++ b/examples/swamp-project/README.md
@@ -10,6 +10,17 @@ This is the infrastructure side of the Swamp story: deploying the engine
 itself. For governance over the *workflows* that run on Swamp, see
 [`swamp-automation`](../swamp-automation/).
 
+## Domain POV (runtime platform owners)
+
+Use this example when your team owns Swamp runtime delivery as infrastructure:
+
+- Helm chart + values overlays define runtime shape,
+- project teams tune approved runtime knobs (gateway, replicas, image),
+- platform teams enforce runtime safety baselines.
+
+This is the infrastructure half of the Swamp story. Pair with
+`swamp-automation` for workflow-change governance.
+
 ## What you get
 
 - **Standard Helm governance**: same field-origin tracing, ownership mapping,


### PR DESCRIPTION
## Summary\n- rewrite top-level cub-gen pitch in plain English as a governance + traceability sidecar\n- align docs index with the same problem-first framing\n- add domain POV matrix and link it from examples entrypoints\n- update per-example README intros with explicit domain POV sections\n- clarify cub-gen/cub-scout/cub-track boundary in planning docs\n\n## Validation\n- make ci