### PR TITLE
[codex] add score governed workload proof

### DIFF
--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -56,6 +56,8 @@ func run(args []string) error {
 		return runGitOps(args[1:])
 	case "bridge":
 		return runBridge(args[1:])
+	case "score":
+		return runScore(args[1:])
 	case "springboot":
 		return runSpringBoot(args[1:])
 	default:

--- a/cmd/cub-gen/score.go
+++ b/cmd/cub-gen/score.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/confighub/cub-gen/internal/score"
+)
+
+func runScore(args []string) error {
+	if len(args) == 0 {
+		printScoreUsage(os.Stderr)
+		return errors.New("score subcommand required")
+	}
+
+	switch args[0] {
+	case "help", "-h", "--help":
+		printScoreUsage(os.Stdout)
+		return nil
+	case "validate-workload":
+		return runScoreValidateWorkload(args[1:])
+	default:
+		printScoreUsage(os.Stderr)
+		return fmt.Errorf("unknown score subcommand: %s", args[0])
+	}
+}
+
+func runScoreValidateWorkload(args []string) error {
+	fs := flag.NewFlagSet("score validate-workload", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage: cub-gen score validate-workload [flags]")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "Validate whether a Score workload stays within the approved workload-class contract.")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "This is a client-side contract check for Score examples and CI paths.")
+		fmt.Fprintln(fs.Output(), "Approved resource types return ALLOW; unapproved resource types return ESCALATE.")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "Examples:")
+		fmt.Fprintln(fs.Output(), "  cub-gen score validate-workload --score ./examples/scoredev-paas/score.yaml --contract ./examples/scoredev-paas/platform/contracts/workload-class.yaml")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "Flags:")
+		fs.PrintDefaults()
+	}
+
+	scorePath := fs.String("score", "", "Path to score.yaml (required)")
+	contractPath := fs.String("contract", "", "Path to workload-class.yaml (required)")
+	jsonOut := fs.Bool("json", false, "Output JSON")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: cub-gen score validate-workload --score <path> --contract <path>")
+	}
+	if strings.TrimSpace(*scorePath) == "" {
+		return errors.New("--score is required")
+	}
+	if strings.TrimSpace(*contractPath) == "" {
+		return errors.New("--contract is required")
+	}
+
+	result, err := score.ValidateWorkload(score.ValidateWorkloadOptions{
+		ScorePath:    *scorePath,
+		ContractPath: *contractPath,
+	})
+	if err != nil {
+		return err
+	}
+
+	if *jsonOut {
+		if err := writeJSON(os.Stdout, result, *pretty); err != nil {
+			return err
+		}
+		if !result.Allowed {
+			return fmt.Errorf("workload requires platform review for resource types: %s", strings.Join(result.UnapprovedResourceTypes, ", "))
+		}
+		return nil
+	}
+
+	sort.Strings(result.ResourceTypes)
+	sort.Strings(result.ApprovedResourceTypes)
+	sort.Strings(result.UnapprovedResourceTypes)
+
+	fmt.Println(result.State)
+	fmt.Printf("  Score:          %s\n", result.ScorePath)
+	fmt.Printf("  Contract:       %s\n", result.ContractPath)
+	if result.WorkloadClass != "" {
+		fmt.Printf("  Workload class: %s\n", result.WorkloadClass)
+	}
+	fmt.Printf("  Resource types: %s\n", strings.Join(result.ResourceTypes, ", "))
+	fmt.Printf("  Approved:       %s\n", strings.Join(result.ApprovedResourceTypes, ", "))
+	fmt.Printf("  Reason:         %s\n", result.Reason)
+
+	if !result.Allowed {
+		fmt.Printf("  Escalated:      %s\n", strings.Join(result.UnapprovedResourceTypes, ", "))
+		return fmt.Errorf("workload requires platform review for resource types: %s", strings.Join(result.UnapprovedResourceTypes, ", "))
+	}
+	return nil
+}
+
+func printScoreUsage(out *os.File) {
+	fmt.Fprintln(out, "Usage: cub-gen score <subcommand> [flags]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Score.dev onboarding and workload-contract checks.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Subcommands:")
+	fmt.Fprintln(out, "  validate-workload  Check if score.yaml resource types stay within the approved workload class")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Run 'cub-gen score <subcommand> --help' for details.")
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -168,6 +168,60 @@ cub-gen bridge promote merge --flow <flow.json> --by <who>
 
 ---
 
+## Generator helper commands
+
+These helper groups are narrower than the main repo-first flow. Use them when a
+generator-specific example wants a local contract check or scaffold step after
+you already know the repo path.
+
+### `score validate-workload`
+
+Check whether a `score.yaml` resource set stays inside the platform-approved
+workload class.
+
+```bash
+cub-gen score validate-workload --score <score.yaml> --contract <workload-class.yaml>
+```
+
+Typical example path:
+
+```bash
+./cub-gen score validate-workload \
+  --score ./examples/scoredev-paas/score.yaml \
+  --contract ./examples/scoredev-paas/platform/contracts/workload-class.yaml
+```
+
+Output:
+
+- `ALLOW` when all declared Score resource types are approved
+- `ESCALATE` when a new resource type needs platform review
+
+### `springboot validate-mutation`
+
+Check whether a Spring field path stays inside the app-owned route map.
+
+```bash
+cub-gen springboot validate-mutation --routes <field-routes.yaml> <field-path>
+```
+
+Typical example path:
+
+```bash
+./cub-gen springboot validate-mutation \
+  --routes ./examples/springboot-paas/operational/field-routes.yaml \
+  feature.inventory.reservationMode
+```
+
+### `springboot init`
+
+Bootstrap the Spring example's operational route files for a repo.
+
+```bash
+cub-gen springboot init [flags] <source-path>
+```
+
+---
+
 ## Generator catalog
 
 ### `generators`

--- a/docs/releases/v0.2-preview.2.md
+++ b/docs/releases/v0.2-preview.2.md
@@ -43,8 +43,10 @@ release-facing proof.
      example-owned governed change wrapper for ALLOW versus BLOCK proof.
    - `springboot-paas` remains the strongest standalone real-app live proof in
      the repo.
-   - `scoredev-paas`, workflow examples, and AI-adjacent examples now have
-     clearer entry surfaces even where deeper acceptance work is still open.
+   - `scoredev-paas` now has an example-owned local governed workload proof for
+     `ALLOW` versus `ESCALATE`, and workflow examples and AI-adjacent examples
+     now have clearer entry surfaces even where deeper acceptance work is still
+     open.
 
 5. The change surface is easier to consume.
    - change CLI and change API flows now prefer repo paths over parity-era
@@ -72,7 +74,6 @@ release-facing proof.
 
 2. Score still needs its strongest end state:
    - standalone live-cluster proof from `score.yaml`
-   - a governed blocked or escalated path that a Score user can inspect
    Ref: `#178`
 
 3. Workflow and AI surfaces are clearer, but not yet fully at the new flagship

--- a/docs/testing/example-truth-matrix.json
+++ b/docs/testing/example-truth-matrix.json
@@ -273,6 +273,9 @@
         "#173",
         "#178",
         "#183"
+      ],
+      "notes": [
+        "Score now has example-owned local governed proof via ./examples/scoredev-paas/demo-governed-workload.sh for ALLOW versus ESCALATE, even though standalone live-cluster proof is still open."
       ]
     },
     {

--- a/docs/testing/example-truth-matrix.md
+++ b/docs/testing/example-truth-matrix.md
@@ -104,6 +104,7 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Connected smoke lane: --
 - Real live: --
 - AI-first: --
+- Notes: Score now has example-owned local governed proof via ./examples/scoredev-paas/demo-governed-workload.sh for ALLOW versus ESCALATE, even though standalone live-cluster proof is still open.
 
 ### `springboot-paas`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ what you already run:
 |---|---|---|---|---|
 | Helm plus Argo/Flux platform repos | `./examples/demo/start-platform-first.sh` | `./examples/helm-paas/demo-governed-change.sh`, then `cub auth login && RECONCILER=argo ./examples/helm-paas/demo-runtime.sh` | values ownership now, local ALLOW/BLOCK proof next, and live Argo/Flux proof from the Helm flagship itself after | Strongest platform-first source-side path today |
 | Spring Boot app repos | `./examples/demo/start-app-first.sh` | `./examples/springboot-paas/demo-governed-routes.sh`, then `cub auth login && ./examples/springboot-paas/demo-connected.sh` | config ownership now, local `ALLOW`/`BLOCKED` route proof next, live `inventory-api` proof after | Strongest standalone end-to-end example in the repo today |
-| Score.dev workloads | `./examples/demo/start-score-first.sh` | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field origin now, governed connected output next | Strongest Score source-side path today; standalone live Score proof is still open work |
+| Score.dev workloads | `./examples/demo/start-score-first.sh` | `./examples/scoredev-paas/demo-governed-workload.sh`, then `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field origin now, local ALLOW/ESCALATE proof next, governed connected output after | Strongest Score source-side path today; standalone live Score proof is still open work |
 | A running cluster and GitOps controller | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | trace one chosen field back to source | live cluster state first, source provenance second | Best when the cluster is already the urgent source of truth |
 
 ## What ends with something live today
@@ -29,7 +29,7 @@ what you already run:
 |---|---|---|---|
 | [`springboot-paas`](./springboot-paas/) | real `inventory-api` app on a kind cluster | `./examples/springboot-paas/verify-e2e.sh` | Standalone live app proof is real |
 | [`helm-paas`](./helm-paas/) | Flux and Argo reconciliation of rendered Helm output plus connected governance evidence | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | Example-owned wrapper, with the shared live-reconcile harness beneath it |
-| [`scoredev-paas`](./scoredev-paas/) | connected governed output plus rendered runtime fields | `./examples/scoredev-paas/demo-connected.sh` | Standalone Score live proof is still open |
+| [`scoredev-paas`](./scoredev-paas/) | local governed contract proof plus connected governed output | `./examples/scoredev-paas/demo-governed-workload.sh` | Standalone Score live proof is still open |
 
 ## Two audiences, one set of wrappers
 
@@ -72,7 +72,7 @@ That split is especially important for:
 |---|---|---|
 | [`helm-paas`](./helm-paas/) | Helm + Argo/Flux + values ownership | Strongest platform-first source-side path, with example-owned ALLOW/BLOCK and runtime wrappers |
 | [`springboot-paas`](./springboot-paas/) | Real app-team + platform-team config ownership | Strongest standalone end-to-end example in the repo today |
-| [`scoredev-paas`](./scoredev-paas/) | Score intent to rendered runtime fields | Strongest Score source-side path today; runtime proof still needs its own standalone finish |
+| [`scoredev-paas`](./scoredev-paas/) | Score intent to rendered runtime fields plus workload-contract escalation | Strongest Score source-side path today, now with example-owned ALLOW/ESCALATE proof; runtime proof still needs its own standalone finish |
 
 ## What happens after import? (Day-2 stories)
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -33,7 +33,7 @@ For workflow and AI example quality, use the
 |---|---|---|---|
 | Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then the example-owned governed-change proof and live wrapper | values ownership now, local ALLOW/BLOCK proof next, connected + live proof after |
 | Spring Boot app repos | `./examples/demo/start-app-first.sh` | local lifecycle for `springboot-paas`, then the example-owned governed-route proof | app-vs-platform config ownership now, local `ALLOW`/`BLOCKED` proof next, standalone live app proof after |
-| Score.dev workloads | `./examples/demo/start-score-first.sh` | Score field trace and inverse edit map | `score.yaml` to runtime-field mapping now, connected governed output after |
+| Score.dev workloads | `./examples/demo/start-score-first.sh` | Score field trace, inverse edit map, and governed workload-contract proof | `score.yaml` to runtime-field mapping now, local ALLOW/ESCALATE proof next, connected governed output after |
 | Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | real Flux and Argo reconciliation on kind | pods, rollout, and drift correction |
 
 Cluster-side follow-on: pair the above with [`cub-scout`](https://github.com/confighub/cub-scout)
@@ -46,7 +46,7 @@ when you want to inspect what is actually running after reconciliation.
 | Spring standalone app path | `inventory-api` on kind plus HTTP verification | `./examples/springboot-paas/verify-e2e.sh` | Strongest standalone app proof |
 | Helm flagship live path | Argo and Flux reconciliation of Helm-derived manifests plus connected governance evidence | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | Example-owned wrapper over the shared live-reconcile harness |
 | Connected smoke | ConfigHub-authenticated flagship bundle/attestation chain | `./examples/demo/run-connected-smoke.sh` | Release-facing connected proof lane |
-| Score path | no standalone live-cluster Score proof yet | `./examples/scoredev-paas/demo-connected.sh` | Honest connected-only flagship for now |
+| Score path | governed workload-contract proof plus connected output, but no standalone live-cluster Score proof yet | `./examples/scoredev-paas/demo-governed-workload.sh` | Honest flagship with local ALLOW/ESCALATE proof and connected next step |
 
 ## 3. Pick your demo by persona
 
@@ -101,6 +101,7 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 | `start-app-first.sh` | [`springboot-paas`](../springboot-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated app-first starter path |
 | `../springboot-paas/demo-governed-routes.sh` | [`springboot-paas`](../springboot-paas/) | App-owned field ALLOW versus platform-owned field BLOCKED with `springboot validate-mutation` |
 | `start-score-first.sh` | [`scoredev-paas`](../scoredev-paas/) | Opinionated Score-first starter path with honest runtime-gap handoff |
+| `../scoredev-paas/demo-governed-workload.sh` | [`scoredev-paas`](../scoredev-paas/) | App-owned image change ALLOW versus unapproved resource type ESCALATE with `score validate-workload` |
 | `module-1-helm-import.sh` | [`helm-paas`](../helm-paas/) | Helm detection, values ownership, field-origin tracing |
 | `module-2-score-field-map.sh` | [`scoredev-paas`](../scoredev-paas/) | Score field-origin and inverse edit mapping |
 | `module-3-spring-ownership.sh` | [`springboot-paas`](../springboot-paas/) | Spring ownership boundaries (app vs platform) |

--- a/examples/demo/start-score-first.sh
+++ b/examples/demo/start-score-first.sh
@@ -7,6 +7,10 @@ cd "$ROOT_DIR"
 echo "[start-score] step 1: keep score.yaml as the app-team contract and trace it to runtime fields"
 ./examples/demo/module-2-score-field-map.sh
 
+echo
+echo "[start-score] step 2: prove app-owned workload changes stay allowed and new resource types escalate"
+./examples/scoredev-paas/demo-governed-workload.sh
+
 cat <<'EOF'
 
 [start-score] next steps
@@ -16,6 +20,7 @@ cat <<'EOF'
 
   what to inspect:
     - local output: score.yaml field origin + inverse edit map
+    - governed output: ALLOW for safe image change, ESCALATE for unapproved resource type
     - connected output: change_id, bundle digest, and decision/query evidence
 
   runtime proof today:

--- a/examples/scoredev-paas/README.md
+++ b/examples/scoredev-paas/README.md
@@ -15,6 +15,7 @@ inverse-edit guidance.
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
 | Source-side Score provenance | Real | `./examples/scoredev-paas/demo-local.sh` |
+| Local governed Score contract proof | Real | `./examples/scoredev-paas/demo-governed-workload.sh` |
 | Connected governance path | Real | `./examples/scoredev-paas/demo-connected.sh` |
 | Standalone Score live app proof | Not yet | still open work in [#178](https://github.com/confighub/cub-gen/issues/178) |
 
@@ -28,7 +29,7 @@ while the Score-specific live path is being finished.
 
 | If you are... | First command | Then do this | What you can inspect |
 |---|---|---|---|
-| Existing Score.dev user | `./examples/scoredev-paas/demo-local.sh` | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field trace now, connected governed output next |
+| Existing Score.dev user | `./examples/scoredev-paas/demo-local.sh` | `./examples/scoredev-paas/demo-governed-workload.sh`, then `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field trace now, local ALLOW/ESCALATE proof next, connected governed output after |
 | Existing ConfigHub user adding Score governance | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `./examples/demo/start-score-first.sh` for the repo-side first-run story | bundle, attestation, and decision evidence plus source mapping |
 | Existing cluster-first operator | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) first | come back to `./examples/scoredev-paas/demo-local.sh` for source provenance | live workload first, Score contract trace second |
 
@@ -39,6 +40,7 @@ Both paths lead to the same outcome: governed Score workloads with field-origin 
 | Step | Command | Inspectable result |
 |---|---|---|
 | Local source-side proof | `./examples/scoredev-paas/demo-local.sh` | `score.yaml` field origin, inverse edit pointers, and rendered targets |
+| Local governed contract proof | `./examples/scoredev-paas/demo-governed-workload.sh` | app-owned image change returns `ALLOW`, unapproved resource type returns `ESCALATE` |
 | Connected governance proof | `./examples/scoredev-paas/demo-connected.sh` | change ID, bundle digest, attestation, and connected decision/query output |
 | Runtime companion today | [`springboot-paas`](../springboot-paas/) or [`live-reconcile`](../live-reconcile/) | current standalone live app proof elsewhere in the repo while Score runtime proof is being finished |
 
@@ -196,6 +198,9 @@ go build -o ./cub-gen ./cmd/cub-gen
 # Local source-side path
 ./examples/scoredev-paas/demo-local.sh
 
+# Local governed contract path
+./examples/scoredev-paas/demo-governed-workload.sh
+
 # Connected ConfigHub path
 cub auth login
 ./examples/scoredev-paas/demo-connected.sh
@@ -259,6 +264,12 @@ allowed to reach Redis?). Both pass → **ALLOW**.
 
 If Redis weren't in the approved resource types, the decision engine would
 **ESCALATE** to the platform owner for review.
+
+You can now prove that branch locally too:
+
+```bash
+./examples/scoredev-paas/demo-governed-workload.sh
+```
 
 ## How it works
 
@@ -376,6 +387,12 @@ resources:
 
 Result: GPU pool not in workload class approved types → **ESCALATE** to platform team
 
+Runnable wrapper for both outcomes:
+
+```bash
+./examples/scoredev-paas/demo-governed-workload.sh
+```
+
 ## Local and Connected Entrypoints
 
 From repo root:
@@ -383,6 +400,7 @@ From repo root:
 ```bash
 # Local/offline
 ./examples/scoredev-paas/demo-local.sh
+./examples/scoredev-paas/demo-governed-workload.sh
 
 # Connected (requires ConfigHub auth)
 cub auth login

--- a/examples/scoredev-paas/demo-governed-workload.sh
+++ b/examples/scoredev-paas/demo-governed-workload.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/scoredev-governed-workload}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="$OUT_ROOT/$RUN_ID"
+WORK_REPO="$OUT_DIR/repo"
+ALLOW_WET_PATH="${ALLOW_WET_PATH:-Deployment/spec/template/spec/containers[name=main]/image}"
+
+mkdir -p "$OUT_DIR"
+rm -rf "$WORK_REPO"
+
+echo "[score-governed] cloning repo into $WORK_REPO"
+git clone --quiet "$ROOT_DIR" "$WORK_REPO"
+
+cd "$WORK_REPO"
+git config user.name "cub-gen demo"
+git config user.email "cub-gen-demo@example.invalid"
+
+echo "[score-governed] build cub-gen once for both workload checks"
+go build -o ./cub-gen ./cmd/cub-gen
+
+echo "[score-governed] proof 1/2: app team updates the image and stays within the approved contract"
+perl -0pi -e 's#ghcr.io/example/checkout-api:v1\.0\.0#ghcr.io/example/checkout-api:v1.0.1#' ./examples/scoredev-paas/score.yaml
+
+./cub-gen change explain --space platform --wet-path "$ALLOW_WET_PATH" ./examples/scoredev-paas > "$OUT_DIR/allow-explain.json"
+./cub-gen score validate-workload \
+  --score ./examples/scoredev-paas/score.yaml \
+  --contract ./examples/scoredev-paas/platform/contracts/workload-class.yaml \
+  > "$OUT_DIR/allow.txt"
+
+echo "[score-governed][allow] inverse edit guidance"
+jq '{
+  owner: .explanation.owner,
+  wet_path: .explanation.wet_path,
+  dry_path: .explanation.dry_path,
+  source_path: .explanation.source_path,
+  confidence: .explanation.confidence,
+  edit_hint: .explanation.edit_hint
+}' "$OUT_DIR/allow-explain.json"
+
+echo "[score-governed][allow] workload contract result"
+cat "$OUT_DIR/allow.txt"
+
+echo "[score-governed] proof 2/2: app team adds an unapproved resource type"
+perl -0pi -e 's/  dns:\n    type: dns/  dns:\n    type: dns\n  ml-gpu:\n    type: gpu-pool/' ./examples/scoredev-paas/score.yaml
+
+set +e
+./cub-gen score validate-workload \
+  --score ./examples/scoredev-paas/score.yaml \
+  --contract ./examples/scoredev-paas/platform/contracts/workload-class.yaml \
+  > "$OUT_DIR/escalate.txt" 2>&1
+escalate_exit="$?"
+set -e
+
+if [ "$escalate_exit" -ne 1 ]; then
+  echo "error: expected ESCALATE path to exit 1, got $escalate_exit" >&2
+  exit 1
+fi
+
+echo "[score-governed][escalate] workload contract result"
+cat "$OUT_DIR/escalate.txt"
+
+cat <<EOF
+
+[score-governed] success
+  allowed path: image change stays app-owned and workload contract returns ALLOW
+  escalate path: unapproved resource type requires platform review
+  artifacts: $OUT_DIR
+EOF

--- a/examples/scoredev-paas/platform/contracts/workload-class.yaml
+++ b/examples/scoredev-paas/platform/contracts/workload-class.yaml
@@ -14,3 +14,7 @@ spec:
     requests:
       cpu: 100m
       memory: 128Mi
+  approvedResourceTypes:
+    - postgres
+    - redis
+    - dns

--- a/internal/exampletruth/matrix.go
+++ b/internal/exampletruth/matrix.go
@@ -154,6 +154,8 @@ func Collect(root string) (Matrix, error) {
 				"./examples/demo/e2e-connected-governed-reconcile-helm.sh",
 			}
 			row.Notes = append(row.Notes, "Runtime harness for WET->LIVE proof; source-side generator proof lives in paired examples.")
+		case "scoredev-paas":
+			row.Notes = append(row.Notes, "Score now has example-owned local governed proof via ./examples/scoredev-paas/demo-governed-workload.sh for ALLOW versus ESCALATE, even though standalone live-cluster proof is still open.")
 		}
 
 		if _, ok := aiExplicit[slug]; ok {

--- a/internal/score/validation.go
+++ b/internal/score/validation.go
@@ -1,0 +1,159 @@
+package score
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type scoreDocument struct {
+	Resources map[string]scoreResourceSpec `yaml:"resources"`
+}
+
+type scoreResourceSpec struct {
+	Type string `yaml:"type"`
+}
+
+type workloadClassDocument struct {
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		ApprovedResourceTypes []string `yaml:"approvedResourceTypes"`
+	} `yaml:"spec"`
+}
+
+type ValidationResult struct {
+	ScorePath               string   `json:"score_path"`
+	ContractPath            string   `json:"contract_path"`
+	WorkloadClass           string   `json:"workload_class"`
+	State                   string   `json:"state"`
+	Allowed                 bool     `json:"allowed"`
+	ResourceTypes           []string `json:"resource_types"`
+	ApprovedResourceTypes   []string `json:"approved_resource_types"`
+	UnapprovedResourceTypes []string `json:"unapproved_resource_types,omitempty"`
+	Reason                  string   `json:"reason"`
+}
+
+type ValidateWorkloadOptions struct {
+	ScorePath    string
+	ContractPath string
+}
+
+func ValidateWorkload(opts ValidateWorkloadOptions) (*ValidationResult, error) {
+	if strings.TrimSpace(opts.ScorePath) == "" {
+		return nil, fmt.Errorf("score_path is required")
+	}
+	if strings.TrimSpace(opts.ContractPath) == "" {
+		return nil, fmt.Errorf("contract_path is required")
+	}
+
+	scorePath, err := filepath.Abs(opts.ScorePath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve score path: %w", err)
+	}
+	contractPath, err := filepath.Abs(opts.ContractPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve contract path: %w", err)
+	}
+
+	scoreData, err := os.ReadFile(scorePath)
+	if err != nil {
+		return nil, fmt.Errorf("read score file: %w", err)
+	}
+	contractData, err := os.ReadFile(contractPath)
+	if err != nil {
+		return nil, fmt.Errorf("read contract file: %w", err)
+	}
+
+	var scoreDoc scoreDocument
+	if err := yaml.Unmarshal(scoreData, &scoreDoc); err != nil {
+		return nil, fmt.Errorf("parse score file: %w", err)
+	}
+	var contractDoc workloadClassDocument
+	if err := yaml.Unmarshal(contractData, &contractDoc); err != nil {
+		return nil, fmt.Errorf("parse contract file: %w", err)
+	}
+
+	resourceTypes := collectResourceTypes(scoreDoc.Resources)
+	approved := uniqueSortedStrings(contractDoc.Spec.ApprovedResourceTypes)
+	if len(approved) == 0 {
+		return nil, fmt.Errorf("contract %s does not declare spec.approvedResourceTypes", opts.ContractPath)
+	}
+
+	approvedSet := make(map[string]struct{}, len(approved))
+	for _, item := range approved {
+		approvedSet[item] = struct{}{}
+	}
+
+	unapproved := make([]string, 0)
+	for _, item := range resourceTypes {
+		if _, ok := approvedSet[item]; !ok {
+			unapproved = append(unapproved, item)
+		}
+	}
+
+	result := &ValidationResult{
+		ScorePath:               scorePath,
+		ContractPath:            contractPath,
+		WorkloadClass:           strings.TrimSpace(contractDoc.Metadata.Name),
+		ResourceTypes:           resourceTypes,
+		ApprovedResourceTypes:   approved,
+		UnapprovedResourceTypes: unapproved,
+	}
+
+	if len(unapproved) == 0 {
+		result.State = "ALLOW"
+		result.Allowed = true
+		result.Reason = "All declared Score resource types are approved by the workload class."
+		return result, nil
+	}
+
+	result.State = "ESCALATE"
+	result.Allowed = false
+	result.Reason = fmt.Sprintf(
+		"Resource types %s are outside the approved workload-class allow list and require platform review.",
+		strings.Join(unapproved, ", "),
+	)
+	return result, nil
+}
+
+func collectResourceTypes(resources map[string]scoreResourceSpec) []string {
+	if len(resources) == 0 {
+		return nil
+	}
+	types := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		item := strings.TrimSpace(resource.Type)
+		if item == "" {
+			continue
+		}
+		types = append(types, item)
+	}
+	return uniqueSortedStrings(types)
+}
+
+func uniqueSortedStrings(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/score/validation_test.go
+++ b/internal/score/validation_test.go
@@ -1,0 +1,76 @@
+package score
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateWorkloadAllowExample(t *testing.T) {
+	result, err := ValidateWorkload(ValidateWorkloadOptions{
+		ScorePath:    filepath.Join("..", "..", "examples", "scoredev-paas", "score.yaml"),
+		ContractPath: filepath.Join("..", "..", "examples", "scoredev-paas", "platform", "contracts", "workload-class.yaml"),
+	})
+	if err != nil {
+		t.Fatalf("ValidateWorkload() error = %v", err)
+	}
+	if !result.Allowed || result.State != "ALLOW" {
+		t.Fatalf("expected ALLOW result, got %+v", result)
+	}
+	if got, want := strings.Join(result.ResourceTypes, ","), "dns,postgres,redis"; got != want {
+		t.Fatalf("resource types = %q, want %q", got, want)
+	}
+	if len(result.UnapprovedResourceTypes) != 0 {
+		t.Fatalf("expected no unapproved resource types, got %+v", result.UnapprovedResourceTypes)
+	}
+}
+
+func TestValidateWorkloadEscalateForUnapprovedResourceType(t *testing.T) {
+	dir := t.TempDir()
+	scorePath := filepath.Join(dir, "score.yaml")
+	contractPath := filepath.Join(dir, "workload-class.yaml")
+
+	scoreYAML := `apiVersion: score.dev/v1b1
+kind: Workload
+metadata:
+  name: checkout-api
+resources:
+  db:
+    type: postgres
+  cache:
+    type: redis
+  ml-gpu:
+    type: gpu-pool
+`
+	contractYAML := `apiVersion: platform.confighub.io/v1alpha1
+kind: WorkloadClass
+metadata:
+  name: web-api-standard
+spec:
+  approvedResourceTypes:
+    - postgres
+    - redis
+    - dns
+`
+	if err := os.WriteFile(scorePath, []byte(scoreYAML), 0o644); err != nil {
+		t.Fatalf("write score file: %v", err)
+	}
+	if err := os.WriteFile(contractPath, []byte(contractYAML), 0o644); err != nil {
+		t.Fatalf("write contract file: %v", err)
+	}
+
+	result, err := ValidateWorkload(ValidateWorkloadOptions{
+		ScorePath:    scorePath,
+		ContractPath: contractPath,
+	})
+	if err != nil {
+		t.Fatalf("ValidateWorkload() error = %v", err)
+	}
+	if result.Allowed || result.State != "ESCALATE" {
+		t.Fatalf("expected ESCALATE result, got %+v", result)
+	}
+	if got, want := strings.Join(result.UnapprovedResourceTypes, ","), "gpu-pool"; got != want {
+		t.Fatalf("unapproved resource types = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What changed

This adds an example-owned local governed proof path for `scoredev-paas` and wires it into the repo-facing surfaces.

- adds `cub-gen score validate-workload` for client-side Score workload-class checks
- adds `internal/score` validation logic and tests
- adds `./examples/scoredev-paas/demo-governed-workload.sh` to prove:
  - image change stays app-owned and returns `ALLOW`
  - unapproved resource type returns `ESCALATE`
- updates the Score starter/docs surfaces to teach `demo-local -> demo-governed-workload -> demo-connected`
- updates the CLI reference and generated example truth matrix notes so the new proof is visible in release-facing docs
- tightens the `scoredev-paas` workload-class contract with explicit `approvedResourceTypes`

## Why

`#178` was still missing an example-owned governed path that a Score user could run and inspect. This narrows that issue from "no local governed proof" to the remaining standalone live-cluster proof gap.

## User impact

Score users now have a clearer first-run path:

1. trace `score.yaml` to rendered fields
2. prove a safe app-owned change returns `ALLOW`
3. prove a new resource type escalates for platform review
4. move to connected ConfigHub proof when ready

This makes the `cub-gen` CLI purpose clearer too: start in the repo, understand what to edit, then ask for governance.

## Validation

- `go test ./...`
- `go run ./cmd/cub-gen score --help`
- `go run ./cmd/cub-gen score validate-workload --score ./examples/scoredev-paas/score.yaml --contract ./examples/scoredev-paas/platform/contracts/workload-class.yaml`
- `./test/checks/check-example-truth-matrix.sh`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`
- `bash ./examples/scoredev-paas/demo-governed-workload.sh`
- `bash ./examples/demo/start-score-first.sh`

Closes part of #178.