### PR TITLE
[codex] remove closed spring blocker from release trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
-| Example quality | `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#208` |
+| Example quality | `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202` |
 | CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
 | Release gate | `#218`, `#226` |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#208`, `#218`, `#226`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#226`, `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -55,12 +55,12 @@ Current open issues:
 - [#187](https://github.com/confighub/cub-gen/issues/187) Kubara-like layered provenance
 - [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
 - [#202](https://github.com/confighub/cub-gen/issues/202) AI-first flagship surfaces
-- [#208](https://github.com/confighub/cub-gen/issues/208) Spring embedded-config mutation gap
 
 Landed on `main`:
 
 - [#182](https://github.com/confighub/cub-gen/issues/182) entrypoint redesign
 - [#207](https://github.com/confighub/cub-gen/issues/207) Spring block/escalate proof
+- [#208](https://github.com/confighub/cub-gen/issues/208) Spring embedded-config mutation support
 
 Required outcome:
 

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -44,12 +44,13 @@ exit-bar rationale still live in
 - [ ] Confirm the current connected smoke lane passes in the intended
   secrets-backed release environment.
 
-## Issue state after #249
+## Issue state after #251
 
 ### Closed or landed on `main`
 
 - [x] `#182` example/demo entrypoint redesign
 - [x] `#207` Spring block/escalate proof
+- [x] `#208` Spring embedded-config mutation support
 - [x] `#227` rethink the size and purpose of `ci-connected`
 - [x] `#232` README structure
 - [x] `#233` help-text duplication
@@ -65,7 +66,6 @@ exit-bar rationale still live in
 - [ ] `#187` layered provenance across overlays/ApplicationSet/labels
 - [ ] `#200` AI best-practice alignment across examples
 - [ ] `#202` AI-first flagship surfaces
-- [ ] `#208` Spring embedded-config mutation support
 - [ ] `#218` release-environment ConfigHub smoke reliability
 - [ ] `#226` standard ConfigHub API/CLI over custom bridge endpoints
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -383,7 +383,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#208`, `#218`, `#226`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#226`, `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 


### PR DESCRIPTION
## What changed

This removes stale `#208` blocker references after PR #251 merged.

- removes `#208` from the active blocker lists in the README and demo status surface
- moves `#208` into the landed-on-main section of the `v0.2-preview.2` release plan
- updates the ship checklist from `after #249` to `after #251` and marks `#208` closed there too

## Why

`#208` is now closed, but the release trackers on `main` were still presenting it as an open blocker. This keeps the release board honest and makes the remaining work easier to see.

## Validation

- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`
- targeted grep across the updated tracker files for stale `#208` blocker wording
