### PR TITLE
docs: align project status with active execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Full guide: [docs/workflows/confidence-scores.md](docs/workflows/confidence-scor
 | C3 Agent | `c3agent.yaml` | [c3agent](examples/c3agent/) |
 | Swamp | `.swamp.yaml` + `workflow-*.yaml` | [swamp-automation](examples/swamp-automation/) |
 
-Per-generator recipes and bridge flow examples: [CLI Reference](https://confighub.github.io/cub-gen/cli-reference/)
+Per-generator recipes and bridge flow examples: [CLI Reference](docs/cli-reference.md)
 
 ## Part of the ConfigHub platform
 
@@ -140,7 +140,7 @@ If you already use ConfigHub's GitOps Import wizard, think of it this way:
 - ConfigHub imports cluster-discovered Argo/Flux applications.
 - `cub-gen` imports source-side generators before they ever become opaque cluster objects.
 
-See the [platform docs](https://confighub.github.io/cub-gen/platform/) for the full story.
+See the [platform docs](docs/platform.md) for the full story.
 
 ## Who this is for
 
@@ -160,13 +160,14 @@ Platform engineers, SREs, and app developers who want to know exactly what chang
 
 ## Documentation
 
-Full docs: **https://confighub.github.io/cub-gen/**
+Docs currently live in this repo:
 
-- [Getting Started](https://confighub.github.io/cub-gen/getting-started/) — 10-minute quickstart
-- [CLI Reference](https://confighub.github.io/cub-gen/cli-reference/) — all commands, flags, and generator recipes
-- [Demo Guide](https://confighub.github.io/cub-gen/demo-guide/) — runnable demo scripts and scenarios
+- [Docs index](docs/index.md) — overview and navigation
+- [Getting Started](docs/getting-started.md) — 10-minute quickstart
+- [CLI Reference](docs/cli-reference.md) — all commands, flags, and generator recipes
+- [Demo Guide](docs/demo-guide.md) — runnable demo scripts and scenarios
 - [Examples](examples/README.md) — complete runnable scenarios for every generator
-- [Platform](https://confighub.github.io/cub-gen/platform/) — how cub-gen connects to ConfigHub
+- [Platform](docs/platform.md) — how cub-gen connects to ConfigHub
 - [Persona 5-minute runbooks](docs/workflows/persona-5-minute-runbooks.md) — stack-specific entry paths
 - [Change CLI contract](docs/contracts/change-cli-v1.md) — change preview/run/explain specification
 - [Operation registry for real apps](docs/workflows/operation-registry-real-apps.md) — registry-backed platform governance
@@ -180,13 +181,17 @@ Full docs: **https://confighub.github.io/cub-gen/**
 
 Both prove create, update, and drift-correction on a real cluster.
 
-## User-story coverage
+## Execution status
 
-| Status | User stories |
+| Status | What is true today |
 |---|---|
-| Met/strong in current demos | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 |
-| Partial (simulated/local-first, not full backend/runtime integration) | None |
-| Deferred | None |
+| Strong now | Dual-mode example entrypoints exist across the main catalog; connected story scripts exist for stories 1-13; Flux and Argo live reconciler proofs run on real clusters |
+| In progress | Flagship examples are still being hardened against the universal example contract: real-cluster outcome, two-audience path, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` proof |
+| Actively tracked | Example reset execution is being driven through issues `#173`, `#177`, `#178`, `#179`, `#180`, `#182`, `#183`, `#185`, and `#187` |
+
+We have runnable paths for the full PRD story surface, but we are not treating every
+story as fully acceptance-complete until the flagship examples and release gates
+prove the new standard end to end.
 
 ## Test and contribute
 

--- a/docs/plans/2026-03-16-example-reset-execution-plan.md
+++ b/docs/plans/2026-03-16-example-reset-execution-plan.md
@@ -33,6 +33,26 @@ It also needs to give platform users credible day-2 stories:
 - how do governed change, promotion, live-origin proposals, or AI-assisted
   changes help me now?
 
+## Current status snapshot
+
+Completed enough to build on:
+
+- the example contract and real-cluster bar are written down,
+- the main catalog has local and connected entrypoints,
+- the messaging around DRY -> WET, ConfigHub MR governance, and AI prompt-as-DRY
+  is materially better than it was.
+
+Still not complete enough to claim victory:
+
+- the flagship examples still need to prove the universal contract end to end,
+- the release gate still needs to act as the enforcement point for that
+  contract,
+- the repo should not claim full PRD-complete proof until those gates exist.
+
+Active execution issues:
+
+- `#173`, `#177`, `#178`, `#179`, `#180`, `#182`, `#183`, `#185`, `#187`
+
 ## Non-negotiable requirements
 
 1. Every featured example must support two audiences explicitly:

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,7 +43,7 @@ Everything in these examples runs locally with no backend:
 - Evidence bundles (`publish`, `verify`, `attest`)
 
 Cross-repo queries, policy enforcement, and governed decisions require
-[ConfigHub](https://confighub.github.io/cub-gen/platform/).
+[ConfigHub](../docs/platform.md).
 
 ## Pick your domain POV first
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -290,13 +290,16 @@ Without a live `WET → LIVE` reconciler loop shown end-to-end, classify the flo
 
 See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` for full loop proofs.
 
-## PRD user-story coverage
+## PRD execution status
 
-| Status | User stories |
-|--------|--------------|
-| Met/strong in current demos | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 |
-| Partial (simulated/local-first, not full backend/runtime integration) | None |
-| Deferred | None |
+| Status | What is true today |
+|--------|--------------------|
+| Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
+| In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
+| Actively tracked | Example reset execution is being driven through issues `#173`, `#177`, `#178`, `#179`, `#180`, `#182`, `#183`, `#185`, and `#187` |
+
+That means the demo surface is broad, but we are still hardening the main examples
+before we claim full PRD-complete product proof.
 
 References:
 - `docs/agentic-gitops/03-worked-examples/04-eight-example-story-cards.md`

--- a/test/checks/check-story-status.sh
+++ b/test/checks/check-story-status.sh
@@ -32,19 +32,43 @@ extract_stories() {
   printf '%s' "$value"
 }
 
-main_met="$(extract_stories "$README_MAIN" "Met/strong in current demos")"
-main_partial="$(extract_stories "$README_MAIN" "Partial (simulated/local-first, not full backend/runtime integration)")"
-main_deferred="$(extract_stories "$README_MAIN" "Deferred")"
+require_heading() {
+  local file="$1"
+  local heading="$2"
+  if ! grep -Eq "^## ${heading}$" "$file"; then
+    echo "error: heading not found in $file: ## ${heading}" >&2
+    exit 1
+  fi
+}
 
-demo_met="$(extract_stories "$README_DEMO" "Met/strong in current demos")"
-demo_partial="$(extract_stories "$README_DEMO" "Partial (simulated/local-first, not full backend/runtime integration)")"
-demo_deferred="$(extract_stories "$README_DEMO" "Deferred")"
+require_absent() {
+  local file="$1"
+  local pattern="$2"
+  if grep -Eq "$pattern" "$file"; then
+    echo "error: stale status language found in $file: $pattern" >&2
+    exit 1
+  fi
+}
 
-if [ "$main_met" != "$demo_met" ] || [ "$main_partial" != "$demo_partial" ] || [ "$main_deferred" != "$demo_deferred" ]; then
-  echo "error: story-status table drift between README.md and examples/demo/README.md" >&2
-  echo "  README.md     met=$main_met partial=$main_partial deferred=$main_deferred" >&2
-  echo "  demo README   met=$demo_met partial=$demo_partial deferred=$demo_deferred" >&2
+require_heading "$README_MAIN" "Execution status"
+require_heading "$README_DEMO" "PRD execution status"
+
+require_absent "$README_MAIN" "Met/strong in current demos"
+require_absent "$README_DEMO" "Met/strong in current demos"
+
+main_tracked="$(extract_stories "$README_MAIN" "Actively tracked")"
+demo_tracked="$(extract_stories "$README_DEMO" "Actively tracked")"
+
+if [ "$main_tracked" != "$demo_tracked" ]; then
+  echo "error: active execution issue list drift between README.md and examples/demo/README.md" >&2
+  echo "  README.md   tracked=$main_tracked" >&2
+  echo "  demo README tracked=$demo_tracked" >&2
   exit 1
 fi
 
-echo "ok: story-status tables are consistent"
+extract_stories "$README_MAIN" "Strong now" >/dev/null
+extract_stories "$README_MAIN" "In progress" >/dev/null
+extract_stories "$README_DEMO" "Strong now" >/dev/null
+extract_stories "$README_DEMO" "In progress" >/dev/null
+
+echo "ok: execution-status tables are consistent"


### PR DESCRIPTION
## Summary
- replace over-claimed PRD/user-story status with an honest execution snapshot
- stop pointing readers at a 404 docs site and use in-repo docs links instead
- reopen and annotate the active example-reset execution issues

## Testing
- not run (docs + issue tracker only)