### PR TITLE
docs: remove closed spring blocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
-| Example quality | `#177`, `#178`, `#180`, `#182`, `#185`, `#187`, `#200`, `#202`, `#207`, `#208` |
+| Example quality | `#177`, `#178`, `#180`, `#182`, `#185`, `#187`, `#200`, `#202`, `#208` |
 | CLI/docs | `#232`, `#233`, `#234`, `#237`, `#238`, `#239`, `#240`, `#241`, `#242` |
 | Release gate | `#218`, `#226`, `#227` |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#182`, `#185`, `#187`, `#200`, `#202`, `#207`, `#208`, `#218`, `#226`, `#227`, `#232`, `#233`, `#234`, `#237`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#182`, `#185`, `#187`, `#200`, `#202`, `#208`, `#218`, `#226`, `#227`, `#232`, `#233`, `#234`, `#237`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -56,7 +56,6 @@ Issues:
 - [#187](https://github.com/confighub/cub-gen/issues/187) Kubara-like layered provenance
 - [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
 - [#202](https://github.com/confighub/cub-gen/issues/202) AI-first flagship surfaces
-- [#207](https://github.com/confighub/cub-gen/issues/207) Spring block/escalate proof
 - [#208](https://github.com/confighub/cub-gen/issues/208) Spring embedded-config mutation gap
 
 Required outcome:

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -65,7 +65,6 @@ to the remaining delta if the merged work only covered part of the issue.
 - [ ] `#187` layered provenance across overlays/ApplicationSet/labels
 - [ ] `#200` AI best-practice alignment across examples
 - [ ] `#202` AI-first flagship surfaces
-- [ ] `#207` Spring block/escalate proof
 - [ ] `#208` Spring embedded-config mutation support
 - [ ] `#218` release-environment ConfigHub smoke reliability
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -381,7 +381,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#182`, `#185`, `#187`, `#200`, `#202`, `#207`, `#208`, `#218`, `#226`, `#227`, `#232`, `#233`, `#234`, `#237`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#182`, `#185`, `#187`, `#200`, `#202`, `#208`, `#218`, `#226`, `#227`, `#232`, `#233`, `#234`, `#237`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 


### PR DESCRIPTION
## Summary
- remove closed issue `#207` from the active release surfaces
- keep the release plan, ship checklist, README, and demo guide aligned with the current blocker set

## Why
PR #247 merged and `#207` is now closed. The active release docs should reflect that the remaining Spring gap is `#208`, not the already-landed block/escalate proof.

## Validation
- `./test/checks/check-docs-entrypoints.sh`
- `rg -n "#207|207\]" README.md docs/releases/v0.2-preview.2-plan.md docs/releases/v0.2-preview.2-ship-checklist.md examples/demo/README.md`
