### PR TITLE
[codex] support direct Spring embedded config mutation

### DIFF
--- a/cmd/cub-gen/springboot.go
+++ b/cmd/cub-gen/springboot.go
@@ -22,6 +22,8 @@ func runSpringBoot(args []string) error {
 		return nil
 	case "init":
 		return runSpringBootInit(args[1:])
+	case "set-embedded-config":
+		return runSpringBootSetEmbeddedConfig(args[1:])
 	case "validate-mutation":
 		return runSpringBootValidateMutation(args[1:])
 	default:
@@ -205,6 +207,118 @@ func runSpringBootValidateMutation(args []string) error {
 	return fmt.Errorf("mutation to %s is blocked by field routes", result.FieldPath)
 }
 
+func runSpringBootSetEmbeddedConfig(args []string) error {
+	fs := flag.NewFlagSet("springboot set-embedded-config", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage: cub-gen springboot set-embedded-config [flags] <field-path> <value>")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "Set a field inside ConfigMap.data[\"application.yaml\"] (or another config key)")
+		fmt.Fprintln(fs.Output(), "for a Spring Boot ConfigHub payload or rendered ConfigMap file.")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "Examples:")
+		fmt.Fprintln(fs.Output(), "  # Allowed: update the app-owned reservation mode directly in the embedded payload")
+		fmt.Fprintln(fs.Output(), "  cub-gen springboot set-embedded-config --routes ./operational/field-routes.yaml --file ./confighub/inventory-api-prod.yaml --configmap inventory-api-config feature.inventory.reservationMode optimistic")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "  # Blocked: platform-owned datasource field")
+		fmt.Fprintln(fs.Output(), "  cub-gen springboot set-embedded-config --routes ./operational/field-routes.yaml --file ./confighub/inventory-api-prod.yaml --configmap inventory-api-config spring.datasource.url jdbc:postgresql://shadow.platform.svc:5432/inventory")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "Flags:")
+		fs.PrintDefaults()
+	}
+
+	filePath := fs.String("file", "", "Path to a Spring ConfigHub payload YAML or ConfigMap YAML (required)")
+	configMapName := fs.String("configmap", "", "ConfigMap name to edit (optional when exactly one ConfigMap matches)")
+	configKey := fs.String("config-key", "application.yaml", "Embedded config key inside the ConfigMap data section")
+	routesPath := fs.String("routes", "", "Optional path to field-routes.yaml for ownership validation before editing")
+	jsonOut := fs.Bool("json", false, "Output JSON")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	if fs.NArg() != 2 {
+		return errors.New("usage: cub-gen springboot set-embedded-config --file <path> [--configmap <name>] [--config-key <key>] [--routes <path>] <field-path> <value>")
+	}
+	if *filePath == "" {
+		return errors.New("--file is required")
+	}
+
+	result, err := springboot.SetEmbeddedConfig(springboot.SetEmbeddedConfigOptions{
+		FilePath:        *filePath,
+		ConfigMapName:   *configMapName,
+		ConfigKey:       *configKey,
+		FieldRoutesPath: *routesPath,
+		FieldPath:       fs.Arg(0),
+		Value:           fs.Arg(1),
+	})
+	if err != nil {
+		return err
+	}
+
+	if *jsonOut {
+		if err := writeJSON(os.Stdout, result, *pretty); err != nil {
+			return err
+		}
+		if !result.Allowed {
+			return fmt.Errorf("mutation to %s is blocked by field routes", result.FieldPath)
+		}
+		return nil
+	}
+
+	if result.Allowed {
+		fmt.Println("UPDATED")
+		fmt.Printf("  File:      %s\n", result.FilePath)
+		if result.ConfigMapName != "" {
+			fmt.Printf("  ConfigMap: %s\n", result.ConfigMapName)
+		}
+		fmt.Printf("  Key:       %s\n", result.ConfigKey)
+		fmt.Printf("  Field:     %s\n", result.FieldPath)
+		if result.Owner != "" {
+			fmt.Printf("  Owner:     %s\n", result.Owner)
+		}
+		if result.Action != "" {
+			fmt.Printf("  Action:    %s\n", result.Action)
+		}
+		if result.MatchedRule != "" {
+			fmt.Printf("  Rule:      %s\n", result.MatchedRule)
+		}
+		if result.OldValue != "" || result.NewValue != "" {
+			fmt.Printf("  Old:       %s\n", result.OldValue)
+			fmt.Printf("  New:       %s\n", result.NewValue)
+		}
+		if result.Reason != "" {
+			fmt.Printf("  Reason:    %s\n", result.Reason)
+		}
+		return nil
+	}
+
+	fmt.Println("BLOCKED")
+	fmt.Printf("  File:      %s\n", result.FilePath)
+	if result.ConfigMapName != "" {
+		fmt.Printf("  ConfigMap: %s\n", result.ConfigMapName)
+	}
+	fmt.Printf("  Key:       %s\n", result.ConfigKey)
+	fmt.Printf("  Field:     %s\n", result.FieldPath)
+	if result.Owner != "" {
+		fmt.Printf("  Owner:     %s\n", result.Owner)
+	}
+	if result.Action != "" {
+		fmt.Printf("  Action:    %s\n", result.Action)
+	}
+	if result.MatchedRule != "" {
+		fmt.Printf("  Rule:      %s\n", result.MatchedRule)
+	}
+	if result.Reason != "" {
+		fmt.Printf("  Reason:    %s\n", result.Reason)
+	}
+	return fmt.Errorf("mutation to %s is blocked by field routes", result.FieldPath)
+}
+
 func printSpringBootUsage(out *os.File) {
 	fmt.Fprintln(out, "Usage: cub-gen springboot <subcommand> [flags]")
 	fmt.Fprintln(out)
@@ -212,6 +326,7 @@ func printSpringBootUsage(out *os.File) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Subcommands:")
 	fmt.Fprintln(out, "  init               Generate starter cub-gen material for a Spring Boot app")
+	fmt.Fprintln(out, "  set-embedded-config Edit an embedded application.yaml field inside a ConfigMap payload")
 	fmt.Fprintln(out, "  validate-mutation  Check if a field mutation is allowed by field-routes.yaml")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Run 'cub-gen springboot <subcommand> --help' for details.")

--- a/cmd/cub-gen/springboot_command_test.go
+++ b/cmd/cub-gen/springboot_command_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSpringBootSetEmbeddedConfigJSON(t *testing.T) {
+	sourcePath := filepath.Join("..", "..", "examples", "springboot-paas", "confighub", "inventory-api-prod.yaml")
+	routesPath := filepath.Join("..", "..", "examples", "springboot-paas", "operational", "field-routes.yaml")
+	tempPath := filepath.Join(t.TempDir(), "inventory-api-prod.yaml")
+
+	raw, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source fixture: %v", err)
+	}
+	if err := os.WriteFile(tempPath, raw, 0o644); err != nil {
+		t.Fatalf("write temp fixture: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"springboot", "set-embedded-config",
+		"--file", tempPath,
+		"--configmap", "inventory-api-config",
+		"--routes", routesPath,
+		"--json",
+		"feature.inventory.reservationMode",
+		"optimistic",
+	})
+	if err != nil {
+		t.Fatalf("set-embedded-config returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal output: %v\noutput=%s", err, out)
+	}
+	if allowed, ok := got["allowed"].(bool); !ok || !allowed {
+		t.Fatalf("expected allowed=true, got %v", got["allowed"])
+	}
+	if action, ok := got["action"].(string); !ok || action != "mutable-in-ch" {
+		t.Fatalf("expected action mutable-in-ch, got %v", got["action"])
+	}
+	if oldValue, ok := got["old_value"].(string); !ok || oldValue != "strict" {
+		t.Fatalf("expected old_value=strict, got %v", got["old_value"])
+	}
+	if newValue, ok := got["new_value"].(string); !ok || newValue != "optimistic" {
+		t.Fatalf("expected new_value=optimistic, got %v", got["new_value"])
+	}
+}
+
+func TestSpringBootSetEmbeddedConfigBlocked(t *testing.T) {
+	sourcePath := filepath.Join("..", "..", "examples", "springboot-paas", "confighub", "inventory-api-prod.yaml")
+	routesPath := filepath.Join("..", "..", "examples", "springboot-paas", "operational", "field-routes.yaml")
+	tempPath := filepath.Join(t.TempDir(), "inventory-api-prod.yaml")
+
+	raw, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source fixture: %v", err)
+	}
+	if err := os.WriteFile(tempPath, raw, 0o644); err != nil {
+		t.Fatalf("write temp fixture: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"springboot", "set-embedded-config",
+		"--file", tempPath,
+		"--configmap", "inventory-api-config",
+		"--routes", routesPath,
+		"spring.datasource.url",
+		"jdbc:postgresql://shadow.platform.svc:5432/inventory",
+	})
+	if err == nil {
+		t.Fatal("expected blocked mutation error")
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(out, "BLOCKED") {
+		t.Fatalf("expected BLOCKED output, got %q", out)
+	}
+	if !strings.Contains(err.Error(), "blocked by field routes") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -212,6 +212,28 @@ Typical example path:
   feature.inventory.reservationMode
 ```
 
+### `springboot set-embedded-config`
+
+Set a field directly inside `ConfigMap.data["application.yaml"]` for a Spring
+ConfigHub payload or rendered ConfigMap file.
+
+```bash
+cub-gen springboot set-embedded-config --file <payload.yaml> [--configmap <name>] [--config-key application.yaml] [--routes <field-routes.yaml>] <field-path> <value>
+```
+
+Typical example path:
+
+```bash
+./cub-gen springboot set-embedded-config \
+  --routes ./examples/springboot-paas/operational/field-routes.yaml \
+  --file ./examples/springboot-paas/confighub/inventory-api-prod.yaml \
+  --configmap inventory-api-config \
+  feature.inventory.reservationMode optimistic
+```
+
+Use `--routes` when you want the command to enforce the same app-owned versus
+platform-owned boundary as `validate-mutation` before writing the file.
+
 ### `springboot init`
 
 Bootstrap the Spring example's operational route files for a repo.

--- a/docs/releases/v0.2-preview.2.md
+++ b/docs/releases/v0.2-preview.2.md
@@ -42,7 +42,8 @@ release-facing proof.
    - `helm-paas` now has an example-owned connected + live wrapper and an
      example-owned governed change wrapper for ALLOW versus BLOCK proof.
    - `springboot-paas` remains the strongest standalone real-app live proof in
-     the repo.
+     the repo, and now has direct embedded ConfigHub payload mutation proof for
+     the app-owned Spring config path.
    - `scoredev-paas` now has an example-owned local governed workload proof for
      `ALLOW` versus `ESCALATE`, and workflow examples and AI-adjacent examples
      now have clearer entry surfaces even where deeper acceptance work is still
@@ -80,11 +81,7 @@ release-facing proof.
    bar for runnable platform stories and AI-first acceptance.
    Refs: `#180`, `#200`, `#202`
 
-4. Spring now has example-owned `ALLOW` versus `BLOCKED` route proof, but the
-   direct embedded-config mutation path is still the notable gap.
-   Ref: `#208`
-
-5. The release environment still needs the final secrets-backed connected smoke
+4. The release environment still needs the final secrets-backed connected smoke
    confirmation for the intended tag environment.
    Refs: `#218`, `#226`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ what you already run:
 | If you already run... | Start here | Then do this | What you can inspect | Current truth |
 |---|---|---|---|---|
 | Helm plus Argo/Flux platform repos | `./examples/demo/start-platform-first.sh` | `./examples/helm-paas/demo-governed-change.sh`, then `cub auth login && RECONCILER=argo ./examples/helm-paas/demo-runtime.sh` | values ownership now, local ALLOW/BLOCK proof next, and live Argo/Flux proof from the Helm flagship itself after | Strongest platform-first source-side path today |
-| Spring Boot app repos | `./examples/demo/start-app-first.sh` | `./examples/springboot-paas/demo-governed-routes.sh`, then `cub auth login && ./examples/springboot-paas/demo-connected.sh` | config ownership now, local `ALLOW`/`BLOCKED` route proof next, live `inventory-api` proof after | Strongest standalone end-to-end example in the repo today |
+| Spring Boot app repos | `./examples/demo/start-app-first.sh` | `./examples/springboot-paas/demo-embedded-config-mutation.sh`, then `cub auth login && ./examples/springboot-paas/demo-connected.sh` | config ownership now, direct embedded apply-here proof next, live `inventory-api` proof after | Strongest standalone end-to-end example in the repo today |
 | Score.dev workloads | `./examples/demo/start-score-first.sh` | `./examples/scoredev-paas/demo-governed-workload.sh`, then `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field origin now, local ALLOW/ESCALATE proof next, governed connected output after | Strongest Score source-side path today; standalone live Score proof is still open work |
 | A running cluster and GitOps controller | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | trace one chosen field back to source | live cluster state first, source provenance second | Best when the cluster is already the urgent source of truth |
 
@@ -71,7 +71,7 @@ That split is especially important for:
 | Example | Best current answer for | Current trust level |
 |---|---|---|
 | [`helm-paas`](./helm-paas/) | Helm + Argo/Flux + values ownership | Strongest platform-first source-side path, with example-owned ALLOW/BLOCK and runtime wrappers |
-| [`springboot-paas`](./springboot-paas/) | Real app-team + platform-team config ownership | Strongest standalone end-to-end example in the repo today |
+| [`springboot-paas`](./springboot-paas/) | Real app-team + platform-team config ownership | Strongest standalone end-to-end example in the repo today, now with direct embedded ConfigHub payload mutation proof |
 | [`scoredev-paas`](./scoredev-paas/) | Score intent to rendered runtime fields plus workload-contract escalation | Strongest Score source-side path today, now with example-owned ALLOW/ESCALATE proof; runtime proof still needs its own standalone finish |
 
 ## What happens after import? (Day-2 stories)

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -32,7 +32,7 @@ For workflow and AI example quality, use the
 | If you already run... | Start here | What actually runs | What you can inspect next |
 |---|---|---|---|
 | Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then the example-owned governed-change proof and live wrapper | values ownership now, local ALLOW/BLOCK proof next, connected + live proof after |
-| Spring Boot app repos | `./examples/demo/start-app-first.sh` | local lifecycle for `springboot-paas`, then the example-owned governed-route proof | app-vs-platform config ownership now, local `ALLOW`/`BLOCKED` proof next, standalone live app proof after |
+| Spring Boot app repos | `./examples/demo/start-app-first.sh` | local lifecycle for `springboot-paas`, then the example-owned embedded payload mutation proof | app-vs-platform config ownership now, direct embedded apply-here proof next, standalone live app proof after |
 | Score.dev workloads | `./examples/demo/start-score-first.sh` | Score field trace, inverse edit map, and governed workload-contract proof | `score.yaml` to runtime-field mapping now, local ALLOW/ESCALATE proof next, connected governed output after |
 | Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | real Flux and Argo reconciliation on kind | pods, rollout, and drift correction |
 
@@ -100,6 +100,7 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 | `../helm-paas/demo-governed-change.sh` | [`helm-paas`](../helm-paas/) | App-team ALLOW path vs platform-contract BLOCK path with the real PR ownership gate |
 | `start-app-first.sh` | [`springboot-paas`](../springboot-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated app-first starter path |
 | `../springboot-paas/demo-governed-routes.sh` | [`springboot-paas`](../springboot-paas/) | App-owned field ALLOW versus platform-owned field BLOCKED with `springboot validate-mutation` |
+| `../springboot-paas/demo-embedded-config-mutation.sh` | [`springboot-paas`](../springboot-paas/) | Direct embedded `application.yaml` mutation in the ConfigHub payload plus blocked datasource proof |
 | `start-score-first.sh` | [`scoredev-paas`](../scoredev-paas/) | Opinionated Score-first starter path with honest runtime-gap handoff |
 | `../scoredev-paas/demo-governed-workload.sh` | [`scoredev-paas`](../scoredev-paas/) | App-owned image change ALLOW versus unapproved resource type ESCALATE with `score validate-workload` |
 | `module-1-helm-import.sh` | [`helm-paas`](../helm-paas/) | Helm detection, values ownership, field-origin tracing |

--- a/examples/demo/start-app-first.sh
+++ b/examples/demo/start-app-first.sh
@@ -10,6 +10,9 @@ echo "[start-app] step 1: Spring config ownership and provenance"
 cat <<'EOF'
 
 [start-app] next steps
+  embedded apply-here proof:
+    ./examples/springboot-paas/demo-embedded-config-mutation.sh
+
   governed route proof:
     ./examples/springboot-paas/demo-governed-routes.sh
 

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -24,6 +24,7 @@ The app is `inventory-api`, a Spring Boot 3.3.2 service (Java 21) deployed acros
 | Connected governance path | Real | `./examples/springboot-paas/demo-connected.sh` |
 | Standalone live-cluster app proof | Real | `./bin/create-cluster && ./bin/build-image && ./bin/install-worker && ./verify-e2e.sh` |
 | Governed route proof (`ALLOW` + `BLOCKED`) | Real but client-side | `./examples/springboot-paas/demo-governed-routes.sh` |
+| Direct embedded ConfigHub payload mutation | Real but client-side | `./examples/springboot-paas/demo-embedded-config-mutation.sh` |
 
 The strongest caveat is enforcement depth, not demo truth. The ownership
 boundary is real and documented, but server-side rejection in ConfigHub is not
@@ -121,6 +122,9 @@ go build -o ./cub-gen ./cmd/cub-gen
 # Governed route proof
 ./examples/springboot-paas/demo-governed-routes.sh
 
+# Direct embedded payload mutation proof
+./examples/springboot-paas/demo-embedded-config-mutation.sh
+
 # Connected ConfigHub path
 cub auth login
 ./examples/springboot-paas/demo-connected.sh
@@ -154,14 +158,20 @@ Before changing anything, see how inputs become outputs:
 
 ## Handle request #1: flip the feature flag
 
-This is the **apply-here** path. The field `feature.inventory.reservationMode` is app-owned — mutate it directly in ConfigHub.
+This is the **apply-here** path. The field `feature.inventory.reservationMode`
+is app-owned, and this example now mutates it directly inside the embedded
+`application.yaml` payload instead of routing through an env-var workaround.
 
 ```bash
-./confighub-setup.sh                  # create dev/stage/prod spaces + units
+# Example-owned direct payload proof
+./examples/springboot-paas/demo-embedded-config-mutation.sh
 
-cub function do --space inventory-api-prod --unit inventory-api \
-  --change-desc "release-day: reservation mode strict → optimistic" \
-  set-env inventory-api "FEATURE_INVENTORY_RESERVATIONMODE=optimistic"
+# Raw command underneath the wrapper
+./cub-gen springboot set-embedded-config \
+  --routes ./operational/field-routes.yaml \
+  --file ./confighub/inventory-api-prod.yaml \
+  --configmap inventory-api-config \
+  feature.inventory.reservationMode optimistic
 ```
 
 Verify it worked:
@@ -207,6 +217,20 @@ That wrapper proves both sides of the route boundary:
 - `feature.inventory.reservationMode` returns `ALLOWED`
 - `spring.datasource.url` returns `BLOCKED`
 
+For the stronger direct payload path, use:
+
+```bash
+./examples/springboot-paas/demo-embedded-config-mutation.sh
+```
+
+That wrapper proves:
+
+- `feature.inventory.reservationMode` is patched directly inside
+  `ConfigMap.data["application.yaml"]`
+- `confighub-compare.sh` shows the prod value diverging as expected
+- `confighub-refresh-preview.sh prod` returns `PRESERVE`
+- `spring.datasource.url` is still blocked when you try the same direct path
+
 If you want the raw commands underneath it:
 
 ```bash
@@ -222,6 +246,19 @@ cub-gen springboot validate-mutation --routes ./operational/field-routes.yaml \
 ```
 
 This command reads `field-routes.yaml` and rejects mutations to fields with `defaultAction: generator-owned` (platform-owned) or `defaultAction: lift-upstream` (requires source change).
+
+Direct embedded payload edits use the companion command:
+
+```bash
+cub-gen springboot set-embedded-config \
+  --routes ./operational/field-routes.yaml \
+  --file ./confighub/inventory-api-prod.yaml \
+  --configmap inventory-api-config \
+  feature.inventory.reservationMode optimistic
+```
+
+It edits `ConfigMap.data["application.yaml"]` in-place, after validating the
+field route when `--routes` is provided.
 
 **What is now enforced:**
 - Field routes are read from `operational/field-routes.yaml`

--- a/examples/springboot-paas/demo-embedded-config-mutation.sh
+++ b/examples/springboot-paas/demo-embedded-config-mutation.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/springboot-embedded-config}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="$OUT_ROOT/$RUN_ID"
+WORK_REPO="$OUT_DIR/repo"
+PAYLOAD="${PAYLOAD:-./examples/springboot-paas/confighub/inventory-api-prod.yaml}"
+ROUTES="${ROUTES:-./examples/springboot-paas/operational/field-routes.yaml}"
+CONFIGMAP="${CONFIGMAP:-inventory-api-config}"
+ALLOW_FIELD="${ALLOW_FIELD:-feature.inventory.reservationMode}"
+ALLOW_VALUE="${ALLOW_VALUE:-optimistic}"
+BLOCK_FIELD="${BLOCK_FIELD:-spring.datasource.url}"
+BLOCK_VALUE="${BLOCK_VALUE:-jdbc:postgresql://shadow.platform.svc:5432/inventory}"
+
+mkdir -p "$OUT_DIR"
+rm -rf "$WORK_REPO"
+
+echo "[spring-embedded] cloning repo into $WORK_REPO"
+git clone --quiet "$ROOT_DIR" "$WORK_REPO"
+
+cd "$WORK_REPO"
+git config user.name "cub-gen demo"
+git config user.email "cub-gen-demo@example.invalid"
+
+echo "[spring-embedded] build cub-gen"
+go build -o ./cub-gen ./cmd/cub-gen
+
+echo "[spring-embedded] proof 1/2: mutate the embedded app-owned field directly in the ConfigHub payload"
+./cub-gen springboot set-embedded-config \
+  --file "$PAYLOAD" \
+  --configmap "$CONFIGMAP" \
+  --routes "$ROUTES" \
+  "$ALLOW_FIELD" \
+  "$ALLOW_VALUE" \
+  > "$OUT_DIR/allow.txt"
+
+./examples/springboot-paas/confighub-compare.sh --json > "$OUT_DIR/compare.json"
+./examples/springboot-paas/confighub-refresh-preview.sh prod --json > "$OUT_DIR/refresh.json"
+
+echo "[spring-embedded][allow] mutation result"
+cat "$OUT_DIR/allow.txt"
+
+echo "[spring-embedded][allow] compare snapshot"
+jq '."feature.inventory.reservationMode".values.prod' "$OUT_DIR/compare.json"
+
+echo "[spring-embedded][allow] refresh preview"
+jq '[.[] | select(.field == "feature.inventory.reservationMode")] | first | {
+  field,
+  liveValue,
+  upstreamValue,
+  action,
+  reason
+}' "$OUT_DIR/refresh.json"
+
+echo "[spring-embedded] proof 2/2: block a platform-owned embedded field mutation"
+set +e
+./cub-gen springboot set-embedded-config \
+  --file "$PAYLOAD" \
+  --configmap "$CONFIGMAP" \
+  --routes "$ROUTES" \
+  "$BLOCK_FIELD" \
+  "$BLOCK_VALUE" \
+  > "$OUT_DIR/block.txt" 2>&1
+block_exit="$?"
+set -e
+
+if [ "$block_exit" -ne 1 ]; then
+  echo "error: expected blocked embedded mutation exit code 1 for $BLOCK_FIELD, got $block_exit" >&2
+  exit 1
+fi
+
+echo "[spring-embedded][block] mutation result"
+cat "$OUT_DIR/block.txt"
+
+cat <<EOF
+
+[spring-embedded] success
+  apply-here path: embedded reservationMode changed directly in the ConfigHub payload
+  preserve proof: refresh preview keeps the local mutable-in-ch override
+  blocked path: platform-owned embedded datasource field is rejected
+  artifacts: $OUT_DIR
+EOF

--- a/examples/springboot-paas/generator/render.sh
+++ b/examples/springboot-paas/generator/render.sh
@@ -211,13 +211,16 @@ Why Mutable:
   re-rendering.
 
 Example mutation:
-  cub function do --space inventory-api-prod --unit inventory-api \
-    set-env inventory-api FEATURE_INVENTORY_RESERVATIONMODE=optimistic
+  cub-gen springboot set-embedded-config \
+    --routes ./operational/field-routes.yaml \
+    --file ./confighub/inventory-api-prod.yaml \
+    --configmap inventory-api-config \
+    feature.inventory.reservationMode optimistic
 
 What happens:
-  1. Change is stored in ConfigHub with audit trail
+  1. The embedded ConfigMap payload is patched directly at the app-owned field
   2. Field survives future generator refreshes (PRESERVE policy)
-  3. Apply delivers the change to targets
+  3. The same route still blocks platform-owned embedded fields
 EOF
       ;;
     spring.cache.*|spring.cache.type)

--- a/examples/springboot-paas/verify.sh
+++ b/examples/springboot-paas/verify.sh
@@ -43,6 +43,7 @@ required_files=(
   "$ROOT_DIR/confighub-verify.sh"
   "$ROOT_DIR/confighub-compare.sh"
   "$ROOT_DIR/confighub-refresh-preview.sh"
+  "$ROOT_DIR/demo-embedded-config-mutation.sh"
   "$ROOT_DIR/generator/render.sh"
   "$ROOT_DIR/verify-e2e.sh"
   "$ROOT_DIR/bin/create-cluster"

--- a/internal/springboot/embedded_config.go
+++ b/internal/springboot/embedded_config.go
@@ -1,0 +1,303 @@
+package springboot
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type SetEmbeddedConfigOptions struct {
+	FilePath        string
+	ConfigMapName   string
+	ConfigKey       string
+	FieldRoutesPath string
+	FieldPath       string
+	Value           string
+}
+
+type SetEmbeddedConfigResult struct {
+	FilePath      string      `json:"file_path"`
+	ConfigMapName string      `json:"configmap_name"`
+	ConfigKey     string      `json:"config_key"`
+	FieldPath     string      `json:"field_path"`
+	Allowed       bool        `json:"allowed"`
+	Action        RouteAction `json:"action,omitempty"`
+	Owner         string      `json:"owner,omitempty"`
+	Reason        string      `json:"reason,omitempty"`
+	MatchedRule   string      `json:"matched_rule,omitempty"`
+	OldValue      string      `json:"old_value,omitempty"`
+	NewValue      string      `json:"new_value,omitempty"`
+	Updated       bool        `json:"updated"`
+}
+
+func SetEmbeddedConfig(opts SetEmbeddedConfigOptions) (*SetEmbeddedConfigResult, error) {
+	if strings.TrimSpace(opts.FilePath) == "" {
+		return nil, fmt.Errorf("file_path is required")
+	}
+	if strings.TrimSpace(opts.FieldPath) == "" {
+		return nil, fmt.Errorf("field_path is required")
+	}
+	if strings.TrimSpace(opts.Value) == "" {
+		return nil, fmt.Errorf("value is required")
+	}
+
+	filePath, err := filepath.Abs(opts.FilePath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve file path: %w", err)
+	}
+
+	configKey := strings.TrimSpace(opts.ConfigKey)
+	if configKey == "" {
+		configKey = "application.yaml"
+	}
+
+	result := &SetEmbeddedConfigResult{
+		FilePath:      filePath,
+		ConfigMapName: strings.TrimSpace(opts.ConfigMapName),
+		ConfigKey:     configKey,
+		FieldPath:     strings.TrimSpace(opts.FieldPath),
+		Allowed:       true,
+	}
+
+	if strings.TrimSpace(opts.FieldRoutesPath) != "" {
+		validation, err := ValidateMutation(ValidateMutationOptions{
+			FieldRoutesPath: opts.FieldRoutesPath,
+			FieldPath:       result.FieldPath,
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Allowed = validation.Allowed
+		result.Action = validation.Action
+		result.Owner = validation.Owner
+		result.Reason = validation.Reason
+		result.MatchedRule = validation.MatchedRule
+		if !validation.Allowed {
+			return result, nil
+		}
+	}
+
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("read config payload: %w", err)
+	}
+
+	docs, err := decodeDocuments(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse config payload: %w", err)
+	}
+
+	configMapRoot, configMapName, err := findConfigMapWithKey(docs, result.ConfigMapName, configKey)
+	if err != nil {
+		return nil, err
+	}
+	result.ConfigMapName = configMapName
+
+	dataNode := mappingValue(configMapRoot, "data")
+	configValueNode := mappingValue(dataNode, configKey)
+	if configValueNode == nil {
+		return nil, fmt.Errorf("config map %s does not contain data[%q]", configMapName, configKey)
+	}
+
+	embeddedDoc, err := decodeSingleDocument([]byte(configValueNode.Value))
+	if err != nil {
+		return nil, fmt.Errorf("parse embedded config %q: %w", configKey, err)
+	}
+	if len(embeddedDoc.Content) == 0 {
+		return nil, fmt.Errorf("embedded config %q is empty", configKey)
+	}
+
+	targetNode, err := lookupPath(embeddedDoc.Content[0], strings.Split(result.FieldPath, "."))
+	if err != nil {
+		return nil, fmt.Errorf("lookup field %s in %s: %w", result.FieldPath, configKey, err)
+	}
+	if targetNode.Kind != yaml.ScalarNode {
+		return nil, fmt.Errorf("field %s in %s is not a scalar value", result.FieldPath, configKey)
+	}
+
+	newValueNode, err := decodeScalar(opts.Value)
+	if err != nil {
+		return nil, fmt.Errorf("parse value: %w", err)
+	}
+
+	result.OldValue = scalarString(targetNode)
+	result.NewValue = scalarString(newValueNode)
+	result.Updated = result.OldValue != result.NewValue
+	*targetNode = *cloneNode(newValueNode)
+
+	embeddedBytes, err := yaml.Marshal(embeddedDoc.Content[0])
+	if err != nil {
+		return nil, fmt.Errorf("encode embedded config %q: %w", configKey, err)
+	}
+	configValueNode.Kind = yaml.ScalarNode
+	configValueNode.Tag = "!!str"
+	configValueNode.Style = yaml.LiteralStyle
+	configValueNode.Value = strings.TrimSuffix(string(embeddedBytes), "\n")
+
+	var out bytes.Buffer
+	enc := yaml.NewEncoder(&out)
+	enc.SetIndent(2)
+	for _, doc := range docs {
+		if err := enc.Encode(doc); err != nil {
+			_ = enc.Close()
+			return nil, fmt.Errorf("encode config payload: %w", err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("finalize config payload: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, out.Bytes(), 0o644); err != nil {
+		return nil, fmt.Errorf("write config payload: %w", err)
+	}
+
+	return result, nil
+}
+
+func decodeDocuments(raw []byte) ([]*yaml.Node, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	docs := make([]*yaml.Node, 0, 4)
+	for {
+		var doc yaml.Node
+		if err := dec.Decode(&doc); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		if len(doc.Content) == 0 {
+			continue
+		}
+		docs = append(docs, &doc)
+	}
+	if len(docs) == 0 {
+		return nil, fmt.Errorf("no YAML documents found")
+	}
+	return docs, nil
+}
+
+func decodeSingleDocument(raw []byte) (*yaml.Node, error) {
+	docs, err := decodeDocuments(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(docs) != 1 {
+		return nil, fmt.Errorf("expected exactly one YAML document, found %d", len(docs))
+	}
+	return docs[0], nil
+}
+
+func findConfigMapWithKey(docs []*yaml.Node, configMapName, configKey string) (*yaml.Node, string, error) {
+	matches := make([]*yaml.Node, 0, 1)
+	names := make([]string, 0, 1)
+	for _, doc := range docs {
+		if len(doc.Content) == 0 {
+			continue
+		}
+		root := doc.Content[0]
+		kindNode := mappingValue(root, "kind")
+		if kindNode == nil || kindNode.Value != "ConfigMap" {
+			continue
+		}
+		name := configMapMetadataName(root)
+		if strings.TrimSpace(configMapName) != "" && name != strings.TrimSpace(configMapName) {
+			continue
+		}
+		dataNode := mappingValue(root, "data")
+		if dataNode == nil || mappingValue(dataNode, configKey) == nil {
+			continue
+		}
+		matches = append(matches, root)
+		names = append(names, name)
+	}
+	if len(matches) == 0 {
+		if strings.TrimSpace(configMapName) != "" {
+			return nil, "", fmt.Errorf("no ConfigMap named %q with data[%q] found", configMapName, configKey)
+		}
+		return nil, "", fmt.Errorf("no ConfigMap with data[%q] found; use --configmap if the payload contains multiple ConfigMaps", configKey)
+	}
+	if len(matches) > 1 && strings.TrimSpace(configMapName) == "" {
+		return nil, "", fmt.Errorf("multiple ConfigMaps with data[%q] found; use --configmap to choose one", configKey)
+	}
+	return matches[0], names[0], nil
+}
+
+func configMapMetadataName(root *yaml.Node) string {
+	metadataNode := mappingValue(root, "metadata")
+	if metadataNode == nil {
+		return ""
+	}
+	nameNode := mappingValue(metadataNode, "name")
+	if nameNode == nil {
+		return ""
+	}
+	return strings.TrimSpace(nameNode.Value)
+}
+
+func mappingValue(root *yaml.Node, key string) *yaml.Node {
+	if root == nil || root.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value == key {
+			return root.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func lookupPath(root *yaml.Node, parts []string) (*yaml.Node, error) {
+	current := root
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("empty path segment")
+		}
+		if current.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("path segment %q is not inside a mapping", part)
+		}
+		next := mappingValue(current, part)
+		if next == nil {
+			return nil, fmt.Errorf("missing path segment %q", part)
+		}
+		current = next
+	}
+	return current, nil
+}
+
+func decodeScalar(raw string) (*yaml.Node, error) {
+	doc, err := decodeSingleDocument([]byte(raw))
+	if err != nil {
+		return nil, err
+	}
+	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.ScalarNode {
+		return nil, fmt.Errorf("value must be a YAML scalar")
+	}
+	return doc.Content[0], nil
+}
+
+func scalarString(node *yaml.Node) string {
+	if node == nil {
+		return ""
+	}
+	return strings.TrimSpace(node.Value)
+}
+
+func cloneNode(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	cloned := *node
+	if len(node.Content) > 0 {
+		cloned.Content = make([]*yaml.Node, len(node.Content))
+		for i, child := range node.Content {
+			cloned.Content[i] = cloneNode(child)
+		}
+	}
+	return &cloned
+}

--- a/internal/springboot/embedded_config_test.go
+++ b/internal/springboot/embedded_config_test.go
@@ -1,0 +1,102 @@
+package springboot
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetEmbeddedConfigMutatesExampleFixture(t *testing.T) {
+	sourcePath := filepath.Join("..", "..", "examples", "springboot-paas", "confighub", "inventory-api-prod.yaml")
+	routesPath := filepath.Join("..", "..", "examples", "springboot-paas", "operational", "field-routes.yaml")
+	tempPath := filepath.Join(t.TempDir(), "inventory-api-prod.yaml")
+
+	raw, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source fixture: %v", err)
+	}
+	if err := os.WriteFile(tempPath, raw, 0o644); err != nil {
+		t.Fatalf("write temp fixture: %v", err)
+	}
+
+	result, err := SetEmbeddedConfig(SetEmbeddedConfigOptions{
+		FilePath:        tempPath,
+		ConfigMapName:   "inventory-api-config",
+		ConfigKey:       "application.yaml",
+		FieldRoutesPath: routesPath,
+		FieldPath:       "feature.inventory.reservationMode",
+		Value:           "optimistic",
+	})
+	if err != nil {
+		t.Fatalf("SetEmbeddedConfig() error = %v", err)
+	}
+	if !result.Allowed {
+		t.Fatalf("expected allowed result, got %+v", result)
+	}
+	if !result.Updated {
+		t.Fatalf("expected updated=true, got %+v", result)
+	}
+	if got, want := result.OldValue, "strict"; got != want {
+		t.Fatalf("old value = %q, want %q", got, want)
+	}
+	if got, want := result.NewValue, "optimistic"; got != want {
+		t.Fatalf("new value = %q, want %q", got, want)
+	}
+
+	mutated, err := os.ReadFile(tempPath)
+	if err != nil {
+		t.Fatalf("read mutated fixture: %v", err)
+	}
+	text := string(mutated)
+	if !strings.Contains(text, "reservationMode: optimistic") {
+		t.Fatalf("mutated fixture missing optimistic reservation mode:\n%s", text)
+	}
+	if strings.Contains(text, "reservationMode: strict") {
+		t.Fatalf("mutated fixture still contains strict reservation mode:\n%s", text)
+	}
+}
+
+func TestSetEmbeddedConfigRespectsBlockedRoutes(t *testing.T) {
+	sourcePath := filepath.Join("..", "..", "examples", "springboot-paas", "confighub", "inventory-api-prod.yaml")
+	routesPath := filepath.Join("..", "..", "examples", "springboot-paas", "operational", "field-routes.yaml")
+	tempPath := filepath.Join(t.TempDir(), "inventory-api-prod.yaml")
+
+	raw, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source fixture: %v", err)
+	}
+	if err := os.WriteFile(tempPath, raw, 0o644); err != nil {
+		t.Fatalf("write temp fixture: %v", err)
+	}
+
+	result, err := SetEmbeddedConfig(SetEmbeddedConfigOptions{
+		FilePath:        tempPath,
+		ConfigMapName:   "inventory-api-config",
+		ConfigKey:       "application.yaml",
+		FieldRoutesPath: routesPath,
+		FieldPath:       "spring.datasource.url",
+		Value:           "jdbc:postgresql://shadow.platform.svc:5432/inventory",
+	})
+	if err != nil {
+		t.Fatalf("SetEmbeddedConfig() error = %v", err)
+	}
+	if result.Allowed {
+		t.Fatalf("expected blocked result, got %+v", result)
+	}
+	if result.Updated {
+		t.Fatalf("expected updated=false for blocked mutation, got %+v", result)
+	}
+
+	mutated, err := os.ReadFile(tempPath)
+	if err != nil {
+		t.Fatalf("read fixture after blocked mutation: %v", err)
+	}
+	text := string(mutated)
+	if !strings.Contains(text, "jdbc:postgresql://postgres.platform.svc:5432/inventory") {
+		t.Fatalf("blocked mutation changed datasource fixture:\n%s", text)
+	}
+	if strings.Contains(text, "shadow.platform.svc") {
+		t.Fatalf("blocked mutation wrote unexpected datasource URL:\n%s", text)
+	}
+}


### PR DESCRIPTION
## What changed

This adds a direct embedded-config mutation path for the Spring flagship example instead of relying on the old env-var workaround.

- adds `cub-gen springboot set-embedded-config`
- adds `internal/springboot` helpers and tests for editing `ConfigMap.data["application.yaml"]`
- validates field ownership with `field-routes.yaml` before writing when `--routes` is provided
- adds `./examples/springboot-paas/demo-embedded-config-mutation.sh`
- updates the Spring README, starter path, generator explanation, and CLI reference to teach the direct embedded payload flow
- updates the draft `v0.2-preview.2` release note to stop listing this as a remaining Spring gap

## Why

`#208` was still leaving the Spring example weaker than it should be: the natural app-visible field to mutate was `feature.inventory.reservationMode`, but the public example only taught an env-var override workaround instead of directly changing the embedded `application.yaml` payload users would expect to edit.

This PR makes the stronger Spring story real:
- app-owned embedded field can be changed directly
- refresh preview shows `PRESERVE`
- platform-owned embedded field is still blocked

## Validation

- `go test ./...`
- `go run ./cmd/cub-gen springboot --help`
- `go run ./cmd/cub-gen springboot set-embedded-config --help`
- manual local mutation run against a temp copy of `examples/springboot-paas/confighub/inventory-api-prod.yaml`
- `bash ./examples/springboot-paas/demo-embedded-config-mutation.sh`
- `./examples/springboot-paas/verify.sh`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`

Closes #208.