### PR TITLE
docs: finish stale prototype wording cleanup

### DIFF
--- a/docs/agentic-gitops/02-design/11-confighub-generator-naming-concepts.md
+++ b/docs/agentic-gitops/02-design/11-confighub-generator-naming-concepts.md
@@ -179,6 +179,6 @@ Adopt:
 1. External + internal primary name: `ConfigHub Generators`
 2. Supporting phrase: `Generator Render Pipeline`
 3. Keep contract triple names unchanged.
-4. Treat `cub-gen` as prototype packaging and `cub gitops` as official integrated surface.
+4. Treat `cub-gen` as the repo-side source surface and `cub gitops` as the cluster-integrated surface.
 
 This gives immediate clarity now and preserves room for stronger branded packaging later.


### PR DESCRIPTION
## Summary
- remove one remaining architecture note that still described `cub-gen` as prototype packaging
- align the old naming-concepts doc with the repo's current repo-side CLI positioning

## Validation
- `./test/checks/check-docs-entrypoints.sh`
- grep for `cub-gen` described as `prototype` or `proposal` across README/docs/AI guidance
