### PR TITLE
[codex] Align AI example hygiene surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Use confidence to decide routing speed:
 
 Full guide: [docs/workflows/confidence-scores.md](docs/workflows/confidence-scores.md)
 
+For AI-assisted and workflow-oriented examples, also use:
+- [docs/workflows/ai-example-hygiene-checklist.md](docs/workflows/ai-example-hygiene-checklist.md)
+- [docs/workflows/prompt-as-dry.md](docs/workflows/prompt-as-dry.md)
+
 ## Supported generators
 
 | Generator | Detects | Example |
@@ -204,10 +208,10 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
-| Example quality | `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202` |
+| Example quality | `#177`, `#178`, `#180`, `#185`, `#187`, `#202` |
 | CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
 | Release gate | `#218` |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#202`, `#218`, `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,6 +130,13 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 
     [Confidence Scores](workflows/confidence-scores.md)
 
+-   **Run AI-Safe Examples**
+
+    See the repo's bar for AI/workflow example quality and the canonical
+    prompt-as-DRY safety model.
+
+    [AI Example Hygiene Checklist](workflows/ai-example-hygiene-checklist.md) · [Prompt as DRY](workflows/prompt-as-dry.md)
+
 -   **Check what is really proven**
 
     Use the derived example matrix to see which examples are source-chain verified, in the connected smoke lane, AI-first, or backed by real live proof.

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -53,12 +53,12 @@ Current open issues:
 - [#180](https://github.com/confighub/cub-gen/issues/180) workflow examples
 - [#185](https://github.com/confighub/cub-gen/issues/185) custom-generator onboarding
 - [#187](https://github.com/confighub/cub-gen/issues/187) Kubara-like layered provenance
-- [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
 - [#202](https://github.com/confighub/cub-gen/issues/202) AI-first flagship surfaces
 
 Landed on `main`:
 
 - [#182](https://github.com/confighub/cub-gen/issues/182) entrypoint redesign
+- [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
 - [#207](https://github.com/confighub/cub-gen/issues/207) Spring block/escalate proof
 - [#208](https://github.com/confighub/cub-gen/issues/208) Spring embedded-config mutation support
 

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -49,6 +49,7 @@ exit-bar rationale still live in
 ### Closed or landed on `main`
 
 - [x] `#182` example/demo entrypoint redesign
+- [x] `#200` AI best-practice alignment across examples
 - [x] `#207` Spring block/escalate proof
 - [x] `#208` Spring embedded-config mutation support
 - [x] `#226` standard ConfigHub API/CLI over custom bridge endpoints
@@ -65,7 +66,6 @@ exit-bar rationale still live in
 - [ ] `#180` workflow example upgrade
 - [ ] `#185` custom-generator onboarding
 - [ ] `#187` layered provenance across overlays/ApplicationSet/labels
-- [ ] `#200` AI best-practice alignment across examples
 - [ ] `#202` AI-first flagship surfaces
 - [ ] `#218` release-environment ConfigHub smoke reliability
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -315,7 +315,9 @@ For AI and workflow examples, the DRY/WET model extends to prompts and context:
 This means human-authored changes and AI-assisted changes can run through the same
 governed ConfigHub MR path. The mutation ledger is what makes this auditable.
 
-See the [AI lane workflow](../docs/workflows/prompt-as-dry.md) for details.
+See the [AI Example Hygiene Checklist](../docs/workflows/ai-example-hygiene-checklist.md)
+for the repo-wide quality bar, and the [AI lane workflow](../docs/workflows/prompt-as-dry.md)
+for the canonical prompt-as-DRY path.
 
 ## Operations patterns
 

--- a/examples/ai-ops-paas/README.md
+++ b/examples/ai-ops-paas/README.md
@@ -24,6 +24,11 @@ full-platform companion to [`c3agent`](../c3agent/), not as the strongest
 source-side proof by itself. Start with `c3agent` first if you want the
 cleanest AI fleet proof, then come here for the registry + constraints layer.
 
+For the repo-wide AI example bar behind this example, use the
+[AI Example Hygiene Checklist](../../docs/workflows/ai-example-hygiene-checklist.md).
+For the non-deterministic companion model, see
+[Prompt as DRY](../../docs/workflows/prompt-as-dry.md).
+
 ## Fastest path to believe it
 
 ```bash
@@ -85,6 +90,8 @@ surface for platform owners.
   render self-service forms
 - **30 lines → 11 targets**: minimal DRY input produces a complete governed
   Kubernetes footprint
+- **Verification + attestation loop**: AI fleet changes still go through the
+  same publish/verify/attest boundary before any connected decision state
 
 ## How AI Ops maps to DRY / WET / LIVE
 

--- a/examples/c3agent/README.md
+++ b/examples/c3agent/README.md
@@ -39,6 +39,11 @@ This is the strongest compact AI fleet example in the repo today. Use
 [`ai-ops-paas`](../ai-ops-paas/) when you need the broader registry/constraint
 platform story, but start here when you want the cleaner source-side proof.
 
+For the repo-wide AI example bar behind this example, use the
+[AI Example Hygiene Checklist](../../docs/workflows/ai-example-hygiene-checklist.md).
+For the non-deterministic companion model, see
+[Prompt as DRY](../../docs/workflows/prompt-as-dry.md).
+
 ## 1. Who this is for
 
 | If you are... | Start here |
@@ -85,6 +90,8 @@ traceability, and safe escalation paths.
 - **Budget visibility**: aggregate budget tracking across all agent fleets
 - **Credential audit**: "which fleets reference prod credentials?" — cross-repo
   query
+- **Verification + attestation loop**: the same publish/verify/attest path used
+  for app changes remains the safety boundary for AI fleet changes too
 
 ## How C3 Agent maps to DRY / WET / LIVE
 

--- a/examples/confighub-actions/README.md
+++ b/examples/confighub-actions/README.md
@@ -24,6 +24,11 @@ This example is strongest as a control-plane governance companion to
 cleaner first proof of governed workflow config, then use this to see the same
 model applied recursively to ConfigHub's own lifecycle.
 
+For the repo-wide AI/workflow example bar behind this example, use the
+[AI Example Hygiene Checklist](../../docs/workflows/ai-example-hygiene-checklist.md).
+For the non-deterministic companion model, see
+[Prompt as DRY](../../docs/workflows/prompt-as-dry.md).
+
 ## Fastest path to believe it
 
 ```bash
@@ -84,6 +89,8 @@ same rigor as app/runtime changes.
   policies are platform-owned configuration
 - **Break-glass override**: emergency changes bypass approval thresholds and
   deploy windows, with mandatory post-incident retrospective
+- **Attestable audit trail**: lifecycle changes keep the same evidence-first
+  review loop as other governed changes in the repo
 
 ## How ConfigHub Actions map to DRY / WET / LIVE
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -390,7 +390,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#202`, `#218`, `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 


### PR DESCRIPTION
## Summary
- make the AI example hygiene checklist and prompt-as-DRY model discoverable from the top-level repo and examples surfaces
- align the main AI-facing companion examples with the same verification/attestation and audit-trail framing
- update the `v0.2-preview.2` trackers so `#200` is no longer listed as an open blocker after merge

## Why
The repo already had the checklist and most of the workflow examples using it, but a few AI-facing companion examples still felt disconnected from that bar. This closes the remaining discoverability and consistency gap so maintainers can point to one checklist and the example surface actually reflects it.

## Validation
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`

Closes #200.