### PR TITLE
examples: add helm flagship live proof wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Docs currently live in this repo:
 - [Demo Guide](docs/demo-guide.md) — runnable demo scripts and scenarios
 - [Current release plan](docs/releases/v0.2-preview.2-plan.md) — must-ship and post-release work for the next preview
 - [Current ship checklist](docs/releases/v0.2-preview.2-ship-checklist.md) — what is already landed on `main`, what still blocks the tag, and what can wait
+- [Draft release notes](docs/releases/v0.2-preview.2.md) — the current `v0.2-preview.2` release-note draft to finalize from green `main`
 - [Examples](examples/README.md) — complete runnable scenarios for every generator
 - [Platform](docs/platform.md) — how cub-gen connects to ConfigHub
 - [Persona 5-minute runbooks](docs/workflows/persona-5-minute-runbooks.md) — stack-specific entry paths

--- a/docs/index.md
+++ b/docs/index.md
@@ -191,7 +191,9 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 See the [v0.2-preview.2 Release Plan](releases/v0.2-preview.2-plan.md) for the
 current must-ship and post-release split, and the
 [v0.2-preview.2 Ship Checklist](releases/v0.2-preview.2-ship-checklist.md) for
-what is already landed on `main` versus what still blocks the tag.
+what is already landed on `main` versus what still blocks the tag. The current
+[draft release notes](releases/v0.2-preview.2.md) are also in the repo now so
+the final tag write-up can be tightened from the eventual green `main`.
 
 - Core flow commands (`discover`, `import`, `cleanup`) frozen and golden-tested
 - Bridge artifacts (`publish`, `verify`, `attest`, `verify-attestation`) symmetric across all 8 generators

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -36,7 +36,7 @@ exit-bar rationale still live in
 
 - [ ] Run `mkdocs build --strict` in the release environment and fix any strict
   doc failures.
-- [ ] Write `docs/releases/v0.2-preview.2.md` from the final green `main`.
+- [ ] Finalize `docs/releases/v0.2-preview.2.md` from the final green `main`.
 - [ ] Re-check the top-level and subcommand help examples from a clean checkout.
 - [ ] Confirm the current connected smoke lane passes in the intended
   secrets-backed release environment.

--- a/docs/releases/v0.2-preview.2.md
+++ b/docs/releases/v0.2-preview.2.md
@@ -79,8 +79,9 @@ release-facing proof.
    bar for runnable platform stories and AI-first acceptance.
    Refs: `#180`, `#200`, `#202`
 
-4. Spring still needs the remaining policy-depth follow-through.
-   Refs: `#207`, `#208`
+4. Spring now has example-owned `ALLOW` versus `BLOCKED` route proof, but the
+   direct embedded-config mutation path is still the notable gap.
+   Ref: `#208`
 
 5. The release environment still needs the final secrets-backed connected smoke
    confirmation for the intended tag environment.

--- a/docs/releases/v0.2-preview.2.md
+++ b/docs/releases/v0.2-preview.2.md
@@ -1,0 +1,119 @@
+# cub-gen v0.2-preview.2
+
+Drafted: 2026-04-11
+Target tag: `v0.2-preview.2`
+Previous release: `v0.2-preview.1` (2026-03-06)
+
+## Status
+
+This is the draft release note for the next preview. Finalize it from the final
+green `main` after the last release checks pass.
+
+## Summary
+
+`v0.2-preview.2` turns `cub-gen` into a more trustworthy repo-first preview:
+clearer CLI purpose, path-first local flows, more honest example entrypoints,
+and a smaller connected smoke lane that the team can actually explain as a
+release-facing proof.
+
+## Highlights
+
+1. CLI and docs now lead with the repo-first mental model.
+   - `cub-gen` is described as tracing repo config to rendered output so you
+     know what to edit.
+   - local-first commands default `<render-target-path>` to `<target-path>` in
+     the common single-repo case.
+   - help output, README examples, getting-started docs, and CLI reference
+     examples were tightened to match clean-checkout behavior.
+
+2. The example catalog is much more honest about proof tiers.
+   - top-level example surfaces now say what to run first, what is real today,
+     and which paths end with live proof versus a documented lower proof tier.
+   - flagship and companion example READMEs now explain who the example is for,
+     what can be inspected after each step, and what is still partial.
+
+3. The connected release signal is smaller and more credible.
+   - the release-facing connected proof is now the ConfigHub smoke lane instead
+     of the old oversized `ci-connected` expectation.
+   - deeper bridge, promotion, and multi-story flows remain available, but are
+     no longer implied to be the tag gate.
+
+4. The flagship examples are stronger.
+   - `helm-paas` now has an example-owned connected + live wrapper and an
+     example-owned governed change wrapper for ALLOW versus BLOCK proof.
+   - `springboot-paas` remains the strongest standalone real-app live proof in
+     the repo.
+   - `scoredev-paas`, workflow examples, and AI-adjacent examples now have
+     clearer entry surfaces even where deeper acceptance work is still open.
+
+5. The change surface is easier to consume.
+   - change CLI and change API flows now prefer repo paths over parity-era
+     slug-first inputs.
+   - responses carry normalized `target_path` and `render_target_path` values
+     so local tooling can see the resolved repo identity directly.
+
+## Boundary (unchanged)
+
+1. `cub-gen` remains local-first.
+2. `cub-gen` does not replace Argo or Flux reconciliation.
+3. `cub-gen` does not itself deploy workloads to clusters.
+4. Deep connected bridge stories remain available without being treated as the
+   default release proof.
+
+## Explicitly Still Partial In This Preview
+
+1. Helm flagship depth is improved, but the deeper Kubara-like acceptance bar
+   remains open:
+   - layered provenance across overlays, labels, and ApplicationSet-style
+     routing
+   - stronger security-boundary examples
+   - more complete multi-layer trace stories
+   Refs: `#177`, `#187`
+
+2. Score still needs its strongest end state:
+   - standalone live-cluster proof from `score.yaml`
+   - a governed blocked or escalated path that a Score user can inspect
+   Ref: `#178`
+
+3. Workflow and AI surfaces are clearer, but not yet fully at the new flagship
+   bar for runnable platform stories and AI-first acceptance.
+   Refs: `#180`, `#200`, `#202`
+
+4. Spring still needs the remaining policy-depth follow-through.
+   Refs: `#207`, `#208`
+
+5. The release environment still needs the final secrets-backed connected smoke
+   confirmation for the intended tag environment.
+   Refs: `#218`, `#226`
+
+This preview should be read as a trustworthy product-surface release, not as
+the final acceptance completion of every featured example.
+
+## Final Tag Gate
+
+Before creating the final `v0.2-preview.2` tag:
+
+1. `make ci-local` must be green on `main`.
+2. `mkdocs build --strict` must be green in the release environment.
+3. Top-level and subcommand help examples should be re-checked from a clean
+   checkout.
+4. The connected smoke lane must pass with real release-environment secrets.
+5. README, docs index, release plan, ship checklist, and this note should agree
+   on what is shipped versus what is still partial.
+
+## Suggested Proof Snapshot For The Final Release Body
+
+Use the final green `main` state to confirm and refresh these points before
+publishing the GitHub release:
+
+- example truth matrix counts
+- connected smoke status in the release environment
+- latest merged flagship example updates
+- final known-partial issue list for the preview
+
+## References
+
+1. [Release Plan](v0.2-preview.2-plan.md)
+2. [Ship Checklist](v0.2-preview.2-ship-checklist.md)
+3. [Example Truth Matrix](../testing/example-truth-matrix.md)
+4. [Previous Release Notes (`v0.2-preview.1`)](v0.2-preview.1.md)

--- a/docs/testing/example-truth-matrix.json
+++ b/docs/testing/example-truth-matrix.json
@@ -125,6 +125,7 @@
         "./examples/demo/e2e-connected-governed-reconcile-helm.sh",
         "./examples/demo/run-connected-smoke.sh",
         "./examples/helm-paas/demo-connected.sh",
+        "./examples/helm-paas/demo-runtime.sh",
         "./examples/live-reconcile/demo-local.sh",
         "go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v",
         "make ci-connected"
@@ -141,6 +142,7 @@
           "./examples/demo/run-connected-smoke.sh"
         ],
         "real_live": [
+          "./examples/helm-paas/demo-runtime.sh",
           "./examples/demo/e2e-connected-governed-reconcile-helm.sh",
           "./examples/live-reconcile/demo-local.sh"
         ]
@@ -152,7 +154,7 @@
         "#187"
       ],
       "notes": [
-        "Real LIVE proof is paired through the live-reconcile harness, not standalone in helm-paas."
+        "Real LIVE proof is exposed through an example-owned helm-paas wrapper, but still uses the shared live-reconcile harness under the hood."
       ]
     },
     {

--- a/docs/testing/example-truth-matrix.md
+++ b/docs/testing/example-truth-matrix.md
@@ -68,9 +68,9 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Source chain: `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v`
 - Connected mode: `./examples/helm-paas/demo-connected.sh`
 - Connected smoke lane: `make ci-connected`, `./examples/demo/run-connected-smoke.sh`
-- Real live: `./examples/demo/e2e-connected-governed-reconcile-helm.sh`, `./examples/live-reconcile/demo-local.sh`
+- Real live: `./examples/helm-paas/demo-runtime.sh`, `./examples/demo/e2e-connected-governed-reconcile-helm.sh`, `./examples/live-reconcile/demo-local.sh`
 - AI-first: --
-- Notes: Real LIVE proof is paired through the live-reconcile harness, not standalone in helm-paas.
+- Notes: Real LIVE proof is exposed through an example-owned helm-paas wrapper, but still uses the shared live-reconcile harness under the hood.
 
 ### `just-apps-no-platform-config`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ what you already run:
 
 | If you already run... | Start here | Then do this | What you can inspect | Current truth |
 |---|---|---|---|---|
-| Helm plus Argo/Flux platform repos | `./examples/demo/start-platform-first.sh` | `cub auth login && RECONCILER=argo ./examples/helm-paas/demo-runtime.sh` | values ownership, connected evidence, and live Argo/Flux proof from the Helm flagship itself | Strongest platform-first source-side path today |
+| Helm plus Argo/Flux platform repos | `./examples/demo/start-platform-first.sh` | `./examples/helm-paas/demo-governed-change.sh`, then `cub auth login && RECONCILER=argo ./examples/helm-paas/demo-runtime.sh` | values ownership now, local ALLOW/BLOCK proof next, and live Argo/Flux proof from the Helm flagship itself after | Strongest platform-first source-side path today |
 | Spring Boot app repos | `./examples/demo/start-app-first.sh` | `cub auth login && ./examples/springboot-paas/demo-connected.sh` | config ownership now, live `inventory-api` proof next | Strongest standalone end-to-end example in the repo today |
 | Score.dev workloads | `./examples/demo/start-score-first.sh` | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field origin now, governed connected output next | Strongest Score source-side path today; standalone live Score proof is still open work |
 | A running cluster and GitOps controller | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | trace one chosen field back to source | live cluster state first, source provenance second | Best when the cluster is already the urgent source of truth |
@@ -70,7 +70,7 @@ That split is especially important for:
 
 | Example | Best current answer for | Current trust level |
 |---|---|---|
-| [`helm-paas`](./helm-paas/) | Helm + Argo/Flux + values ownership | Strongest platform-first source-side path; pair with [`live-reconcile`](./live-reconcile/) for runtime proof |
+| [`helm-paas`](./helm-paas/) | Helm + Argo/Flux + values ownership | Strongest platform-first source-side path, with example-owned ALLOW/BLOCK and runtime wrappers |
 | [`springboot-paas`](./springboot-paas/) | Real app-team + platform-team config ownership | Strongest standalone end-to-end example in the repo today |
 | [`scoredev-paas`](./scoredev-paas/) | Score intent to rendered runtime fields | Strongest Score source-side path today; runtime proof still needs its own standalone finish |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ what you already run:
 
 | If you already run... | Start here | Then do this | What you can inspect | Current truth |
 |---|---|---|---|---|
-| Helm plus Argo/Flux platform repos | `./examples/demo/start-platform-first.sh` | `cub auth login && ./examples/helm-paas/demo-connected.sh` | values ownership, rendered targets, then paired runtime proof via [`live-reconcile`](./live-reconcile/) | Strongest platform-first source-side path today |
+| Helm plus Argo/Flux platform repos | `./examples/demo/start-platform-first.sh` | `cub auth login && RECONCILER=argo ./examples/helm-paas/demo-runtime.sh` | values ownership, connected evidence, and live Argo/Flux proof from the Helm flagship itself | Strongest platform-first source-side path today |
 | Spring Boot app repos | `./examples/demo/start-app-first.sh` | `cub auth login && ./examples/springboot-paas/demo-connected.sh` | config ownership now, live `inventory-api` proof next | Strongest standalone end-to-end example in the repo today |
 | Score.dev workloads | `./examples/demo/start-score-first.sh` | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field origin now, governed connected output next | Strongest Score source-side path today; standalone live Score proof is still open work |
 | A running cluster and GitOps controller | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | trace one chosen field back to source | live cluster state first, source provenance second | Best when the cluster is already the urgent source of truth |
@@ -28,7 +28,7 @@ what you already run:
 | Path | Live thing you can inspect | Command | Truth today |
 |---|---|---|---|
 | [`springboot-paas`](./springboot-paas/) | real `inventory-api` app on a kind cluster | `./examples/springboot-paas/verify-e2e.sh` | Standalone live app proof is real |
-| [`helm-paas`](./helm-paas/) + [`live-reconcile`](./live-reconcile/) | Flux and Argo reconciliation of rendered Helm output | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | Runtime proof is paired, not standalone in `helm-paas` |
+| [`helm-paas`](./helm-paas/) | Flux and Argo reconciliation of rendered Helm output plus connected governance evidence | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | Example-owned wrapper, with the shared live-reconcile harness beneath it |
 | [`scoredev-paas`](./scoredev-paas/) | connected governed output plus rendered runtime fields | `./examples/scoredev-paas/demo-connected.sh` | Standalone Score live proof is still open |
 
 ## Two audiences, one set of wrappers

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ what you already run:
 | If you already run... | Start here | Then do this | What you can inspect | Current truth |
 |---|---|---|---|---|
 | Helm plus Argo/Flux platform repos | `./examples/demo/start-platform-first.sh` | `./examples/helm-paas/demo-governed-change.sh`, then `cub auth login && RECONCILER=argo ./examples/helm-paas/demo-runtime.sh` | values ownership now, local ALLOW/BLOCK proof next, and live Argo/Flux proof from the Helm flagship itself after | Strongest platform-first source-side path today |
-| Spring Boot app repos | `./examples/demo/start-app-first.sh` | `cub auth login && ./examples/springboot-paas/demo-connected.sh` | config ownership now, live `inventory-api` proof next | Strongest standalone end-to-end example in the repo today |
+| Spring Boot app repos | `./examples/demo/start-app-first.sh` | `./examples/springboot-paas/demo-governed-routes.sh`, then `cub auth login && ./examples/springboot-paas/demo-connected.sh` | config ownership now, local `ALLOW`/`BLOCKED` route proof next, live `inventory-api` proof after | Strongest standalone end-to-end example in the repo today |
 | Score.dev workloads | `./examples/demo/start-score-first.sh` | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field origin now, governed connected output next | Strongest Score source-side path today; standalone live Score proof is still open work |
 | A running cluster and GitOps controller | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | trace one chosen field back to source | live cluster state first, source provenance second | Best when the cluster is already the urgent source of truth |
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -32,7 +32,7 @@ For workflow and AI example quality, use the
 | If you already run... | Start here | What actually runs | What you can inspect next |
 |---|---|---|---|
 | Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then the example-owned governed-change proof and live wrapper | values ownership now, local ALLOW/BLOCK proof next, connected + live proof after |
-| Spring Boot app repos | `./examples/demo/start-app-first.sh` | local lifecycle for `springboot-paas` | app-vs-platform config ownership now, standalone live app proof after |
+| Spring Boot app repos | `./examples/demo/start-app-first.sh` | local lifecycle for `springboot-paas`, then the example-owned governed-route proof | app-vs-platform config ownership now, local `ALLOW`/`BLOCKED` proof next, standalone live app proof after |
 | Score.dev workloads | `./examples/demo/start-score-first.sh` | Score field trace and inverse edit map | `score.yaml` to runtime-field mapping now, connected governed output after |
 | Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | real Flux and Argo reconciliation on kind | pods, rollout, and drift correction |
 
@@ -99,6 +99,7 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 | `start-platform-first.sh` | [`helm-paas`](../helm-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated platform-first starter path |
 | `../helm-paas/demo-governed-change.sh` | [`helm-paas`](../helm-paas/) | App-team ALLOW path vs platform-contract BLOCK path with the real PR ownership gate |
 | `start-app-first.sh` | [`springboot-paas`](../springboot-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated app-first starter path |
+| `../springboot-paas/demo-governed-routes.sh` | [`springboot-paas`](../springboot-paas/) | App-owned field ALLOW versus platform-owned field BLOCKED with `springboot validate-mutation` |
 | `start-score-first.sh` | [`scoredev-paas`](../scoredev-paas/) | Opinionated Score-first starter path with honest runtime-gap handoff |
 | `module-1-helm-import.sh` | [`helm-paas`](../helm-paas/) | Helm detection, values ownership, field-origin tracing |
 | `module-2-score-field-map.sh` | [`scoredev-paas`](../scoredev-paas/) | Score field-origin and inverse edit mapping |

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -31,7 +31,7 @@ For workflow and AI example quality, use the
 
 | If you already run... | Start here | What actually runs | What you can inspect next |
 |---|---|---|---|
-| Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then paired runtime next steps | values ownership now, `live-reconcile` runtime proof after |
+| Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then the Helm flagship's own live wrapper next | values ownership now, connected + live proof after |
 | Spring Boot app repos | `./examples/demo/start-app-first.sh` | local lifecycle for `springboot-paas` | app-vs-platform config ownership now, standalone live app proof after |
 | Score.dev workloads | `./examples/demo/start-score-first.sh` | Score field trace and inverse edit map | `score.yaml` to runtime-field mapping now, connected governed output after |
 | Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | real Flux and Argo reconciliation on kind | pods, rollout, and drift correction |
@@ -44,7 +44,7 @@ when you want to inspect what is actually running after reconciliation.
 | Path | Live thing you can inspect | Command | Truth today |
 |---|---|---|---|
 | Spring standalone app path | `inventory-api` on kind plus HTTP verification | `./examples/springboot-paas/verify-e2e.sh` | Strongest standalone app proof |
-| Helm runtime companion path | Argo and Flux reconciliation of Helm-derived manifests | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | Paired runtime proof for `helm-paas` |
+| Helm flagship live path | Argo and Flux reconciliation of Helm-derived manifests plus connected governance evidence | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | Example-owned wrapper over the shared live-reconcile harness |
 | Connected smoke | ConfigHub-authenticated flagship bundle/attestation chain | `./examples/demo/run-connected-smoke.sh` | Release-facing connected proof lane |
 | Score path | no standalone live-cluster Score proof yet | `./examples/scoredev-paas/demo-connected.sh` | Honest connected-only flagship for now |
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -31,7 +31,7 @@ For workflow and AI example quality, use the
 
 | If you already run... | Start here | What actually runs | What you can inspect next |
 |---|---|---|---|
-| Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then the Helm flagship's own live wrapper next | values ownership now, connected + live proof after |
+| Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then the example-owned governed-change proof and live wrapper | values ownership now, local ALLOW/BLOCK proof next, connected + live proof after |
 | Spring Boot app repos | `./examples/demo/start-app-first.sh` | local lifecycle for `springboot-paas` | app-vs-platform config ownership now, standalone live app proof after |
 | Score.dev workloads | `./examples/demo/start-score-first.sh` | Score field trace and inverse edit map | `score.yaml` to runtime-field mapping now, connected governed output after |
 | Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | real Flux and Argo reconciliation on kind | pods, rollout, and drift correction |
@@ -97,6 +97,7 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 | Script | Example | What it demonstrates |
 |--------|---------|---------------------|
 | `start-platform-first.sh` | [`helm-paas`](../helm-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated platform-first starter path |
+| `../helm-paas/demo-governed-change.sh` | [`helm-paas`](../helm-paas/) | App-team ALLOW path vs platform-contract BLOCK path with the real PR ownership gate |
 | `start-app-first.sh` | [`springboot-paas`](../springboot-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated app-first starter path |
 | `start-score-first.sh` | [`scoredev-paas`](../scoredev-paas/) | Opinionated Score-first starter path with honest runtime-gap handoff |
 | `module-1-helm-import.sh` | [`helm-paas`](../helm-paas/) | Helm detection, values ownership, field-origin tracing |

--- a/examples/demo/e2e-connected-governed-reconcile-helm.sh
+++ b/examples/demo/e2e-connected-governed-reconcile-helm.sh
@@ -19,6 +19,9 @@ REPO_URL="${REPO_URL:-https://github.com/confighub/cub-gen}"
 REPO_BRANCH="${REPO_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 FIXTURE_PATH_V1="${FIXTURE_PATH_V1:-./examples/live-reconcile/helm-paas/manifests-v1}"
 FIXTURE_PATH_V2="${FIXTURE_PATH_V2:-./examples/live-reconcile/helm-paas/manifests-v2}"
+SOURCE_NAME="${SOURCE_NAME:-cub-gen-live-helm}"
+KUSTOM_NAME="${KUSTOM_NAME:-cub-gen-live-helm}"
+APP_NAME="${APP_NAME:-cub-gen-live-helm}"
 
 case "$RECONCILER" in
   flux|argo|both) ;;
@@ -94,8 +97,8 @@ if [ "$RECONCILER" = "flux" ] || [ "$RECONCILER" = "both" ]; then
     PATH_V2="$FIXTURE_PATH_V2" \
     TARGET_NS="$TARGET_NS" \
     DEPLOYMENT_NAME="$DEPLOYMENT_NAME" \
-    SOURCE_NAME="cub-gen-live-helm" \
-    KUSTOM_NAME="cub-gen-live-helm" \
+    SOURCE_NAME="$SOURCE_NAME" \
+    KUSTOM_NAME="$KUSTOM_NAME" \
     ./examples/demo/e2e-live-reconcile-flux.sh | tee "$OUT_DIR/flux.log"; then
     flux_ok=true
   fi
@@ -109,7 +112,7 @@ if [ "$RECONCILER" = "argo" ] || [ "$RECONCILER" = "both" ]; then
     PATH_V2="${FIXTURE_PATH_V2#./}" \
     TARGET_NS="$TARGET_NS" \
     DEPLOYMENT_NAME="$DEPLOYMENT_NAME" \
-    APP_NAME="cub-gen-live-helm" \
+    APP_NAME="$APP_NAME" \
     ./examples/demo/e2e-live-reconcile-argo.sh | tee "$OUT_DIR/argo.log"; then
     argo_ok=true
   fi

--- a/examples/demo/start-app-first.sh
+++ b/examples/demo/start-app-first.sh
@@ -10,6 +10,9 @@ echo "[start-app] step 1: Spring config ownership and provenance"
 cat <<'EOF'
 
 [start-app] next steps
+  governed route proof:
+    ./examples/springboot-paas/demo-governed-routes.sh
+
   connected governance:
     cub auth login
     ./examples/springboot-paas/demo-connected.sh

--- a/examples/demo/start-platform-first.sh
+++ b/examples/demo/start-platform-first.sh
@@ -10,6 +10,9 @@ echo "[start-platform] step 1: source-side provenance and governance"
 cat <<'EOF'
 
 [start-platform] next steps
+  governed ownership proof from the same example:
+    ./examples/helm-paas/demo-governed-change.sh
+
   connected governance only:
     cub auth login
     ./examples/helm-paas/demo-connected.sh

--- a/examples/demo/start-platform-first.sh
+++ b/examples/demo/start-platform-first.sh
@@ -10,12 +10,14 @@ echo "[start-platform] step 1: source-side provenance and governance"
 cat <<'EOF'
 
 [start-platform] next steps
-  connected governance:
+  connected governance only:
     cub auth login
     ./examples/helm-paas/demo-connected.sh
 
-  runtime proof:
-    RECONCILER=both ./examples/live-reconcile/demo-local.sh
+  connected + live proof in the helm flagship:
+    cub auth login
+    RECONCILER=argo ./examples/helm-paas/demo-runtime.sh
+    RECONCILER=both ./examples/helm-paas/demo-runtime.sh
 
   cluster-side inspection:
     use cub-scout against the reconciled workload after the runtime proof

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -20,8 +20,8 @@ pair it with [`live-reconcile`](../live-reconcile/).
 |-------|--------|---------------------|
 | Source-side Helm provenance | Real | `./examples/helm-paas/demo-local.sh` |
 | Connected governance path | Real | `./examples/helm-paas/demo-connected.sh` |
-| Runtime WET->LIVE proof | Paired | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` |
-| Standalone live Helm proof in this example | Not yet | pair `helm-paas` with `live-reconcile` today |
+| Connected + live Helm proof from this example | Real | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` |
+| Runtime WET->LIVE harness beneath the wrapper | Paired | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` |
 
 Known gaps still open:
 
@@ -33,8 +33,8 @@ Known gaps still open:
 
 | If you are... | First command | Then do this | What you can inspect |
 |---|---|---|---|
-| Existing Helm plus Argo/Flux user | `./examples/helm-paas/demo-local.sh` | `cub auth login && ./examples/helm-paas/demo-connected.sh` | values ownership, rendered targets, then connected evidence |
-| Existing ConfigHub user adding Helm governance | `cub auth login && ./examples/helm-paas/demo-connected.sh` | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | change/bundle/decision output, then Argo+Flux runtime proof |
+| Existing Helm plus Argo/Flux user | `./examples/helm-paas/demo-local.sh` | `cub auth login && RECONCILER=argo ./examples/helm-paas/demo-runtime.sh` | values ownership, rendered targets, connected evidence, and a live Argo deployment |
+| Existing ConfigHub user adding Helm governance | `cub auth login && ./examples/helm-paas/demo-connected.sh` | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | change/bundle/decision output, then Argo+Flux runtime proof |
 | Existing Argo-first operator starting from a running app | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) first | come back to `./examples/helm-paas/demo-local.sh` for source provenance | live app first, source trace second |
 
 That sequence gives you:
@@ -50,7 +50,7 @@ That sequence gives you:
 |---|---|---|
 | Local source-side proof | `./examples/helm-paas/demo-local.sh` | field origin, inverse-edit guidance, dry inputs, and rendered targets |
 | Connected governance proof | `./examples/helm-paas/demo-connected.sh` | change ID, bundle digest, attestation, and backend decision/query output |
-| Runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | live Deployment rollout, pods, and drift correction for Flux and Argo |
+| Connected + live proof | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | live Deployment rollout, pods, services, and reconciler status for Flux and Argo |
 
 ## 1. Who this is for
 
@@ -77,8 +77,9 @@ Argo is not an afterthought in this example. The repo includes both:
 - `gitops/argo/application.yaml`
 - `gitops/flux/helmrelease.yaml`
 
-The current runtime proof is paired through [`live-reconcile`](../live-reconcile/)
-so you can inspect both reconcilers from the same flagship Helm story.
+The current runtime proof is exposed through `./examples/helm-paas/demo-runtime.sh`,
+which uses the shared [`live-reconcile`](../live-reconcile/) harness under the
+hood so you can inspect both reconcilers from the same flagship Helm story.
 
 ## 3. Why ConfigHub + cub-gen helps here
 
@@ -205,8 +206,9 @@ go build -o ./cub-gen ./cmd/cub-gen
 cub auth login
 ./examples/helm-paas/demo-connected.sh
 
-# Runtime proof paired through the reconciler harness
-RECONCILER=both ./examples/live-reconcile/demo-local.sh
+# Connected + live proof from the example itself
+RECONCILER=argo ./examples/helm-paas/demo-runtime.sh
+RECONCILER=both ./examples/helm-paas/demo-runtime.sh
 ```
 
 If you want the raw commands underneath the wrappers:
@@ -348,7 +350,7 @@ WET:  Deployment/spec/template/spec/containers[0]/image = "ghcr.io/example/payme
 ## Next steps
 
 - **Runtime proof companion**: [`live-reconcile`](../live-reconcile/) — prove
-  the same governed path survives real Flux/Argo reconciliation
+  the same governed path survives real Flux/Argo reconciliation under the hood
 - **Cluster-side inspection companion**: [`cub-scout`](https://github.com/confighub/cub-scout)
   — inspect the reconciled runtime side after delivery
 - **Spring Boot version**: [`springboot-paas`](../springboot-paas/) — same
@@ -380,6 +382,17 @@ cub auth login
 
 That is the current first-run connected path for this example and the same
 surface used by the connected smoke lane.
+
+If you want the connected path that also deploys and proves the live result:
+
+```bash
+cub auth login
+RECONCILER=argo ./examples/helm-paas/demo-runtime.sh
+RECONCILER=both ./examples/helm-paas/demo-runtime.sh
+```
+
+That example-owned wrapper runs the connected governed lifecycle first, then
+shows live Deployment, Pod, Service, and reconciler status for Argo or Flux.
 
 If you specifically need the deeper bridge API path, use:
 
@@ -458,4 +471,8 @@ From repo root:
 # Connected (requires ConfigHub auth)
 cub auth login
 ./examples/helm-paas/demo-connected.sh
+
+# Connected + live proof
+cub auth login
+RECONCILER=both ./examples/helm-paas/demo-runtime.sh
 ```

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -11,14 +11,18 @@ The first question it should answer is:
 
 "Which values file or chart layer actually controls the field I am looking at?"
 
-This example is the source-side half of that story. For the runtime proof half,
-pair it with [`live-reconcile`](../live-reconcile/).
+This example now owns three flagship proof paths:
+
+1. source-side provenance,
+2. governed ownership proof for allowed vs blocked edits,
+3. connected + live Helm proof through an example-owned runtime wrapper.
 
 ## What this proves today
 
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
 | Source-side Helm provenance | Real | `./examples/helm-paas/demo-local.sh` |
+| Governed ALLOW + BLOCK ownership proof | Real | `./examples/helm-paas/demo-governed-change.sh` |
 | Connected governance path | Real | `./examples/helm-paas/demo-connected.sh` |
 | Connected + live Helm proof from this example | Real | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` |
 | Runtime WET->LIVE harness beneath the wrapper | Paired | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` |
@@ -49,6 +53,7 @@ That sequence gives you:
 | Step | Command | Inspectable result |
 |---|---|---|
 | Local source-side proof | `./examples/helm-paas/demo-local.sh` | field origin, inverse-edit guidance, dry inputs, and rendered targets |
+| Local governed ownership proof | `./examples/helm-paas/demo-governed-change.sh` | one app-team change that passes and one platform-contract change that fails the DRY ownership gate |
 | Connected governance proof | `./examples/helm-paas/demo-connected.sh` | change ID, bundle digest, attestation, and backend decision/query output |
 | Connected + live proof | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | live Deployment rollout, pods, services, and reconciler status for Flux and Argo |
 
@@ -201,6 +206,9 @@ go build -o ./cub-gen ./cmd/cub-gen
 
 # Local source-side path
 ./examples/helm-paas/demo-local.sh
+
+# Local governed change path
+./examples/helm-paas/demo-governed-change.sh
 
 # Connected ConfigHub path
 cub auth login
@@ -393,6 +401,17 @@ RECONCILER=both ./examples/helm-paas/demo-runtime.sh
 
 That example-owned wrapper runs the connected governed lifecycle first, then
 shows live Deployment, Pod, Service, and reconciler status for Argo or Flux.
+
+If you want the local governed edit proof before the connected path, run:
+
+```bash
+./examples/helm-paas/demo-governed-change.sh
+```
+
+That wrapper clones the repo into `.tmp`, proves an app-team `values.yaml`
+change passes the ownership gate, then proves an app-team edit to
+`templates/deployment.yaml` is rejected as a platform-owned runtime contract
+change.
 
 If you specifically need the deeper bridge API path, use:
 

--- a/examples/helm-paas/demo-governed-change.sh
+++ b/examples/helm-paas/demo-governed-change.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/helm-paas-governed-change}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="$OUT_ROOT/$RUN_ID"
+WORK_REPO="$OUT_DIR/repo"
+ALLOW_WET_PATH="${ALLOW_WET_PATH:-Deployment/spec/template/spec/containers[0]/image}"
+
+mkdir -p "$OUT_DIR"
+rm -rf "$WORK_REPO"
+
+echo "[helm-governed] cloning repo into $WORK_REPO"
+git clone --quiet "$ROOT_DIR" "$WORK_REPO"
+
+cd "$WORK_REPO"
+git config user.name "cub-gen demo"
+git config user.email "cub-gen-demo@example.invalid"
+
+echo "[helm-governed] build cub-gen once for both ownership-gate checks"
+go build -o ./cub-gen ./cmd/cub-gen
+
+BASE_SHA="$(git rev-parse HEAD)"
+
+echo "[helm-governed] proof 1/2: app-team change stays on the allowed DRY path"
+./cub-gen change explain --space platform --wet-path "$ALLOW_WET_PATH" ./examples/helm-paas > "$OUT_DIR/allow-explain.json"
+
+git checkout --quiet -b demo-allow "$BASE_SHA"
+perl -0pi -e 's/tag: v1\.0\.0/tag: v1.0.1/' ./examples/helm-paas/values.yaml
+git add ./examples/helm-paas/values.yaml
+git commit --quiet -m "demo: app team updates image tag"
+
+SKIP_BUILD=1 ./test/checks/pr-dry-ownership-gate.sh \
+  ./examples/helm-paas \
+  "$BASE_SHA" \
+  HEAD \
+  app-team \
+  --report-json "$OUT_DIR/allow-report.json" \
+  >"$OUT_DIR/allow-gate.log" 2>&1
+
+echo "[helm-governed][allow] inverse edit guidance"
+jq '{
+  owner: .explanation.owner,
+  wet_path: .explanation.wet_path,
+  dry_path: .explanation.dry_path,
+  source_path: .explanation.source_path,
+  confidence: .explanation.confidence,
+  edit_hint: .explanation.edit_hint
+}' "$OUT_DIR/allow-explain.json"
+
+echo "[helm-governed][allow] ownership gate result"
+jq '{
+  status,
+  changed_files,
+  failures
+}' "$OUT_DIR/allow-report.json"
+
+echo "[helm-governed] proof 2/2: app-team edits the platform-owned runtime contract directly"
+git checkout --quiet -B demo-block "$BASE_SHA"
+perl -0pi -e 's#path: /healthz#path: /readyz#' ./examples/helm-paas/templates/deployment.yaml
+git add ./examples/helm-paas/templates/deployment.yaml
+git commit --quiet -m "demo: app team edits platform runtime contract"
+
+set +e
+SKIP_BUILD=1 ./test/checks/pr-dry-ownership-gate.sh \
+  ./examples/helm-paas \
+  "$BASE_SHA" \
+  HEAD \
+  app-team \
+  --report-json "$OUT_DIR/block-report.json" \
+  >"$OUT_DIR/block-gate.log" 2>&1
+block_exit="$?"
+set -e
+
+if [ "$block_exit" -eq 0 ]; then
+  echo "error: expected the platform-owned template edit to fail the ownership gate." >&2
+  exit 1
+fi
+if [ "$block_exit" -ne 2 ]; then
+  echo "error: expected ownership gate exit code 2 for the blocked change, got $block_exit." >&2
+  exit 1
+fi
+
+echo "[helm-governed][block] ownership gate result"
+jq '{
+  status,
+  changed_files,
+  failures
+}' "$OUT_DIR/block-report.json"
+
+echo "[helm-governed][block] gate hint"
+grep '^hint:' "$OUT_DIR/block-gate.log" || true
+
+cat <<EOF
+
+[helm-governed] success
+  allowed path: app-team edits the chart values file and passes the ownership gate
+  blocked path: app-team edits the platform-owned deployment template and is rejected
+  artifacts: $OUT_DIR
+EOF

--- a/examples/helm-paas/demo-runtime.sh
+++ b/examples/helm-paas/demo-runtime.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+RECONCILER="${RECONCILER:-both}" # flux|argo|both
+TARGET_NS="${TARGET_NS:-demo-live-helm}"
+DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-payments-api}"
+LIVE_NAME="${LIVE_NAME:-helm-paas-live}"
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/helm-paas-runtime}"
+FLUX_CONTEXT="${FLUX_CONTEXT:-kind-${FLUX_CLUSTER_NAME:-${CLUSTER_NAME:-cub-gen-live}}}"
+ARGO_CONTEXT="${ARGO_CONTEXT:-kind-${ARGO_CLUSTER_NAME:-${CLUSTER_NAME:-cub-gen-live-argo}}}"
+
+print_flux_snapshot() {
+  echo
+  echo "[helm-runtime][flux] live deployment snapshot"
+  kubectl --context "$FLUX_CONTEXT" -n "$TARGET_NS" get deploy,pods,svc
+  kubectl --context "$FLUX_CONTEXT" -n flux-system get kustomization "$LIVE_NAME" -o json \
+    | jq '{
+        name: .metadata.name,
+        ready: (([.status.conditions[]? | select(.type=="Ready") | .status] | first) // "Unknown")
+      }'
+}
+
+print_argo_snapshot() {
+  echo
+  echo "[helm-runtime][argo] live deployment snapshot"
+  kubectl --context "$ARGO_CONTEXT" -n "$TARGET_NS" get deploy,pods,svc
+  kubectl --context "$ARGO_CONTEXT" -n argocd get application "$LIVE_NAME" -o json \
+    | jq '{
+        name: .metadata.name,
+        sync: (.status.sync.status // "Unknown"),
+        health: (.status.health.status // "Unknown")
+      }'
+}
+
+echo "[helm-runtime] connected governance + live reconcile proof for helm-paas"
+APP_NAME="$LIVE_NAME" \
+SOURCE_NAME="$LIVE_NAME" \
+KUSTOM_NAME="$LIVE_NAME" \
+EXAMPLE_SLUG="helm-paas" \
+REPO_PATH="./examples/helm-paas" \
+RENDER_TARGET="./examples/helm-paas" \
+TARGET_NS="$TARGET_NS" \
+DEPLOYMENT_NAME="$DEPLOYMENT_NAME" \
+OUT_ROOT="$OUT_ROOT" \
+RECONCILER="$RECONCILER" \
+./examples/demo/e2e-connected-governed-reconcile-helm.sh
+
+case "$RECONCILER" in
+  flux)
+    print_flux_snapshot
+    NEXT_CONTEXT_LINES="  kubectl --context ${FLUX_CONTEXT} -n ${TARGET_NS} get deployment ${DEPLOYMENT_NAME} -o yaml"
+    ;;
+  argo)
+    print_argo_snapshot
+    NEXT_CONTEXT_LINES="  kubectl --context ${ARGO_CONTEXT} -n ${TARGET_NS} get deployment ${DEPLOYMENT_NAME} -o yaml"
+    ;;
+  both)
+    print_flux_snapshot
+    print_argo_snapshot
+    NEXT_CONTEXT_LINES="$(cat <<EOF_BOTH
+  kubectl --context ${FLUX_CONTEXT} -n ${TARGET_NS} get deployment ${DEPLOYMENT_NAME} -o yaml
+  kubectl --context ${ARGO_CONTEXT} -n ${TARGET_NS} get deployment ${DEPLOYMENT_NAME} -o yaml
+EOF_BOTH
+)"
+    ;;
+  *)
+    echo "error: unsupported RECONCILER value: $RECONCILER (expected flux|argo|both)" >&2
+    exit 1
+    ;;
+esac
+
+cat <<EOF
+
+[helm-runtime] next checks
+${NEXT_CONTEXT_LINES}
+  use cub-scout after this when you want the cluster-side ownership/drift view
+EOF

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -23,7 +23,7 @@ The app is `inventory-api`, a Spring Boot 3.3.2 service (Java 21) deployed acros
 | Source-side provenance and ownership | Real | `./examples/springboot-paas/demo-local.sh` |
 | Connected governance path | Real | `./examples/springboot-paas/demo-connected.sh` |
 | Standalone live-cluster app proof | Real | `./bin/create-cluster && ./bin/build-image && ./bin/install-worker && ./verify-e2e.sh` |
-| Block/escalate boundary | Real but client-side | `cub-gen springboot validate-mutation --routes ./operational/field-routes.yaml spring.datasource.url` |
+| Governed route proof (`ALLOW` + `BLOCKED`) | Real but client-side | `./examples/springboot-paas/demo-governed-routes.sh` |
 
 The strongest caveat is enforcement depth, not demo truth. The ownership
 boundary is real and documented, but server-side rejection in ConfigHub is not
@@ -118,6 +118,9 @@ example to learn from spring-platform. They complement each other.
 go build -o ./cub-gen ./cmd/cub-gen
 ./examples/springboot-paas/demo-local.sh
 
+# Governed route proof
+./examples/springboot-paas/demo-governed-routes.sh
+
 # Connected ConfigHub path
 cub auth login
 ./examples/springboot-paas/demo-connected.sh
@@ -192,7 +195,19 @@ This is the **block/escalate** path. The field `spring.datasource.*` is platform
 
 ### Enforcement via validate-mutation
 
-Use `cub-gen springboot validate-mutation` to enforce field routes:
+Use `cub-gen springboot validate-mutation` to enforce field routes directly, or
+run the example-owned wrapper first:
+
+```bash
+./examples/springboot-paas/demo-governed-routes.sh
+```
+
+That wrapper proves both sides of the route boundary:
+
+- `feature.inventory.reservationMode` returns `ALLOWED`
+- `spring.datasource.url` returns `BLOCKED`
+
+If you want the raw commands underneath it:
 
 ```bash
 # Allowed: app-owned field

--- a/examples/springboot-paas/demo-governed-routes.sh
+++ b/examples/springboot-paas/demo-governed-routes.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/springboot-governed-routes}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="$OUT_ROOT/$RUN_ID"
+ROUTES="${ROUTES:-./examples/springboot-paas/operational/field-routes.yaml}"
+ALLOW_FIELD="${ALLOW_FIELD:-feature.inventory.reservationMode}"
+BLOCK_FIELD="${BLOCK_FIELD:-spring.datasource.url}"
+
+mkdir -p "$OUT_DIR"
+
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  echo "[spring-routes] build cub-gen"
+  go build -o ./cub-gen ./cmd/cub-gen
+fi
+
+echo "[spring-routes] proof 1/2: app-owned field stays mutable"
+./cub-gen springboot validate-mutation --routes "$ROUTES" "$ALLOW_FIELD" \
+  | tee "$OUT_DIR/allow.txt"
+
+echo "[spring-routes] proof 2/2: platform-owned field is blocked"
+set +e
+./cub-gen springboot validate-mutation --routes "$ROUTES" "$BLOCK_FIELD" \
+  >"$OUT_DIR/block.txt" 2>&1
+block_exit="$?"
+set -e
+
+if [ "$block_exit" -ne 1 ]; then
+  echo "error: expected blocked mutation exit code 1 for $BLOCK_FIELD, got $block_exit" >&2
+  exit 1
+fi
+
+cat "$OUT_DIR/block.txt"
+
+cat <<EOF
+
+[spring-routes] success
+  allowed field: $ALLOW_FIELD
+  blocked field: $BLOCK_FIELD
+  artifacts: $OUT_DIR
+EOF

--- a/internal/exampletruth/matrix.go
+++ b/internal/exampletruth/matrix.go
@@ -132,10 +132,11 @@ func Collect(root string) (Matrix, error) {
 		case "helm-paas":
 			row.RealLiveProof = RealLivePairedHarness
 			row.ProofRefs.RealLive = []string{
+				"./examples/helm-paas/demo-runtime.sh",
 				"./examples/demo/e2e-connected-governed-reconcile-helm.sh",
 				"./examples/live-reconcile/demo-local.sh",
 			}
-			row.Notes = append(row.Notes, "Real LIVE proof is paired through the live-reconcile harness, not standalone in helm-paas.")
+			row.Notes = append(row.Notes, "Real LIVE proof is exposed through an example-owned helm-paas wrapper, but still uses the shared live-reconcile harness under the hood.")
 		case "springboot-paas":
 			row.RealLiveProof = RealLiveStandalone
 			row.ProofRefs.RealLive = []string{

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,6 +184,7 @@ nav:
       - "Contract Drift Checklist": testing/contract-drift-checklist.md
       - "Current Release Plan (v0.2-preview.2)": releases/v0.2-preview.2-plan.md
       - "Current Ship Checklist (v0.2-preview.2)": releases/v0.2-preview.2-ship-checklist.md
+      - "Draft Release Notes (v0.2-preview.2)": releases/v0.2-preview.2.md
       - "Release Notes (v0.2-preview.1)": releases/v0.2-preview.1.md
       - Decisions:
           - "Sprint 2 Go/No-Go": decisions/2026-03-06-sprint-2-go-no-go.md


### PR DESCRIPTION
## Summary
- add an example-owned `helm-paas` runtime wrapper for connected + live proof
- route starter/docs surfaces to that wrapper so the Helm flagship has a clearer first-run and live-proof path
- update the example truth matrix to reflect the new example-owned live entrypoint

## Why
This advances `#177` by giving `examples/helm-paas` its own live-proof entrypoint instead of making the live story feel external to the example.

## What this does not claim
This does not finish the deeper Kubara/ApplicationSet / multi-layer trace / security-boundary work still called for in `#177`.

## Validation
- `bash -n examples/helm-paas/demo-runtime.sh examples/demo/start-platform-first.sh examples/helm-paas/demo-connected.sh examples/helm-paas/demo-local.sh`
- `go test ./internal/exampletruth ./tools/example-truth-matrix`
- `./test/checks/check-example-truth-matrix.sh`
- `./test/checks/check-docs-entrypoints.sh`
- `./examples/demo/start-platform-first.sh`
