### PR TITLE
docs: clarify cluster import vs source import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ to source file, line, and owner.
 
 Flux/Argo still reconcile to LIVE. `cub-gen` adds governance before deploy and traceability after deploy.
 
+## Two import paths, two jobs
+
+There are two related import flows in the ConfigHub world:
+
+- `cub gitops import` in ConfigHub imports existing Argo/Flux applications from a cluster or worker target.
+- `cub-gen gitops import` reads source repos such as Helm, Score.dev, Spring Boot, or workflow config and emits provenance, inverse-edit guidance, and evidence.
+
+They complement each other:
+
+- use ConfigHub GitOps import for brownfield cluster/app onboarding,
+- use `cub-gen` when you want source-to-runtime traceability and governed changes from DRY config.
+
 ## What it looks like
 
 ```bash
@@ -122,6 +134,11 @@ Per-generator recipes and bridge flow examples: [CLI Reference](https://confighu
 `cub-gen` is the local-first on-ramp. It runs standalone with no backend required.
 
 When you need cross-repo queries, policy enforcement, and governed decisions, connect to [ConfigHub](https://github.com/confighubai/confighub). The flow: DRY files in Git &rarr; `cub-gen` classifies and traces &rarr; `publish` produces change bundles &rarr; ConfigHub ingests, enforces policy (ALLOW/ESCALATE/BLOCK) &rarr; bridge workers connect to clusters &rarr; Flux/Argo reconciles as before.
+
+If you already use ConfigHub's GitOps Import wizard, think of it this way:
+
+- ConfigHub imports cluster-discovered Argo/Flux applications.
+- `cub-gen` imports source-side generators before they ever become opaque cluster objects.
 
 See the [platform docs](https://confighub.github.io/cub-gen/platform/) for the full story.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,18 @@ AI-assisted changes make this gap wider because more changes happen faster.
 
 cub-gen adds the import/provenance layer that answers these questions while keeping Flux/Argo as reconciler.
 
+## Two import paths, not one
+
+ConfigHub now has two complementary import stories:
+
+- `cub gitops import` imports existing ArgoCD/Flux application resources from a cluster or worker target into ConfigHub.
+- `cub-gen gitops import` reads source-side generators such as Helm, Score.dev, Spring Boot, and workflow config, then emits provenance, inverse-edit guidance, and evidence.
+
+Use them for different jobs:
+
+- brownfield GitOps app onboarding -> ConfigHub GitOps import
+- source-to-runtime traceability and governed edits -> `cub-gen`
+
 ## What cub-gen is not
 
 - Not a Kubernetes reconciler — Flux/Argo still own WET→LIVE
@@ -74,6 +86,11 @@ ConfigHub backend OSS is available today:
 4. **ConfigHub** ingests bundles, enforces governed decision state, manages units with revision history
 5. **Bridge workers** connect ConfigHub to clusters via HTTP/2 SSE
 6. **Flux/Argo** continue to reconcile WET to LIVE — unchanged
+
+This is why the import surfaces both exist:
+
+- ConfigHub cluster import starts from Argo/Flux objects that already exist,
+- `cub-gen` starts from the source repo before those objects become opaque cluster state.
 
 Teams can start with cub-gen locally today and connect to ConfigHub when they need cross-repo queries, policy at write time, and governed execution.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,18 @@ Deeper persona framing (from domain feedback): [Domain POV Matrix](../docs/workf
 4. inverse-edit guidance (where to edit),
 5. evidence bundles (`publish`, `verify`, `attest`).
 
+## How this differs from ConfigHub GitOps Import
+
+If you have also seen ConfigHub's GitOps Import wizard or `cub gitops import`, the split is:
+
+- ConfigHub GitOps import starts from ArgoCD/Flux resources already represented in a cluster.
+- `cub-gen` starts from source repos and generator inputs such as `Chart.yaml`, `score.yaml`, `application.yaml`, or workflow files.
+
+That means:
+
+- use ConfigHub import for brownfield cluster/app discovery,
+- use these `cub-gen` examples for source-side provenance, ownership routing, and governed edits.
+
 If confidence scores are new to your team, use:
 - [Confidence score guide](../docs/workflows/confidence-scores.md)
 

--- a/examples/scoredev-paas/README.md
+++ b/examples/scoredev-paas/README.md
@@ -21,6 +21,24 @@ This example is for organizations already using Score at scale:
 The first value is post-render clarity: which runtime fields came from Score
 intent vs platform defaults, and who should edit each one.
 
+## Which import path should a Score team use?
+
+For Score users, start with `cub-gen`, not ConfigHub's GitOps Import wizard.
+
+- ConfigHub GitOps Import is for importing ArgoCD/Flux application resources that already exist in a cluster.
+- This example is about source-side Score intent in `score.yaml`.
+
+That distinction matters because a Score team thinks in workload intent, workload
+classes, and provisioners, not in Argo `Application` or Flux `HelmRelease`
+objects.
+
+So the recommended path is:
+
+1. keep `score.yaml` as the app-team contract,
+2. add `cub-gen` for field-origin tracing and inverse-edit guidance,
+3. connect to ConfigHub when you want governed decisions, evidence, and
+   cross-repo visibility.
+
 ## What you get
 
 - **Full field-origin mapping**: every rendered Kubernetes field traces back to
@@ -77,6 +95,12 @@ This example is for teams already committed to Score-style app specs:
 
 cub-gen keeps Score as the app-team interface and adds deterministic provenance
 and ownership routing so debugging and governance use the same contract.
+
+If you are already a ConfigHub user, the framing is slightly different:
+
+- use ConfigHub's cluster-side GitOps import for existing Argo/Flux-managed apps,
+- use this Score example when you want to govern the source-side `score.yaml`
+  contract directly.
 
 ## Why this maps cleanly to the cub-gen framework
 


### PR DESCRIPTION
## Summary
- clarify the difference between ConfigHub cluster-side GitOps import and cub-gen source-side import
- add the distinction to the main README, docs index, examples index, and Score example
- steer Score users toward cub-gen first and ConfigHub GitOps Import only for cluster-discovered Argo/Flux apps

## Testing
- make ci