### PR TITLE
feat: add Wave 2 PR-MR pairing and promotion flow demos (#188, #189)

### DIFF
--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -107,6 +107,64 @@ Use these when you want merge-blocking enforcement, not just local guidance:
 | `story-11-live-breakglass-proposal-connected.sh` | 11 | Persist accept/revert break-glass proposals as backend changesets with queryable evidence |
 | `run-phase-4-connected-stories.sh` | 8,10,11 | Runs all three connected Phase 4 stories |
 
+## PR-MR pairing and promotion flows (Wave 2)
+
+These scripts demonstrate the bidirectional handoff between Git PR workflow and
+ConfigHub MR workflow, plus upstream DRY promotion:
+
+| Script | Flow | What it demonstrates |
+|--------|------|---------------------|
+| `flow-a-git-pr-to-mr-connected.sh` | A | Git PR → ConfigHub MR: developer opens PR, ConfigHub creates/updates MR with evidence |
+| `flow-b-mr-to-git-pr-connected.sh` | B | ConfigHub MR → Git PR: ConfigHub initiates change, generates Git PR after approval |
+| `fr8-promotion-upstream-dry-connected.sh` | FR8 | Promotion to upstream DRY: successful app change promoted to platform base |
+
+### Flow A: Git PR → ConfigHub MR
+
+The most common governed change flow:
+
+```bash
+export GIT_REPO=owner/repo
+export PR_NUMBER=123
+./examples/demo/flow-a-git-pr-to-mr-connected.sh ./examples/helm-paas
+```
+
+Steps:
+1. Developer makes changes and opens Git PR
+2. CI/webhook triggers cub-gen import
+3. cub-gen creates/updates ConfigHub MR with evidence bundle
+4. ConfigHub evaluates and returns governed decision (ALLOW/ESCALATE/BLOCK)
+5. Decision is posted back to Git PR as status check
+
+### Flow B: ConfigHub MR → Git PR
+
+Reverse flow for ConfigHub-initiated changes:
+
+```bash
+./examples/demo/flow-b-mr-to-git-pr-connected.sh ./examples/helm-paas
+```
+
+Used for:
+- Live-origin proposals (story 11 accept path)
+- Platform-initiated changes
+- Upstream DRY promotions
+
+### FR8: Promotion to Upstream Platform DRY
+
+Full promotion flow from live observation through WET to upstream DRY:
+
+```bash
+./examples/demo/fr8-promotion-upstream-dry-connected.sh ./examples/helm-paas
+```
+
+Phases:
+1. **LIVE → WET**: Observe live state, capture delta
+2. **WET → governed**: Evaluate against policies, reach ALLOW
+3. **governed → promotion**: After successful rollout, propose promotion
+4. **promotion → upstream DRY**: Platform team reviews and merges
+5. **cleanup**: Reduce/remove app overlay to avoid drift
+
+See also: [PR-MR Linkage Contract](../../docs/contracts/pr-mr-linkage-and-dry-promotion.md)
+
 Story 10 required inputs (real GitHub evidence):
 
 ```bash

--- a/examples/demo/flow-a-git-pr-to-mr-connected.sh
+++ b/examples/demo/flow-a-git-pr-to-mr-connected.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# Flow A: Git PR → ConfigHub MR
+#
+# This demo shows the most common governed change flow:
+# 1. Developer makes changes and opens Git PR
+# 2. CI/webhook triggers cub-gen import
+# 3. cub-gen creates/updates ConfigHub MR with evidence bundle
+# 4. ConfigHub evaluates and returns governed decision (ALLOW/ESCALATE/BLOCK)
+# 5. Decision is posted back to Git PR as status check
+#
+# Usage:
+#   ./examples/demo/flow-a-git-pr-to-mr-connected.sh [REPO_PATH] [PR_NUMBER]
+#
+# Required env:
+#   - ConfigHub auth (CONFIGHUB_TOKEN or `cub auth login`)
+#   - GitHub auth (GH_TOKEN/GITHUB_TOKEN or `gh auth login`)
+#
+# Optional env:
+#   - GIT_REPO: owner/repo (default: detect from remote)
+#   - PR_NUMBER: pull request number to link
+#   - OUT_ROOT: output directory root
+#   - SKIP_BUILD: set to 1 to skip cub-gen rebuild
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/examples/demo/lib/connected-preflight.sh"
+
+REPO_PATH="${1:-./examples/helm-paas}"
+PR_NUMBER="${2:-${PR_NUMBER:-}}"
+EXAMPLE_SLUG="$(basename "$REPO_PATH")"
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/flow-a}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="$OUT_ROOT/$RUN_ID/$EXAMPLE_SLUG"
+SPACE="${SPACE:-}"
+VERIFIER="${VERIFIER:-ci-bot}"
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+normalize_repo() {
+  local value="$1"
+  value="${value#https://github.com/}"
+  value="${value#http://github.com/}"
+  value="${value#git@github.com:}"
+  value="${value#github.com/}"
+  value="${value%.git}"
+  printf '%s' "$value"
+}
+
+resolve_default_repo() {
+  local remote
+  remote="$(git config --get remote.origin.url 2>/dev/null || true)"
+  if [ -z "$remote" ]; then
+    return 0
+  fi
+  normalize_repo "$remote"
+}
+
+resolve_gh_token() {
+  local token
+  token="$(printf '%s' "${GH_TOKEN:-${GITHUB_TOKEN:-}}" | tr -d '\r\n')"
+  if [ -n "$token" ]; then
+    printf '%s' "$token"
+    return 0
+  fi
+  if token="$(gh auth token 2>/dev/null | tr -d '\r\n')" && [ -n "$token" ]; then
+    printf '%s' "$token"
+    return 0
+  fi
+  return 1
+}
+
+sanitize_slug() {
+  local input="$1"
+  input="$(printf '%s' "$input" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+  input="$(printf '%s' "$input" | sed -E 's/^-+//; s/-+$//; s/-+/-/g')"
+  printf '%s' "${input:0:63}"
+}
+
+if [ ! -d "$REPO_PATH" ]; then
+  echo "error: repo path not found: $REPO_PATH" >&2
+  exit 1
+fi
+
+require_cmd gh
+require_cmd jq
+require_cmd shasum
+
+# Resolve GitHub auth
+gh_token="$(resolve_gh_token || true)"
+if [ -z "$gh_token" ]; then
+  echo "error: missing GitHub auth for Flow A demo." >&2
+  echo "remediation: set GH_TOKEN/GITHUB_TOKEN or run 'gh auth login'." >&2
+  exit 1
+fi
+export GH_TOKEN="$gh_token"
+
+# Resolve Git repo
+GIT_REPO="${GIT_REPO:-$(resolve_default_repo)}"
+if [ -z "$GIT_REPO" ]; then
+  echo "error: unable to resolve Git repository." >&2
+  echo "remediation: set GIT_REPO=owner/repo or run from a Git repo with remote.origin.url." >&2
+  exit 1
+fi
+
+# Require ConfigHub preflight
+require_connected_preflight
+if [ -z "$SPACE" ]; then
+  SPACE="$CONFIGHUB_SPACE"
+fi
+
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  echo "[flow-a] building cub-gen"
+  go build -o ./cub-gen ./cmd/cub-gen
+fi
+
+mkdir -p "$OUT_DIR"
+
+echo "[flow-a] Git PR → ConfigHub MR governed flow"
+echo "[flow-a] repo: $GIT_REPO"
+echo "[flow-a] example: $EXAMPLE_SLUG"
+echo "[flow-a] output: $OUT_DIR"
+print_connected_context
+
+# Step 1: Discover and import
+echo "[flow-a][step-1] discover and import DRY source"
+./cub-gen gitops discover --space "$SPACE" --json "$REPO_PATH" > "$OUT_DIR/discover.json"
+./cub-gen gitops import --space "$SPACE" --json "$REPO_PATH" "$REPO_PATH" > "$OUT_DIR/import.json"
+
+# Step 2: Publish evidence bundle
+echo "[flow-a][step-2] publish evidence bundle"
+./cub-gen publish --in "$OUT_DIR/import.json" > "$OUT_DIR/bundle.json"
+./cub-gen verify --json --in "$OUT_DIR/bundle.json" > "$OUT_DIR/verify.json"
+./cub-gen attest --in "$OUT_DIR/bundle.json" --verifier "$VERIFIER" > "$OUT_DIR/attestation.json"
+
+change_id="$(jq -r .change_id "$OUT_DIR/bundle.json")"
+bundle_digest="$(jq -r .bundle_digest "$OUT_DIR/bundle.json")"
+
+# Step 3: Ingest into ConfigHub (creates/updates MR)
+echo "[flow-a][step-3] ingest bundle into ConfigHub"
+./cub-gen bridge ingest \
+  --in "$OUT_DIR/bundle.json" \
+  --base-url "$CONFIGHUB_BASE_URL" \
+  --token "$CONFIGHUB_TOKEN" \
+  > "$OUT_DIR/ingest.json"
+
+ingest_status="$(jq -r '.status // "unknown"' "$OUT_DIR/ingest.json")"
+artifact_id="$(jq -r '.artifact_id // empty' "$OUT_DIR/ingest.json")"
+
+# Step 4: Query backend decision
+echo "[flow-a][step-4] query ConfigHub decision"
+./cub-gen bridge decision query \
+  --base-url "$CONFIGHUB_BASE_URL" \
+  --token "$CONFIGHUB_TOKEN" \
+  --change-id "$change_id" \
+  > "$OUT_DIR/decision.json"
+
+decision_state="$(jq -r '.state // "PENDING"' "$OUT_DIR/decision.json")"
+policy_ref="$(jq -r '.policy_decision_ref // ""' "$OUT_DIR/decision.json")"
+
+# Step 5: Create PR-MR linkage record
+echo "[flow-a][step-5] create PR-MR linkage record"
+now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+linkage_slug="$(sanitize_slug "flow-a-${change_id}")"
+
+pr_url=""
+pr_state=""
+if [ -n "$PR_NUMBER" ]; then
+  pr_json="$OUT_DIR/github-pr.json"
+  if gh api -H "Accept: application/vnd.github+json" "repos/${GIT_REPO}/pulls/${PR_NUMBER}" > "$pr_json" 2>/dev/null; then
+    pr_url="$(jq -r '.html_url // ""' "$pr_json")"
+    pr_state="$(jq -r '.state // ""' "$pr_json")"
+  fi
+fi
+
+jq -n \
+  --arg schema "cub.confighub.io/pr-mr-promotion-flow/v1" \
+  --arg change_id "$change_id" \
+  --arg git_repo "$GIT_REPO" \
+  --arg git_pr_number "${PR_NUMBER:-}" \
+  --arg git_pr_url "$pr_url" \
+  --arg git_pr_state "$pr_state" \
+  --arg confighub_mr_id "$artifact_id" \
+  --arg confighub_mr_status "$ingest_status" \
+  --arg decision_state "$decision_state" \
+  --arg policy_ref "$policy_ref" \
+  --arg flow "A" \
+  --arg flow_direction "git-pr-to-confighub-mr" \
+  --arg updated_at "$now" \
+  '{
+    schema: $schema,
+    change_id: $change_id,
+    flow: $flow,
+    flow_direction: $flow_direction,
+    git_pr: {
+      repo: $git_repo,
+      number: (if $git_pr_number == "" then null else ($git_pr_number | tonumber) end),
+      url: (if $git_pr_url == "" then null else $git_pr_url end),
+      state: (if $git_pr_state == "" then null else $git_pr_state end)
+    },
+    confighub_mr: {
+      id: $confighub_mr_id,
+      status: $confighub_mr_status
+    },
+    decision: {
+      state: $decision_state,
+      policy_ref: (if $policy_ref == "" then null else $policy_ref end)
+    },
+    updated_at: $updated_at
+  }' > "$OUT_DIR/pr-mr-linkage.json"
+
+# Step 6: Create ConfigHub changeset for audit trail
+echo "[flow-a][step-6] record linkage in ConfigHub changeset"
+cub changeset create \
+  --space "$CONFIGHUB_SPACE" \
+  --json \
+  --allow-exists \
+  "$linkage_slug" \
+  --description "Flow A: Git PR #${PR_NUMBER:-none} → ConfigHub MR for change_id=${change_id}" \
+  --label "flow=A" \
+  --label "flow_direction=git-pr-to-confighub-mr" \
+  --label "change_id=${change_id}" \
+  --label "git_repo=$(echo "$GIT_REPO" | tr '/' '-')" \
+  --label "git_pr_number=${PR_NUMBER:-none}" \
+  --label "decision_state=${decision_state}" \
+  > "$OUT_DIR/linkage-changeset.json"
+
+# Step 7: Post status to GitHub PR (if PR_NUMBER provided)
+if [ -n "$PR_NUMBER" ]; then
+  echo "[flow-a][step-7] post status to GitHub PR #${PR_NUMBER}"
+
+  case "$decision_state" in
+    ALLOW)
+      gh_state="success"
+      gh_description="ConfigHub: ALLOW - change approved"
+      ;;
+    ESCALATE)
+      gh_state="pending"
+      gh_description="ConfigHub: ESCALATE - requires additional review"
+      ;;
+    BLOCK)
+      gh_state="failure"
+      gh_description="ConfigHub: BLOCK - change rejected"
+      ;;
+    *)
+      gh_state="pending"
+      gh_description="ConfigHub: decision pending"
+      ;;
+  esac
+
+  # Get head SHA from PR
+  head_sha="$(jq -r '.head.sha // empty' "$pr_json")"
+  if [ -n "$head_sha" ]; then
+    gh api -X POST "repos/${GIT_REPO}/statuses/${head_sha}" \
+      -f state="$gh_state" \
+      -f description="$gh_description" \
+      -f context="confighub/governed-change" \
+      -f target_url="${CONFIGHUB_BASE_URL}/spaces/${CONFIGHUB_SPACE}/changes/${change_id}" \
+      > "$OUT_DIR/github-status.json" 2>/dev/null || echo "[flow-a] warning: failed to post GitHub status"
+  fi
+else
+  echo "[flow-a][step-7] skipped GitHub status (no PR_NUMBER provided)"
+fi
+
+# Summary
+echo ""
+echo "[flow-a] summary"
+jq -n \
+  --arg flow "A" \
+  --arg direction "Git PR → ConfigHub MR" \
+  --arg change_id "$change_id" \
+  --arg bundle_digest "$bundle_digest" \
+  --arg ingest_status "$ingest_status" \
+  --arg decision_state "$decision_state" \
+  --arg policy_ref "$policy_ref" \
+  --arg git_repo "$GIT_REPO" \
+  --arg git_pr_number "${PR_NUMBER:-none}" \
+  --arg confighub_mr_id "$artifact_id" \
+  --argjson wet_targets "$(jq '.wet_manifest_targets | length' "$OUT_DIR/import.json")" \
+  '{
+    flow: $flow,
+    direction: $direction,
+    change_id: $change_id,
+    bundle_digest: $bundle_digest,
+    ingest_status: $ingest_status,
+    decision_state: $decision_state,
+    policy_ref: $policy_ref,
+    git: {
+      repo: $git_repo,
+      pr_number: $git_pr_number
+    },
+    confighub: {
+      mr_id: $confighub_mr_id
+    },
+    wet_targets: $wet_targets
+  }' | tee "$OUT_DIR/flow-a-summary.json"

--- a/examples/demo/flow-b-mr-to-git-pr-connected.sh
+++ b/examples/demo/flow-b-mr-to-git-pr-connected.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# Flow B: ConfigHub MR → Git PR
+#
+# This demo shows the reverse governed flow:
+# 1. ConfigHub detects a change (live observation, platform update, or promotion)
+# 2. ConfigHub creates an MR with proposed changes
+# 3. After MR approval, cub-gen generates a Git PR
+# 4. Git PR is linked back to ConfigHub MR
+# 5. Platform team reviews and merges Git PR
+#
+# This flow is common for:
+# - Live-origin proposals (story 11 accept path)
+# - Platform-initiated changes
+# - Upstream DRY promotions
+#
+# Usage:
+#   ./examples/demo/flow-b-mr-to-git-pr-connected.sh [REPO_PATH] [CHANGESET_SLUG]
+#
+# Required env:
+#   - ConfigHub auth (CONFIGHUB_TOKEN or `cub auth login`)
+#   - GitHub auth (GH_TOKEN/GITHUB_TOKEN or `gh auth login`)
+#
+# Optional env:
+#   - GIT_REPO: owner/repo (default: detect from remote)
+#   - CHANGESET_SLUG: ConfigHub changeset to use as MR source
+#   - OUT_ROOT: output directory root
+#   - SKIP_BUILD: set to 1 to skip cub-gen rebuild
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/examples/demo/lib/connected-preflight.sh"
+
+REPO_PATH="${1:-./examples/helm-paas}"
+CHANGESET_SLUG="${2:-${CHANGESET_SLUG:-}}"
+EXAMPLE_SLUG="$(basename "$REPO_PATH")"
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/flow-b}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="$OUT_ROOT/$RUN_ID/$EXAMPLE_SLUG"
+SPACE="${SPACE:-}"
+TARGET_BRANCH="${TARGET_BRANCH:-main}"
+PR_TITLE_PREFIX="${PR_TITLE_PREFIX:-[ConfigHub]}"
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+normalize_repo() {
+  local value="$1"
+  value="${value#https://github.com/}"
+  value="${value#http://github.com/}"
+  value="${value#git@github.com:}"
+  value="${value#github.com/}"
+  value="${value%.git}"
+  printf '%s' "$value"
+}
+
+resolve_default_repo() {
+  local remote
+  remote="$(git config --get remote.origin.url 2>/dev/null || true)"
+  if [ -z "$remote" ]; then
+    return 0
+  fi
+  normalize_repo "$remote"
+}
+
+resolve_gh_token() {
+  local token
+  token="$(printf '%s' "${GH_TOKEN:-${GITHUB_TOKEN:-}}" | tr -d '\r\n')"
+  if [ -n "$token" ]; then
+    printf '%s' "$token"
+    return 0
+  fi
+  if token="$(gh auth token 2>/dev/null | tr -d '\r\n')" && [ -n "$token" ]; then
+    printf '%s' "$token"
+    return 0
+  fi
+  return 1
+}
+
+sanitize_slug() {
+  local input="$1"
+  input="$(printf '%s' "$input" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+  input="$(printf '%s' "$input" | sed -E 's/^-+//; s/-+$//; s/-+/-/g')"
+  printf '%s' "${input:0:63}"
+}
+
+if [ ! -d "$REPO_PATH" ]; then
+  echo "error: repo path not found: $REPO_PATH" >&2
+  exit 1
+fi
+
+require_cmd gh
+require_cmd jq
+
+# Resolve GitHub auth
+gh_token="$(resolve_gh_token || true)"
+if [ -z "$gh_token" ]; then
+  echo "error: missing GitHub auth for Flow B demo." >&2
+  echo "remediation: set GH_TOKEN/GITHUB_TOKEN or run 'gh auth login'." >&2
+  exit 1
+fi
+export GH_TOKEN="$gh_token"
+
+# Resolve Git repo
+GIT_REPO="${GIT_REPO:-$(resolve_default_repo)}"
+if [ -z "$GIT_REPO" ]; then
+  echo "error: unable to resolve Git repository." >&2
+  echo "remediation: set GIT_REPO=owner/repo or run from a Git repo with remote.origin.url." >&2
+  exit 1
+fi
+
+# Require ConfigHub preflight
+require_connected_preflight
+if [ -z "$SPACE" ]; then
+  SPACE="$CONFIGHUB_SPACE"
+fi
+
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  echo "[flow-b] building cub-gen"
+  go build -o ./cub-gen ./cmd/cub-gen
+fi
+
+mkdir -p "$OUT_DIR"
+
+echo "[flow-b] ConfigHub MR → Git PR governed flow"
+echo "[flow-b] repo: $GIT_REPO"
+echo "[flow-b] example: $EXAMPLE_SLUG"
+echo "[flow-b] output: $OUT_DIR"
+print_connected_context
+
+# Step 1: Create or retrieve ConfigHub changeset (simulating MR)
+echo "[flow-b][step-1] create/retrieve ConfigHub MR changeset"
+now="$(date -u +%Y-%m-%dT%H%M%SZ)"
+
+if [ -z "$CHANGESET_SLUG" ]; then
+  CHANGESET_SLUG="$(sanitize_slug "flow-b-mr-${EXAMPLE_SLUG}-${RUN_ID}")"
+  echo "[flow-b] creating new changeset: $CHANGESET_SLUG"
+
+  # Create a changeset representing a ConfigHub-initiated change
+  cub changeset create \
+    --space "$CONFIGHUB_SPACE" \
+    --json \
+    --allow-exists \
+    "$CHANGESET_SLUG" \
+    --description "Flow B: ConfigHub-initiated change for ${EXAMPLE_SLUG}" \
+    --label "flow=B" \
+    --label "flow_direction=confighub-mr-to-git-pr" \
+    --label "origin=confighub-mr" \
+    --label "target_repo=$(echo "$GIT_REPO" | tr '/' '-')" \
+    --label "target_branch=${TARGET_BRANCH}" \
+    > "$OUT_DIR/mr-changeset.json"
+else
+  echo "[flow-b] using existing changeset: $CHANGESET_SLUG"
+  cub changeset get --space "$CONFIGHUB_SPACE" --json "$CHANGESET_SLUG" > "$OUT_DIR/mr-changeset.json"
+fi
+
+changeset_id="$(jq -r '.ChangeSetID // .ChangeSet.ChangeSetID // empty' "$OUT_DIR/mr-changeset.json")"
+if [ -z "$changeset_id" ]; then
+  echo "error: unable to resolve changeset ID." >&2
+  exit 1
+fi
+
+# Step 2: Discover current state and generate proposed changes
+echo "[flow-b][step-2] discover current state"
+./cub-gen gitops discover --space "$SPACE" --json "$REPO_PATH" > "$OUT_DIR/discover.json"
+./cub-gen gitops import --space "$SPACE" --json "$REPO_PATH" "$REPO_PATH" > "$OUT_DIR/import.json"
+
+# Step 3: Extract inverse-edit guidance for proposed change
+echo "[flow-b][step-3] extract inverse-edit guidance"
+jq '.inverse_transform_plans // []' "$OUT_DIR/import.json" > "$OUT_DIR/inverse-guidance.json"
+
+# Get a representative DRY file to edit
+dry_file="$(jq -r '[.inverse_transform_plans[]?.patches[]?.dry_file // empty][0] // "values.yaml"' "$OUT_DIR/import.json")"
+dry_path="$(jq -r '[.inverse_transform_plans[]?.patches[]?.dry_path // empty][0] // "image.tag"' "$OUT_DIR/import.json")"
+
+# Step 4: Simulate ConfigHub MR approval
+echo "[flow-b][step-4] simulate ConfigHub MR approval"
+approval_slug="$(sanitize_slug "flow-b-approval-${EXAMPLE_SLUG}-${RUN_ID}")"
+cub changeset create \
+  --space "$CONFIGHUB_SPACE" \
+  --json \
+  --allow-exists \
+  "$approval_slug" \
+  --description "Flow B: MR approval for changeset ${CHANGESET_SLUG}" \
+  --label "flow=B" \
+  --label "flow_stage=mr-approved" \
+  --label "parent_changeset_id=${changeset_id}" \
+  --label "approved_by=platform-lead" \
+  --label "approved_at=${now}" \
+  > "$OUT_DIR/approval-changeset.json"
+
+# Step 5: Generate Git PR content
+echo "[flow-b][step-5] generate Git PR proposal"
+branch_name="confighub/${CHANGESET_SLUG}"
+pr_title="${PR_TITLE_PREFIX} ${EXAMPLE_SLUG}: ConfigHub-initiated change"
+pr_body="## ConfigHub MR → Git PR
+
+This PR was generated from ConfigHub MR approval.
+
+### Source
+- **ConfigHub Changeset**: \`${CHANGESET_SLUG}\`
+- **Changeset ID**: \`${changeset_id}\`
+- **Space**: \`${CONFIGHUB_SPACE}\`
+
+### Proposed Changes
+Based on inverse-edit guidance:
+- **DRY File**: \`${dry_file}\`
+- **DRY Path**: \`${dry_path}\`
+
+### Flow
+This is **Flow B** (ConfigHub MR → Git PR):
+1. ConfigHub detected/initiated a change
+2. ConfigHub MR was approved
+3. This Git PR was generated for review
+4. Platform team reviews and merges
+
+### Linkage
+\`\`\`json
+$(jq -c '{flow: "B", changeset_slug: "'"$CHANGESET_SLUG"'", changeset_id: "'"$changeset_id"'"}')
+\`\`\`
+
+---
+Generated by: cub-gen Flow B demo"
+
+jq -n \
+  --arg branch "$branch_name" \
+  --arg title "$pr_title" \
+  --arg body "$pr_body" \
+  --arg target_branch "$TARGET_BRANCH" \
+  --arg dry_file "$dry_file" \
+  --arg dry_path "$dry_path" \
+  '{
+    branch: $branch,
+    title: $title,
+    body: $body,
+    target_branch: $target_branch,
+    proposed_edit: {
+      dry_file: $dry_file,
+      dry_path: $dry_path
+    }
+  }' > "$OUT_DIR/pr-proposal.json"
+
+# Step 6: Create PR-MR linkage record
+echo "[flow-b][step-6] create PR-MR linkage record"
+linkage_slug="$(sanitize_slug "flow-b-linkage-${EXAMPLE_SLUG}-${RUN_ID}")"
+
+jq -n \
+  --arg schema "cub.confighub.io/pr-mr-promotion-flow/v1" \
+  --arg changeset_id "$changeset_id" \
+  --arg changeset_slug "$CHANGESET_SLUG" \
+  --arg git_repo "$GIT_REPO" \
+  --arg git_branch "$branch_name" \
+  --arg git_target_branch "$TARGET_BRANCH" \
+  --arg flow "B" \
+  --arg flow_direction "confighub-mr-to-git-pr" \
+  --arg status "PR_PROPOSED" \
+  --arg updated_at "$now" \
+  '{
+    schema: $schema,
+    flow: $flow,
+    flow_direction: $flow_direction,
+    confighub_mr: {
+      changeset_id: $changeset_id,
+      changeset_slug: $changeset_slug,
+      status: "APPROVED"
+    },
+    git_pr: {
+      repo: $git_repo,
+      branch: $git_branch,
+      target_branch: $git_target_branch,
+      status: "PROPOSED",
+      number: null,
+      url: null
+    },
+    status: $status,
+    updated_at: $updated_at
+  }' > "$OUT_DIR/pr-mr-linkage.json"
+
+# Record linkage in ConfigHub
+cub changeset create \
+  --space "$CONFIGHUB_SPACE" \
+  --json \
+  --allow-exists \
+  "$linkage_slug" \
+  --description "Flow B: PR-MR linkage for ${CHANGESET_SLUG} → Git PR" \
+  --label "flow=B" \
+  --label "flow_stage=pr-proposed" \
+  --label "confighub_changeset_id=${changeset_id}" \
+  --label "git_repo=$(echo "$GIT_REPO" | tr '/' '-')" \
+  --label "git_branch=${branch_name}" \
+  > "$OUT_DIR/linkage-changeset.json"
+
+# Step 7: Instructions for creating actual Git PR
+echo ""
+echo "[flow-b][step-7] Git PR creation instructions"
+echo ""
+echo "To complete Flow B, create the Git PR:"
+echo ""
+echo "  1. Create branch: git checkout -b ${branch_name}"
+echo "  2. Apply changes from inverse-edit guidance"
+echo "  3. Commit with linkage metadata:"
+echo "     git commit -m \"${pr_title}"
+echo ""
+echo "     ConfigHub-Changeset-ID: ${changeset_id}\""
+echo "  4. Push and create PR:"
+echo "     git push -u origin ${branch_name}"
+echo "     gh pr create --title \"${pr_title}\" --body-file ${OUT_DIR}/pr-proposal.json"
+echo ""
+
+# Summary
+echo "[flow-b] summary"
+jq -n \
+  --arg flow "B" \
+  --arg direction "ConfigHub MR → Git PR" \
+  --arg changeset_slug "$CHANGESET_SLUG" \
+  --arg changeset_id "$changeset_id" \
+  --arg git_repo "$GIT_REPO" \
+  --arg git_branch "$branch_name" \
+  --arg target_branch "$TARGET_BRANCH" \
+  --arg dry_file "$dry_file" \
+  --arg dry_path "$dry_path" \
+  --arg status "PR_PROPOSED" \
+  '{
+    flow: $flow,
+    direction: $direction,
+    confighub: {
+      changeset_slug: $changeset_slug,
+      changeset_id: $changeset_id,
+      status: "APPROVED"
+    },
+    git: {
+      repo: $git_repo,
+      branch: $git_branch,
+      target_branch: $target_branch,
+      status: "PROPOSED"
+    },
+    proposed_edit: {
+      dry_file: $dry_file,
+      dry_path: $dry_path
+    },
+    status: $status
+  }' | tee "$OUT_DIR/flow-b-summary.json"

--- a/examples/demo/fr8-promotion-upstream-dry-connected.sh
+++ b/examples/demo/fr8-promotion-upstream-dry-connected.sh
@@ -1,0 +1,449 @@
+#!/usr/bin/env bash
+# FR8: Promotion to Upstream Platform DRY
+#
+# This demo shows the full promotion flow from live observation through
+# WET evidence to upstream DRY promotion:
+#
+# 1. LIVE → WET: Observe live state, capture delta as WET evidence
+# 2. WET → governed: Evaluate delta against policies, reach ALLOW decision
+# 3. governed → promotion: After successful rollout, propose promotion
+# 4. promotion → upstream DRY: Platform team reviews and merges upstream PR
+# 5. app overlay cleanup: Reduce/remove app overlay to avoid drift
+#
+# This flow implements the "reusable default promotion" pattern from the
+# PR-MR linkage contract, where successful app-level changes are promoted
+# to the platform's base DRY when they represent a good default.
+#
+# Usage:
+#   ./examples/demo/fr8-promotion-upstream-dry-connected.sh [REPO_PATH]
+#
+# Required env:
+#   - ConfigHub auth (CONFIGHUB_TOKEN or `cub auth login`)
+#   - GitHub auth (GH_TOKEN/GITHUB_TOKEN or `gh auth login`)
+#
+# Optional env:
+#   - GIT_REPO: owner/repo (default: detect from remote)
+#   - UPSTREAM_REPO: upstream platform repo (default: same as GIT_REPO)
+#   - OUT_ROOT: output directory root
+#   - SKIP_BUILD: set to 1 to skip cub-gen rebuild
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/examples/demo/lib/connected-preflight.sh"
+source "$ROOT_DIR/examples/demo/lib/lifecycle-update.sh"
+
+REPO_PATH="${1:-./examples/helm-paas}"
+EXAMPLE_SLUG="$(basename "$REPO_PATH")"
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/fr8-promotion}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="$OUT_ROOT/$RUN_ID/$EXAMPLE_SLUG"
+SPACE="${SPACE:-}"
+VERIFIER="${VERIFIER:-ci-bot}"
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+normalize_repo() {
+  local value="$1"
+  value="${value#https://github.com/}"
+  value="${value#http://github.com/}"
+  value="${value#git@github.com:}"
+  value="${value#github.com/}"
+  value="${value%.git}"
+  printf '%s' "$value"
+}
+
+resolve_default_repo() {
+  local remote
+  remote="$(git config --get remote.origin.url 2>/dev/null || true)"
+  if [ -z "$remote" ]; then
+    return 0
+  fi
+  normalize_repo "$remote"
+}
+
+resolve_gh_token() {
+  local token
+  token="$(printf '%s' "${GH_TOKEN:-${GITHUB_TOKEN:-}}" | tr -d '\r\n')"
+  if [ -n "$token" ]; then
+    printf '%s' "$token"
+    return 0
+  fi
+  if token="$(gh auth token 2>/dev/null | tr -d '\r\n')" && [ -n "$token" ]; then
+    printf '%s' "$token"
+    return 0
+  fi
+  return 1
+}
+
+sanitize_slug() {
+  local input="$1"
+  input="$(printf '%s' "$input" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+  input="$(printf '%s' "$input" | sed -E 's/^-+//; s/-+$//; s/-+/-/g')"
+  printf '%s' "${input:0:63}"
+}
+
+is_terminal_decision_state() {
+  local state="$1"
+  case "$state" in
+    ALLOW|ESCALATE|BLOCK) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ ! -d "$REPO_PATH" ]; then
+  echo "error: repo path not found: $REPO_PATH" >&2
+  exit 1
+fi
+
+require_cmd gh
+require_cmd jq
+require_cmd shasum
+
+# Resolve GitHub auth
+gh_token="$(resolve_gh_token || true)"
+if [ -z "$gh_token" ]; then
+  echo "error: missing GitHub auth for FR8 promotion demo." >&2
+  echo "remediation: set GH_TOKEN/GITHUB_TOKEN or run 'gh auth login'." >&2
+  exit 1
+fi
+export GH_TOKEN="$gh_token"
+
+# Resolve Git repos
+GIT_REPO="${GIT_REPO:-$(resolve_default_repo)}"
+UPSTREAM_REPO="${UPSTREAM_REPO:-$GIT_REPO}"
+
+if [ -z "$GIT_REPO" ]; then
+  echo "error: unable to resolve Git repository." >&2
+  echo "remediation: set GIT_REPO=owner/repo or run from a Git repo with remote.origin.url." >&2
+  exit 1
+fi
+
+# Require ConfigHub preflight
+require_connected_preflight
+if [ -z "$SPACE" ]; then
+  SPACE="$CONFIGHUB_SPACE"
+fi
+
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  echo "[fr8] building cub-gen"
+  go build -o ./cub-gen ./cmd/cub-gen
+fi
+
+mkdir -p "$OUT_DIR"
+
+echo "[fr8] Promotion to Upstream Platform DRY"
+echo "[fr8] app repo: $GIT_REPO"
+echo "[fr8] upstream repo: $UPSTREAM_REPO"
+echo "[fr8] example: $EXAMPLE_SLUG"
+echo "[fr8] output: $OUT_DIR"
+print_connected_context
+
+# Prepare working copy
+work_repo="$OUT_DIR/repo"
+mkdir -p "$work_repo"
+cp -R "$REPO_PATH"/. "$work_repo"
+
+#############################################################################
+# Phase 1: LIVE → WET (Observe and capture current state)
+#############################################################################
+echo ""
+echo "[fr8][phase-1] LIVE → WET: Observe and capture state"
+
+# Discover and import baseline
+./cub-gen gitops discover --space "$SPACE" --json "$work_repo" > "$OUT_DIR/discover-baseline.json"
+./cub-gen gitops import --space "$SPACE" --json "$work_repo" "$work_repo" > "$OUT_DIR/import-baseline.json"
+./cub-gen publish --in "$OUT_DIR/import-baseline.json" > "$OUT_DIR/bundle-baseline.json"
+
+baseline_change_id="$(jq -r .change_id "$OUT_DIR/bundle-baseline.json")"
+echo "[fr8] baseline change_id: $baseline_change_id"
+
+#############################################################################
+# Phase 2: Apply app-level change (simulate feature rollout)
+#############################################################################
+echo ""
+echo "[fr8][phase-2] Apply app-level change"
+
+apply_update "$EXAMPLE_SLUG" "$work_repo"
+
+# Import after change
+./cub-gen gitops import --space "$SPACE" --json "$work_repo" "$work_repo" > "$OUT_DIR/import-changed.json"
+./cub-gen publish --in "$OUT_DIR/import-changed.json" > "$OUT_DIR/bundle-changed.json"
+./cub-gen verify --json --in "$OUT_DIR/bundle-changed.json" > "$OUT_DIR/verify-changed.json"
+./cub-gen attest --in "$OUT_DIR/bundle-changed.json" --verifier "$VERIFIER" > "$OUT_DIR/attestation-changed.json"
+
+changed_change_id="$(jq -r .change_id "$OUT_DIR/bundle-changed.json")"
+echo "[fr8] changed change_id: $changed_change_id"
+
+#############################################################################
+# Phase 3: WET → governed (Ingest and evaluate)
+#############################################################################
+echo ""
+echo "[fr8][phase-3] WET → governed: Ingest and evaluate"
+
+./cub-gen bridge ingest \
+  --in "$OUT_DIR/bundle-changed.json" \
+  --base-url "$CONFIGHUB_BASE_URL" \
+  --token "$CONFIGHUB_TOKEN" \
+  > "$OUT_DIR/ingest.json"
+
+# Query decision
+./cub-gen bridge decision query \
+  --base-url "$CONFIGHUB_BASE_URL" \
+  --token "$CONFIGHUB_TOKEN" \
+  --change-id "$changed_change_id" \
+  > "$OUT_DIR/decision.json"
+
+decision_state="$(jq -r '.state // "PENDING"' "$OUT_DIR/decision.json")"
+echo "[fr8] decision state: $decision_state"
+
+if [ "$decision_state" != "ALLOW" ]; then
+  echo "[fr8] warning: decision is $decision_state; promotion requires ALLOW"
+  echo "[fr8] continuing demo to show promotion proposal structure"
+fi
+
+#############################################################################
+# Phase 4: governed → promotion (Propose upstream promotion)
+#############################################################################
+echo ""
+echo "[fr8][phase-4] governed → promotion: Propose upstream DRY promotion"
+
+now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+promotion_slug="$(sanitize_slug "fr8-promotion-${EXAMPLE_SLUG}-${RUN_ID}")"
+
+# Extract what changed (inverse-edit guidance)
+jq -r '.inverse_transform_plans // []' "$OUT_DIR/import-changed.json" > "$OUT_DIR/inverse-guidance.json"
+
+# Identify fields suitable for promotion
+# (fields that are app-overlay overrides but could be platform defaults)
+jq '[.inverse_transform_plans[]?.patches[]? | select(.owner == "app-team" or .owner == null) | {
+  dry_file: .dry_file,
+  dry_path: .dry_path,
+  current_value: .current_value,
+  promotion_candidate: true
+}]' "$OUT_DIR/import-changed.json" > "$OUT_DIR/promotion-candidates.json"
+
+# Create promotion proposal changeset
+cub changeset create \
+  --space "$CONFIGHUB_SPACE" \
+  --json \
+  --allow-exists \
+  "$promotion_slug" \
+  --description "FR8: Promotion proposal for ${EXAMPLE_SLUG} (change_id=${changed_change_id})" \
+  --label "flow=FR8" \
+  --label "flow_stage=promotion-proposed" \
+  --label "source_change_id=${changed_change_id}" \
+  --label "baseline_change_id=${baseline_change_id}" \
+  --label "decision_state=${decision_state}" \
+  --label "app_repo=$(echo "$GIT_REPO" | tr '/' '-')" \
+  --label "upstream_repo=$(echo "$UPSTREAM_REPO" | tr '/' '-')" \
+  > "$OUT_DIR/promotion-changeset.json"
+
+promotion_changeset_id="$(jq -r '.ChangeSetID // .ChangeSet.ChangeSetID // empty' "$OUT_DIR/promotion-changeset.json")"
+
+#############################################################################
+# Phase 5: Generate upstream promotion PR proposal
+#############################################################################
+echo ""
+echo "[fr8][phase-5] Generate upstream promotion PR"
+
+# Determine promotion target files
+upstream_branch="confighub/fr8-promotion-${RUN_ID}"
+upstream_target_branch="${UPSTREAM_TARGET_BRANCH:-main}"
+
+# Build PR content
+promotion_pr_title="[FR8 Promotion] ${EXAMPLE_SLUG}: promote app defaults to platform base"
+promotion_pr_body="## FR8: Promotion to Upstream Platform DRY
+
+This PR promotes successful app-level changes to the platform's base DRY,
+making them the new default for all deployments.
+
+### Promotion Chain
+
+| Stage | Change ID | Status |
+|-------|-----------|--------|
+| Baseline | \`${baseline_change_id}\` | captured |
+| App Change | \`${changed_change_id}\` | ${decision_state} |
+| Promotion | \`${promotion_changeset_id}\` | proposed |
+
+### What's Being Promoted
+
+$(jq -r 'if length > 0 then
+  "| DRY File | DRY Path |\n|----------|----------|\n" +
+  (map("| \(.dry_file) | \(.dry_path) |") | join("\n"))
+else
+  "No specific promotion candidates identified."
+end' "$OUT_DIR/promotion-candidates.json")
+
+### Promotion Contract
+
+Per the PR-MR linkage contract, this promotion:
+- [x] Follows a prior \`ALLOW\` decision (or demo mode)
+- [x] Requires separate platform review approval
+- [ ] Will reduce/remove app overlay after merge
+
+### Flow
+
+1. **LIVE → WET**: Observed live state, captured delta
+2. **WET → governed**: Evaluated against policies → ${decision_state}
+3. **governed → promotion**: This promotion PR
+4. **promotion → upstream DRY**: Platform team reviews
+5. **cleanup**: App overlay reduced after merge
+
+### Linkage
+
+\`\`\`json
+{
+  \"flow\": \"FR8\",
+  \"source_change_id\": \"${changed_change_id}\",
+  \"promotion_changeset_id\": \"${promotion_changeset_id}\"
+}
+\`\`\`
+
+---
+Generated by: cub-gen FR8 promotion demo"
+
+jq -n \
+  --arg branch "$upstream_branch" \
+  --arg title "$promotion_pr_title" \
+  --arg body "$promotion_pr_body" \
+  --arg target_branch "$upstream_target_branch" \
+  --arg upstream_repo "$UPSTREAM_REPO" \
+  --slurpfile candidates "$OUT_DIR/promotion-candidates.json" \
+  '{
+    upstream_repo: $upstream_repo,
+    branch: $branch,
+    title: $title,
+    body: $body,
+    target_branch: $target_branch,
+    promotion_candidates: $candidates[0]
+  }' > "$OUT_DIR/promotion-pr-proposal.json"
+
+#############################################################################
+# Phase 6: Create promotion linkage record
+#############################################################################
+echo ""
+echo "[fr8][phase-6] Create promotion linkage record"
+
+linkage_slug="$(sanitize_slug "fr8-linkage-${EXAMPLE_SLUG}-${RUN_ID}")"
+
+jq -n \
+  --arg schema "cub.confighub.io/pr-mr-promotion-flow/v1" \
+  --arg flow "FR8" \
+  --arg flow_stage "promotion-proposed" \
+  --arg baseline_change_id "$baseline_change_id" \
+  --arg source_change_id "$changed_change_id" \
+  --arg decision_state "$decision_state" \
+  --arg promotion_changeset_id "$promotion_changeset_id" \
+  --arg app_repo "$GIT_REPO" \
+  --arg upstream_repo "$UPSTREAM_REPO" \
+  --arg upstream_branch "$upstream_branch" \
+  --arg upstream_target_branch "$upstream_target_branch" \
+  --arg updated_at "$now" \
+  '{
+    schema: $schema,
+    flow: $flow,
+    flow_stage: $flow_stage,
+    source: {
+      baseline_change_id: $baseline_change_id,
+      change_id: $source_change_id,
+      decision_state: $decision_state,
+      app_repo: $app_repo
+    },
+    promotion: {
+      changeset_id: $promotion_changeset_id,
+      upstream_repo: $upstream_repo,
+      branch: $upstream_branch,
+      target_branch: $upstream_target_branch,
+      pr_number: null,
+      pr_url: null,
+      status: "PROPOSED"
+    },
+    updated_at: $updated_at
+  }' > "$OUT_DIR/promotion-linkage.json"
+
+# Record in ConfigHub
+cub changeset create \
+  --space "$CONFIGHUB_SPACE" \
+  --json \
+  --allow-exists \
+  "$linkage_slug" \
+  --description "FR8: Promotion linkage for ${EXAMPLE_SLUG}" \
+  --label "flow=FR8" \
+  --label "flow_stage=linkage" \
+  --label "source_change_id=${changed_change_id}" \
+  --label "promotion_changeset_id=${promotion_changeset_id}" \
+  > "$OUT_DIR/linkage-changeset.json"
+
+#############################################################################
+# Instructions
+#############################################################################
+echo ""
+echo "[fr8] promotion instructions"
+echo ""
+echo "To complete FR8 promotion:"
+echo ""
+echo "  1. Review promotion candidates:"
+echo "     cat ${OUT_DIR}/promotion-candidates.json"
+echo ""
+echo "  2. Create upstream promotion PR:"
+echo "     cd <upstream-repo>"
+echo "     git checkout -b ${upstream_branch}"
+echo "     # Apply promotion changes to base DRY files"
+echo "     git commit -m \"${promotion_pr_title}"
+echo ""
+echo "     ConfigHub-Changeset-ID: ${promotion_changeset_id}\""
+echo "     git push -u origin ${upstream_branch}"
+echo "     gh pr create --title \"${promotion_pr_title}\" --body-file ${OUT_DIR}/promotion-pr-proposal.json"
+echo ""
+echo "  3. After merge, clean up app overlay:"
+echo "     # Remove app-specific overrides that are now platform defaults"
+echo ""
+
+#############################################################################
+# Summary
+#############################################################################
+echo "[fr8] summary"
+jq -n \
+  --arg flow "FR8" \
+  --arg flow_name "Promotion to Upstream Platform DRY" \
+  --arg baseline_change_id "$baseline_change_id" \
+  --arg source_change_id "$changed_change_id" \
+  --arg decision_state "$decision_state" \
+  --arg promotion_changeset_id "$promotion_changeset_id" \
+  --arg app_repo "$GIT_REPO" \
+  --arg upstream_repo "$UPSTREAM_REPO" \
+  --arg upstream_branch "$upstream_branch" \
+  --argjson promotion_candidates "$(jq 'length' "$OUT_DIR/promotion-candidates.json")" \
+  '{
+    flow: $flow,
+    flow_name: $flow_name,
+    phases: [
+      "LIVE → WET (observe)",
+      "WET → governed (evaluate)",
+      "governed → promotion (propose)",
+      "promotion → upstream DRY (review)",
+      "cleanup (reduce overlay)"
+    ],
+    source: {
+      baseline_change_id: $baseline_change_id,
+      change_id: $source_change_id,
+      decision_state: $decision_state,
+      app_repo: $app_repo
+    },
+    promotion: {
+      changeset_id: $promotion_changeset_id,
+      upstream_repo: $upstream_repo,
+      branch: $upstream_branch,
+      candidates: $promotion_candidates,
+      status: "PROPOSED"
+    }
+  }' | tee "$OUT_DIR/fr8-summary.json"

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -283,6 +283,15 @@ WET:  Deployment/spec/template/spec/containers[0]/image = "ghcr.io/example/payme
 - **E2E demo script**: `../demo/module-1-helm-import.sh`
 - **Bridge governance demo**: `../demo/module-4-bridge-governance.sh`
 
+### PR-MR pairing and promotion flows
+
+- **Flow A (Git PR → ConfigHub MR)**: `../demo/flow-a-git-pr-to-mr-connected.sh`
+  — developer opens PR, ConfigHub creates MR with evidence
+- **Flow B (ConfigHub MR → Git PR)**: `../demo/flow-b-mr-to-git-pr-connected.sh`
+  — ConfigHub initiates change, generates Git PR after approval
+- **FR8 promotion**: `../demo/fr8-promotion-upstream-dry-connected.sh`
+  — promote successful app change to upstream platform DRY
+
 ## Run from ConfigHub (connected mode)
 
 If you already have ConfigHub, start here:

--- a/examples/scoredev-paas/README.md
+++ b/examples/scoredev-paas/README.md
@@ -260,6 +260,15 @@ WET:  Deployment/spec/template/spec/containers[name=main]/image
 - **E2E demo**: `../demo/module-2-score-field-map.sh`
 - **Worked example**: `../../docs/agentic-gitops/03-worked-examples/01-scoredev-dry-wet-unit-worked-example.md`
 
+### PR-MR pairing and promotion flows
+
+- **Flow A (Git PR → ConfigHub MR)**: `../demo/flow-a-git-pr-to-mr-connected.sh`
+  — developer opens PR, ConfigHub creates MR with evidence
+- **Flow B (ConfigHub MR → Git PR)**: `../demo/flow-b-mr-to-git-pr-connected.sh`
+  — ConfigHub initiates change, generates Git PR after approval
+- **FR8 promotion**: `../demo/fr8-promotion-upstream-dry-connected.sh`
+  — promote successful app change to upstream platform DRY
+
 ## Run from ConfigHub (connected mode)
 
 If you already have ConfigHub, start here:

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -286,6 +286,15 @@ WET:  Deployment/spec/template/spec/containers[0]/env[name=SERVER_PORT]/value = 
 - **E2E demo**: `../demo/module-3-spring-ownership.sh`
 - **Worked example**: `../../docs/agentic-gitops/03-worked-examples/03-spring-boot-dry-wet-unit-worked-example.md`
 
+### PR-MR pairing and promotion flows
+
+- **Flow A (Git PR → ConfigHub MR)**: `../demo/flow-a-git-pr-to-mr-connected.sh`
+  — developer opens PR, ConfigHub creates MR with evidence
+- **Flow B (ConfigHub MR → Git PR)**: `../demo/flow-b-mr-to-git-pr-connected.sh`
+  — ConfigHub initiates change, generates Git PR after approval
+- **FR8 promotion**: `../demo/fr8-promotion-upstream-dry-connected.sh`
+  — promote successful app change to upstream platform DRY
+
 ## Run from ConfigHub (connected mode)
 
 If you already have ConfigHub, start here:


### PR DESCRIPTION
## Summary
- Add Flow A demo: Git PR → ConfigHub MR governed change flow
- Add Flow B demo: ConfigHub MR → Git PR reverse flow
- Add FR8 promotion demo: live→WET→DRY upstream promotion flow
- Update demo README with new PR-MR pairing section
- Add PR-MR flows to flagship example Next steps sections

## Test plan
- [x] All parity/golden tests pass
- [x] All example path mode tests pass
- [x] Shell script syntax validation passes

## Issues
Addresses #188 (real Git PR <-> ConfigHub MR pairing flows A and B)
Addresses #189 (FR8 promotion and live->wet->dry first-class flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)