### PR TITLE
docs: define generator concept in README and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ See where every deployed config value came from.
 
 `cub-gen` is a governance + traceability sidecar for GitOps.
 
+**gen = generator.** A generator is a function that maps DRY source (your `values.yaml`, `score.yaml`, etc.) to WET rendered output (the manifests that reach your cluster). `cub-gen` detects which generators your repo uses, runs the mapping, and records provenance — so every deployed field traces back to a source file, line, and owner.
+
 If you already run app/config in Git, OCI artifacts, and Flux/Argo reconciliation, `cub-gen` answers:
 
 - Which source file/path controls this live field?

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 **Governance + traceability sidecar for GitOps.**
 
+**gen = generator.** A generator is a function that maps DRY source (`values.yaml`, `score.yaml`, `application.yaml`) to WET rendered output (the manifests that reach your cluster). `cub-gen` detects which generators your repo uses, runs the mapping, and records provenance — so every deployed field traces back to a source file, line, and owner.
+
 cub-gen works with what teams already run today:
 
 - app/config in Git


### PR DESCRIPTION
## Summary
- Adds a one-line definition of "generator" early in README.md and docs/index.md
- Directly addresses Chanwit's feedback: "gen is from generator?" / "generate something or scan?"
- The definition that unblocked him in Slack was never in the docs: *generator = function mapping DRY→WET with provenance*

## Test plan
- [x] `make ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)