### PR TITLE
docs: add two-loops model to platform and index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,9 +34,11 @@ cub-gen adds the import/provenance layer that answers these questions while keep
 
 ## What cub-gen is not
 
-- Not a Kubernetes reconciler
+- Not a Kubernetes reconciler — Flux/Argo still own WET→LIVE
 - Not a Flux/Argo replacement
 - Not an OCI replacement
+
+DRY→WET is a one-way deterministic transform. There is no automatic LIVE→DRY path. But there is an outer loop: observe live state → decide what to change → edit DRY → re-render WET → reconcile to LIVE. cub-gen makes that outer loop safe by tracing every field back to its source and gating changes through governed decisions. See [Two loops, not a triangle](platform.md#two-loops-not-a-triangle).
 
 ---
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -11,6 +11,24 @@ ConfigHub backend OSS is available today:
 
 ---
 
+## Two loops, not a triangle
+
+```
+Inner loop (seconds/minutes, automated):
+  WET ←→ LIVE    Flux/Argo reconcile continuously
+
+Outer loop (hours/days, human or agent-mediated):
+  LIVE → observe → decide → edit DRY → render WET → apply LIVE
+```
+
+DRY→WET is a one-way deterministic transform (the generator function). There is no automatic LIVE→DRY path — that would undermine the entire governance model.
+
+But there *is* an outer loop: someone observes a live value, asks "where do I change this?", and cub-gen's inverse-edit map points them back to the right DRY source file and line. A human or agent then edits DRY, the generator re-renders WET, and Flux/Argo apply to LIVE.
+
+The inner loop is what classical GitOps already does well. The outer loop is where teams lose time — and where AI agents compress cycle time dangerously if there is no verification step. cub-gen adds the traceability and governed gating that makes the outer loop safe at speed.
+
+---
+
 ## The full picture
 
 ```mermaid


### PR DESCRIPTION
## Summary
- Adds "Two loops, not a triangle" section to `docs/platform.md`
- Adds a brief reference in `docs/index.md` under "What cub-gen is not"
- Captures the Brian/Jesper/Alexis consensus: DRY→WET is one-way, the inner loop is WET↔LIVE (Flux/Argo), the outer loop is human/agent-mediated observe→decide→edit DRY→render→apply
- Directly addresses Jesper's "what does it mean to go from LIVE to DRY?" and Brian's "it's not a loop, it's a line"

## Test plan
- [x] `make ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)