### PR TITLE
docs: refocus entrypoints on existing GitOps adoption

### DIFF
--- a/AI-HANDOVER.md
+++ b/AI-HANDOVER.md
@@ -69,12 +69,13 @@ For layered platforms like Helm/Argo/Kubara-like stacks, also prove:
 
 ## Files that matter most
 
-- [README.md](/Users/alexis/Public/github-repos/cub-gen/README.md)
-- [examples/README.md](/Users/alexis/Public/github-repos/cub-gen/examples/README.md)
-- [examples/demo/README.md](/Users/alexis/Public/github-repos/cub-gen/examples/demo/README.md)
-- [docs/plans/2026-03-16-example-reset-execution-plan.md](/Users/alexis/Public/github-repos/cub-gen/docs/plans/2026-03-16-example-reset-execution-plan.md)
-- [docs/testing/ilya-coreweave-acceptance-checklist.md](/Users/alexis/Public/github-repos/cub-gen/docs/testing/ilya-coreweave-acceptance-checklist.md)
-- [test/checks/check-story-status.sh](/Users/alexis/Public/github-repos/cub-gen/test/checks/check-story-status.sh)
+- [README.md](README.md)
+- [examples/README.md](examples/README.md)
+- [examples/demo/README.md](examples/demo/README.md)
+- [docs/plans/2026-03-16-example-reset-execution-plan.md](docs/plans/2026-03-16-example-reset-execution-plan.md)
+- [docs/plans/2026-03-20-existing-gitops-adoption-plan.md](docs/plans/2026-03-20-existing-gitops-adoption-plan.md)
+- [docs/testing/ilya-coreweave-acceptance-checklist.md](docs/testing/ilya-coreweave-acceptance-checklist.md)
+- [test/checks/check-story-status.sh](test/checks/check-story-status.sh)
 
 ## Important recent fixes
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,33 @@
 
 Working on this repo as the next maintainer or AI? Start with [AI-HANDOVER.md](AI-HANDOVER.md).
 
-See where every deployed config value came from.
+See where every deployed config value came from, starting from the repo you
+already have.
 
-`cub-gen` is a governance + traceability sidecar for GitOps.
+`cub-gen` is a source-side provenance and governed-change companion for GitOps
+teams. It is for people who already run GitHub, Helm, Score, Spring Boot, or
+workflow config, and already rely on Flux or Argo CD to reconcile what reaches
+their clusters.
 
 **gen = generator.** A generator is a function that maps DRY source (your `values.yaml`, `score.yaml`, etc.) to WET rendered output (the manifests that reach your cluster). `cub-gen` detects which generators your repo uses, runs the mapping, and records provenance — so every deployed field traces back to a source file, line, and owner.
 
 If you already run app/config in Git, OCI artifacts, and Flux/Argo reconciliation, `cub-gen` answers:
 
 - Which source file/path controls this live field?
+- What rendered manifests did this repo actually produce?
 - Did the right team edit the right thing?
 - Can we block unsafe edits before they hit cluster?
 
 It does this by classifying your existing repo and mapping rendered fields back
 to source file, line, and owner.
+
+## Start with the path you already have
+
+| If you already run... | Start here | First useful answer |
+|-----------|-----------|---------------------|
+| Helm plus Flux/Argo platform repos | [helm-paas](examples/helm-paas/) | Which values file owns this rendered field? |
+| Spring Boot services in GitOps | [springboot-paas](examples/springboot-paas/) | Which `application.yaml` setting or platform file should I edit? |
+| Cluster-first GitOps operations | ConfigHub GitOps import + [cub-scout](https://github.com/confighub/cub-scout) + then `cub-gen` | What is running, and what source produced it? |
 
 ## What it is not
 
@@ -24,6 +37,16 @@ to source file, line, and owner.
 - Not an OCI replacement
 
 Flux/Argo still reconcile to LIVE. `cub-gen` adds governance before deploy and traceability after deploy.
+
+## Why import?
+
+Import should answer something useful right away:
+
+- what rendered manifests this repo produces,
+- which DRY file controls a deployed field,
+- what evidence bundle or governed change to inspect next,
+- how the repo-side answer lines up with cluster-side inspection in `cub-scout`
+  and ConfigHub.
 
 ## Two import paths, two jobs
 
@@ -36,6 +59,14 @@ They complement each other:
 
 - use ConfigHub GitOps import for brownfield cluster/app onboarding,
 - use `cub-gen` when you want source-to-runtime traceability and governed changes from DRY config.
+
+## How the tools fit together
+
+| Tool | Starts from | Best first question |
+|------|-------------|---------------------|
+| `cub-gen` | Source repo and generator inputs | Which DRY file/path produced this rendered field? |
+| [`cub-scout`](https://github.com/confighub/cub-scout) | Cluster, reconciler, and live runtime state | What is running, who owns it, and where is drift? |
+| [ConfigHub](https://github.com/confighubai/confighub) | Shared intended state, evidence, and governance state | What changed, what was approved, and what evidence exists across repos and clusters? |
 
 ## What it looks like
 
@@ -73,18 +104,16 @@ You see exactly which source field produced each deployed value, who owns it, an
 - **Inverse-edit guidance** — tells you where to edit DRY source to change a deployed value
 - **Change CLI** — `change preview`, `change run`, `change explain` for day-to-day workflows
 
-## Quickstart (local, no login)
+## First runs (local, no login)
 
 ```bash
 go build -o ./cub-gen ./cmd/cub-gen
 
-# One-command change preview
-./cub-gen change preview --space platform ./examples/scoredev-paas ./examples/scoredev-paas
+# Platform-first: existing Helm + Flux/Argo team
+./examples/helm-paas/demo-local.sh
 
-# Or the core flow
-./cub-gen gitops discover --space platform ./examples/helm-paas
-./cub-gen gitops import --space platform --json ./examples/helm-paas ./examples/helm-paas \
-  | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets}'
+# App-first: existing Spring Boot team
+./examples/springboot-paas/demo-local.sh
 ```
 
 ## Use Your Repo in 3 Commands
@@ -92,19 +121,27 @@ go build -o ./cub-gen ./cmd/cub-gen
 ```bash
 REPO=/path/to/your/repo
 ./cub-gen change preview --space platform "$REPO" "$REPO"
-./cub-gen change run --mode local --space platform "$REPO" "$REPO"
+./cub-gen gitops import --space platform --json "$REPO" "$REPO" \
+  | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets}'
 ./cub-gen change explain --space platform --owner app-team "$REPO" "$REPO"
 ```
 
-## Quickstart (connected, ConfigHub)
+## Next step (connected, ConfigHub)
 
 ```bash
 cub auth login
-TOKEN="$(cub auth get-token)"
-BASE_URL="${CONFIGHUB_BASE_URL:-$(cub context get --json | jq -r '.coordinate.serverURL')}"
-./cub-gen change run --mode connected --base-url "$BASE_URL" --token "$TOKEN" \
-  --space platform ./examples/helm-paas ./examples/helm-paas
+
+# Platform-first connected path
+./examples/helm-paas/demo-connected.sh
+
+# App-first connected path
+./examples/springboot-paas/demo-connected.sh
 ```
+
+If you are starting from a cluster or controller rather than a repo, use
+ConfigHub GitOps import and [`cub-scout`](https://github.com/confighub/cub-scout)
+for the cluster-side path first, then use `cub-gen` to trace a chosen field back
+to DRY source.
 
 ## Confidence scores
 
@@ -141,6 +178,7 @@ If you already use ConfigHub's GitOps Import wizard, think of it this way:
 
 - ConfigHub imports cluster-discovered Argo/Flux applications.
 - `cub-gen` imports source-side generators before they ever become opaque cluster objects.
+- `cub-scout` inspects the cluster-side and controller-side reality after those objects reach runtime.
 
 See the [platform docs](docs/platform.md) for the full story.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,24 @@
 # Getting Started
 
-Get from zero to provenance-traced import in under 10 minutes.
+Get from an existing GitOps repo to a first useful answer in under 10 minutes.
+
+This guide is for teams that already have:
+
+- a source repo in GitHub or Git,
+- Helm, Score, Spring Boot, or workflow config as authoring input,
+- Flux or Argo CD handling WET to LIVE reconciliation.
+
+`cub-gen` adds source-side provenance. ConfigHub adds shared governance and
+evidence. [`cub-scout`](https://github.com/confighub/cub-scout) adds
+cluster-side inspection.
+
+## Start from the setup you already have
+
+| If you already have... | Start here | First value |
+|----------|------------|-------------|
+| Helm plus Flux/Argo | [`../examples/helm-paas`](../examples/helm-paas/) | Values ownership and rendered-field provenance |
+| Spring Boot app repos | [`../examples/springboot-paas`](../examples/springboot-paas/) | App-vs-platform ownership in familiar config |
+| A running cluster and GitOps controller | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | Cluster/runtime view first, source provenance second |
 
 ## What cub-gen does
 
@@ -14,6 +32,14 @@ and tells you:
 | Which files are rendered output? | WET manifest classification |
 | For any deployed field, where do I edit it? | Field-origin tracing + inverse-edit guidance |
 | How do I prove what changed? | Verification, attestation, and evidence bundles |
+
+## How the tools fit together
+
+| Tool | Starts from | What it answers first |
+|------|-------------|-----------------------|
+| `cub-gen` | Source repo | Which DRY file/path produced this rendered field? |
+| [`cub-scout`](https://github.com/confighub/cub-scout) | Cluster and controller reality | What is running and where is drift? |
+| ConfigHub | Shared intended/evidence/governance state | What changed, what was approved, and what evidence exists? |
 
 ## The DRY → WET model
 
@@ -48,9 +74,10 @@ go build -o cub-gen ./cmd/cub-gen
 
 ```bash
 REPO=/path/to/your/repo
+./cub-gen gitops discover --space platform "$REPO"
+./cub-gen gitops import --space platform --json "$REPO" "$REPO" \
+  | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets}'
 ./cub-gen change preview --space platform "$REPO" "$REPO"
-./cub-gen change run --mode local --space platform "$REPO" "$REPO"
-./cub-gen change explain --space platform --owner app-team "$REPO" "$REPO"
 ```
 
 Connected mode for the same repo:
@@ -115,6 +142,22 @@ The key value of cub-gen is the provenance trail. Focus on the inverse-edit poin
 
 This tells you: for any WET field, where is the DRY source to edit it safely.
 
+## Why this matters right after import
+
+Import should give you an immediate answer before any migration story:
+
+1. what this repo renders,
+2. which source file owns the deployed field you care about,
+3. what evidence bundle you can verify next,
+4. how to connect the repo-side answer to cluster-side inspection and ConfigHub.
+
+That is why the first useful sequence is:
+
+1. import the repo,
+2. inspect provenance,
+3. build or verify evidence,
+4. compare that answer with runtime inspection.
+
 ## Try other generators
 
 Each generator follows the same three-command flow:
@@ -173,6 +216,13 @@ Emit an attestation record:
   | jq '{status, verifier, bundle_digest, attestation_digest}'
 ```
 
+## If you are starting from a cluster, not a repo
+
+Use ConfigHub GitOps import and [`cub-scout`](https://github.com/confighub/cub-scout)
+first when your first question is "what is running?" rather than "what source
+produced this?" Then come back to `cub-gen` when you want the source-side DRY to
+WET answer for the field or workload you found.
+
 ## What happens after import? (Day-2)
 
 Import is day 1. The real value shows on day 2:
@@ -223,6 +273,8 @@ What you add:
 - `cub-gen gitops discover` to classify generator roots
 - `cub-gen gitops import` to emit DRY/WET contracts + provenance/inverse pointers
 - `cub-gen gitops cleanup` to clear local discover state
+- ConfigHub for shared evidence and governed decisions
+- `cub-scout` for cluster-side inspection after reconciliation
 
 Boundary language (aligned with [PARITY.md](parity.md)):
 

--- a/docs/plans/2026-03-20-existing-gitops-adoption-plan.md
+++ b/docs/plans/2026-03-20-existing-gitops-adoption-plan.md
@@ -1,0 +1,295 @@
+# Existing GitOps Adoption Plan
+
+Status: proposed execution plan
+Date: 2026-03-20
+Owner: cub-gen maintainers
+
+## Goal
+
+Make `cub-gen` feel immediately useful to teams that already run GitHub plus
+Argo CD or Flux, with real app or platform repos they already care about.
+
+Within the first 10 minutes, a new user should be able to:
+
+1. point `cub-gen` at an existing repo or a realistic demo repo,
+2. see rendered-manifest provenance and ownership,
+3. connect that repo-side view to ConfigHub and `cub-scout`,
+4. understand why import matters before any migration or controller replacement.
+
+## Product wedge
+
+The near-term wedge is:
+
+`GitHub + Helm/Score/Spring source repo + Argo/Flux + cub-gen + cub-scout + ConfigHub`
+
+The story is additive:
+
+1. Git remains the source authoring path,
+2. Argo CD and Flux remain the reconcilers,
+3. `cub-scout` explains cluster and controller reality,
+4. `cub-gen` explains source-to-rendered provenance,
+5. ConfigHub becomes the shared place to compare, validate, govern, and inspect evidence.
+
+## Why this plan exists
+
+The repo is stronger than it was:
+
+1. the example catalog is broad,
+2. the main examples have local and connected entrypoints,
+3. live reconcile proof exists for both Flux and Argo,
+4. the docs now describe the product more honestly.
+
+But the current first-run experience still feels too internal and too
+generator-centric.
+
+The main gaps are:
+
+1. the top entry docs still lead with `cub-gen` mechanics more than existing-app relevance,
+2. there is no single obvious first-run path for "I already have an app in GitOps",
+3. `cub-scout` continuity is missing from the primary entry surfaces,
+4. demo breadth is better than demo focus,
+5. mutation and lifecycle depth are more visible than the immediate "why import?" answer.
+
+## North-star user stories
+
+### 1. Repo-first platform team
+
+"We already run Helm plus Flux or Argo. Show us which values file controls the
+running thing, who owns it, and why ConfigHub is worth adding."
+
+### 2. Repo-first app team
+
+"We already ship a Spring Boot or Score-based app. Show us where to edit safely
+without making us think in raw rendered YAML first."
+
+### 3. Cluster-first GitOps operator
+
+"We already have an Argo CD or Flux application running. Start from what exists
+in cluster, inspect it with `cub-scout` and ConfigHub, then show how `cub-gen`
+connects that back to source."
+
+`cub-gen` owns the repo-first path directly and must link cleanly into the
+cluster-first companion path.
+
+## Non-negotiable requirements
+
+1. Start from an existing app, repo, or GitOps setup users already recognize.
+2. Show value immediately after import: inspect, validate, compare, explain.
+3. Keep Flux, Argo, GitHub, Git, and OCI as first-class existing parts of the story.
+4. Make `cub-scout` and ConfigHub continuity explicit in the first-run docs.
+5. Keep AI plus CLI as the primary operating surface.
+6. Use the GUI for evidence, tables, diffs, and review, not as the only entry path.
+7. Do not make mutate/apply/status the critical path for first value.
+8. Keep example claims conservative until the flagship proofs and gates really exist.
+
+## Canonical first-run journeys
+
+### Journey A: existing Helm plus Flux or Argo team
+
+This should be the primary platform-first path.
+
+Use:
+
+1. `helm-paas` for repo-side DRY to WET provenance,
+2. `live-reconcile` for WET to LIVE proof,
+3. ConfigHub connected mode for validation, evidence, and governed decision state,
+4. `cub-scout` for cluster-side inspection and comparison.
+
+The first useful questions should be:
+
+1. which values file controls this field,
+2. what rendered output changed,
+3. what is actually running,
+4. what evidence or validation result should we look at next.
+
+### Journey B: existing Spring Boot app team
+
+This should be the primary app-first path.
+
+Use:
+
+1. `springboot-paas` as the most recognizable existing-app story,
+2. one concrete config question a Spring team already asks,
+3. one local import path,
+4. one connected ConfigHub path,
+5. one explicit handoff to cluster/runtime inspection.
+
+`scoredev-paas` remains important, but Spring should be the more universal
+entry point for new users.
+
+### Journey C: cluster-first companion path
+
+This path may span repos, but it must be visible from `cub-gen`.
+
+Use:
+
+1. ConfigHub GitOps import or existing cluster-side discovery,
+2. `cub-scout` for cluster and controller inspection,
+3. `cub-gen` to trace a chosen field or workload back to DRY source.
+
+The point is continuity:
+
+1. cluster-side discovery does not replace source-side provenance,
+2. source-side provenance does not replace runtime inspection,
+3. ConfigHub links both views into one operational story.
+
+## Workstreams
+
+## 1. Entry-surface reset
+
+Primary files:
+
+1. `README.md`
+2. `docs/getting-started.md`
+3. `examples/README.md`
+4. `examples/demo/README.md`
+
+Changes:
+
+1. lead with existing app and existing GitOps wording,
+2. highlight two canonical starts: platform-first and app-first,
+3. add one visible cluster-first companion path using `cub-scout` plus ConfigHub,
+4. make "why import?" concrete: inspect rendered manifests, run validation, compare, inspect evidence,
+5. move advanced flow depth behind the first-run path instead of ahead of it.
+
+Exit criteria:
+
+1. a new user can choose a starting path in under 30 seconds,
+2. the first commands feel tied to existing repos and apps,
+3. `cub-scout` is visible in the main entry surfaces,
+4. the docs answer "why import?" before asking for deeper adoption.
+
+## 2. Flagship example reset
+
+Primary examples:
+
+1. `helm-paas`
+2. `live-reconcile`
+3. `springboot-paas`
+
+Changes:
+
+1. tighten `helm-paas` and `live-reconcile` into one coherent platform-first journey,
+2. make `springboot-paas` the clearest app-first journey,
+3. ensure each flagship example starts with a real user question,
+4. ensure each flagship example includes one local first step, one connected first step, and one runtime inspection step,
+5. show what ConfigHub adds without claiming reconciler replacement.
+
+Exit criteria:
+
+1. one platform-first flagship path is obviously stronger than the rest,
+2. one app-first flagship path is obviously stronger than the rest,
+3. each flagship example feels like a real adoption story, not a feature checklist.
+
+## 3. Demo surface simplification
+
+Primary files and scripts:
+
+1. `examples/demo/README.md`
+2. one new platform-first starter script
+3. one new app-first starter script
+4. existing advanced lifecycle and promotion scripts
+
+Changes:
+
+1. promote one primary script per canonical journey,
+2. demote broad "run everything" paths for first-time users,
+3. keep lifecycle, PR/MR, and promotion flows as follow-on proof,
+4. add expected outcomes for the starter scripts in plain English.
+
+Exit criteria:
+
+1. the demo page no longer feels like a menu of equal-weight options,
+2. first-time users start with one of two scripts,
+3. advanced scripts remain available but clearly secondary.
+
+## 4. `cub-scout` and ConfigHub continuity
+
+Primary deliverable:
+
+1. a documented repo-first to cluster-first handoff path
+
+Changes:
+
+1. add explicit references from `cub-gen` entry docs to the matching `cub-scout` and ConfigHub paths,
+2. show the sequence "source repo -> rendered import -> cluster inspection -> evidence view",
+3. make it clear which questions belong to `cub-gen`, which belong to `cub-scout`, and which belong to ConfigHub.
+
+Exit criteria:
+
+1. a new user can see how the tools fit together,
+2. `cub-gen` no longer reads like a standalone island,
+3. the additive story is stronger than the replacement story.
+
+## 5. AI-first packaging
+
+This matters, but it should package the canonical journeys rather than replace them.
+
+Changes:
+
+1. add `AI_START_HERE.md` once the primary journeys are stable,
+2. add prompts and machine-readable contracts for the starter flows,
+3. add repo-level agent guidance only after the first-run paths are clear,
+4. make read-only versus mutating boundaries explicit in the starter flows.
+
+Exit criteria:
+
+1. an AI assistant can safely execute the same primary journeys a human would choose,
+2. AI docs reinforce the main adoption wedge instead of introducing a parallel story.
+
+## 6. Acceptance gate
+
+Primary issues:
+
+1. `#183` connected acceptance gate
+2. `#182` example and demo entrypoint redesign
+3. `#200` AI best practices from public examples
+
+Changes:
+
+1. enforce the new flagship entry criteria in docs and example checks,
+2. verify the primary docs still point to the canonical journeys,
+3. verify the starter scripts keep working,
+4. keep connected checks strict about what is truly proven.
+
+Exit criteria:
+
+1. the release gate fails when the primary adoption story regresses,
+2. the repo stops drifting back toward broad but unfocused example coverage.
+
+## Recommended execution order
+
+1. rewrite the entry surfaces around the existing GitOps adoption wedge,
+2. strengthen `helm-paas` plus `live-reconcile` into the primary platform-first journey,
+3. strengthen `springboot-paas` into the primary app-first journey,
+4. document and link the `cub-gen` plus `cub-scout` plus ConfigHub handoff,
+5. package the canonical journeys for AI-first execution,
+6. lock the above into the acceptance gate.
+
+## Issue alignment
+
+This plan should drive the current issue stack rather than replace it:
+
+1. `#182` is the entry-surface and demo simplification work,
+2. `#183` is the enforcement and acceptance work,
+3. `#177` plus `#187` are the platform-first flagship work,
+4. `#179` is the app-first flagship work,
+5. `#178` becomes the next app-platform story after the primary Spring path lands,
+6. `#200` packages the proven journeys for AI-first usage.
+
+## What to de-prioritize until this lands
+
+1. adding more example families,
+2. leading with abstract generator inventory,
+3. making apply flows the main first-run story,
+4. spending more effort on advanced lifecycle demos than on the first 10 minutes,
+5. AI-doc packaging that is not tied to a concrete canonical journey.
+
+## Success signal
+
+`cub-gen` is in a useful, usable, relevant state when a new user can say:
+
+"I already have a repo and a GitOps runtime. In a few minutes, I can see what
+source controls the running thing, compare it with cluster reality, inspect
+evidence in ConfigHub, and understand why these tools are worth adding without
+changing how we already deploy."

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,16 @@ You already have a deployment pipeline: Git, Helm, Flux, Argo, Spring Boot, Scor
 
 Each example in this directory is runnable and maps to a real platform/app pattern.
 
+## Start here first
+
+Do not start by scanning the whole catalog. Start with one of these:
+
+| Journey | Start here | Why this should be first |
+|---------|------------|--------------------------|
+| Platform-first GitOps team | [`helm-paas`](./helm-paas/) then [`live-reconcile`](./live-reconcile/) | Most direct story for existing Helm plus Flux/Argo users |
+| App-first team | [`springboot-paas`](./springboot-paas/) | Most recognizable "I already ship this app" path |
+| Cluster-first companion path | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | Start from running reality, then trace back to source |
+
 ## Two audiences, two entry points
 
 Every example supports both paths explicitly:
@@ -21,6 +31,14 @@ Every example supports both paths explicitly:
 | **Existing platform-tool user** adding ConfigHub | Start with local mode, see value first, then connect |
 
 Neither audience is an afterthought. Pick your path and each example will guide you.
+
+## How the tools fit together
+
+| Tool | Starts from | Best first question |
+|------|-------------|---------------------|
+| `cub-gen` | Source repo | Which DRY file or path produced this rendered field? |
+| [`cub-scout`](https://github.com/confighub/cub-scout) | Cluster and reconciler runtime | What is running and where is drift? |
+| ConfigHub | Shared evidence and governance state | What changed, what was approved, and what proof exists? |
 
 ## What happens after import? (Day-2 stories)
 
@@ -95,8 +113,12 @@ If confidence scores are new to your team, use:
 
 ```bash
 go build -o ./cub-gen ./cmd/cub-gen
-./examples/demo/run-all-modules.sh
-./examples/demo/run-all-confighub-lifecycles.sh
+
+# Platform-first
+./examples/helm-paas/demo-local.sh
+
+# App-first
+./examples/springboot-paas/demo-local.sh
 ```
 
 ## Connected mode (ConfigHub)
@@ -107,13 +129,17 @@ TOKEN="$(cub auth get-token)"
 cub context get --json | jq -r '.coordinate.user'
 BASE_URL="${CONFIGHUB_BASE_URL:-$(cub context get --json | jq -r '.coordinate.serverURL')}"
 
-./cub-gen publish --space platform ./examples/helm-paas ./examples/helm-paas > /tmp/bundle.json
-./cub-gen verify --in /tmp/bundle.json
-./cub-gen attest --in /tmp/bundle.json --verifier ci-bot > /tmp/attestation.json
-./cub-gen bridge ingest --in /tmp/bundle.json --base-url "$BASE_URL" --token "$TOKEN" > /tmp/ingest.json
+# Platform-first
+./examples/helm-paas/demo-connected.sh
+
+# App-first
+./examples/springboot-paas/demo-connected.sh
 ```
 
 Use local mode for first value. Use connected mode for centralized governance state and cross-repo visibility.
+
+After that, use [`live-reconcile`](./live-reconcile/) for WET to LIVE proof and
+[`cub-scout`](https://github.com/confighub/cub-scout) for cluster-side inspection.
 
 ## Use your own repo quickly
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -7,7 +7,21 @@ part of the governed change flow:
 detect → import → publish → verify → attest → (optional) bridge ingest/query
 ```
 
-## 1. Pick your demo by persona
+If you are new, do not start with "run everything." Start with one concrete
+adoption path that matches what you already run.
+
+## 1. Start with one of these
+
+| If you already run... | Start here | What you should prove first |
+|---------|-----------|------------------------------|
+| Helm plus Flux/Argo | `./examples/helm-paas/demo-local.sh` | Which values file/path controls the rendered field |
+| Spring Boot app repos | `./examples/springboot-paas/demo-local.sh` | Which app or platform config file should be edited |
+| Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | WET to LIVE create, update, and drift-correction |
+
+Cluster-side follow-on: pair the above with [`cub-scout`](https://github.com/confighub/cub-scout)
+when you want to inspect what is actually running after reconciliation.
+
+## 2. Pick your demo by persona
 
 | Persona | Start here | What you'll prove |
 |---------|------------|-------------------|
@@ -24,22 +38,29 @@ detect → import → publish → verify → attest → (optional) bridge ingest
 
 See also: [Domain POV Matrix](../../docs/workflows/domain-pov-matrix.md) | [Persona 5-minute runbooks](../../docs/workflows/persona-5-minute-runbooks.md)
 
-## 2. Quick start
+## 3. Quick start
 
 ```bash
 go build -o ./cub-gen ./cmd/cub-gen
 
-# Run your first demo (Score example)
-./examples/demo/app-ai-change-run.sh ./examples/scoredev-paas
+# Platform-first first run
+./examples/helm-paas/demo-local.sh
 
-# Run all core modules
+# App-first first run
+./examples/springboot-paas/demo-local.sh
+
+# Runtime proof after source-side import
+RECONCILER=both ./examples/live-reconcile/demo-local.sh
+```
+
+Once those are clear, then expand into the broader module and lifecycle surface.
+
+```bash
 ./examples/demo/run-all-modules.sh
-
-# Run all AI platform scenarios
 ./examples/demo/ai-work-platform/run-all.sh
 ```
 
-## 3. Local mode (no ConfigHub login required)
+## 4. Local mode (no ConfigHub login required)
 
 ### Core platform/app track
 
@@ -78,7 +99,7 @@ If your platform is workflow-heavy, start here before app-manifest demos:
   | jq '.provenance[0].ops_workflow_analysis'
 ```
 
-## 4. Connected mode (ConfigHub)
+## 5. Connected mode (ConfigHub)
 
 Start with authentication:
 
@@ -117,7 +138,7 @@ CI behavior:
 
 See also: [connected-ci-bootstrap.md](../../docs/workflows/connected-ci-bootstrap.md)
 
-## 5. Live reconciler e2e (Flux + Argo + kind)
+## 6. Live reconciler e2e (Flux + Argo + kind)
 
 | Script | What it demonstrates |
 |--------|---------------------|
@@ -139,7 +160,7 @@ cub auth login
 RECONCILER=both ./examples/demo/e2e-connected-governed-reconcile-helm.sh
 ```
 
-## 6. Lifecycle simulation scripts
+## 7. Lifecycle simulation scripts
 
 | Script | What it demonstrates |
 |--------|---------------------|
@@ -158,7 +179,7 @@ RECONCILER=both ./examples/demo/e2e-connected-governed-reconcile-helm.sh
 | `change-api-adapter.sh --request <json> [--out <json>]` | API-style JSON adapter for `change preview\|run\|explain` |
 | `change-api-http-e2e.sh [repo] [target]` | Native HTTP compatibility flow using `/v1/changes` endpoints |
 
-## 7. CI policy gates (PR path)
+## 8. CI policy gates (PR path)
 
 Use these when you want merge-blocking enforcement, not just local guidance:
 
@@ -169,7 +190,7 @@ Use these when you want merge-blocking enforcement, not just local guidance:
   - Runs the gate for Helm + Spring examples
   - Posts a PR comment with actionable DRY edit guidance
 
-## 8. PR-MR pairing and promotion flows
+## 9. PR-MR pairing and promotion flows
 
 | Script | What it demonstrates |
 |--------|---------------------|
@@ -177,7 +198,7 @@ Use these when you want merge-blocking enforcement, not just local guidance:
 | `flow-b-mr-to-git-pr-connected.sh` | Flow B: ConfigHub MR → Git PR proposal |
 | `fr8-promotion-upstream-dry-connected.sh` | FR8: live→WET→DRY upstream promotion |
 
-## 9. Phase 3 connected story scripts
+## 10. Phase 3 connected story scripts
 
 | Script | User story | What it demonstrates |
 |--------|------------|---------------------|
@@ -188,7 +209,7 @@ Use these when you want merge-blocking enforcement, not just local guidance:
 | `story-12-unified-actor-evidence.sh` | 12 | Unified human/CI/AI attestation chain |
 | `run-phase-3-connected-stories.sh` | 1,7,9,12 | Run all Phase 3 stories |
 
-## 10. Phase 4 connected story scripts
+## 11. Phase 4 connected story scripts
 
 | Script | User story | What it demonstrates |
 |--------|------------|---------------------|


### PR DESCRIPTION
## Summary
- refocus the main entry docs around existing GitOps users and immediate post-import value
- make the platform-first and app-first starter paths explicit
- connect the cub-gen story to ConfigHub and cub-scout continuity
- add an execution plan for the existing GitOps adoption wedge and link it from the handover

## Validation
- ./test/checks/check-docs-entrypoints.sh
- ./test/checks/check-story-status.sh