### PR TITLE
[codex] Close custom generator onboarding gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Full guide: [docs/workflows/confidence-scores.md](docs/workflows/confidence-scor
 | C3 Agent | `c3agent.yaml` | [c3agent](examples/c3agent/) |
 | Swamp | `.swamp.yaml` + `workflow-*.yaml` | [swamp-automation](examples/swamp-automation/) |
 
+Need support for your own platform framework? See [Custom Generator Onboarding](docs/workflows/custom-generator-onboarding.md) for the fork-and-extend path, request-inclusion path, and Kubara-like layered-generator guidance.
+
 Per-generator recipes and bridge flow examples: [CLI Reference](docs/cli-reference.md)
 
 ## Part of the ConfigHub platform
@@ -176,6 +178,7 @@ Docs currently live in this repo:
 - [Getting Started](docs/getting-started.md) — 10-minute quickstart
 - [CLI Reference](docs/cli-reference.md) — all commands, flags, and generator recipes
 - [Demo Guide](docs/demo-guide.md) — runnable demo scripts and scenarios
+- [Custom Generator Onboarding](docs/workflows/custom-generator-onboarding.md) — add support for your own framework-specific generator
 - [Current release plan](docs/releases/v0.2-preview.2-plan.md) — must-ship and post-release work for the next preview
 - [Current ship checklist](docs/releases/v0.2-preview.2-ship-checklist.md) — what is already landed on `main`, what still blocks the tag, and what can wait
 - [Draft release notes](docs/releases/v0.2-preview.2.md) — the current `v0.2-preview.2` release-note draft to finalize from green `main`
@@ -204,10 +207,10 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
-| Example quality | `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202` |
+| Example quality | `#177`, `#178`, `#180`, `#187`, `#200`, `#202` |
 | CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
 | Release gate | `#218`, `#226` |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#226`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#187`, `#200`, `#202`, `#218`, `#226`, `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,6 +130,13 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 
     [Confidence Scores](workflows/confidence-scores.md)
 
+-   **Add your own generator**
+
+    Follow the user-facing path for framework-specific platforms and layered
+    Kubara-like stacks.
+
+    [Custom Generator Onboarding](workflows/custom-generator-onboarding.md)
+
 -   **Check what is really proven**
 
     Use the derived example matrix to see which examples are source-chain verified, in the connected smoke lane, AI-first, or backed by real live proof.

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -51,7 +51,6 @@ Current open issues:
 - [#177](https://github.com/confighub/cub-gen/issues/177) Helm flagship
 - [#178](https://github.com/confighub/cub-gen/issues/178) Score flagship remaining standalone live proof
 - [#180](https://github.com/confighub/cub-gen/issues/180) workflow examples
-- [#185](https://github.com/confighub/cub-gen/issues/185) custom-generator onboarding
 - [#187](https://github.com/confighub/cub-gen/issues/187) Kubara-like layered provenance
 - [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
 - [#202](https://github.com/confighub/cub-gen/issues/202) AI-first flagship surfaces
@@ -59,6 +58,7 @@ Current open issues:
 Landed on `main`:
 
 - [#182](https://github.com/confighub/cub-gen/issues/182) entrypoint redesign
+- [#185](https://github.com/confighub/cub-gen/issues/185) custom-generator onboarding
 - [#207](https://github.com/confighub/cub-gen/issues/207) Spring block/escalate proof
 - [#208](https://github.com/confighub/cub-gen/issues/208) Spring embedded-config mutation support
 

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -49,6 +49,7 @@ exit-bar rationale still live in
 ### Closed or landed on `main`
 
 - [x] `#182` example/demo entrypoint redesign
+- [x] `#185` custom-generator onboarding
 - [x] `#207` Spring block/escalate proof
 - [x] `#208` Spring embedded-config mutation support
 - [x] `#227` rethink the size and purpose of `ci-connected`
@@ -62,7 +63,6 @@ exit-bar rationale still live in
 - [ ] `#177` Helm flagship example
 - [ ] `#178` Score flagship remaining standalone live proof
 - [ ] `#180` workflow example upgrade
-- [ ] `#185` custom-generator onboarding
 - [ ] `#187` layered provenance across overlays/ApplicationSet/labels
 - [ ] `#200` AI best-practice alignment across examples
 - [ ] `#202` AI-first flagship surfaces

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -383,7 +383,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#226`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#187`, `#200`, `#202`, `#218`, `#226`, `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -458,6 +458,10 @@ The key question: "Why does this cluster have this addon enabled?"
 
 Answer: Trace from cluster labels through overlay selection to the deployed field.
 
+If your platform follows a similar layered pattern but uses its own framework,
+see [Custom Generator Onboarding](../../docs/workflows/custom-generator-onboarding.md)
+for the fork-and-extend path and the minimum custom-generator shape.
+
 ```bash
 # Show rendered lineage
 ./cub-gen gitops import --space platform --json ./examples/helm-paas \


### PR DESCRIPTION
## Summary
- make the custom-generator onboarding path discoverable from the top-level README and docs index
- link the Helm/Kubara-like flagship example directly to the onboarding guide
- update the `v0.2-preview.2` release trackers so `#185` is no longer listed as an open blocker

## Why
The onboarding guide already existed, but it was still too easy to miss from the main user-facing surfaces. This finishes the user-facing path promised by `#185` and makes the Helm/Kubara example link to it cleanly.

## Validation
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`

Closes #185.