### PR TITLE
[codex] Make deep connected bridge paths explicitly advanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
 | Example quality | `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202` |
 | CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
-| Release gate | `#218`, `#226` |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#226`, `#238`-`#242` |
+| Release gate | `#218` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/ai/cub-gen-tasks.md
+++ b/docs/ai/cub-gen-tasks.md
@@ -39,8 +39,8 @@ When the operator asks... | Run this | What you get
 "Where do I edit this field?" | `./cub-gen change explain --wet-path "<path>" $REPO` | DRY file/path/owner
 "Run a governed change" | `./cub-gen change run --mode local --space my-space $REPO` | Local change report (or connected to ConfigHub)
 "Verify the connected smoke path" | `cub auth login && ./examples/demo/run-connected-smoke.sh` | ConfigHub auth/context + flagship connected wrappers
-"Use the deep bridge API path" | `./cub-gen bridge ingest --in bundle.json --base-url <url>` | Ingest receipt
-"Check deep decision status" | `./cub-gen bridge decision query --change-id <id> --base-url <url>` | ALLOW / ESCALATE / BLOCK
+"Use the advanced bridge-only path" | `./cub-gen bridge ingest --in bundle.json --base-url <url>` | Explicit bridge receipt for deep demos or bridge-only gaps
+"Check advanced bridge decision status" | `./cub-gen bridge decision query --change-id <id> --base-url <url>` | ALLOW / ESCALATE / BLOCK
 
 ## First commands for any source repo
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -128,8 +128,9 @@ cub-gen verify-attestation --in <attestation.json> --bundle <bundle.json>
 ## Bridge flow (advanced ConfigHub API path)
 
 These are the deeper connected commands. For the repo's default connected
-first run, use `./examples/demo/run-connected-smoke.sh` or an example's
-`demo-connected.sh` wrapper first.
+first run, use `./examples/demo/run-connected-smoke.sh` first. Use bridge
+commands only for deeper bridge-backed walkthroughs or bridge-only capability
+gaps.
 
 ### `bridge ingest`
 
@@ -432,7 +433,17 @@ go build -o ./cub-gen ./cmd/cub-gen
 ./cub-gen verify-attestation --in attestation.json --bundle bundle.json
 ```
 
-### Bridge flow (ConfigHub API path)
+### Bridge flow (advanced bridge-only ConfigHub API path)
+
+Most users should start with the standard connected environment check:
+
+```bash
+cub auth login
+./examples/demo/run-connected-smoke.sh
+```
+
+Use the commands below only when you explicitly need the deeper bridge-backed
+connected path.
 
 ```bash
 # 1) Build bundle and attestation artifacts

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -54,7 +54,7 @@ Run all current platform examples (10 fixtures):
 Each run shows:
 
 1. Create path (`discover` &rarr; `import` &rarr; `publish` &rarr; `verify` &rarr; `attest`)
-2. Decision/promotion path (`bridge decision` + `bridge promote`)
+2. Decision/promotion path (standard ConfigHub flow where available, bridge-only path where needed)
 3. Update path (source config mutation + re-run chain)
 4. Visibility surfaces:
    - OCI (bundle digest + output URIs)

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -155,7 +155,7 @@ It proves:
 
 It does **not** depend on the bridge ingest/query endpoints.
 
-## The deep bridge pipeline
+## The deep connected pipeline (bridge-only where needed)
 
 This is the path from cub-gen's local output to governed deployment:
 
@@ -163,6 +163,16 @@ This is the path from cub-gen's local output to governed deployment:
 publish → verify → attest → bridge ingest → decision → promote
   (local, offline)            (requires ConfigHub)
 ```
+
+Start with the standard connected path first:
+
+```bash
+cub auth login
+./examples/demo/run-connected-smoke.sh
+```
+
+Use the commands below only when you specifically need the deeper bridge-backed
+connected walkthrough or a bridge-only capability gap.
 
 ### Local phase (cub-gen, no backend)
 
@@ -179,7 +189,7 @@ publish → verify → attest → bridge ingest → decision → promote
 
 These three commands work offline. The bundle and attestation are portable JSON files.
 
-### Connected phase (deep ConfigHub API path)
+### Connected phase (advanced bridge-backed API path)
 
 ```bash
 # Submit bundle to ConfigHub
@@ -200,8 +210,9 @@ BASE_URL="${CONFIGHUB_BASE_URL:-$(cub context get --json | jq -r '.coordinate.se
 ./cub-gen bridge promote merge --flow flow.json --by platform-owner
 ```
 
-Deep connected demos and scripts treat ConfigHub decision query output as the source of truth.
-Local `bridge decision create|attach|apply` commands are still available for offline contract simulation.
+Deep connected demos and scripts treat ConfigHub decision query output as the
+source of truth. Local `bridge decision create|attach|apply` commands are
+still available for offline contract simulation.
 
 ---
 
@@ -214,7 +225,7 @@ You don't have to use ConfigHub to use cub-gen. The progression is:
 | **0. Local CLI** | `cub-gen` only | DRY/WET classification, provenance, inverse-edit guidance. Works today against any Git repo. |
 | **1. Bridge artifacts** | `cub-gen publish + verify + attest` | Portable change bundles with digest verification and attestation. Still local, still offline. |
 | **2. ConfigHub smoke** | ConfigHub auth + flagship connected wrappers | Confirm the real connected environment and wrapper entrypoints work. |
-| **3. Deep connected bridge path** | ConfigHub backend + bridge ingest | Governed WET state, decision authority, cross-repo queries, retention, policy at write time. |
+| **3. Deep connected example path** | ConfigHub backend + example wrappers | Deeper connected evidence and decision flows; some examples still rely on bridge-only APIs behind the wrapper. |
 | **4. Governed execution** | ConfigHub + bridge workers + Flux/ArgoCD | Full governed pipeline: nothing deploys without an explicit ALLOW decision with attestation linkage. |
 
 Each stage is additive. You keep everything from the previous stage and add new capability.

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -81,10 +81,10 @@ credible.
 Current open issues:
 
 - [#218](https://github.com/confighub/cub-gen/issues/218) provision secrets and get a green connected run
-- [#226](https://github.com/confighub/cub-gen/issues/226) standard ConfigHub API/CLI over custom bridge endpoints
 
 Landed on `main`:
 
+- [#226](https://github.com/confighub/cub-gen/issues/226) standard ConfigHub API/CLI over custom bridge endpoints
 - [#227](https://github.com/confighub/cub-gen/issues/227) rethink the size and purpose of `ci-connected`
 
 Required outcome:

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -51,6 +51,7 @@ exit-bar rationale still live in
 - [x] `#182` example/demo entrypoint redesign
 - [x] `#207` Spring block/escalate proof
 - [x] `#208` Spring embedded-config mutation support
+- [x] `#226` standard ConfigHub API/CLI over custom bridge endpoints
 - [x] `#227` rethink the size and purpose of `ci-connected`
 - [x] `#232` README structure
 - [x] `#233` help-text duplication
@@ -67,7 +68,6 @@ exit-bar rationale still live in
 - [ ] `#200` AI best-practice alignment across examples
 - [ ] `#202` AI-first flagship surfaces
 - [ ] `#218` release-environment ConfigHub smoke reliability
-- [ ] `#226` standard ConfigHub API/CLI over custom bridge endpoints
 
 For this preview, "all examples working well" means each featured example has:
 

--- a/docs/workflows/example-checklist.md
+++ b/docs/workflows/example-checklist.md
@@ -69,8 +69,9 @@ Connected mode instructions for users who already have ConfigHub:
 
 ```bash
 cub auth login
-./cub-gen publish --space <space> ./examples/<name> > /tmp/bundle.json
-./cub-gen bridge ingest --in /tmp/bundle.json ...
+./examples/demo/run-connected-smoke.sh
+# If this example also has a deeper bridge-backed walkthrough,
+# document it separately and label it bridge-only / advanced.
 ```
 
 ### 5. Run it from the platform tool (tool-first path)

--- a/examples/ai-ops-paas/README.md
+++ b/examples/ai-ops-paas/README.md
@@ -15,7 +15,7 @@ fleet config (without registry and constraints), see [`c3agent`](../c3agent/).
 
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
-| Runnable local and connected platform walkthrough | Real | `./examples/ai-ops-paas/demo-local.sh` then `./examples/ai-ops-paas/demo-connected.sh` |
+| Runnable local walkthrough + deep connected bridge companion | Real | `./examples/ai-ops-paas/demo-local.sh` then `./examples/ai-ops-paas/demo-connected.sh` |
 | First-class source-chain coverage in the truth matrix | Not yet | this example is still a companion platform story, not a first-class verified fixture |
 | Standalone live fleet runtime proof | Not yet | current proof is platform contract + governance, not live runtime |
 
@@ -32,7 +32,7 @@ go build -o ./cub-gen ./cmd/cub-gen
 # Local platform walkthrough
 ./examples/ai-ops-paas/demo-local.sh
 
-# Connected governance path
+# Deep connected bridge path
 cub auth login
 ./examples/ai-ops-paas/demo-connected.sh
 ```
@@ -282,7 +282,9 @@ cub auth login
 ./examples/ai-ops-paas/demo-connected.sh
 ```
 
-That is the current first-run connected path for this example.
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.
 
 If you specifically need the deeper bridge API path, use:
 

--- a/examples/backstage-idp/README.md
+++ b/examples/backstage-idp/README.md
@@ -15,7 +15,7 @@ change traceable, auditable, and queryable across repos.
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
 | Source-side catalog provenance | Real | `./examples/backstage-idp/demo-local.sh` |
-| Connected governance path | Real | `./examples/backstage-idp/demo-connected.sh` |
+| Deep connected bridge path | Real | `./examples/backstage-idp/demo-connected.sh` |
 | Catalog standards and ownership scenario | Real | inspect `platform/catalog-standards.yaml` after either wrapper run |
 | Standalone live Backstage portal proof | Not yet | this repo proves governed source flow more than a seeded live portal deployment |
 
@@ -36,7 +36,7 @@ go build -o ./cub-gen ./cmd/cub-gen
 # Local catalog governance walkthrough
 ./examples/backstage-idp/demo-local.sh
 
-# Connected governance path
+# Deep connected bridge path
 cub auth login
 ./examples/backstage-idp/demo-connected.sh
 ```
@@ -262,7 +262,9 @@ cub auth login
 ./examples/backstage-idp/demo-connected.sh
 ```
 
-That is the current first-run connected path for this example.
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.
 
 If you specifically need the deeper bridge API path, use:
 

--- a/examples/c3agent/README.md
+++ b/examples/c3agent/README.md
@@ -18,7 +18,7 @@ properly isolated? ConfigHub makes AI fleet governance explicit and traceable.
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
 | Source-side fleet provenance | Real | `./examples/c3agent/demo-local.sh` |
-| Connected governance path | Real | `./examples/c3agent/demo-connected.sh` |
+| Deep connected bridge path | Real | `./examples/c3agent/demo-connected.sh` |
 | First-class source-chain coverage in the truth matrix | Real | `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v` |
 | Standalone live fleet runtime proof | Not yet | current example stops at governed fleet config and connected evidence |
 
@@ -30,7 +30,7 @@ go build -o ./cub-gen ./cmd/cub-gen
 # Local source-side path
 ./examples/c3agent/demo-local.sh
 
-# Connected governance path
+# Deep connected bridge path
 cub auth login
 ./examples/c3agent/demo-connected.sh
 ```
@@ -263,7 +263,9 @@ cub auth login
 ./examples/c3agent/demo-connected.sh
 ```
 
-That is the current first-run connected path for this example.
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.
 
 If you specifically need the deeper bridge API path, use:
 

--- a/examples/confighub-actions/README.md
+++ b/examples/confighub-actions/README.md
@@ -15,7 +15,7 @@ pipeline that governs your app changes also governs the governance rules.
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
 | Recursive governance walkthrough | Real | `./examples/confighub-actions/demo-local.sh` |
-| Connected governance path | Real | `./examples/confighub-actions/demo-connected.sh` |
+| Deep connected bridge path | Real | `./examples/confighub-actions/demo-connected.sh` |
 | First-class source-chain coverage in the truth matrix | Not yet | this example is still a companion workflow story, not a first-class verified fixture |
 | Standalone live execution artifact | Not yet | current example proves governed lifecycle config more than a real executed platform run |
 
@@ -32,7 +32,7 @@ go build -o ./cub-gen ./cmd/cub-gen
 # Local recursive-governance walkthrough
 ./examples/confighub-actions/demo-local.sh
 
-# Connected governance path
+# Deep connected bridge path
 cub auth login
 ./examples/confighub-actions/demo-connected.sh
 ```
@@ -273,7 +273,9 @@ cub auth login
 ./examples/confighub-actions/demo-connected.sh
 ```
 
-That is the current first-run connected path for this example.
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.
 
 If you specifically need the deeper bridge API path, use:
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -4,7 +4,9 @@ Runnable demo scripts for every `cub-gen` example. Each script demonstrates
 part of the governed change flow:
 
 ```
-detect → import → publish → verify → attest → (optional, deep) bridge ingest/query
+detect → import → publish → verify → attest
+                                          → connected smoke
+                                          → (optional, deep) bridge ingest/query
 ```
 
 If you are new, do not start with "run everything." Start with one concrete
@@ -16,7 +18,7 @@ Use the demo surface in this order:
 
 1. **Local source-side proof**: `detect -> import -> publish -> verify -> attest`
 2. **Connected smoke proof**: `cub auth login` plus `./examples/demo/run-connected-smoke.sh`
-3. **Deep connected proof**: bridge ingest/query, promotion, and multi-story ConfigHub flows
+3. **Deep connected proof**: example wrappers, standard changeset-based flows, and bridge-only demos when needed
 4. **Runtime proof**: real WET->LIVE reconciliation or a real deployed app
 
 That ordering matters. The first run should answer "do I trust the source-side
@@ -161,7 +163,8 @@ cub auth login
 Deep connected flow shape:
 
 ```
-publish → verify → attest → bridge ingest → decision query
+publish → verify → attest → standard connected wrapper or changeset flow
+                         → (optional, deep) bridge ingest → decision query
 ```
 
 ### Connected smoke runner
@@ -189,7 +192,11 @@ The extended deep-proof lane also covers:
 - `flow-b-mr-to-git-pr-connected.sh`
 - evidence validation via `test/checks/check-flow-evidence.sh`
 
-### Bridge endpoint behavior
+These are advanced connected lanes. Some still depend on bridge-backed flows or
+changeset fallbacks because they are demonstrating deeper optional behavior,
+not the release-facing default connected path.
+
+### Advanced bridge endpoint behavior
 
 | Mode | Behavior |
 |------|----------|
@@ -383,7 +390,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#226`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 

--- a/examples/demo/run-confighub-lifecycle-connected.sh
+++ b/examples/demo/run-confighub-lifecycle-connected.sh
@@ -40,6 +40,9 @@ if [ -z "$SPACE" ]; then
 fi
 print_connected_context
 
+echo "[lifecycle][connected] note: this is the advanced bridge-backed connected walkthrough."
+echo "[lifecycle][connected] note: use ./examples/demo/run-connected-smoke.sh first for the standard connected environment check."
+
 if [ "${SKIP_BUILD:-0}" != "1" ]; then
   echo "[lifecycle][connected] build cub-gen"
   go build -o ./cub-gen ./cmd/cub-gen

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -23,7 +23,7 @@ This example now owns three flagship proof paths:
 |-------|--------|---------------------|
 | Source-side Helm provenance | Real | `./examples/helm-paas/demo-local.sh` |
 | Governed ALLOW + BLOCK ownership proof | Real | `./examples/helm-paas/demo-governed-change.sh` |
-| Connected governance path | Real | `./examples/helm-paas/demo-connected.sh` |
+| Deep connected bridge path | Real | `./examples/helm-paas/demo-connected.sh` |
 | Connected + live Helm proof from this example | Real | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` |
 | Runtime WET->LIVE harness beneath the wrapper | Paired | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` |
 
@@ -54,7 +54,7 @@ That sequence gives you:
 |---|---|---|
 | Local source-side proof | `./examples/helm-paas/demo-local.sh` | field origin, inverse-edit guidance, dry inputs, and rendered targets |
 | Local governed ownership proof | `./examples/helm-paas/demo-governed-change.sh` | one app-team change that passes and one platform-contract change that fails the DRY ownership gate |
-| Connected governance proof | `./examples/helm-paas/demo-connected.sh` | change ID, bundle digest, attestation, and backend decision/query output |
+| Deep connected bridge proof | `./examples/helm-paas/demo-connected.sh` | change ID, bundle digest, attestation, and backend decision/query output |
 | Connected + live proof | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | live Deployment rollout, pods, services, and reconciler status for Flux and Argo |
 
 ## 1. Who this is for
@@ -388,8 +388,9 @@ cub auth login
 ./examples/helm-paas/demo-connected.sh
 ```
 
-That is the current first-run connected path for this example and the same
-surface used by the connected smoke lane.
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.
 
 If you want the connected path that also deploys and proves the live result:
 

--- a/examples/just-apps-no-platform-config/README.md
+++ b/examples/just-apps-no-platform-config/README.md
@@ -14,7 +14,7 @@ just Kubernetes workloads.
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
 | Source-side provider-config provenance | Real | `./examples/just-apps-no-platform-config/demo-local.sh` |
-| Connected governance path | Real | `./examples/just-apps-no-platform-config/demo-connected.sh` |
+| Deep connected bridge path | Real | `./examples/just-apps-no-platform-config/demo-connected.sh` |
 | Empty-platform governance baseline | Real | this example intentionally keeps `platform/` empty and still produces provenance |
 | Standalone provider runtime proof | Not yet | this repo proves governed config flow more than a specific live provider deployment |
 
@@ -35,7 +35,7 @@ go build -o ./cub-gen ./cmd/cub-gen
 # Local app-only governance walkthrough
 ./examples/just-apps-no-platform-config/demo-local.sh
 
-# Connected governance path
+# Deep connected bridge path
 cub auth login
 ./examples/just-apps-no-platform-config/demo-connected.sh
 ```
@@ -274,7 +274,9 @@ cub auth login
 ./examples/just-apps-no-platform-config/demo-connected.sh
 ```
 
-That is the current first-run connected path for this example.
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.
 
 If you specifically need the deeper bridge API path, use:
 

--- a/examples/ops-workflow/README.md
+++ b/examples/ops-workflow/README.md
@@ -15,7 +15,7 @@ ALLOW decision.
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
 | Source-side workflow provenance | Real | `./examples/ops-workflow/demo-local.sh` |
-| Connected governance path | Real | `./examples/ops-workflow/demo-connected.sh` |
+| Deep connected bridge path | Real | `./examples/ops-workflow/demo-connected.sh` |
 | AI/workflow governance story | Partial | strong workflow governance story today; `swamp-automation` is still the stronger AI-first workflow example |
 | Standalone live workflow run or runtime artifact | Not yet | current example proves governed workflow config more than a real executed workflow result |
 
@@ -32,7 +32,7 @@ go build -o ./cub-gen ./cmd/cub-gen
 # Local source-side path
 ./examples/ops-workflow/demo-local.sh
 
-# Connected governance path
+# Deep connected bridge path
 cub auth login
 ./examples/ops-workflow/demo-connected.sh
 ```
@@ -308,7 +308,9 @@ cub auth login
 ./examples/ops-workflow/demo-connected.sh
 ```
 
-That is the current first-run connected path for this example.
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.
 
 If you specifically need the deeper bridge API path, use:
 

--- a/examples/scoredev-paas/README.md
+++ b/examples/scoredev-paas/README.md
@@ -16,7 +16,7 @@ inverse-edit guidance.
 |-------|--------|---------------------|
 | Source-side Score provenance | Real | `./examples/scoredev-paas/demo-local.sh` |
 | Local governed Score contract proof | Real | `./examples/scoredev-paas/demo-governed-workload.sh` |
-| Connected governance path | Real | `./examples/scoredev-paas/demo-connected.sh` |
+| Deep connected bridge path | Real | `./examples/scoredev-paas/demo-connected.sh` |
 | Standalone Score live app proof | Not yet | still open work in [#178](https://github.com/confighub/cub-gen/issues/178) |
 
 This README is intentionally honest: today the strongest Score proof in this
@@ -41,7 +41,7 @@ Both paths lead to the same outcome: governed Score workloads with field-origin 
 |---|---|---|
 | Local source-side proof | `./examples/scoredev-paas/demo-local.sh` | `score.yaml` field origin, inverse edit pointers, and rendered targets |
 | Local governed contract proof | `./examples/scoredev-paas/demo-governed-workload.sh` | app-owned image change returns `ALLOW`, unapproved resource type returns `ESCALATE` |
-| Connected governance proof | `./examples/scoredev-paas/demo-connected.sh` | change ID, bundle digest, attestation, and connected decision/query output |
+| Deep connected bridge proof | `./examples/scoredev-paas/demo-connected.sh` | change ID, bundle digest, attestation, and connected decision/query output |
 | Runtime companion today | [`springboot-paas`](../springboot-paas/) or [`live-reconcile`](../live-reconcile/) | current standalone live app proof elsewhere in the repo while Score runtime proof is being finished |
 
 ## 1. Who this is for
@@ -330,7 +330,9 @@ cub auth login
 ./examples/scoredev-paas/demo-connected.sh
 ```
 
-That is the current first-run connected path for this example.
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.
 
 If you specifically need the deeper bridge API path, use:
 

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -21,7 +21,7 @@ The app is `inventory-api`, a Spring Boot 3.3.2 service (Java 21) deployed acros
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
 | Source-side provenance and ownership | Real | `./examples/springboot-paas/demo-local.sh` |
-| Connected governance path | Real | `./examples/springboot-paas/demo-connected.sh` |
+| Deep connected bridge path | Real | `./examples/springboot-paas/demo-connected.sh` |
 | Standalone live-cluster app proof | Real | `./bin/create-cluster && ./bin/build-image && ./bin/install-worker && ./verify-e2e.sh` |
 | Governed route proof (`ALLOW` + `BLOCKED`) | Real but client-side | `./examples/springboot-paas/demo-governed-routes.sh` |
 | Direct embedded ConfigHub payload mutation | Real but client-side | `./examples/springboot-paas/demo-embedded-config-mutation.sh` |
@@ -136,6 +136,11 @@ cub auth login
 ./confighub-setup.sh
 ./verify-e2e.sh
 ```
+
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. Use
+`./examples/springboot-paas/demo-connected.sh` when you specifically want the
+deeper bridge-backed walkthrough for this example.
 
 Fixture consistency checks and bundle-only proofs:
 
@@ -435,6 +440,10 @@ Customize these based on your actual ownership boundaries.
 cub auth login
 ./examples/springboot-paas/demo-connected.sh
 ```
+
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.
 
 ## Next steps
 

--- a/examples/swamp-automation/README.md
+++ b/examples/swamp-automation/README.md
@@ -12,7 +12,7 @@ slowing down the agent iteration loop.
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
 | Source-side structural workflow governance | Real | `./examples/swamp-automation/demo-local.sh` |
-| Connected governance path | Real | `./examples/swamp-automation/demo-connected.sh` |
+| Deep connected bridge path | Real | `./examples/swamp-automation/demo-connected.sh` |
 | AI-first prompt-as-DRY story | Strongest current lane | `./examples/demo/prompt-as-dry-local.sh` then `./examples/demo/prompt-as-dry-connected.sh` |
 | Standalone live workflow runtime or task artifact | Not yet | current example proves structural governance more than runtime execution |
 
@@ -32,7 +32,7 @@ go build -o ./cub-gen ./cmd/cub-gen
 # AI-first prompt-as-DRY path
 ./examples/demo/prompt-as-dry-local.sh
 
-# Connected governance path
+# Deep connected bridge path
 cub auth login
 ./examples/swamp-automation/demo-connected.sh
 ```
@@ -329,7 +329,9 @@ cub auth login
 ./examples/swamp-automation/demo-connected.sh
 ```
 
-That is the current first-run connected path for this example.
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.
 
 If you specifically need the deeper bridge API path, use:
 

--- a/examples/swamp-project/README.md
+++ b/examples/swamp-project/README.md
@@ -14,7 +14,7 @@ itself. For governance over the *workflows* that run on Swamp, see
 
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
-| Runnable local and connected runtime walkthrough | Real | `./examples/swamp-project/demo-local.sh` then `./examples/swamp-project/demo-connected.sh` |
+| Runnable local walkthrough + deep connected bridge companion | Real | `./examples/swamp-project/demo-local.sh` then `./examples/swamp-project/demo-connected.sh` |
 | First-class source-chain coverage in the truth matrix | Not yet | this example is still a companion runtime story, not a first-class verified fixture |
 | Standalone live Swamp runtime proof | Not yet | current proof is runtime deployment governance, not live runtime evidence |
 
@@ -31,10 +31,15 @@ go build -o ./cub-gen ./cmd/cub-gen
 # Local runtime walkthrough
 ./examples/swamp-project/demo-local.sh
 
-# Connected governance path
+# Deep connected bridge path
 cub auth login
 ./examples/swamp-project/demo-connected.sh
 ```
+
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. Use
+`./examples/swamp-project/demo-connected.sh` when you specifically want this
+example's deeper bridge-backed walkthrough.
 
 ## Domain POV (runtime platform owners)
 
@@ -218,3 +223,7 @@ echo "connected (requires ConfigHub auth)"
 cub auth login
 ./examples/swamp-project/demo-connected.sh
 ```
+
+Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
+standard ConfigHub-connected environment. This wrapper is the deeper
+bridge-backed walkthrough for this example.


### PR DESCRIPTION
## Summary
- make the release-facing and example-facing docs default to the standard connected smoke path
- relabel deep `demo-connected.sh` flows and bridge commands as advanced bridge-backed walkthroughs
- update the release trackers so `#226` no longer appears as an open blocker after merge

## Why
`#226` was already partly solved in code: `make ci-connected` is bridge-free and the release-facing smoke lane no longer depends on bridge ingest. The remaining problem was the docs and example surfaces still teaching deep bridge flows as if they were the default connected story. This patch makes the default connected path smoke-first and leaves remaining bridge usage explicitly documented as optional deep lanes.

## Validation
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`
- `bash -n examples/demo/run-confighub-lifecycle-connected.sh examples/helm-paas/demo-connected.sh examples/scoredev-paas/demo-connected.sh examples/swamp-automation/demo-connected.sh`

Closes #226.