### PR TITLE
docs: add example reset execution plan

### DIFF
--- a/docs/plans/2026-03-16-example-reset-execution-plan.md
+++ b/docs/plans/2026-03-16-example-reset-execution-plan.md
@@ -1,0 +1,206 @@
+# Example Reset Execution Plan
+
+Status: active execution plan
+Date: 2026-03-16
+Owner: cub-gen maintainers
+
+## Goal
+
+Turn the `cub-gen` example catalog into the main user-facing product surface:
+real-cluster, real-app, two-audience examples that clearly show why someone
+would add `cub-gen` + ConfigHub to an existing platform/app workflow.
+
+This plan replaces the weaker standard of "good explanatory docs" with the
+stronger standard of "compelling runnable examples that deploy something real and
+show concrete ConfigHub value."
+
+## Non-negotiable requirements
+
+1. Every featured example must support two audiences explicitly:
+   - existing ConfigHub user adding the platform tool/scenario
+   - existing platform-tool user adding `cub-gen` + ConfigHub
+2. Every featured example must use a real cluster.
+3. Every featured example must deploy a real app, runtime, or workflow engine.
+4. Every connected example must use ConfigHub in a way that adds visible value.
+5. Every example must use current app/deployment concepts from ConfigHub.
+6. Every example must provide a live inspection target.
+7. Every example must include one governed `ALLOW` path and one governed
+   `ESCALATE` or `BLOCK` path.
+8. Examples are the primary discovery surface; supporting docs are secondary.
+
+## Universal example contract
+
+Every example README and entrypoint must include these sections and behaviors:
+
+1. `Who this is for`
+   - existing ConfigHub user adding this platform tool/scenario
+   - existing platform-tool user adding ConfigHub
+2. `What runs`
+   - real app/runtime/workflow engine
+   - real cluster objects
+   - real live thing to inspect
+3. `Why ConfigHub + cub-gen helps here`
+   - one concrete pain
+   - one concrete answer
+   - one concrete governed change win
+4. `Run it from ConfigHub`
+   - connected-first path
+5. `Run it from the platform tool`
+   - tool-first path, then add `cub-gen`, then connect ConfigHub
+6. `Inspect the result`
+   - URL, pods, app/deployment objects, ConfigHub evidence, decision, or query
+7. `Try one governed change`
+   - at least one `ALLOW`
+   - at least one `ESCALATE` or `BLOCK`
+
+## Execution waves
+
+### Wave 0: contract and foundations
+
+Purpose: define what a "good example" is and make it enforceable.
+
+Issues:
+- [#174](https://github.com/confighub/cub-gen/issues/174) universal example contract
+- [#175](https://github.com/confighub/cub-gen/issues/175) shared real-cluster connected harness
+- [#176](https://github.com/confighub/cub-gen/issues/176) app/deployment concept alignment + Ilya checklist capture
+- [#183](https://github.com/confighub/cub-gen/issues/183) connected acceptance suite and release gate
+
+Exit criteria:
+- example contract is written and testable
+- shared harness exists for connected runs
+- current app/deployment concepts are encoded
+- Ilya complaint checklist is written and mapped to tests
+- release gate can fail on example regressions
+
+### Wave 1: flagship app-platform examples
+
+Purpose: fix the examples most users will recognize first.
+
+Issues:
+- [#177](https://github.com/confighub/cub-gen/issues/177) Helm / Argo / Kubara-like flagship example
+- [#178](https://github.com/confighub/cub-gen/issues/178) Score.dev flagship example
+- [#179](https://github.com/confighub/cub-gen/issues/179) Spring Boot flagship example
+
+Exit criteria:
+- Helm, Score, and Spring all satisfy the universal example contract
+- each one deploys a real app to a real cluster
+- each one has both audience paths
+- each one shows a real ConfigHub connected value path
+
+### Wave 2: workflow platform examples
+
+Purpose: make workflow/automation stories equally strong and credible.
+
+Issues:
+- [#180](https://github.com/confighub/cub-gen/issues/180) Ops Workflow + Swamp stories
+
+Exit criteria:
+- workflow examples are real workflow-platform stories, not just structural scans
+- runtime and governance concerns are separated and both made concrete
+- each example ends with a real inspectable outcome
+
+### Wave 3: supporting example catalog
+
+Purpose: bring the rest of the catalog up to the same user-facing quality bar.
+
+Issues:
+- [#181](https://github.com/confighub/cub-gen/issues/181) supporting examples (`backstage-idp`, `just-apps-no-platform-config`, `confighub-actions`, `c3agent`, `ai-ops-paas`, `live-reconcile`)
+- [#182](https://github.com/confighub/cub-gen/issues/182) examples/demo entrypoint redesign
+
+Exit criteria:
+- no example remains a second-class citizen
+- examples index helps users find a relevant live demo quickly
+- demo index is organized around outcomes, not just script names
+
+## Issue map
+
+### Umbrella tracking issue
+- [#173](https://github.com/confighub/cub-gen/issues/173) turn examples into real-cluster, two-audience product surfaces
+
+### Foundation issues
+- [#174](https://github.com/confighub/cub-gen/issues/174) define and enforce a universal example contract
+- [#175](https://github.com/confighub/cub-gen/issues/175) build shared real-cluster connected harness for examples
+- [#176](https://github.com/confighub/cub-gen/issues/176) align examples to current app/deployment concepts and capture Ilya acceptance checklist
+- [#183](https://github.com/confighub/cub-gen/issues/183) add connected acceptance suite and release gate for the example reset
+
+### Primary example issues
+- [#177](https://github.com/confighub/cub-gen/issues/177) upgrade `helm-paas` into the flagship Helm/Argo/Kubara-like example
+- [#178](https://github.com/confighub/cub-gen/issues/178) upgrade `scoredev-paas` for ConfigHub-first and Score-first adoption
+- [#179](https://github.com/confighub/cub-gen/issues/179) upgrade `springboot-paas` into a real app + governed config example
+- [#180](https://github.com/confighub/cub-gen/issues/180) upgrade `ops-workflow` and Swamp examples into runnable workflow platform stories
+
+### Catalog and UX issues
+- [#181](https://github.com/confighub/cub-gen/issues/181) upgrade supporting examples to the same product standard
+- [#182](https://github.com/confighub/cub-gen/issues/182) redesign example and demo entrypoints around audience and live outcomes
+
+## Priority stack
+
+1. Universal example contract and acceptance gates
+2. Shared real-cluster connected harness
+3. App/deployment concept alignment + Ilya checklist capture
+4. Helm flagship example
+5. Score flagship example
+6. Spring flagship example
+7. Workflow examples
+8. Supporting catalog cleanup
+9. Entry-point/index redesign
+10. Connected release gate hardening
+
+## Detailed expectations by example family
+
+### Helm / Kubara-like
+
+We should treat `helm-paas` as the closest current answer for users of:
+- Helm + Argo/Flux
+- umbrella charts
+- overlays
+- secure-by-default platform baselines
+- Kubara-like platform frameworks
+
+The example must feel like a real platform engineering story, not a template demo.
+
+### Score.dev
+
+This is the cleanest two-audience split in the catalog:
+- ConfigHub-first: govern `score.yaml` before it becomes opaque cluster/app state
+- Score-first: keep Score as the contract, add `cub-gen` for traceability, then add ConfigHub for decisions/evidence
+
+### Spring Boot
+
+The example must speak in Spring terms first:
+- profiles
+- properties
+- actuator/health
+- app-team vs platform/DBA ownership
+
+The Kubernetes layer should support the story, not lead it.
+
+### Workflow platforms
+
+The workflow examples must no longer read like static YAML governance demos.
+They need to show a real workflow engine or real runnable workflow artifact,
+plus the value of ConfigHub-connected governance.
+
+## Dependencies and open inputs
+
+1. Ilya complaint details must be captured explicitly and added to the checklist
+   before we can declare the reset complete.
+2. Jesper's current app/deployment concepts must be treated as the canonical
+   model for example language and live proof.
+3. Some supporting examples may need to split into sub-issues if their runtime
+   story becomes too large for one PR.
+
+## Definition of done
+
+We can call this reset complete when all of the following are true:
+
+1. A user can open `examples/README.md`, recognize their stack, and find a
+   fitting example immediately.
+2. Primary examples run in connected mode on real clusters.
+3. Primary examples deploy real apps/runtimes/workflow platforms.
+4. Every primary example supports both audiences explicitly.
+5. Every primary example shows one `ALLOW` and one `ESCALATE`/`BLOCK` path.
+6. Every primary example exposes a real live inspection target.
+7. CI/release gates prove the claims.
+8. We no longer need hidden supporting docs to explain the examples' value.
+


### PR DESCRIPTION
## Summary
- add a concrete execution plan for turning the example catalog into real-cluster, two-audience product examples
- link the plan to the newly filed issue backlog (#173-#183)
- define waves, acceptance criteria, and definition of done

## Testing
- docs-only change