### PR TITLE
[codex] sync v0.2-preview.2 release trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
-| Example quality | `#177`, `#178`, `#180`, `#182`, `#185`, `#187`, `#200`, `#202`, `#207`, `#208` |
-| CLI/docs | `#232`, `#233`, `#234`, `#237`, `#238`, `#239`, `#240`, `#241`, `#242` |
-| Release gate | `#218`, `#226`, `#227` |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#182`, `#185`, `#187`, `#200`, `#202`, `#207`, `#208`, `#218`, `#226`, `#227`, `#232`, `#233`, `#234`, `#237`-`#242` |
+| Example quality | `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#208` |
+| CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
+| Release gate | `#218`, `#226` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#208`, `#218`, `#226`, `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -26,7 +26,7 @@ For `v0.2-preview.2`, that means:
 
 Goal: the first commands a user sees should work exactly as documented.
 
-Issues:
+Landed on `main`:
 
 - [#232](https://github.com/confighub/cub-gen/issues/232) README structure
 - [#233](https://github.com/confighub/cub-gen/issues/233) help-text duplication
@@ -46,18 +46,21 @@ Required outcome:
 Goal: "all examples working well" means the whole catalog is trustworthy, not
 only the flagship path.
 
-Issues:
+Current open issues:
 
 - [#177](https://github.com/confighub/cub-gen/issues/177) Helm flagship
-- [#178](https://github.com/confighub/cub-gen/issues/178) Score flagship
+- [#178](https://github.com/confighub/cub-gen/issues/178) Score flagship remaining standalone live proof
 - [#180](https://github.com/confighub/cub-gen/issues/180) workflow examples
-- [#182](https://github.com/confighub/cub-gen/issues/182) entrypoint redesign
 - [#185](https://github.com/confighub/cub-gen/issues/185) custom-generator onboarding
 - [#187](https://github.com/confighub/cub-gen/issues/187) Kubara-like layered provenance
 - [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
 - [#202](https://github.com/confighub/cub-gen/issues/202) AI-first flagship surfaces
-- [#207](https://github.com/confighub/cub-gen/issues/207) Spring block/escalate proof
 - [#208](https://github.com/confighub/cub-gen/issues/208) Spring embedded-config mutation gap
+
+Landed on `main`:
+
+- [#182](https://github.com/confighub/cub-gen/issues/182) entrypoint redesign
+- [#207](https://github.com/confighub/cub-gen/issues/207) Spring block/escalate proof
 
 Required outcome:
 
@@ -75,10 +78,13 @@ Required outcome:
 Goal: decide what the connected release gate really proves, then make it
 credible.
 
-Issues:
+Current open issues:
 
 - [#218](https://github.com/confighub/cub-gen/issues/218) provision secrets and get a green connected run
 - [#226](https://github.com/confighub/cub-gen/issues/226) standard ConfigHub API/CLI over custom bridge endpoints
+
+Landed on `main`:
+
 - [#227](https://github.com/confighub/cub-gen/issues/227) rethink the size and purpose of `ci-connected`
 
 Required outcome:
@@ -110,9 +116,9 @@ Required outcome:
 
 ## Planned release sequence
 
-1. Land the CLI/docs truth pass.
-2. Land the full example-catalog sweep and entrypoint cleanup.
-3. Decide and implement the connected release-gate shape.
+1. Finalize the remaining flagship example gaps and issue narrowing.
+2. Confirm the release-environment connected smoke lane.
+3. Run strict docs/help checks from the release environment.
 4. Cut `v0.2-preview.2` release notes from a green `main`.
 
 ## Post-release backlog

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -29,6 +29,9 @@ exit-bar rationale still live in
   optional lane instead of one oversized release gate.
 - Example READMEs and central docs now say what is proven today, what to run
   first, and what is still partial.
+- `scoredev-paas` now has an example-owned local governed proof path with
+  `ALLOW` versus `ESCALATE`; the remaining Score gap is standalone live-cluster
+  proof.
 - The change API and demo flows now prefer repo paths over parity-era slug-only
   inputs.
 
@@ -41,33 +44,30 @@ exit-bar rationale still live in
 - [ ] Confirm the current connected smoke lane passes in the intended
   secrets-backed release environment.
 
-## Issue triage after #243
+## Issue state after #249
 
-### Likely close or narrow now
+### Closed or landed on `main`
 
-- [ ] `#232` README structure
-- [ ] `#233` help-text duplication
-- [ ] `#234` remove stale prototype framing
-- [ ] `#237` explain current variants/overlays behavior clearly
-- [ ] `#226` standard ConfigHub API/CLI over custom bridge endpoints
-- [ ] `#227` rethink the size and purpose of `ci-connected`
-
-These should be reviewed against `main` and either closed as landed, or narrowed
-to the remaining delta if the merged work only covered part of the issue.
+- [x] `#182` example/demo entrypoint redesign
+- [x] `#207` Spring block/escalate proof
+- [x] `#227` rethink the size and purpose of `ci-connected`
+- [x] `#232` README structure
+- [x] `#233` help-text duplication
+- [x] `#234` remove stale prototype framing
+- [x] `#237` explain current variants/overlays behavior clearly
 
 ### Still true release blockers
 
 - [ ] `#177` Helm flagship example
-- [ ] `#178` Score flagship example
+- [ ] `#178` Score flagship remaining standalone live proof
 - [ ] `#180` workflow example upgrade
-- [ ] `#182` example/demo entrypoint redesign
 - [ ] `#185` custom-generator onboarding
 - [ ] `#187` layered provenance across overlays/ApplicationSet/labels
 - [ ] `#200` AI best-practice alignment across examples
 - [ ] `#202` AI-first flagship surfaces
-- [ ] `#207` Spring block/escalate proof
 - [ ] `#208` Spring embedded-config mutation support
 - [ ] `#218` release-environment ConfigHub smoke reliability
+- [ ] `#226` standard ConfigHub API/CLI over custom bridge endpoints
 
 For this preview, "all examples working well" means each featured example has:
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -382,7 +382,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#182`, `#185`, `#187`, `#200`, `#202`, `#207`, `#208`, `#218`, `#226`, `#227`, `#232`, `#233`, `#234`, `#237`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#208`, `#218`, `#226`, `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 


### PR DESCRIPTION
## What changed

This cleans up the active release-tracking surfaces after the recent merges.

- removes closed issues from the README and demo status tables
- updates the release plan to separate landed work from still-open work
- updates the ship checklist from the old `#243` triage framing to the current post-`#249` blocker set
- narrows Score wording so the remaining gap is described as standalone live-cluster proof, not the already-landed governed path

## Why

`main` was still advertising several closed issues as active blockers (`#182`, `#207`, `#227`, `#232`, `#233`, `#234`, `#237`). That makes the release board noisier than it needs to be and makes it harder to see the real remaining work.

## Validation

- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`
- issue-state verification via `gh issue view` for the updated tracker list
