### PR TITLE
docs: strengthen flagship example adoption paths

### DIFF
--- a/AI-HANDOVER.md
+++ b/AI-HANDOVER.md
@@ -109,6 +109,62 @@ These are currently untracked locally and should not be swept up casually:
 
 Treat them as user/local work unless explicitly asked to modify them.
 
+## Safe cold-start
+
+If you are the next AI, start read-only and machine-readable first.
+
+These are the safest first commands:
+
+```bash
+go run ./cmd/cub-gen generators --json
+go run ./cmd/cub-gen gitops discover --space platform ./examples/helm-paas
+go run ./cmd/cub-gen change preview --space platform --json ./examples/springboot-paas ./examples/springboot-paas
+```
+
+What they do:
+
+- `generators --json`: shows the supported generator families and capabilities
+- `gitops discover`: classifies a repo without pushing anything to ConfigHub or a cluster
+- `change preview --json`: shows the governed change shape without executing it
+
+Treat these as read-only first steps.
+
+Only move to connected or state-changing paths after you understand which
+example or workflow you are touching.
+
+Examples of heavier paths:
+
+- `make ci`: local validation suite
+- `make ci-connected`: connected validation suite, only if the environment is ready
+- `change run --mode connected`: uses ConfigHub APIs
+- demo scripts that ingest/query ConfigHub or apply to Flux/Argo/kind
+
+## How to frame proof tasks
+
+When a user asks you to prove a GitOps, ConfigHub, or example workflow, strong
+task framing helps more than generic "run the demo" wording.
+
+Good proof requests should say:
+
+- start read-only,
+- use the documented path from the repo, not an improvised sequence,
+- call out contaminated or hybrid state explicitly,
+- state what does *not* count as proof,
+- list the exact artifacts or states that must be shown,
+- end with a clear result classification.
+
+For GitOps proof in particular:
+
+- do not count pre-existing running resources as proof of delivery,
+- do not count direct `kubectl apply` of app manifests as proof of GitOps delivery,
+- if the documented flow is hybrid, say exactly what it proves and what it does not.
+
+Preferred end states:
+
+- `full GitOps proof`
+- `partial/hybrid GitOps proof`
+- `not proven`
+
 ## Validation commands
 
 Use these before claiming progress:

--- a/docs/plans/2026-03-20-existing-gitops-adoption-plan.md
+++ b/docs/plans/2026-03-20-existing-gitops-adoption-plan.md
@@ -230,7 +230,15 @@ Changes:
 1. add `AI_START_HERE.md` once the primary journeys are stable,
 2. add prompts and machine-readable contracts for the starter flows,
 3. add repo-level agent guidance only after the first-run paths are clear,
-4. make read-only versus mutating boundaries explicit in the starter flows.
+4. make read-only versus mutating boundaries explicit in the starter flows,
+5. provide strong proof-task templates that define what counts as proof, what
+   does not count, and how to classify the result (`full`, `partial/hybrid`, or
+   `not proven`),
+6. keep the root guidance in `CLAUDE.md` for now because `cub-gen` and
+   `cub-scout` are currently optimized for Claude Code discovery; add
+   `AI_START_HERE.md` as the tool-agnostic companion when the canonical
+   journeys are stable; only reconsider `AGENTS.md` if a stronger multi-tool
+   convention becomes worth following.
 
 Exit criteria:
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -14,8 +14,8 @@ adoption path that matches what you already run.
 
 | If you already run... | Start here | What you should prove first |
 |---------|-----------|------------------------------|
-| Helm plus Flux/Argo | `./examples/helm-paas/demo-local.sh` | Which values file/path controls the rendered field |
-| Spring Boot app repos | `./examples/springboot-paas/demo-local.sh` | Which app or platform config file should be edited |
+| Helm plus Flux/Argo | `./examples/demo/start-platform-first.sh` | Which values file/path controls the rendered field |
+| Spring Boot app repos | `./examples/demo/start-app-first.sh` | Which app or platform config file should be edited |
 | Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | WET to LIVE create, update, and drift-correction |
 
 Cluster-side follow-on: pair the above with [`cub-scout`](https://github.com/confighub/cub-scout)
@@ -44,10 +44,10 @@ See also: [Domain POV Matrix](../../docs/workflows/domain-pov-matrix.md) | [Pers
 go build -o ./cub-gen ./cmd/cub-gen
 
 # Platform-first first run
-./examples/helm-paas/demo-local.sh
+./examples/demo/start-platform-first.sh
 
 # App-first first run
-./examples/springboot-paas/demo-local.sh
+./examples/demo/start-app-first.sh
 
 # Runtime proof after source-side import
 RECONCILER=both ./examples/live-reconcile/demo-local.sh
@@ -66,6 +66,8 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 
 | Script | Example | What it demonstrates |
 |--------|---------|---------------------|
+| `start-platform-first.sh` | [`helm-paas`](../helm-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated platform-first starter path |
+| `start-app-first.sh` | [`springboot-paas`](../springboot-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated app-first starter path |
 | `module-1-helm-import.sh` | [`helm-paas`](../helm-paas/) | Helm detection, values ownership, field-origin tracing |
 | `module-2-score-field-map.sh` | [`scoredev-paas`](../scoredev-paas/) | Score field-origin and inverse edit mapping |
 | `module-3-spring-ownership.sh` | [`springboot-paas`](../springboot-paas/) | Spring ownership boundaries (app vs platform) |

--- a/examples/demo/start-app-first.sh
+++ b/examples/demo/start-app-first.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[start-app] step 1: Spring config ownership and provenance"
+./examples/springboot-paas/demo-local.sh
+
+cat <<'EOF'
+
+[start-app] next steps
+  connected governance:
+    cub auth login
+    ./examples/springboot-paas/demo-connected.sh
+
+  runtime proof:
+    RECONCILER=both ./examples/live-reconcile/demo-local.sh
+
+  cluster-side inspection:
+    use cub-scout after the runtime proof when you want to inspect live state
+EOF

--- a/examples/demo/start-platform-first.sh
+++ b/examples/demo/start-platform-first.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[start-platform] step 1: source-side provenance and governance"
+./examples/helm-paas/demo-local.sh
+
+cat <<'EOF'
+
+[start-platform] next steps
+  connected governance:
+    cub auth login
+    ./examples/helm-paas/demo-connected.sh
+
+  runtime proof:
+    RECONCILER=both ./examples/live-reconcile/demo-local.sh
+
+  cluster-side inspection:
+    use cub-scout against the reconciled workload after the runtime proof
+EOF

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -5,6 +5,31 @@ The platform owns the chart structure; app teams own their values overlays.
 ConfigHub makes that contract explicit, traceable, and auditable — without
 changing how you use Helm.
 
+This is the platform-first flagship path for `cub-gen`.
+
+The first question it should answer is:
+
+"Which values file or chart layer actually controls the field I am looking at?"
+
+This example is the source-side half of that story. For the runtime proof half,
+pair it with [`live-reconcile`](../live-reconcile/).
+
+## Start here first
+
+If you are new, use this sequence:
+
+1. `./examples/helm-paas/demo-local.sh`
+2. `./examples/helm-paas/demo-connected.sh`
+3. `RECONCILER=both ./examples/live-reconcile/demo-local.sh`
+4. inspect the runtime side with [`cub-scout`](https://github.com/confighub/cub-scout)
+
+That gives you:
+
+1. source-side provenance and ownership,
+2. connected ConfigHub evidence and governed decision state,
+3. WET to LIVE reconciliation proof,
+4. cluster-side inspection of what actually ran.
+
 ## 1. Who this is for
 
 | If you are... | Start here |
@@ -136,9 +161,22 @@ incidents.
 
 ## Try it
 
+Start with the documented entrypoints:
+
 ```bash
 go build -o ./cub-gen ./cmd/cub-gen
 
+# Local source-side path
+./examples/helm-paas/demo-local.sh
+
+# Connected ConfigHub path
+cub auth login
+./examples/helm-paas/demo-connected.sh
+```
+
+If you want the raw commands underneath the wrappers:
+
+```bash
 # Detect the generator and classify all files
 ./cub-gen gitops discover --space platform --json ./examples/helm-paas
 
@@ -274,6 +312,10 @@ WET:  Deployment/spec/template/spec/containers[0]/image = "ghcr.io/example/payme
 
 ## Next steps
 
+- **Runtime proof companion**: [`live-reconcile`](../live-reconcile/) — prove
+  the same governed path survives real Flux/Argo reconciliation
+- **Cluster-side inspection companion**: [`cub-scout`](https://github.com/confighub/cub-scout)
+  — inspect the reconciled runtime side after delivery
 - **Spring Boot version**: [`springboot-paas`](../springboot-paas/) — same
   governance model for Java services with `application.yaml`
 - **Score.dev version**: [`scoredev-paas`](../scoredev-paas/) — platform-agnostic

--- a/examples/live-reconcile/README.md
+++ b/examples/live-reconcile/README.md
@@ -4,6 +4,37 @@ This example proves LIVE reconciliation loops with both Flux and Argo CD using a
 
 Without a real WET→LIVE reconciler loop shown end-to-end, the flow is "governed config automation" not full "Agentic GitOps." This harness proves the full loop.
 
+This is the runtime half of the platform-first flagship story.
+
+If your first question is "which values file or source path owns this field?",
+start with [`helm-paas`](../helm-paas/) first. Come here when you want to prove
+that the governed WET output really survives Flux or Argo reconciliation.
+
+## What this example proves
+
+- Flux or Argo can create the workload from the declared source
+- Flux or Argo can update it when the source changes
+- Flux or Argo can correct manual drift back to declared state
+
+## What this example does not prove by itself
+
+- DRY ownership boundaries
+- source-side field provenance
+- whether a repo change should be ALLOW, ESCALATE, or BLOCK before delivery
+
+Those are the source-side and governance questions handled by `cub-gen`,
+ConfigHub, and the paired [`helm-paas`](../helm-paas/) example.
+
+## Start here first
+
+Use this sequence:
+
+1. `./examples/helm-paas/demo-local.sh`
+2. `./examples/live-reconcile/demo-local.sh`
+3. `RECONCILER=argo ./examples/live-reconcile/demo-local.sh`
+4. if you want the full governed loop, `RECONCILER=both ./examples/demo/e2e-connected-governed-reconcile-helm.sh`
+5. inspect the runtime side with [`cub-scout`](https://github.com/confighub/cub-scout)
+
 ## 1. Who this is for
 
 | If you are... | Start here |
@@ -106,15 +137,17 @@ fast proof harness:
 # Build cub-gen (if not already built)
 go build -o ./cub-gen ./cmd/cub-gen
 
-# Run Flux live reconcile proof (requires kind + flux CLI)
-./examples/demo/e2e-live-reconcile-flux.sh
+# If you are new, do the source-side half first
+./examples/helm-paas/demo-local.sh
 
-# Run Argo live reconcile proof (requires kind + network access)
-./examples/demo/e2e-live-reconcile-argo.sh
-
-# Run both side-by-side
-./examples/demo/e2e-live-reconcile-flux.sh && ./examples/demo/e2e-live-reconcile-argo.sh
+# Runtime proof: documented wrapper entrypoints
+./examples/live-reconcile/demo-local.sh
+RECONCILER=argo ./examples/live-reconcile/demo-local.sh
+RECONCILER=both ./examples/live-reconcile/demo-local.sh
 ```
+
+These wrapper entrypoints call the documented Flux and Argo e2e paths without
+you having to improvise the sequence yourself.
 
 ## Real-world scenario: proving drift correction
 
@@ -174,6 +207,8 @@ Result: Reconciler corrects manual drift → **PASS**
 ## Next steps
 
 - **Helm + governance**: [`helm-paas`](../helm-paas/) — DRY→WET governance before reconciliation
+- **Cluster-side inspection**: [`cub-scout`](https://github.com/confighub/cub-scout)
+  — inspect the reconciled runtime side and compare it with declared intent
 - **Full connected loop**: `e2e-connected-governed-reconcile-helm.sh` — ConfigHub → Flux/Argo
 
 ## Run from ConfigHub (connected mode)

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -10,6 +10,29 @@ When someone changes `spring.datasource.hikari.maximum-pool-size`, is that an
 app change or a platform change? Today, your PR reviewer has to know. With
 ConfigHub, the ownership boundary is explicit and enforced.
 
+This is the app-first flagship path for `cub-gen`.
+
+The first question it should answer is:
+
+"Which Spring config file should I edit, and when does this become a
+platform-owned change instead of an app-owned one?"
+
+## Start here first
+
+If you are new, use this sequence:
+
+1. `./examples/springboot-paas/demo-local.sh`
+2. `./examples/springboot-paas/demo-connected.sh`
+3. if you want runtime proof after the source-side path, use [`live-reconcile`](../live-reconcile/)
+4. inspect the runtime side with [`cub-scout`](https://github.com/confighub/cub-scout)
+
+That keeps the story concrete:
+
+1. source-side Spring ownership,
+2. connected ConfigHub evidence and decisions,
+3. runtime and reconciler follow-through,
+4. cluster-side inspection when needed.
+
 ## 1. Who this is for
 
 | If you are... | Start here |
@@ -145,9 +168,22 @@ ownership boundaries.
 
 ## Try it
 
+Start with the documented entrypoints:
+
 ```bash
 go build -o ./cub-gen ./cmd/cub-gen
 
+# Local source-side path
+./examples/springboot-paas/demo-local.sh
+
+# Connected ConfigHub path
+cub auth login
+./examples/springboot-paas/demo-connected.sh
+```
+
+If you want the raw commands underneath the wrappers:
+
+```bash
 # Detect Spring Boot project structure
 ./cub-gen gitops discover --space platform --json ./examples/springboot-paas
 
@@ -281,6 +317,10 @@ WET:  Deployment/spec/template/spec/containers[0]/env[name=SERVER_PORT]/value = 
 
 - **Helm version**: [`helm-paas`](../helm-paas/) — same governance for
   chart-based deployments
+- **Runtime proof companion**: [`live-reconcile`](../live-reconcile/) — prove
+  the governed output survives Flux/Argo reconciliation
+- **Cluster-side inspection companion**: [`cub-scout`](https://github.com/confighub/cub-scout)
+  — inspect runtime behavior after delivery
 - **Score.dev version**: [`scoredev-paas`](../scoredev-paas/) — platform-agnostic
   workload specs
 - **E2E demo**: `../demo/module-3-spring-ownership.sh`


### PR DESCRIPTION
## Summary
- strengthen the flagship Helm, live-reconcile, and Spring Boot example journeys around real user questions
- add opinionated platform-first and app-first starter scripts in the demo surface
- record stronger AI proof-task and guidance-file naming notes in the handover/adoption plan

## Validation
- bash -n examples/demo/start-platform-first.sh examples/demo/start-app-first.sh
- ./test/checks/check-docs-entrypoints.sh
- ./test/checks/check-story-status.sh