### PR TITLE
docs: clarify flagship example entrypoints

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,68 +11,82 @@ You already have a deployment pipeline: Git, Helm, Flux, Argo, Spring Boot, Scor
 
 Each example in this directory is runnable and maps to a real platform/app pattern.
 
-## Start here first
+## Pick a path in 30 seconds
 
-Do not start by scanning the whole catalog. Start with one of these:
+Do not start by scanning the whole catalog. Start with the path that matches
+what you already run:
 
-| Journey | Start here | What is real today | Why this should be first |
-|---------|------------|--------------------|--------------------------|
-| Platform-first GitOps team | [`helm-paas`](./helm-paas/) then [`live-reconcile`](./live-reconcile/) | `helm-paas` has real source-side + connected proof; runtime proof is paired through `live-reconcile` | Most direct story for existing Helm plus Flux/Argo users |
-| App-first team | [`springboot-paas`](./springboot-paas/) | Real source-side, connected, and standalone live-cluster proof | Most recognizable "I already ship this app" path |
-| Score-first team | [`scoredev-paas`](./scoredev-paas/) | Real source-side + connected proof; standalone live Score runtime proof is still open work | Canonical "keep `score.yaml` as the contract" path |
-| Cluster-first companion path | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | Start from live reality, then trace back to source | Best path when the cluster is already the source of urgency |
+| If you already run... | Start here | Then do this | What you can inspect | Current truth |
+|---|---|---|---|---|
+| Helm plus Argo/Flux platform repos | `./examples/demo/start-platform-first.sh` | `cub auth login && ./examples/helm-paas/demo-connected.sh` | values ownership, rendered targets, then paired runtime proof via [`live-reconcile`](./live-reconcile/) | Strongest platform-first source-side path today |
+| Spring Boot app repos | `./examples/demo/start-app-first.sh` | `cub auth login && ./examples/springboot-paas/demo-connected.sh` | config ownership now, live `inventory-api` proof next | Strongest standalone end-to-end example in the repo today |
+| Score.dev workloads | `./examples/demo/start-score-first.sh` | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field origin now, governed connected output next | Strongest Score source-side path today; standalone live Score proof is still open work |
+| A running cluster and GitOps controller | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | trace one chosen field back to source | live cluster state first, source provenance second | Best when the cluster is already the urgent source of truth |
+
+## What ends with something live today
+
+| Path | Live thing you can inspect | Command | Truth today |
+|---|---|---|---|
+| [`springboot-paas`](./springboot-paas/) | real `inventory-api` app on a kind cluster | `./examples/springboot-paas/verify-e2e.sh` | Standalone live app proof is real |
+| [`helm-paas`](./helm-paas/) + [`live-reconcile`](./live-reconcile/) | Flux and Argo reconciliation of rendered Helm output | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | Runtime proof is paired, not standalone in `helm-paas` |
+| [`scoredev-paas`](./scoredev-paas/) | connected governed output plus rendered runtime fields | `./examples/scoredev-paas/demo-connected.sh` | Standalone Score live proof is still open |
+
+## Two audiences, one set of wrappers
+
+Every flagship example supports the same two entry points:
+
+- Local first: `./examples/<example>/demo-local.sh`
+- Connected next: `cub auth login && ./examples/<example>/demo-connected.sh`
+
+If you already use ConfigHub, start with the connected wrapper for one example.
+If you already use Helm, Argo, Flux, Score, or Spring, start with local mode so
+you see value before backend setup.
+
+## What `--space` means
+
+`--space` is the ConfigHub space where cub-gen records bundle metadata and
+decision-related context.
+
+- In local examples, `platform` is the default teaching value.
+- In connected runs, use the space from your current ConfigHub context.
+- If you only want source-side proof, you can treat `--space` as descriptive
+  context rather than a deployment target.
+
+## Source-first vs cluster-first
+
+Use the `cub-gen` examples when your starting point is a source repo and your
+question is "what rendered this field?" Use ConfigHub GitOps import plus
+[`cub-scout`](https://github.com/confighub/cub-scout) when your starting point
+is a live Argo or Flux workload and your question is "what is running right
+now?"
+
+That split is especially important for:
+
+- Helm plus Argo/Flux teams using chart values and overlays,
+- Score teams keeping `score.yaml` as the app-team contract,
+- platform teams tracing one cluster field back to the DRY source that produced it.
 
 ## Flagship truth right now
 
-Use these three first when evaluating whether `cub-gen` feels trustworthy:
-
 | Example | Best current answer for | Current trust level |
-|---------|-------------------------|---------------------|
-| [`helm-paas`](./helm-paas/) | Helm + Flux/Argo + values ownership | Strongest platform-first source-side path; pair with [`live-reconcile`](./live-reconcile/) for runtime proof |
+|---|---|---|
+| [`helm-paas`](./helm-paas/) | Helm + Argo/Flux + values ownership | Strongest platform-first source-side path; pair with [`live-reconcile`](./live-reconcile/) for runtime proof |
 | [`springboot-paas`](./springboot-paas/) | Real app-team + platform-team config ownership | Strongest standalone end-to-end example in the repo today |
 | [`scoredev-paas`](./scoredev-paas/) | Score intent to rendered runtime fields | Strongest Score source-side path today; runtime proof still needs its own standalone finish |
-
-## Two audiences, two entry points
-
-Every example supports both paths explicitly:
-
-| If you are... | Your path |
-|---------------|-----------|
-| **Existing ConfigHub user** adding a platform tool | Start with the connected wrapper for one example, then expand into deeper bridge/promotion flows only if you need them |
-| **Existing platform-tool user** adding ConfigHub | Start with local mode, see value first, then connect |
-
-Neither audience is an afterthought. Pick your path and each example will guide you.
-
-## How the tools fit together
-
-| Tool | Starts from | Best first question |
-|------|-------------|---------------------|
-| `cub-gen` | Source repo | Which DRY file or path produced this rendered field? |
-| [`cub-scout`](https://github.com/confighub/cub-scout) | Cluster and reconciler runtime | What is running and where is drift? |
-| ConfigHub | Shared evidence and governance state | What changed, what was approved, and what proof exists? |
 
 ## What happens after import? (Day-2 stories)
 
 Import is day 1. The real value shows on day 2:
 
 | Day | What you do | What you gain |
-|-----|-------------|---------------|
+|---|---|---|
 | **Day 1** | Import and explain | Field-origin tracing, ownership clarity, inverse-edit guidance |
 | **Day 2** | Governed change, promotion, or live-origin proposal | ALLOW/BLOCK decisions, cross-repo promotion, live→DRY proposals |
 | **Day 3** | Optional AI-assisted change lane | Prompt-as-DRY, mutation-ledger evidence, verification boundary |
 
 Every example should answer: "I imported my config. Now what?" The answer is
-governed change, promotion, or live-origin proposal — not "wait for the next feature."
-
-## What runs locally vs what needs ConfigHub
-
-Everything in these examples runs locally with no backend:
-- Generator detection
-- Field-origin tracing
-- Evidence bundles (`publish`, `verify`, `attest`)
-
-Cross-repo queries, policy enforcement, and governed decisions require
-[ConfigHub](../docs/platform.md).
+governed change, promotion, or live-origin proposal, not "wait for the next
+feature."
 
 ## Current truth matrix
 
@@ -148,6 +162,9 @@ go build -o ./cub-gen ./cmd/cub-gen
 
 # App-first
 ./examples/springboot-paas/demo-local.sh
+
+# Score-first
+./examples/scoredev-paas/demo-local.sh
 ```
 
 ## Connected mode (ConfigHub smoke first)
@@ -164,6 +181,9 @@ cub info
 
 # App-first
 ./examples/springboot-paas/demo-connected.sh
+
+# Score-first
+./examples/scoredev-paas/demo-connected.sh
 ```
 
 Use local mode for first value. Use connected smoke to confirm your ConfigHub

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -29,22 +29,31 @@ For workflow and AI example quality, use the
 
 ## 1. Start with one of these
 
-| If you already run... | Start here | What you should prove first |
-|---------|-----------|------------------------------|
-| Helm plus Flux/Argo | `./examples/demo/start-platform-first.sh` | Which values file/path controls the rendered field |
-| Spring Boot app repos | `./examples/demo/start-app-first.sh` | Which app or platform config file should be edited |
-| Score.dev workloads | `./examples/demo/module-2-score-field-map.sh` | Which `score.yaml` field produced the runtime field |
-| Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | WET to LIVE create, update, and drift-correction |
+| If you already run... | Start here | What actually runs | What you can inspect next |
+|---|---|---|---|
+| Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then paired runtime next steps | values ownership now, `live-reconcile` runtime proof after |
+| Spring Boot app repos | `./examples/demo/start-app-first.sh` | local lifecycle for `springboot-paas` | app-vs-platform config ownership now, standalone live app proof after |
+| Score.dev workloads | `./examples/demo/start-score-first.sh` | Score field trace and inverse edit map | `score.yaml` to runtime-field mapping now, connected governed output after |
+| Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | real Flux and Argo reconciliation on kind | pods, rollout, and drift correction |
 
 Cluster-side follow-on: pair the above with [`cub-scout`](https://github.com/confighub/cub-scout)
 when you want to inspect what is actually running after reconciliation.
 
-## 2. Pick your demo by persona
+## 2. What ends with live proof today
+
+| Path | Live thing you can inspect | Command | Truth today |
+|---|---|---|---|
+| Spring standalone app path | `inventory-api` on kind plus HTTP verification | `./examples/springboot-paas/verify-e2e.sh` | Strongest standalone app proof |
+| Helm runtime companion path | Argo and Flux reconciliation of Helm-derived manifests | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | Paired runtime proof for `helm-paas` |
+| Connected smoke | ConfigHub-authenticated flagship bundle/attestation chain | `./examples/demo/run-connected-smoke.sh` | Release-facing connected proof lane |
+| Score path | no standalone live-cluster Score proof yet | `./examples/scoredev-paas/demo-connected.sh` | Honest connected-only flagship for now |
+
+## 3. Pick your demo by persona
 
 | Persona | Start here | What you'll prove |
 |---------|------------|-------------------|
 | **Helm platform engineer** | `module-1-helm-import.sh` | DRY source mapping for chart/value changes |
-| **Score platform team** | `module-2-score-field-map.sh` | `score.yaml` → runtime field trace |
+| **Score platform team** | `start-score-first.sh` | `score.yaml` → runtime field trace with connected next steps |
 | **Spring app/platform team** | `module-3-spring-ownership.sh` | App-vs-platform ownership boundaries |
 | **Backstage catalog admin** | [`backstage-idp`](../backstage-idp/) demo | Owner/lifecycle governance |
 | **AI fleet operator** | `ai-work-platform/scenario-1-c3agent.sh` | 30 DRY lines → 11 governed WET targets |
@@ -56,7 +65,7 @@ when you want to inspect what is actually running after reconciliation.
 
 See also: [Domain POV Matrix](../../docs/workflows/domain-pov-matrix.md) | [Persona 5-minute runbooks](../../docs/workflows/persona-5-minute-runbooks.md)
 
-## 3. Quick start
+## 4. Quick start
 
 ```bash
 go build -o ./cub-gen ./cmd/cub-gen
@@ -68,7 +77,7 @@ go build -o ./cub-gen ./cmd/cub-gen
 ./examples/demo/start-app-first.sh
 
 # Score-first first run
-./examples/demo/module-2-score-field-map.sh
+./examples/demo/start-score-first.sh
 
 # Runtime proof after source-side import
 RECONCILER=both ./examples/live-reconcile/demo-local.sh
@@ -81,7 +90,7 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 ./examples/demo/ai-work-platform/run-all.sh
 ```
 
-## 4. Local mode (no ConfigHub login required)
+## 5. Local mode (no ConfigHub login required)
 
 ### Core platform/app track
 
@@ -89,6 +98,7 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 |--------|---------|---------------------|
 | `start-platform-first.sh` | [`helm-paas`](../helm-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated platform-first starter path |
 | `start-app-first.sh` | [`springboot-paas`](../springboot-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated app-first starter path |
+| `start-score-first.sh` | [`scoredev-paas`](../scoredev-paas/) | Opinionated Score-first starter path with honest runtime-gap handoff |
 | `module-1-helm-import.sh` | [`helm-paas`](../helm-paas/) | Helm detection, values ownership, field-origin tracing |
 | `module-2-score-field-map.sh` | [`scoredev-paas`](../scoredev-paas/) | Score field-origin and inverse edit mapping |
 | `module-3-spring-ownership.sh` | [`springboot-paas`](../springboot-paas/) | Spring ownership boundaries (app vs platform) |
@@ -122,7 +132,7 @@ If your platform is workflow-heavy, start here before app-manifest demos:
   | jq '.provenance[0].ops_workflow_analysis'
 ```
 
-## 5. Connected mode (ConfigHub)
+## 6. Connected mode (ConfigHub)
 
 Start with authentication:
 
@@ -131,6 +141,11 @@ cub auth login
 cub info
 cub context get --json | jq -r '.coordinate.user'
 ```
+
+`--space` means the ConfigHub space where the connected scripts record their
+bundle, decision, and evidence context. In the starter scripts, the current
+ConfigHub context is the source of truth. In local-only runs, `platform` is the
+default teaching value.
 
 Connected smoke shape:
 
@@ -185,7 +200,7 @@ CI behavior:
 
 See also: [connected-ci-bootstrap.md](../../docs/workflows/connected-ci-bootstrap.md)
 
-## 6. Live reconciler e2e (Flux + Argo + kind)
+## 7. Live reconciler e2e (Flux + Argo + kind)
 
 | Script | What it demonstrates |
 |--------|---------------------|
@@ -207,7 +222,7 @@ cub auth login
 RECONCILER=both ./examples/demo/e2e-connected-governed-reconcile-helm.sh
 ```
 
-## 7. Lifecycle simulation scripts
+## 8. Lifecycle simulation scripts
 
 | Script | What it demonstrates |
 |--------|---------------------|
@@ -226,7 +241,7 @@ RECONCILER=both ./examples/demo/e2e-connected-governed-reconcile-helm.sh
 | `change-api-adapter.sh --request <json> [--out <json>]` | API-style JSON wrapper for `change preview\|run\|explain` |
 | `change-api-http-e2e.sh [repo] [render-target]` | Native repo-first HTTP flow using `/v1/changes` endpoints |
 
-## 8. CI policy gates (PR path)
+## 9. CI policy gates (PR path)
 
 Use these when you want merge-blocking enforcement, not just local guidance:
 
@@ -237,7 +252,7 @@ Use these when you want merge-blocking enforcement, not just local guidance:
   - Runs the gate for Helm + Spring examples
   - Posts a PR comment with actionable DRY edit guidance
 
-## 9. PR-MR pairing and promotion flows
+## 10. PR-MR pairing and promotion flows
 
 | Script | What it demonstrates |
 |--------|---------------------|
@@ -245,7 +260,7 @@ Use these when you want merge-blocking enforcement, not just local guidance:
 | `flow-b-mr-to-git-pr-connected.sh` | Flow B: ConfigHub MR → Git PR proposal |
 | `fr8-promotion-upstream-dry-connected.sh` | FR8: live→WET→DRY upstream promotion |
 
-## 10. Phase 3 connected story scripts
+## 11. Phase 3 connected story scripts
 
 | Script | User story | What it demonstrates |
 |--------|------------|---------------------|
@@ -256,7 +271,7 @@ Use these when you want merge-blocking enforcement, not just local guidance:
 | `story-12-unified-actor-evidence.sh` | 12 | Unified human/CI/AI attestation chain |
 | `run-phase-3-connected-stories.sh` | 1,7,9,12 | Run all Phase 3 stories |
 
-## 11. Phase 4 connected story scripts
+## 12. Phase 4 connected story scripts
 
 | Script | User story | What it demonstrates |
 |--------|------------|---------------------|

--- a/examples/demo/start-score-first.sh
+++ b/examples/demo/start-score-first.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[start-score] step 1: keep score.yaml as the app-team contract and trace it to runtime fields"
+./examples/demo/module-2-score-field-map.sh
+
+cat <<'EOF'
+
+[start-score] next steps
+  connected governance:
+    cub auth login
+    ./examples/scoredev-paas/demo-connected.sh
+
+  what to inspect:
+    - local output: score.yaml field origin + inverse edit map
+    - connected output: change_id, bundle digest, and decision/query evidence
+
+  runtime proof today:
+    standalone Score live-cluster proof is still open work
+    use RECONCILER=both ./examples/live-reconcile/demo-local.sh for reconciler proof
+    and ./examples/scoredev-paas/README.md for the current Score-specific truth
+EOF

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -29,28 +29,35 @@ Known gaps still open:
 - one-command multi-variant fan-out is not exposed yet ([#237](https://github.com/confighub/cub-gen/issues/237))
 - CLI override capture for `--set` / `--set-file` is not modeled yet ([#242](https://github.com/confighub/cub-gen/issues/242))
 
-## Start here first
+## Start here by audience
 
-If you are new, use this sequence:
+| If you are... | First command | Then do this | What you can inspect |
+|---|---|---|---|
+| Existing Helm plus Argo/Flux user | `./examples/helm-paas/demo-local.sh` | `cub auth login && ./examples/helm-paas/demo-connected.sh` | values ownership, rendered targets, then connected evidence |
+| Existing ConfigHub user adding Helm governance | `cub auth login && ./examples/helm-paas/demo-connected.sh` | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | change/bundle/decision output, then Argo+Flux runtime proof |
+| Existing Argo-first operator starting from a running app | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) first | come back to `./examples/helm-paas/demo-local.sh` for source provenance | live app first, source trace second |
 
-1. `./examples/helm-paas/demo-local.sh`
-2. `./examples/helm-paas/demo-connected.sh`
-3. `RECONCILER=both ./examples/live-reconcile/demo-local.sh`
-4. inspect the runtime side with [`cub-scout`](https://github.com/confighub/cub-scout)
-
-That gives you:
+That sequence gives you:
 
 1. source-side provenance and ownership,
 2. connected ConfigHub evidence and governed decision state,
-3. WET to LIVE reconciliation proof,
+3. WET to LIVE reconciliation proof across Argo and Flux,
 4. cluster-side inspection of what actually ran.
+
+## What you can inspect after each step
+
+| Step | Command | Inspectable result |
+|---|---|---|
+| Local source-side proof | `./examples/helm-paas/demo-local.sh` | field origin, inverse-edit guidance, dry inputs, and rendered targets |
+| Connected governance proof | `./examples/helm-paas/demo-connected.sh` | change ID, bundle digest, attestation, and backend decision/query output |
+| Runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | live Deployment rollout, pods, and drift correction for Flux and Argo |
 
 ## 1. Who this is for
 
 | If you are... | Start here |
 |---------------|------------|
 | **Existing ConfigHub user** adding Helm governance | Jump to [Run from ConfigHub](#run-from-configHub-connected-mode) |
-| **Existing Helm/Flux/Argo user** adding ConfigHub | Jump to [Fastest path](#fastest-path-to-believe-it) then connect later |
+| **Existing Helm/Argo/Flux user** adding ConfigHub | Jump to [Fastest path](#fastest-path-to-believe-it) then connect later |
 
 Both paths lead to the same outcome: governed Helm with field-origin tracing.
 
@@ -61,7 +68,17 @@ Both paths lead to the same outcome: governed Helm with field-origin tracing.
 | **Real app** | `payments-api` Helm chart (Deployment + Service + ConfigMap) |
 | **Real cluster objects** | Kubernetes Deployment, Service, ConfigMap |
 | **Real inspection target** | `kubectl get deployment payments-api -o yaml` |
-| **GitOps transport** | Flux HelmRelease or ArgoCD Application |
+| **GitOps transport** | Argo CD Application or Flux HelmRelease |
+
+## Argo/Flux note
+
+Argo is not an afterthought in this example. The repo includes both:
+
+- `gitops/argo/application.yaml`
+- `gitops/flux/helmrelease.yaml`
+
+The current runtime proof is paired through [`live-reconcile`](../live-reconcile/)
+so you can inspect both reconcilers from the same flagship Helm story.
 
 ## 3. Why ConfigHub + cub-gen helps here
 

--- a/examples/scoredev-paas/README.md
+++ b/examples/scoredev-paas/README.md
@@ -24,14 +24,30 @@ runtime proof elsewhere in the repo right now, use [`springboot-paas`](../spring
 or [`live-reconcile`](../live-reconcile/) as the current runtime companions
 while the Score-specific live path is being finished.
 
+## Start here by audience
+
+| If you are... | First command | Then do this | What you can inspect |
+|---|---|---|---|
+| Existing Score.dev user | `./examples/scoredev-paas/demo-local.sh` | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field trace now, connected governed output next |
+| Existing ConfigHub user adding Score governance | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `./examples/demo/start-score-first.sh` for the repo-side first-run story | bundle, attestation, and decision evidence plus source mapping |
+| Existing cluster-first operator | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) first | come back to `./examples/scoredev-paas/demo-local.sh` for source provenance | live workload first, Score contract trace second |
+
+Both paths lead to the same outcome: governed Score workloads with field-origin tracing.
+
+## What you can inspect after each step
+
+| Step | Command | Inspectable result |
+|---|---|---|
+| Local source-side proof | `./examples/scoredev-paas/demo-local.sh` | `score.yaml` field origin, inverse edit pointers, and rendered targets |
+| Connected governance proof | `./examples/scoredev-paas/demo-connected.sh` | change ID, bundle digest, attestation, and connected decision/query output |
+| Runtime companion today | [`springboot-paas`](../springboot-paas/) or [`live-reconcile`](../live-reconcile/) | current standalone live app proof elsewhere in the repo while Score runtime proof is being finished |
+
 ## 1. Who this is for
 
 | If you are... | Start here |
 |---------------|------------|
 | **Existing ConfigHub user** adding Score governance | Jump to [Run from ConfigHub](#run-from-configHub-connected-mode) |
 | **Existing Score.dev user** adding ConfigHub | Jump to [Fastest path](#fastest-path-to-believe-it) then connect later |
-
-Both paths lead to the same outcome: governed Score workloads with field-origin tracing.
 
 ## 2. What runs
 
@@ -40,7 +56,7 @@ Both paths lead to the same outcome: governed Score workloads with field-origin 
 | **Real app** | Node.js checkout API defined in `score.yaml` |
 | **Real cluster objects** | Kubernetes Deployment, Service, ConfigMap |
 | **Real inspection target** | `kubectl get deployment checkout-api -o yaml` |
-| **GitOps transport** | Flux Kustomization or ArgoCD Application |
+| **GitOps transport** | Argo CD Application or Flux Kustomization |
 
 ## 3. Why ConfigHub + cub-gen helps here
 
@@ -68,9 +84,9 @@ For Score users, start with `cub-gen`, not ConfigHub's GitOps Import wizard.
 - ConfigHub GitOps Import is for importing ArgoCD/Flux application resources that already exist in a cluster.
 - This example is about source-side Score intent in `score.yaml`.
 
-That distinction matters because a Score team thinks in workload intent, workload
-classes, and provisioners, not in Argo `Application` or Flux `HelmRelease`
-objects.
+That distinction matters because a Score team thinks in workload intent,
+workload classes, and provisioners, not in Argo `Application` or Flux
+transport objects.
 
 So the recommended path is:
 


### PR DESCRIPTION
## Summary
- redesign the top-level example and demo entry surfaces around user recognition, stack choice, and honest live outcomes
- add a consistent Score-first starter wrapper to match the existing platform-first and app-first paths
- tighten the Helm and Score flagship READMEs around audience split, inspectable outcomes, and Argo/Flux or source-vs-cluster positioning

## Why
- advances #182 by making the first screens route users faster and explain what actually runs
- narrows the entrypoint/documentation part of #177 and #178 without claiming the remaining runtime-proof work is done

## Validation
- `bash -n examples/demo/start-score-first.sh examples/demo/start-platform-first.sh examples/demo/start-app-first.sh`
- `./examples/demo/start-score-first.sh`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`
