### PR TITLE
docs: add v0.2-preview.2 ship checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Docs currently live in this repo:
 - [CLI Reference](docs/cli-reference.md) — all commands, flags, and generator recipes
 - [Demo Guide](docs/demo-guide.md) — runnable demo scripts and scenarios
 - [Current release plan](docs/releases/v0.2-preview.2-plan.md) — must-ship and post-release work for the next preview
+- [Current ship checklist](docs/releases/v0.2-preview.2-ship-checklist.md) — what is already landed on `main`, what still blocks the tag, and what can wait
 - [Examples](examples/README.md) — complete runnable scenarios for every generator
 - [Platform](docs/platform.md) — how cub-gen connects to ConfigHub
 - [Persona 5-minute runbooks](docs/workflows/persona-5-minute-runbooks.md) — stack-specific entry paths
@@ -201,6 +202,7 @@ Both prove create, update, and drift-correction on a real cluster.
 | In progress | Flagship examples are still being hardened against the universal example contract: real-cluster outcome, two-audience path, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` proof |
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
+| Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
 | Example quality | `#177`, `#178`, `#180`, `#182`, `#185`, `#187`, `#200`, `#202`, `#207`, `#208` |
 | CLI/docs | `#232`, `#233`, `#234`, `#237`, `#238`, `#239`, `#240`, `#241`, `#242` |
 | Release gate | `#218`, `#226`, `#227` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,7 +189,9 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 - connected release status must be backed by a credible lane the team actually runs.
 
 See the [v0.2-preview.2 Release Plan](releases/v0.2-preview.2-plan.md) for the
-current must-ship and post-release split.
+current must-ship and post-release split, and the
+[v0.2-preview.2 Ship Checklist](releases/v0.2-preview.2-ship-checklist.md) for
+what is already landed on `main` versus what still blocks the tag.
 
 - Core flow commands (`discover`, `import`, `cleanup`) frozen and golden-tested
 - Bridge artifacts (`publish`, `verify`, `attest`, `verify-attestation`) symmetric across all 8 generators

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -5,6 +5,8 @@ Latest release: `v0.2-preview.1` (2026-03-06)
 Next target: `v0.2-preview.2`
 
 This plan supersedes `docs/roadmap-v0.2-preview.md` for active release planning.
+For day-to-day release closure, use
+[`docs/releases/v0.2-preview.2-ship-checklist.md`](v0.2-preview.2-ship-checklist.md).
 
 ## Release goal
 

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -1,0 +1,93 @@
+# cub-gen v0.2-preview.2 Ship Checklist
+
+Status date: 2026-04-11
+Latest shipped release: `v0.2-preview.1` (2026-03-06)
+Current branch to cut from: `main`
+
+Use this checklist for day-to-day release closure. The broader scope and
+exit-bar rationale still live in
+[`docs/releases/v0.2-preview.2-plan.md`](v0.2-preview.2-plan.md).
+
+## Current snapshot
+
+- `make ci-local` is green on `main`.
+- `mkdocs build --strict` still needs to be run in the release environment.
+  `mkdocs` is not installed in this shell.
+- The generated example truth matrix currently reports:
+  - `12` featured examples
+  - `8` source-chain verified
+  - `12` with connected mode entrypoints
+  - `2` covered by the connected smoke lane
+  - real live proof: `none=9`, `paired-harness=1`, `standalone=2`
+  - AI-first surface: `none=6`, `partial=2`, `explicit=4`
+
+## Landed on `main` already
+
+- Repo-first CLI purpose, cleaner help output, and path-first local examples are
+  on `main` via the merged release-polish work.
+- The connected release story is now split into a small smoke lane and a deeper
+  optional lane instead of one oversized release gate.
+- Example READMEs and central docs now say what is proven today, what to run
+  first, and what is still partial.
+- The change API and demo flows now prefer repo paths over parity-era slug-only
+  inputs.
+
+## Before tagging `v0.2-preview.2`
+
+- [ ] Run `mkdocs build --strict` in the release environment and fix any strict
+  doc failures.
+- [ ] Write `docs/releases/v0.2-preview.2.md` from the final green `main`.
+- [ ] Re-check the top-level and subcommand help examples from a clean checkout.
+- [ ] Confirm the current connected smoke lane passes in the intended
+  secrets-backed release environment.
+
+## Issue triage after #243
+
+### Likely close or narrow now
+
+- [ ] `#232` README structure
+- [ ] `#233` help-text duplication
+- [ ] `#234` remove stale prototype framing
+- [ ] `#237` explain current variants/overlays behavior clearly
+- [ ] `#226` standard ConfigHub API/CLI over custom bridge endpoints
+- [ ] `#227` rethink the size and purpose of `ci-connected`
+
+These should be reviewed against `main` and either closed as landed, or narrowed
+to the remaining delta if the merged work only covered part of the issue.
+
+### Still true release blockers
+
+- [ ] `#177` Helm flagship example
+- [ ] `#178` Score flagship example
+- [ ] `#180` workflow example upgrade
+- [ ] `#182` example/demo entrypoint redesign
+- [ ] `#185` custom-generator onboarding
+- [ ] `#187` layered provenance across overlays/ApplicationSet/labels
+- [ ] `#200` AI best-practice alignment across examples
+- [ ] `#202` AI-first flagship surfaces
+- [ ] `#207` Spring block/escalate proof
+- [ ] `#208` Spring embedded-config mutation support
+- [ ] `#218` release-environment ConfigHub smoke reliability
+
+For this preview, "all examples working well" means each featured example has:
+
+- a clear local start path,
+- a working connected path,
+- one concrete governed outcome,
+- an inspection target or an honest lower-proof note,
+- docs that explain who the example is for and why it matters.
+
+Do not tag `v0.2-preview.2` until the remaining blockers meet that bar or are
+explicitly re-scoped with agreement in the release notes and plan.
+
+## Not blockers for `v0.2-preview.2`
+
+- [ ] `#238` umbrella chart support
+- [ ] `#239` provenance honesty for helpers/built-ins/external refs
+- [ ] `#240` render diff / impact / revision diff
+- [ ] `#241` generator chaining
+- [ ] `#242` CLI override provenance
+- [ ] `#236` future `cub gen` plugin packaging
+
+These can still improve the release if they land early, but they should not
+expand the ship bar silently.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,8 +181,9 @@ nav:
           - "Example Truth Matrix": testing/example-truth-matrix.md
           - "Ilya/CoreWeave Acceptance Checklist": testing/ilya-coreweave-acceptance-checklist.md
           - "App/Deployment Concepts": testing/app-deployment-concepts.md
-          - "Contract Drift Checklist": testing/contract-drift-checklist.md
+      - "Contract Drift Checklist": testing/contract-drift-checklist.md
       - "Current Release Plan (v0.2-preview.2)": releases/v0.2-preview.2-plan.md
+      - "Current Ship Checklist (v0.2-preview.2)": releases/v0.2-preview.2-ship-checklist.md
       - "Release Notes (v0.2-preview.1)": releases/v0.2-preview.1.md
       - Decisions:
           - "Sprint 2 Go/No-Go": decisions/2026-03-06-sprint-2-go-no-go.md


### PR DESCRIPTION
## Summary
- add a dedicated `v0.2-preview.2` ship checklist next to the broader release plan
- capture what is already landed on `main`, what still blocks the tag, and what can wait
- link the checklist from the README, docs index, release plan, and MkDocs nav

## Validation
- `make ci-local`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`
