### PR TITLE
Add AI-first flagship example bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ to source file, line, and owner before anything reaches the cluster.
 | Spring Boot services in GitOps | [springboot-paas](examples/springboot-paas/) | Which `application.yaml` setting or platform file should I edit? |
 | Cluster-first GitOps operations | ConfigHub GitOps import + [cub-scout](https://github.com/confighub/cub-scout) + then `cub-gen` | What is running, and what source produced it? |
 
+## AI-first flagship bundles
+
+The flagship examples now include a matching operator bundle for humans and AI
+assistants:
+
+- [helm-paas](examples/helm-paas/) -> [AI_START_HERE](examples/helm-paas/AI_START_HERE.md), [prompts](examples/helm-paas/prompts.md), [contracts](examples/helm-paas/contracts.md)
+- [scoredev-paas](examples/scoredev-paas/) -> [AI_START_HERE](examples/scoredev-paas/AI_START_HERE.md), [prompts](examples/scoredev-paas/prompts.md), [contracts](examples/scoredev-paas/contracts.md)
+- [springboot-paas](examples/springboot-paas/) -> [AI_START_HERE](examples/springboot-paas/AI_START_HERE.md), [prompts](examples/springboot-paas/prompts.md), [contracts](examples/springboot-paas/contracts.md)
+- [swamp-automation](examples/swamp-automation/) -> [AI_START_HERE](examples/swamp-automation/AI_START_HERE.md), [prompts](examples/swamp-automation/prompts.md), [contracts](examples/swamp-automation/contracts.md)
+
 ## What it looks like
 
 ```bash
@@ -204,10 +214,10 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
-| Example quality | `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202` |
+| Example quality | `#177`, `#178`, `#180`, `#185`, `#187`, `#200` |
 | CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
 | Release gate | `#218` |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#218`, `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -186,6 +186,8 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 - repo-first CLI and contract coverage remain green,
 - current release work is focused on full example-catalog quality,
 - CLI/help/docs must match clean-checkout behavior,
+- flagship Helm, Score, Spring, and Swamp examples now carry explicit
+  `AI_START_HERE.md`, `prompts.md`, and `contracts.md` bundles,
 - connected release status must be backed by a credible lane the team actually runs.
 
 See the [v0.2-preview.2 Release Plan](releases/v0.2-preview.2-plan.md) for the

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -54,11 +54,11 @@ Current open issues:
 - [#185](https://github.com/confighub/cub-gen/issues/185) custom-generator onboarding
 - [#187](https://github.com/confighub/cub-gen/issues/187) Kubara-like layered provenance
 - [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
-- [#202](https://github.com/confighub/cub-gen/issues/202) AI-first flagship surfaces
 
 Landed on `main`:
 
 - [#182](https://github.com/confighub/cub-gen/issues/182) entrypoint redesign
+- [#202](https://github.com/confighub/cub-gen/issues/202) AI-first flagship surfaces
 - [#207](https://github.com/confighub/cub-gen/issues/207) Spring block/escalate proof
 - [#208](https://github.com/confighub/cub-gen/issues/208) Spring embedded-config mutation support
 

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -19,7 +19,7 @@ exit-bar rationale still live in
   - `12` with connected mode entrypoints
   - `2` covered by the connected smoke lane
   - real live proof: `none=9`, `paired-harness=1`, `standalone=2`
-  - AI-first surface: `none=6`, `partial=2`, `explicit=4`
+  - AI-first surface: `none=3`, `partial=2`, `explicit=7`
 
 ## Landed on `main` already
 
@@ -53,6 +53,7 @@ exit-bar rationale still live in
 - [x] `#208` Spring embedded-config mutation support
 - [x] `#226` standard ConfigHub API/CLI over custom bridge endpoints
 - [x] `#227` rethink the size and purpose of `ci-connected`
+- [x] `#202` AI-first flagship surfaces
 - [x] `#232` README structure
 - [x] `#233` help-text duplication
 - [x] `#234` remove stale prototype framing
@@ -66,7 +67,6 @@ exit-bar rationale still live in
 - [ ] `#185` custom-generator onboarding
 - [ ] `#187` layered provenance across overlays/ApplicationSet/labels
 - [ ] `#200` AI best-practice alignment across examples
-- [ ] `#202` AI-first flagship surfaces
 - [ ] `#218` release-environment ConfigHub smoke reliability
 
 For this preview, "all examples working well" means each featured example has:

--- a/docs/releases/v0.2-preview.2.md
+++ b/docs/releases/v0.2-preview.2.md
@@ -77,9 +77,9 @@ release-facing proof.
    - standalone live-cluster proof from `score.yaml`
    Ref: `#178`
 
-3. Workflow and AI surfaces are clearer, but not yet fully at the new flagship
-   bar for runnable platform stories and AI-first acceptance.
-   Refs: `#180`, `#200`, `#202`
+3. Workflow and AI surfaces are clearer, but still need deeper runnable
+   platform-story completion beyond the new flagship AI bundles.
+   Refs: `#180`, `#200`
 
 4. The release environment still needs the final secrets-backed connected smoke
    confirmation for the intended tag environment.

--- a/docs/testing/example-truth-matrix.json
+++ b/docs/testing/example-truth-matrix.json
@@ -23,8 +23,7 @@
       "tracking_issues": [
         "#173",
         "#181",
-        "#183",
-        "#202"
+        "#183"
       ]
     },
     {
@@ -82,7 +81,6 @@
         "#173",
         "#181",
         "#183",
-        "#202",
         "#216"
       ]
     },
@@ -108,8 +106,7 @@
       "tracking_issues": [
         "#173",
         "#181",
-        "#183",
-        "#202"
+        "#183"
       ]
     },
     {
@@ -120,7 +117,7 @@
       "connected_mode_present": true,
       "connected_release_gated": true,
       "real_live_proof": "paired-harness",
-      "ai_first_surface": "none",
+      "ai_first_surface": "explicit",
       "proof_commands": [
         "./examples/demo/e2e-connected-governed-reconcile-helm.sh",
         "./examples/demo/run-connected-smoke.sh",
@@ -145,6 +142,11 @@
           "./examples/helm-paas/demo-runtime.sh",
           "./examples/demo/e2e-connected-governed-reconcile-helm.sh",
           "./examples/live-reconcile/demo-local.sh"
+        ],
+        "ai_first": [
+          "./examples/helm-paas/AI_START_HERE.md",
+          "./examples/helm-paas/prompts.md",
+          "./examples/helm-paas/contracts.md"
         ]
       },
       "tracking_issues": [
@@ -244,8 +246,7 @@
       "tracking_issues": [
         "#173",
         "#180",
-        "#183",
-        "#202"
+        "#183"
       ]
     },
     {
@@ -256,7 +257,7 @@
       "connected_mode_present": true,
       "connected_release_gated": false,
       "real_live_proof": "none",
-      "ai_first_surface": "none",
+      "ai_first_surface": "explicit",
       "proof_commands": [
         "./examples/scoredev-paas/demo-connected.sh",
         "go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v"
@@ -267,6 +268,11 @@
         ],
         "connected_mode": [
           "./examples/scoredev-paas/demo-connected.sh"
+        ],
+        "ai_first": [
+          "./examples/scoredev-paas/AI_START_HERE.md",
+          "./examples/scoredev-paas/prompts.md",
+          "./examples/scoredev-paas/contracts.md"
         ]
       },
       "tracking_issues": [
@@ -286,7 +292,7 @@
       "connected_mode_present": true,
       "connected_release_gated": true,
       "real_live_proof": "standalone",
-      "ai_first_surface": "none",
+      "ai_first_surface": "explicit",
       "proof_commands": [
         "./examples/demo/run-connected-smoke.sh",
         "./examples/springboot-paas/bin/build-image",
@@ -313,6 +319,11 @@
           "./examples/springboot-paas/confighub-verify.sh",
           "./examples/springboot-paas/bin/create-cluster",
           "./examples/springboot-paas/bin/build-image"
+        ],
+        "ai_first": [
+          "./examples/springboot-paas/AI_START_HERE.md",
+          "./examples/springboot-paas/prompts.md",
+          "./examples/springboot-paas/contracts.md"
         ]
       },
       "tracking_issues": [
@@ -345,14 +356,15 @@
           "./examples/swamp-automation/demo-connected.sh"
         ],
         "ai_first": [
-          "examples/README.md#ai--automation-patterns"
+          "./examples/swamp-automation/AI_START_HERE.md",
+          "./examples/swamp-automation/prompts.md",
+          "./examples/swamp-automation/contracts.md"
         ]
       },
       "tracking_issues": [
         "#173",
         "#180",
-        "#183",
-        "#202"
+        "#183"
       ]
     },
     {
@@ -377,8 +389,7 @@
       "tracking_issues": [
         "#173",
         "#180",
-        "#183",
-        "#202"
+        "#183"
       ]
     }
   ],
@@ -394,8 +405,8 @@
       "standalone": 2
     },
     "ai_first_surface": {
-      "explicit": 4,
-      "none": 6,
+      "explicit": 7,
+      "none": 3,
       "partial": 2
     }
   }

--- a/docs/testing/example-truth-matrix.md
+++ b/docs/testing/example-truth-matrix.md
@@ -10,24 +10,24 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Connected mode present: `12`
 - Connected smoke gated: `2`
 - Real live proof: `none=9`, `paired-harness=1`, `standalone=2`
-- AI-first surface: `none=6`, `partial=2`, `explicit=4`
+- AI-first surface: `none=3`, `partial=2`, `explicit=7`
 
 ## Matrix
 
 | Example | Generator fixture | Source chain verified | Connected mode | Connected smoke lane | Real live proof | AI-first surface | Tracking issues |
 |---|---|---|---|---|---|---|---|
-| `ai-ops-paas` | no | no | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183), [#202](https://github.com/confighub/cub-gen/issues/202) |
+| `ai-ops-paas` | no | no | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
 | `backstage-idp` | yes | yes | yes | no | `none` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `c3agent` | yes | yes | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183), [#202](https://github.com/confighub/cub-gen/issues/202), [#216](https://github.com/confighub/cub-gen/issues/216) |
-| `confighub-actions` | no | no | yes | no | `none` | `partial` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183), [#202](https://github.com/confighub/cub-gen/issues/202) |
-| `helm-paas` | yes | yes | yes | yes | `paired-harness` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#177](https://github.com/confighub/cub-gen/issues/177), [#183](https://github.com/confighub/cub-gen/issues/183), [#187](https://github.com/confighub/cub-gen/issues/187) |
+| `c3agent` | yes | yes | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183), [#216](https://github.com/confighub/cub-gen/issues/216) |
+| `confighub-actions` | no | no | yes | no | `none` | `partial` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
+| `helm-paas` | yes | yes | yes | yes | `paired-harness` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#177](https://github.com/confighub/cub-gen/issues/177), [#183](https://github.com/confighub/cub-gen/issues/183), [#187](https://github.com/confighub/cub-gen/issues/187) |
 | `just-apps-no-platform-config` | yes | yes | yes | no | `none` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
 | `live-reconcile` | no | no | yes | no | `standalone` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `ops-workflow` | yes | yes | yes | no | `none` | `partial` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183), [#202](https://github.com/confighub/cub-gen/issues/202) |
-| `scoredev-paas` | yes | yes | yes | no | `none` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#178](https://github.com/confighub/cub-gen/issues/178), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `springboot-paas` | yes | yes | yes | yes | `standalone` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#179](https://github.com/confighub/cub-gen/issues/179), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `swamp-automation` | yes | yes | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183), [#202](https://github.com/confighub/cub-gen/issues/202) |
-| `swamp-project` | no | no | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183), [#202](https://github.com/confighub/cub-gen/issues/202) |
+| `ops-workflow` | yes | yes | yes | no | `none` | `partial` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183) |
+| `scoredev-paas` | yes | yes | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#178](https://github.com/confighub/cub-gen/issues/178), [#183](https://github.com/confighub/cub-gen/issues/183) |
+| `springboot-paas` | yes | yes | yes | yes | `standalone` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#179](https://github.com/confighub/cub-gen/issues/179), [#183](https://github.com/confighub/cub-gen/issues/183) |
+| `swamp-automation` | yes | yes | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183) |
+| `swamp-project` | no | no | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183) |
 
 ## Proof References
 
@@ -69,7 +69,7 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Connected mode: `./examples/helm-paas/demo-connected.sh`
 - Connected smoke lane: `make ci-connected`, `./examples/demo/run-connected-smoke.sh`
 - Real live: `./examples/helm-paas/demo-runtime.sh`, `./examples/demo/e2e-connected-governed-reconcile-helm.sh`, `./examples/live-reconcile/demo-local.sh`
-- AI-first: --
+- AI-first: `./examples/helm-paas/AI_START_HERE.md`, `./examples/helm-paas/prompts.md`, `./examples/helm-paas/contracts.md`
 - Notes: Real LIVE proof is exposed through an example-owned helm-paas wrapper, but still uses the shared live-reconcile harness under the hood.
 
 ### `just-apps-no-platform-config`
@@ -103,7 +103,7 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Connected mode: `./examples/scoredev-paas/demo-connected.sh`
 - Connected smoke lane: --
 - Real live: --
-- AI-first: --
+- AI-first: `./examples/scoredev-paas/AI_START_HERE.md`, `./examples/scoredev-paas/prompts.md`, `./examples/scoredev-paas/contracts.md`
 - Notes: Score now has example-owned local governed proof via ./examples/scoredev-paas/demo-governed-workload.sh for ALLOW versus ESCALATE, even though standalone live-cluster proof is still open.
 
 ### `springboot-paas`
@@ -112,7 +112,7 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Connected mode: `./examples/springboot-paas/demo-connected.sh`
 - Connected smoke lane: `make ci-connected`, `./examples/demo/run-connected-smoke.sh`
 - Real live: `./examples/springboot-paas/verify-e2e.sh`, `./examples/springboot-paas/confighub-verify.sh`, `./examples/springboot-paas/bin/create-cluster`, `./examples/springboot-paas/bin/build-image`
-- AI-first: --
+- AI-first: `./examples/springboot-paas/AI_START_HERE.md`, `./examples/springboot-paas/prompts.md`, `./examples/springboot-paas/contracts.md`
 - Notes: Standalone real-cluster proof: Kind cluster + ConfigHub worker + inventory-api HTTP verification.
 
 ### `swamp-automation`
@@ -121,7 +121,7 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Connected mode: `./examples/swamp-automation/demo-connected.sh`
 - Connected smoke lane: --
 - Real live: --
-- AI-first: `examples/README.md#ai--automation-patterns`
+- AI-first: `./examples/swamp-automation/AI_START_HERE.md`, `./examples/swamp-automation/prompts.md`, `./examples/swamp-automation/contracts.md`
 
 ### `swamp-project`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,17 @@ what you already run:
 | Score.dev workloads | `./examples/demo/start-score-first.sh` | `./examples/scoredev-paas/demo-governed-workload.sh`, then `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field origin now, local ALLOW/ESCALATE proof next, governed connected output after | Strongest Score source-side path today; standalone live Score proof is still open work |
 | A running cluster and GitOps controller | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | trace one chosen field back to source | live cluster state first, source provenance second | Best when the cluster is already the urgent source of truth |
 
+## Flagship AI bundles
+
+The four flagship examples now carry the same AI-first operator bundle:
+
+| Example | AI start | Prompt pack | Inspection contract |
+|---|---|---|---|
+| [`helm-paas`](./helm-paas/) | [AI_START_HERE.md](./helm-paas/AI_START_HERE.md) | [prompts.md](./helm-paas/prompts.md) | [contracts.md](./helm-paas/contracts.md) |
+| [`scoredev-paas`](./scoredev-paas/) | [AI_START_HERE.md](./scoredev-paas/AI_START_HERE.md) | [prompts.md](./scoredev-paas/prompts.md) | [contracts.md](./scoredev-paas/contracts.md) |
+| [`springboot-paas`](./springboot-paas/) | [AI_START_HERE.md](./springboot-paas/AI_START_HERE.md) | [prompts.md](./springboot-paas/prompts.md) | [contracts.md](./springboot-paas/contracts.md) |
+| [`swamp-automation`](./swamp-automation/) | [AI_START_HERE.md](./swamp-automation/AI_START_HERE.md) | [prompts.md](./swamp-automation/prompts.md) | [contracts.md](./swamp-automation/contracts.md) |
+
 ## What ends with something live today
 
 | Path | Live thing you can inspect | Command | Truth today |

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -29,6 +29,13 @@ For exact per-example proof tiers, use the generated
 For workflow and AI example quality, use the
 [AI Example Hygiene Checklist](../../docs/workflows/ai-example-hygiene-checklist.md).
 
+The flagship examples also now publish an explicit AI-first bundle:
+
+- [`helm-paas`](../helm-paas/AI_START_HERE.md) with companion [prompts](../helm-paas/prompts.md) and [contracts](../helm-paas/contracts.md)
+- [`scoredev-paas`](../scoredev-paas/AI_START_HERE.md) with companion [prompts](../scoredev-paas/prompts.md) and [contracts](../scoredev-paas/contracts.md)
+- [`springboot-paas`](../springboot-paas/AI_START_HERE.md) with companion [prompts](../springboot-paas/prompts.md) and [contracts](../springboot-paas/contracts.md)
+- [`swamp-automation`](../swamp-automation/AI_START_HERE.md) with companion [prompts](../swamp-automation/prompts.md) and [contracts](../swamp-automation/contracts.md)
+
 ## 1. Start with one of these
 
 | If you already run... | Start here | What actually runs | What you can inspect next |
@@ -390,7 +397,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#202`, `#218`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#218`, `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 

--- a/examples/helm-paas/AI_START_HERE.md
+++ b/examples/helm-paas/AI_START_HERE.md
@@ -1,0 +1,92 @@
+# AI Start Here: `helm-paas`
+
+Use this example when the repo already uses Helm plus Flux or Argo and the
+first question is: "which values file or chart layer controls this field?"
+
+## What this proves
+
+- Helm field-origin tracing from chart/value inputs to rendered Kubernetes fields
+- a local `ALLOW` path and a local `BLOCK` path for ownership boundaries
+- a deeper connected ConfigHub walkthrough
+- optional live Flux/Argo runtime proof
+
+## What you need installed
+
+- Go 1.22+
+- `jq`
+- `cub` only for connected mode
+- `kubectl` and kind only for the live runtime path
+
+## What this reads and writes
+
+| Step | Reads | Writes | Mutates repo/backend/live? |
+|---|---|---|---|
+| `go build -o ./cub-gen ./cmd/cub-gen` | local source | `./cub-gen` binary | local binary only |
+| `gitops discover/import` | `Chart.yaml`, `values*.yaml`, `templates/`, `platform/`, `gitops/` | stdout JSON only | no |
+| `demo-governed-change.sh` | example repo + ownership gate scripts | `.tmp/helm-paas-governed-change/<run>/...` | scratch clone only |
+| `run-connected-smoke.sh` | repo + ConfigHub auth/context | `.tmp/connected-smoke/<run>/...` | backend evidence only |
+| `demo-connected.sh` | repo + ConfigHub auth/context | temporary connected lifecycle artifacts unless `OUTPUT_DIR` is set | backend evidence only |
+| `demo-runtime.sh` | repo + ConfigHub auth/context + clusters | `.tmp/helm-paas-runtime/...` plus live namespace objects | yes, live cluster |
+
+## Safest first step
+
+Build once, then start with a read-only preview:
+
+```bash
+go build -o ./cub-gen ./cmd/cub-gen
+./cub-gen gitops import --space platform --json ./examples/helm-paas \
+  | jq '{
+      profile: .discovered[0].generator_profile,
+      dry_inputs,
+      wet_manifest_targets,
+      inverse_hint: .provenance[0].inverse_edit_pointers[0]
+    }'
+```
+
+What it does:
+- reads the Helm example only
+- writes nothing except stdout
+- shows the generator profile, DRY inputs, rendered targets, and one edit hint
+
+Success looks like:
+- `generator_profile` is `helm-paas`
+- `dry_inputs` includes values/chart inputs
+- `wet_manifest_targets` is non-empty
+- `inverse_hint.owner` is populated
+
+## Safe run order
+
+1. Repo-only preview:
+   `./cub-gen gitops import --space platform --json ./examples/helm-paas`
+2. Local governed proof:
+   `./examples/helm-paas/demo-governed-change.sh`
+3. Connected environment check:
+   `cub auth login && ./examples/demo/run-connected-smoke.sh`
+4. Deep connected walkthrough:
+   `cub auth login && ./examples/helm-paas/demo-connected.sh`
+5. Live runtime proof:
+   `cub auth login && RECONCILER=both ./examples/helm-paas/demo-runtime.sh`
+
+## What to verify after each major step
+
+- Repo-only preview: `dry_inputs`, `wet_manifest_targets`, and one inverse-edit pointer are present.
+- Local governed proof: the allowed path passes and the template edit is rejected; artifacts land under `.tmp/helm-paas-governed-change/...`.
+- Connected smoke: ConfigHub auth/context is valid and the flagship smoke summaries include a non-empty `change_id`.
+- Deep connected walkthrough: a terminal decision state is returned for the same `change_id`.
+- Live runtime: Flux and/or Argo report a healthy rollout and `kubectl get deploy,pods,svc` shows live objects.
+
+## GUI checkpoints
+
+- ConfigHub GUI: inspect the change referenced by `change_id` after smoke or deep connected mode.
+- Flux/Argo UI or kubectl: inspect the live `payments-api` deployment after `demo-runtime.sh`.
+
+## Trust order when outputs disagree
+
+1. Trust local `gitops import --json` for source-to-render mapping.
+2. Trust the connected backend decision output for `ALLOW/ESCALATE/BLOCK`.
+3. Trust live Flux/Argo and `kubectl` for runtime truth.
+
+## Cleanup
+
+- Remove local proof artifacts with `rm -rf .tmp/helm-paas-governed-change .tmp/connected-smoke .tmp/helm-paas-runtime`
+- Remove live namespaces/clusters with the same scripts you normally use for the live reconcile harness

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -33,6 +33,15 @@ Known gaps still open:
 - one-command multi-variant fan-out is not exposed yet ([#237](https://github.com/confighub/cub-gen/issues/237))
 - CLI override capture for `--set` / `--set-file` is not modeled yet ([#242](https://github.com/confighub/cub-gen/issues/242))
 
+## AI-first bundle
+
+Use these together if the first operator is an AI assistant or if you want a
+safe, step-by-step handoff:
+
+- [AI_START_HERE.md](./AI_START_HERE.md)
+- [prompts.md](./prompts.md)
+- [contracts.md](./contracts.md)
+
 ## Start here by audience
 
 | If you are... | First command | Then do this | What you can inspect |

--- a/examples/helm-paas/contracts.md
+++ b/examples/helm-paas/contracts.md
@@ -1,0 +1,113 @@
+# Contracts: `helm-paas`
+
+Treat these as stable inspection contracts for human operators and AI
+assistants. If any `expects` check fails, stop and report the mismatch.
+
+## Repo preview
+
+```yaml
+id: helm_repo_preview
+command: ./cub-gen gitops import --space platform --json ./examples/helm-paas
+mutates:
+  repo: false
+  backend: false
+  live: false
+expects:
+  generator_profile: helm-paas
+  dry_inputs_min: 1
+  wet_manifest_targets_min: 1
+  inverse_edit_pointers_min: 1
+inspect_with:
+  - jq '.discovered[0].generator_profile'
+  - jq '.dry_inputs | length'
+  - jq '.wet_manifest_targets | length'
+  - jq '.provenance[0].inverse_edit_pointers[0]'
+```
+
+## Local governed ownership proof
+
+```yaml
+id: helm_local_governed_change
+command: ./examples/helm-paas/demo-governed-change.sh
+mutates:
+  repo: scratch_clone_only
+  backend: false
+  live: false
+expects:
+  stdout_contains:
+    - "[helm-governed] success"
+  files_exist:
+    - ".tmp/helm-paas-governed-change/<run>/allow-explain.json"
+    - ".tmp/helm-paas-governed-change/<run>/allow-report.json"
+    - ".tmp/helm-paas-governed-change/<run>/block-report.json"
+    - ".tmp/helm-paas-governed-change/<run>/block-gate.log"
+  evidence:
+    allow_path: "app-team edit in values.yaml passes"
+    block_path: "app-team edit in templates/deployment.yaml fails"
+inspect_with:
+  - jq '.explanation.owner, .explanation.dry_path' allow-explain.json
+  - jq '{status, changed_files, failures}' allow-report.json
+  - jq '{status, changed_files, failures}' block-report.json
+```
+
+## Connected smoke preflight
+
+```yaml
+id: helm_connected_smoke
+command: cub auth login && ./examples/demo/run-connected-smoke.sh
+mutates:
+  repo: false
+  backend: true
+  live: false
+expects:
+  files_exist:
+    - ".tmp/connected-smoke/<run>/helm-paas/summary.json"
+  summary_fields:
+    change_id: non_empty
+    verify_valid: true
+    attestation_valid: true
+    linked_bundle_check: true
+inspect_with:
+  - jq '{change_id, verify_valid, attestation_valid, linked_bundle_check}' .tmp/connected-smoke/<run>/helm-paas/summary.json
+```
+
+## Deep connected walkthrough
+
+```yaml
+id: helm_connected_deep
+command: OUTPUT_DIR=.tmp/helm-paas-connected ./examples/helm-paas/demo-connected.sh
+mutates:
+  repo: false
+  backend: true
+  live: false
+expects:
+  files_exist:
+    - ".tmp/helm-paas-connected/create/summary.json"
+    - ".tmp/helm-paas-connected/update/summary.json"
+    - ".tmp/helm-paas-connected/create/decision-final.json"
+    - ".tmp/helm-paas-connected/update/decision-final.json"
+  decision_state: terminal_allow_escalate_or_block
+inspect_with:
+  - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/helm-paas-connected/create/summary.json
+  - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/helm-paas-connected/update/summary.json
+```
+
+## Live runtime proof
+
+```yaml
+id: helm_live_runtime
+command: RECONCILER=both ./examples/helm-paas/demo-runtime.sh
+mutates:
+  repo: false
+  backend: true
+  live: true
+expects:
+  live_checks:
+    - "Flux and Argo report healthy reconciliation"
+    - "kubectl get deploy,pods,svc shows payments-api objects"
+  artifact_root: ".tmp/helm-paas-runtime"
+inspect_with:
+  - kubectl get deploy,pods,svc -n payments-platform
+  - flux get helmreleases -A
+  - kubectl get applications -A
+```

--- a/examples/helm-paas/prompts.md
+++ b/examples/helm-paas/prompts.md
@@ -1,0 +1,73 @@
+# Prompts: `helm-paas`
+
+Copy one block into Claude, Codex, or Cursor when you want an assistant to run
+this example safely from the repo root.
+
+## Safe preview prompt
+
+```text
+You are helping me inspect ./examples/helm-paas in the cub-gen repo.
+
+Start in read-only mode.
+
+1. Build ./cub-gen only if it is missing.
+2. Run:
+   ./cub-gen gitops import --space platform --json ./examples/helm-paas | jq '{
+     profile: .discovered[0].generator_profile,
+     dry_inputs,
+     wet_manifest_targets,
+     inverse_hint: .provenance[0].inverse_edit_pointers[0]
+   }'
+3. Summarize:
+   - generator profile
+   - main DRY inputs
+   - one rendered target
+   - one inverse edit hint with owner and confidence
+4. Tell me exactly what the command read and what it did not mutate.
+
+Do not run connected or live commands yet.
+Stop if any prerequisite is missing.
+```
+
+## Local governed proof prompt
+
+```text
+Run the local governed ownership proof for ./examples/helm-paas.
+
+1. Use:
+   ./examples/helm-paas/demo-governed-change.sh
+2. Capture the artifact directory from the script output.
+3. Summarize:
+   - which app-team edit passed
+   - which platform-owned edit failed
+   - the key files created under the artifact directory
+4. Show me the most important evidence from:
+   - allow-explain.json
+   - allow-report.json
+   - block-report.json
+
+Do not run ConfigHub or live cluster steps in this prompt.
+```
+
+## Connected plus live prompt
+
+```text
+Help me run the connected and optional live Helm proof for ./examples/helm-paas.
+
+Safety rules:
+- Run the shared connected smoke check before the example-specific connected flow.
+- Stop immediately if cub auth/context is missing.
+- Do not run the live runtime path unless I explicitly asked for cluster mutation.
+
+Sequence:
+1. cub auth login
+2. ./examples/demo/run-connected-smoke.sh
+3. OUTPUT_DIR=.tmp/helm-paas-connected ./examples/helm-paas/demo-connected.sh
+4. Only if I confirmed the live step:
+   RECONCILER=both ./examples/helm-paas/demo-runtime.sh
+
+After each step, tell me:
+- what changed
+- what stayed local/backend/live
+- what to inspect next in ConfigHub or the cluster
+```

--- a/examples/ops-workflow/README.md
+++ b/examples/ops-workflow/README.md
@@ -22,7 +22,8 @@ ALLOW decision.
 Known gaps still open:
 
 - real workflow runtime or live artifact proof is still open work ([#180](https://github.com/confighub/cub-gen/issues/180))
-- the fuller AI-first example bundle standard is still open work ([#202](https://github.com/confighub/cub-gen/issues/202))
+- `swamp-automation` is still the stronger AI-first workflow bundle today; this
+  example remains a lighter workflow companion surface
 
 ## Fastest path to believe it
 

--- a/examples/scoredev-paas/AI_START_HERE.md
+++ b/examples/scoredev-paas/AI_START_HERE.md
@@ -1,0 +1,93 @@
+# AI Start Here: `scoredev-paas`
+
+Use this example when developers keep `score.yaml` as the app-team contract and
+you need to explain how that intent becomes governed runtime config.
+
+## What this proves
+
+- Score field-origin tracing from `score.yaml` to rendered runtime fields
+- a local `ALLOW` path and a local `ESCALATE` path for workload contracts
+- a deeper connected ConfigHub walkthrough
+- honest current limit: no standalone live Score runtime proof yet
+
+## What you need installed
+
+- Go 1.22+
+- `jq`
+- `cub` only for connected mode
+
+## What this reads and writes
+
+| Step | Reads | Writes | Mutates repo/backend/live? |
+|---|---|---|---|
+| `go build -o ./cub-gen ./cmd/cub-gen` | local source | `./cub-gen` binary | local binary only |
+| `gitops discover/import` | `score.yaml`, `platform/contracts`, `platform/policies`, `gitops/` | stdout JSON only | no |
+| `score validate-workload` | `score.yaml`, workload class contract | stdout only | no |
+| `demo-governed-workload.sh` | example repo + contract | `.tmp/scoredev-governed-workload/<run>/...` | scratch clone only |
+| `run-connected-smoke.sh` | repo + ConfigHub auth/context | `.tmp/connected-smoke/<run>/...` | backend evidence only |
+| `demo-connected.sh` | repo + ConfigHub auth/context | temporary connected lifecycle artifacts unless `OUTPUT_DIR` is set | backend evidence only |
+
+## Safest first step
+
+Build once, then run a read-only preview plus a read-only contract check:
+
+```bash
+go build -o ./cub-gen ./cmd/cub-gen
+./cub-gen gitops import --space platform --json ./examples/scoredev-paas \
+  | jq '{
+      profile: .discovered[0].generator_profile,
+      dry_inputs,
+      wet_manifest_targets,
+      inverse_hint: .provenance[0].inverse_edit_pointers[0]
+    }'
+./cub-gen score validate-workload \
+  --score ./examples/scoredev-paas/score.yaml \
+  --contract ./examples/scoredev-paas/platform/contracts/workload-class.yaml
+```
+
+What it does:
+- reads the Score example only
+- writes nothing except stdout
+- shows field provenance and whether the current workload stays inside contract
+
+Success looks like:
+- `generator_profile` is `scoredev-paas`
+- `dry_inputs` includes `score.yaml`
+- `wet_manifest_targets` is non-empty
+- the workload contract returns an allowed result for the current fixture
+
+## Safe run order
+
+1. Repo-only preview:
+   `./cub-gen gitops import --space platform --json ./examples/scoredev-paas`
+2. Read-only contract check:
+   `./cub-gen score validate-workload --score ./examples/scoredev-paas/score.yaml --contract ./examples/scoredev-paas/platform/contracts/workload-class.yaml`
+3. Local governed proof:
+   `./examples/scoredev-paas/demo-governed-workload.sh`
+4. Connected environment check:
+   `cub auth login && ./examples/demo/run-connected-smoke.sh`
+5. Deep connected walkthrough:
+   `cub auth login && ./examples/scoredev-paas/demo-connected.sh`
+
+## What to verify after each major step
+
+- Repo-only preview: the import JSON includes `score.yaml` lineage and inverse-edit hints.
+- Read-only contract check: the current example returns an allowed result without mutating anything.
+- Local governed proof: the image update stays allowed and the unapproved resource type escalates; artifacts land under `.tmp/scoredev-governed-workload/...`.
+- Connected smoke: ConfigHub auth/context is valid and the smoke summaries include a non-empty `change_id`.
+- Deep connected walkthrough: a terminal connected decision state is returned for the same `change_id`.
+
+## GUI checkpoints
+
+- ConfigHub GUI: inspect the change referenced by `change_id` after smoke or deep connected mode.
+- Runtime note: use `springboot-paas` or `live-reconcile` if you specifically need an in-repo live runtime proof today.
+
+## Trust order when outputs disagree
+
+1. Trust local `gitops import --json` for source-to-render mapping.
+2. Trust `score validate-workload` for current workload-class contract evaluation.
+3. Trust the connected backend decision output for final connected decision state.
+
+## Cleanup
+
+- Remove local proof artifacts with `rm -rf .tmp/scoredev-governed-workload .tmp/connected-smoke`

--- a/examples/scoredev-paas/README.md
+++ b/examples/scoredev-paas/README.md
@@ -25,6 +25,15 @@ runtime proof elsewhere in the repo right now, use [`springboot-paas`](../spring
 or [`live-reconcile`](../live-reconcile/) as the current runtime companions
 while the Score-specific live path is being finished.
 
+## AI-first bundle
+
+Use these together if the first operator is an AI assistant or if you want a
+safe, step-by-step handoff:
+
+- [AI_START_HERE.md](./AI_START_HERE.md)
+- [prompts.md](./prompts.md)
+- [contracts.md](./contracts.md)
+
 ## Start here by audience
 
 | If you are... | First command | Then do this | What you can inspect |

--- a/examples/scoredev-paas/contracts.md
+++ b/examples/scoredev-paas/contracts.md
@@ -1,0 +1,107 @@
+# Contracts: `scoredev-paas`
+
+Treat these as stable inspection contracts for human operators and AI
+assistants. If any `expects` check fails, stop and report the mismatch.
+
+## Repo preview
+
+```yaml
+id: score_repo_preview
+command: ./cub-gen gitops import --space platform --json ./examples/scoredev-paas
+mutates:
+  repo: false
+  backend: false
+  live: false
+expects:
+  generator_profile: scoredev-paas
+  dry_inputs_include:
+    - score.yaml
+  wet_manifest_targets_min: 1
+  inverse_edit_pointers_min: 1
+inspect_with:
+  - jq '.discovered[0].generator_profile'
+  - jq '.dry_inputs'
+  - jq '.wet_manifest_targets | length'
+  - jq '.provenance[0].inverse_edit_pointers[0]'
+```
+
+## Read-only workload contract check
+
+```yaml
+id: score_validate_workload
+command: ./cub-gen score validate-workload --score ./examples/scoredev-paas/score.yaml --contract ./examples/scoredev-paas/platform/contracts/workload-class.yaml
+mutates:
+  repo: false
+  backend: false
+  live: false
+expects:
+  exit_code: 0
+  stdout_contains:
+    - "ALLOW"
+inspect_with:
+  - cat
+```
+
+## Local governed workload proof
+
+```yaml
+id: score_local_governed_workload
+command: ./examples/scoredev-paas/demo-governed-workload.sh
+mutates:
+  repo: scratch_clone_only
+  backend: false
+  live: false
+expects:
+  stdout_contains:
+    - "[score-governed] success"
+  files_exist:
+    - ".tmp/scoredev-governed-workload/<run>/allow-explain.json"
+    - ".tmp/scoredev-governed-workload/<run>/allow.txt"
+    - ".tmp/scoredev-governed-workload/<run>/escalate.txt"
+  evidence:
+    allow_path: "image update stays allowed"
+    escalate_path: "unapproved resource type escalates"
+inspect_with:
+  - jq '.explanation.owner, .explanation.dry_path' allow-explain.json
+  - cat allow.txt
+  - cat escalate.txt
+```
+
+## Connected preflight
+
+```yaml
+id: score_connected_preflight
+command: cub auth login && ./examples/demo/run-connected-smoke.sh
+mutates:
+  repo: false
+  backend: true
+  live: false
+expects:
+  shared_smoke_examples:
+    - helm-paas
+    - springboot-paas
+  purpose: "confirm auth and backend health before the Score deep walkthrough"
+inspect_with:
+  - jq '{change_id, verify_valid, attestation_valid}' .tmp/connected-smoke/<run>/helm-paas/summary.json
+  - jq '{change_id, verify_valid, attestation_valid}' .tmp/connected-smoke/<run>/springboot-paas/summary.json
+```
+
+## Deep connected walkthrough
+
+```yaml
+id: score_connected_deep
+command: OUTPUT_DIR=.tmp/scoredev-connected ./examples/scoredev-paas/demo-connected.sh
+mutates:
+  repo: false
+  backend: true
+  live: false
+expects:
+  files_exist:
+    - ".tmp/scoredev-connected/create/summary.json"
+    - ".tmp/scoredev-connected/update/summary.json"
+  decision_state: terminal_allow_escalate_or_block
+  note: "standalone live-cluster Score proof is still out of scope for this contract"
+inspect_with:
+  - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/scoredev-connected/create/summary.json
+  - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/scoredev-connected/update/summary.json
+```

--- a/examples/scoredev-paas/prompts.md
+++ b/examples/scoredev-paas/prompts.md
@@ -1,0 +1,63 @@
+# Prompts: `scoredev-paas`
+
+Copy one block into Claude, Codex, or Cursor when you want an assistant to run
+this example safely from the repo root.
+
+## Safe preview prompt
+
+```text
+You are helping me inspect ./examples/scoredev-paas in the cub-gen repo.
+
+Start read-only.
+
+1. Build ./cub-gen only if needed.
+2. Run:
+   ./cub-gen gitops import --space platform --json ./examples/scoredev-paas | jq '{
+     profile: .discovered[0].generator_profile,
+     dry_inputs,
+     wet_manifest_targets,
+     inverse_hint: .provenance[0].inverse_edit_pointers[0]
+   }'
+3. Run:
+   ./cub-gen score validate-workload \
+     --score ./examples/scoredev-paas/score.yaml \
+     --contract ./examples/scoredev-paas/platform/contracts/workload-class.yaml
+4. Summarize the provenance result and whether the current workload is allowed.
+
+Do not run connected flows yet.
+Tell me exactly what was read and what stayed unmodified.
+```
+
+## Local governed proof prompt
+
+```text
+Run the local governed Score proof for ./examples/scoredev-paas.
+
+1. Use:
+   ./examples/scoredev-paas/demo-governed-workload.sh
+2. Capture the artifact directory from the script output.
+3. Summarize:
+   - which app-owned change stayed allowed
+   - which resource addition escalated
+   - which files in the artifact directory prove each outcome
+
+Do not run backend or live-cluster steps in this prompt.
+```
+
+## Connected prompt
+
+```text
+Help me run the connected Score walkthrough for ./examples/scoredev-paas.
+
+Safety rules:
+- Start with the shared connected smoke check even though Score is not in the smoke lane.
+- Stop if cub auth/context is missing.
+- Be explicit that this example still does not claim standalone live-cluster Score proof.
+
+Sequence:
+1. cub auth login
+2. ./examples/demo/run-connected-smoke.sh
+3. OUTPUT_DIR=.tmp/scoredev-connected ./examples/scoredev-paas/demo-connected.sh
+
+After each step, tell me what to inspect in ConfigHub and what the remaining proof gap is.
+```

--- a/examples/springboot-paas/AI_START_HERE.md
+++ b/examples/springboot-paas/AI_START_HERE.md
@@ -1,0 +1,103 @@
+# AI Start Here: `springboot-paas`
+
+Use this example when the question is not just "what rendered this field?" but
+"should this Spring config be changed here, lifted upstream, or blocked?"
+
+## What this proves
+
+- Spring config provenance and ownership from `application*.yaml` plus platform policy
+- a local `ALLOW` path and a local `BLOCKED` path for mutation routing
+- direct embedded ConfigHub payload mutation for an app-owned field
+- a deeper connected ConfigHub walkthrough
+- a real standalone live-cluster app proof
+
+## What you need installed
+
+- Go 1.22+
+- `jq`
+- Java 21 + Maven if you want the app/runtime path
+- `cub` only for connected mode
+- kind, kubectl, and the helper scripts only for the live-cluster path
+
+## What this reads and writes
+
+| Step | Reads | Writes | Mutates repo/backend/live? |
+|---|---|---|---|
+| `go build -o ./cub-gen ./cmd/cub-gen` | local source | `./cub-gen` binary | local binary only |
+| `./generator/render.sh --explain` | Spring config + platform policy | stdout only | no |
+| `gitops import --json` | `application*.yaml`, `pom.xml`, `platform/`, `gitops/` | stdout JSON only | no |
+| `demo-governed-routes.sh` | field-routes contract | `.tmp/springboot-governed-routes/<run>/...` | no repo/backend/live mutation |
+| `demo-embedded-config-mutation.sh` | payload yaml + field routes | `.tmp/springboot-embedded-config/<run>/...` | scratch clone only |
+| `run-connected-smoke.sh` | repo + ConfigHub auth/context | `.tmp/connected-smoke/<run>/...` | backend evidence only |
+| `demo-connected.sh` | repo + ConfigHub auth/context | temporary connected lifecycle artifacts unless `OUTPUT_DIR` is set | backend evidence only |
+| live-cluster proof | repo + cluster helpers | cluster objects, image build artifacts, worker install state | yes, live cluster |
+
+## Safest first step
+
+Build once, then use the read-only explanation and import paths:
+
+```bash
+go build -o ./cub-gen ./cmd/cub-gen
+./examples/springboot-paas/generator/render.sh --explain
+./cub-gen gitops import --space platform --json ./examples/springboot-paas \
+  | jq '{
+      profile: .discovered[0].generator_profile,
+      dry_inputs,
+      wet_manifest_targets,
+      inverse_hint: .provenance[0].inverse_edit_pointers[0]
+    }'
+```
+
+What it does:
+- reads source config and platform policy only
+- writes nothing except stdout
+- explains the generator boundary before any mutation route proof
+
+Success looks like:
+- the explain output describes the Spring source/config boundary
+- `generator_profile` is `springboot-paas`
+- `dry_inputs` and `wet_manifest_targets` are non-empty
+
+## Safe run order
+
+1. Repo-only preview:
+   `./examples/springboot-paas/generator/render.sh --explain`
+2. Repo-only provenance:
+   `./cub-gen gitops import --space platform --json ./examples/springboot-paas`
+3. Local route proof:
+   `./examples/springboot-paas/demo-governed-routes.sh`
+4. Local apply-here proof:
+   `./examples/springboot-paas/demo-embedded-config-mutation.sh`
+5. Connected environment check:
+   `cub auth login && ./examples/demo/run-connected-smoke.sh`
+6. Deep connected walkthrough:
+   `cub auth login && ./examples/springboot-paas/demo-connected.sh`
+7. Live-cluster proof:
+   `./bin/create-cluster && ./bin/build-image && ./bin/install-worker && ./verify-e2e.sh`
+
+## What to verify after each major step
+
+- Repo-only preview: the explain output and import JSON agree on the source/config boundary.
+- Local route proof: `feature.inventory.reservationMode` is allowed and `spring.datasource.url` is blocked; artifacts land under `.tmp/springboot-governed-routes/...`.
+- Local apply-here proof: the reservation mode changes in the embedded payload and the datasource mutation is rejected; artifacts land under `.tmp/springboot-embedded-config/...`.
+- Connected smoke: ConfigHub auth/context is valid and the smoke summaries include a non-empty `change_id`.
+- Deep connected walkthrough: a terminal connected decision state is returned for the same `change_id`.
+- Live-cluster proof: `verify-e2e.sh` succeeds and `inventory-api` is reachable on the kind cluster.
+
+## GUI checkpoints
+
+- ConfigHub GUI: inspect the change referenced by `change_id` after smoke or deep connected mode.
+- Spring payload helpers: compare and refresh-preview outputs should show the app-owned override preserved.
+- Live runtime: inspect `inventory-api` health and cluster objects after `verify-e2e.sh`.
+
+## Trust order when outputs disagree
+
+1. Trust the generator explain/import output for ownership and field routing.
+2. Trust `springboot validate-mutation` and embedded-config mutation results for local route enforcement.
+3. Trust the connected backend decision output for connected decision state.
+4. Trust live HTTP and kubectl checks for runtime truth.
+
+## Cleanup
+
+- Remove local proof artifacts with `rm -rf .tmp/springboot-governed-routes .tmp/springboot-embedded-config .tmp/connected-smoke`
+- Tear down clusters and workers with the same helper scripts used for the live path

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -30,6 +30,15 @@ The strongest caveat is enforcement depth, not demo truth. The ownership
 boundary is real and documented, but server-side rejection in ConfigHub is not
 implemented yet.
 
+## AI-first bundle
+
+Use these together if the first operator is an AI assistant or if you want a
+safe, step-by-step handoff:
+
+- [AI_START_HERE.md](./AI_START_HERE.md)
+- [prompts.md](./prompts.md)
+- [contracts.md](./contracts.md)
+
 ## What this example is (and isn't)
 
 This is a minimal but real Spring Boot application. You can build it with

--- a/examples/springboot-paas/contracts.md
+++ b/examples/springboot-paas/contracts.md
@@ -1,0 +1,149 @@
+# Contracts: `springboot-paas`
+
+Treat these as stable inspection contracts for human operators and AI
+assistants. If any `expects` check fails, stop and report the mismatch.
+
+## Read-only generator preview
+
+```yaml
+id: spring_generator_preview
+command: ./examples/springboot-paas/generator/render.sh --explain
+mutates:
+  repo: false
+  backend: false
+  live: false
+expects:
+  stdout_contains:
+    - "application"
+    - "platform"
+inspect_with:
+  - cat
+```
+
+## Repo provenance import
+
+```yaml
+id: spring_repo_import
+command: ./cub-gen gitops import --space platform --json ./examples/springboot-paas
+mutates:
+  repo: false
+  backend: false
+  live: false
+expects:
+  generator_profile: springboot-paas
+  dry_inputs_min: 1
+  wet_manifest_targets_min: 1
+  inverse_edit_pointers_min: 1
+inspect_with:
+  - jq '.discovered[0].generator_profile'
+  - jq '.dry_inputs | length'
+  - jq '.wet_manifest_targets | length'
+  - jq '.provenance[0].inverse_edit_pointers[0]'
+```
+
+## Local route proof
+
+```yaml
+id: spring_governed_routes
+command: ./examples/springboot-paas/demo-governed-routes.sh
+mutates:
+  repo: false
+  backend: false
+  live: false
+expects:
+  stdout_contains:
+    - "[spring-routes] success"
+    - "ALLOWED"
+    - "BLOCKED"
+  files_exist:
+    - ".tmp/springboot-governed-routes/<run>/allow.txt"
+    - ".tmp/springboot-governed-routes/<run>/block.txt"
+inspect_with:
+  - cat .tmp/springboot-governed-routes/<run>/allow.txt
+  - cat .tmp/springboot-governed-routes/<run>/block.txt
+```
+
+## Local embedded payload proof
+
+```yaml
+id: spring_embedded_config
+command: ./examples/springboot-paas/demo-embedded-config-mutation.sh
+mutates:
+  repo: scratch_clone_only
+  backend: false
+  live: false
+expects:
+  stdout_contains:
+    - "[spring-embedded] success"
+  files_exist:
+    - ".tmp/springboot-embedded-config/<run>/allow.txt"
+    - ".tmp/springboot-embedded-config/<run>/compare.json"
+    - ".tmp/springboot-embedded-config/<run>/refresh.json"
+    - ".tmp/springboot-embedded-config/<run>/block.txt"
+  evidence:
+    apply_here: "feature.inventory.reservationMode is changed directly in ConfigMap.data[\"application.yaml\"]"
+    blocked: "spring.datasource.url is rejected"
+inspect_with:
+  - cat allow.txt
+  - jq '.\"feature.inventory.reservationMode\".values.prod' compare.json
+  - jq '[.[] | select(.field == \"feature.inventory.reservationMode\")] | first' refresh.json
+  - cat block.txt
+```
+
+## Connected smoke preflight
+
+```yaml
+id: spring_connected_smoke
+command: cub auth login && ./examples/demo/run-connected-smoke.sh
+mutates:
+  repo: false
+  backend: true
+  live: false
+expects:
+  files_exist:
+    - ".tmp/connected-smoke/<run>/springboot-paas/summary.json"
+  summary_fields:
+    change_id: non_empty
+    verify_valid: true
+    attestation_valid: true
+    linked_bundle_check: true
+inspect_with:
+  - jq '{change_id, verify_valid, attestation_valid, linked_bundle_check}' .tmp/connected-smoke/<run>/springboot-paas/summary.json
+```
+
+## Deep connected walkthrough
+
+```yaml
+id: spring_connected_deep
+command: OUTPUT_DIR=.tmp/springboot-connected ./examples/springboot-paas/demo-connected.sh
+mutates:
+  repo: false
+  backend: true
+  live: false
+expects:
+  files_exist:
+    - ".tmp/springboot-connected/create/summary.json"
+    - ".tmp/springboot-connected/update/summary.json"
+  decision_state: terminal_allow_escalate_or_block
+inspect_with:
+  - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/springboot-connected/create/summary.json
+  - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/springboot-connected/update/summary.json
+```
+
+## Live standalone app proof
+
+```yaml
+id: spring_live_runtime
+command: ./examples/springboot-paas/verify-e2e.sh
+mutates:
+  repo: false
+  backend: false
+  live: true
+expects:
+  live_checks:
+    - "inventory-api is reachable"
+    - "verify-e2e.sh exits 0"
+inspect_with:
+  - kubectl get pods,svc -A
+  - curl http://localhost:18080/actuator/health
+```

--- a/examples/springboot-paas/prompts.md
+++ b/examples/springboot-paas/prompts.md
@@ -1,0 +1,68 @@
+# Prompts: `springboot-paas`
+
+Copy one block into Claude, Codex, or Cursor when you want an assistant to run
+this example safely from the repo root.
+
+## Safe preview prompt
+
+```text
+You are helping me inspect ./examples/springboot-paas in the cub-gen repo.
+
+Stay read-only first.
+
+1. Build ./cub-gen only if needed.
+2. Run:
+   ./examples/springboot-paas/generator/render.sh --explain
+3. Run:
+   ./cub-gen gitops import --space platform --json ./examples/springboot-paas | jq '{
+     profile: .discovered[0].generator_profile,
+     dry_inputs,
+     wet_manifest_targets,
+     inverse_hint: .provenance[0].inverse_edit_pointers[0]
+   }'
+4. Summarize the source boundary, one edit hint, and what the preview did not mutate.
+
+Do not run connected or live-cluster steps yet.
+```
+
+## Local route and apply-here proof prompt
+
+```text
+Run the local Spring governance proofs for ./examples/springboot-paas.
+
+1. Run:
+   ./examples/springboot-paas/demo-governed-routes.sh
+2. Then run:
+   ./examples/springboot-paas/demo-embedded-config-mutation.sh
+3. Capture both artifact directories.
+4. Summarize:
+   - which field is allowed
+   - which field is blocked
+   - how the embedded payload mutation proves the apply-here path
+   - where the compare and refresh evidence lives
+
+Do not run backend or live-cluster steps in this prompt.
+```
+
+## Connected plus live prompt
+
+```text
+Help me run the connected and optional live Spring proof for ./examples/springboot-paas.
+
+Safety rules:
+- Run the shared connected smoke check first.
+- Stop immediately if cub auth/context is missing.
+- Do not run the live-cluster commands unless I explicitly asked for cluster mutation.
+
+Sequence:
+1. cub auth login
+2. ./examples/demo/run-connected-smoke.sh
+3. OUTPUT_DIR=.tmp/springboot-connected ./examples/springboot-paas/demo-connected.sh
+4. Only if I confirmed the live step:
+   ./bin/create-cluster
+   ./bin/build-image
+   ./bin/install-worker
+   ./examples/springboot-paas/verify-e2e.sh
+
+After each step, tell me what to inspect in ConfigHub, the payload helpers, or the kind cluster.
+```

--- a/examples/swamp-automation/AI_START_HERE.md
+++ b/examples/swamp-automation/AI_START_HERE.md
@@ -1,0 +1,106 @@
+# AI Start Here: `swamp-automation`
+
+Use this example when the first operator may be an AI assistant and the real
+authoring surface is prompt/context plus a workflow spec.
+
+## What this proves
+
+- structural workflow governance for agent-written workflow YAML
+- prompt-as-DRY as a first-class governed path
+- a local `ALLOW` path and a local `BLOCK` path for model/method and required-step policy
+- a deeper connected ConfigHub walkthrough
+- honest current limit: structural governance is stronger than live runtime proof here
+
+## What you need installed
+
+- Go 1.22+
+- `jq`
+- `cub` only for connected mode
+
+## What this reads and writes
+
+| Step | Reads | Writes | Mutates repo/backend/live? |
+|---|---|---|---|
+| `go build -o ./cub-gen ./cmd/cub-gen` | local source | `./cub-gen` binary | local binary only |
+| `gitops import --json` | `workflow-deploy.yaml`, `.swamp.yaml`, `platform/registry.yaml`, `platform/swamp-constraints.yaml` | stdout JSON only | no |
+| `prompt-as-dry-local.sh` | workflow files + AI-only guardrails | `.tmp/app-ai-change-run/<repo>-<timestamp>/...` | no repo/backend/live mutation |
+| `demo-local.sh` | example repo | temporary lifecycle simulation artifacts | no live/backend mutation |
+| `run-connected-smoke.sh` | repo + ConfigHub auth/context | `.tmp/connected-smoke/<run>/...` | backend evidence only |
+| `prompt-as-dry-connected.sh` | workflow files + ConfigHub auth/context | temporary connected lifecycle artifacts unless `OUTPUT_DIR` is set | backend evidence only |
+| `demo-connected.sh` | repo + ConfigHub auth/context | temporary connected lifecycle artifacts unless `OUTPUT_DIR` is set | backend evidence only |
+
+## Safest first step
+
+Build once, then start with the read-only provenance preview:
+
+```bash
+go build -o ./cub-gen ./cmd/cub-gen
+./cub-gen gitops import --space platform --json ./examples/swamp-automation \
+  | jq '{
+      profile: .discovered[0].generator_profile,
+      dry_inputs,
+      wet_manifest_targets,
+      inverse_hint: .provenance[0].inverse_edit_pointers[0]
+    }'
+```
+
+What it does:
+- reads workflow files and platform constraints only
+- writes nothing except stdout
+- shows the workflow profile, governed outputs, and one inverse-edit hint
+
+Success looks like:
+- `generator_profile` is `swamp`
+- `dry_inputs` is non-empty
+- `wet_manifest_targets` is non-empty
+- `inverse_hint.owner` is populated
+
+The safest AI-first mutation-free next step is:
+
+```bash
+./examples/demo/prompt-as-dry-local.sh ./examples/swamp-automation
+```
+
+That path still avoids repo, backend, and live mutation; it writes only local
+`.tmp/app-ai-change-run/...` artifacts after enforcing the AI-only guardrails.
+
+## Safe run order
+
+1. Repo-only provenance:
+   `./cub-gen gitops import --space platform --json ./examples/swamp-automation`
+2. AI-safe local loop:
+   `./examples/demo/prompt-as-dry-local.sh ./examples/swamp-automation`
+3. Local structural walkthrough:
+   `./examples/swamp-automation/demo-local.sh`
+4. Connected environment check:
+   `cub auth login && ./examples/demo/run-connected-smoke.sh`
+5. AI-safe connected loop:
+   `cub auth login && ./examples/demo/prompt-as-dry-connected.sh ./examples/swamp-automation`
+6. Deep connected example walkthrough:
+   `cub auth login && ./examples/swamp-automation/demo-connected.sh`
+
+## What to verify after each major step
+
+- Repo-only provenance: the import JSON includes workflow provenance and inverse-edit hints.
+- AI-safe local loop: `.tmp/app-ai-change-run/.../mutation-card.json` exists and verification is true.
+- Local structural walkthrough: the create/update lifecycle completes with valid attestation outputs.
+- Connected smoke: ConfigHub auth/context is valid and the smoke summaries include a non-empty `change_id`.
+- AI-safe connected loop: the same prompt-as-DRY path reaches a connected decision state.
+- Deep connected example walkthrough: a terminal decision state is returned for the workflow change.
+
+## GUI checkpoints
+
+- ConfigHub GUI: inspect the change referenced by `change_id` after connected prompt-as-DRY or deep connected mode.
+- Audit/evidence view: compare the local mutation card with the connected decision state for the same workflow change.
+
+## Trust order when outputs disagree
+
+1. Trust the local mutation card and import JSON for source-to-governed evidence.
+2. Trust the AI-only guardrail script for whether the prompt-as-DRY lane is even allowed to run.
+3. Trust the connected backend decision output for final connected decision state.
+4. Treat runtime claims as partial unless you have an external Swamp runtime proof.
+
+## Cleanup
+
+- Remove local proof artifacts with `rm -rf .tmp/app-ai-change-run .tmp/connected-smoke`
+- If you set `OUTPUT_DIR` for connected runs, remove that directory when finished

--- a/examples/swamp-automation/README.md
+++ b/examples/swamp-automation/README.md
@@ -19,7 +19,15 @@ slowing down the agent iteration loop.
 Known gaps still open:
 
 - a real live workflow runtime proof is still open work ([#180](https://github.com/confighub/cub-gen/issues/180))
-- the fuller flagship AI doc bundle standard is still open work ([#202](https://github.com/confighub/cub-gen/issues/202))
+
+## AI-first bundle
+
+Use these together if the first operator is an AI assistant or if you want a
+safe, step-by-step handoff:
+
+- [AI_START_HERE.md](./AI_START_HERE.md)
+- [prompts.md](./prompts.md)
+- [contracts.md](./contracts.md)
 
 ## Fastest path to believe it
 

--- a/examples/swamp-automation/contracts.md
+++ b/examples/swamp-automation/contracts.md
@@ -1,0 +1,125 @@
+# Contracts: `swamp-automation`
+
+Treat these as stable inspection contracts for human operators and AI
+assistants. If any `expects` check fails, stop and report the mismatch.
+
+## Repo preview
+
+```yaml
+id: swamp_repo_preview
+command: ./cub-gen gitops import --space platform --json ./examples/swamp-automation
+mutates:
+  repo: false
+  backend: false
+  live: false
+expects:
+  generator_profile: swamp
+  dry_inputs_min: 1
+  wet_manifest_targets_min: 1
+  inverse_edit_pointers_min: 1
+inspect_with:
+  - jq '.discovered[0].generator_profile'
+  - jq '.dry_inputs | length'
+  - jq '.wet_manifest_targets | length'
+  - jq '.provenance[0].inverse_edit_pointers[0]'
+```
+
+## AI-safe local prompt-as-DRY loop
+
+```yaml
+id: swamp_prompt_as_dry_local
+command: OUT_DIR=.tmp/swamp-prompt-local ./examples/demo/prompt-as-dry-local.sh ./examples/swamp-automation
+mutates:
+  repo: false
+  backend: false
+  live: false
+expects:
+  files_exist:
+    - ".tmp/swamp-prompt-local/import.json"
+    - ".tmp/swamp-prompt-local/bundle.json"
+    - ".tmp/swamp-prompt-local/attestation.json"
+    - ".tmp/swamp-prompt-local/mutation-card.json"
+  mutation_card:
+    change_id: non_empty
+    verification.bundle_valid: true
+    verification.attestation_valid: true
+inspect_with:
+  - jq '{change, edit_recommendation, verification}' .tmp/swamp-prompt-local/mutation-card.json
+```
+
+## Local structural walkthrough
+
+```yaml
+id: swamp_local_structural_walkthrough
+command: ./examples/swamp-automation/demo-local.sh
+mutates:
+  repo: false
+  backend: false
+  live: false
+expects:
+  stdout_contains:
+    - "[phase:create]"
+    - "[phase:update]"
+    - "\"attested_valid\": true"
+  note: "this script uses a temporary directory that is cleaned automatically"
+inspect_with:
+  - stdout
+```
+
+## Connected preflight
+
+```yaml
+id: swamp_connected_preflight
+command: cub auth login && ./examples/demo/run-connected-smoke.sh
+mutates:
+  repo: false
+  backend: true
+  live: false
+expects:
+  shared_smoke_examples:
+    - helm-paas
+    - springboot-paas
+  purpose: "confirm auth and backend health before the workflow-specific connected lanes"
+inspect_with:
+  - jq '{change_id, verify_valid, attestation_valid}' .tmp/connected-smoke/<run>/helm-paas/summary.json
+  - jq '{change_id, verify_valid, attestation_valid}' .tmp/connected-smoke/<run>/springboot-paas/summary.json
+```
+
+## AI-safe connected prompt-as-DRY loop
+
+```yaml
+id: swamp_prompt_as_dry_connected
+command: OUTPUT_DIR=.tmp/swamp-prompt-connected ./examples/demo/prompt-as-dry-connected.sh ./examples/swamp-automation
+mutates:
+  repo: false
+  backend: true
+  live: false
+expects:
+  files_exist:
+    - ".tmp/swamp-prompt-connected/create/summary.json"
+    - ".tmp/swamp-prompt-connected/update/summary.json"
+  decision_state: terminal_allow_escalate_or_block
+inspect_with:
+  - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/swamp-prompt-connected/create/summary.json
+  - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/swamp-prompt-connected/update/summary.json
+```
+
+## Deep connected walkthrough
+
+```yaml
+id: swamp_connected_deep
+command: OUTPUT_DIR=.tmp/swamp-connected ./examples/swamp-automation/demo-connected.sh
+mutates:
+  repo: false
+  backend: true
+  live: false
+expects:
+  files_exist:
+    - ".tmp/swamp-connected/create/summary.json"
+    - ".tmp/swamp-connected/update/summary.json"
+  decision_state: terminal_allow_escalate_or_block
+  note: "runtime execution artifacts remain outside the in-repo proof for this example"
+inspect_with:
+  - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/swamp-connected/create/summary.json
+  - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/swamp-connected/update/summary.json
+```

--- a/examples/swamp-automation/prompts.md
+++ b/examples/swamp-automation/prompts.md
@@ -1,0 +1,67 @@
+# Prompts: `swamp-automation`
+
+Copy one block into Claude, Codex, or Cursor when you want an assistant to run
+this example safely from the repo root.
+
+## Safe preview prompt
+
+```text
+You are helping me inspect ./examples/swamp-automation in the cub-gen repo.
+
+Start in read-only mode.
+
+1. Build ./cub-gen only if needed.
+2. Run:
+   ./cub-gen gitops import --space platform --json ./examples/swamp-automation | jq '{
+     profile: .discovered[0].generator_profile,
+     dry_inputs,
+     wet_manifest_targets,
+     inverse_hint: .provenance[0].inverse_edit_pointers[0]
+   }'
+3. Summarize:
+   - generator profile
+   - workflow DRY inputs
+   - one governed output target
+   - one inverse edit hint
+4. Tell me exactly what was read and what stayed unmodified.
+
+Do not run prompt-as-DRY or connected steps yet.
+```
+
+## AI-safe local prompt-as-DRY prompt
+
+```text
+Run the AI-safe local prompt-as-DRY loop for ./examples/swamp-automation.
+
+1. Use:
+   OUT_DIR=.tmp/swamp-prompt-local ./examples/demo/prompt-as-dry-local.sh ./examples/swamp-automation
+2. Confirm the AI-only guardrails passed.
+3. Summarize:
+   - change_id
+   - bundle_digest
+   - attestation_digest
+   - the top edit recommendation from mutation-card.json
+4. Tell me which files were written under .tmp/swamp-prompt-local and whether anything touched repo, backend, or live state.
+
+Do not run connected steps in this prompt.
+```
+
+## Connected workflow prompt
+
+```text
+Help me run the connected workflow proof for ./examples/swamp-automation.
+
+Safety rules:
+- Start with the shared connected smoke check.
+- Enforce the AI-only guardrails before the connected workflow run.
+- Stop if cub auth/context is missing.
+- Be explicit that this example proves structural governance more strongly than live runtime execution.
+
+Sequence:
+1. cub auth login
+2. ./examples/demo/run-connected-smoke.sh
+3. OUTPUT_DIR=.tmp/swamp-prompt-connected ./examples/demo/prompt-as-dry-connected.sh ./examples/swamp-automation
+4. OUTPUT_DIR=.tmp/swamp-connected ./examples/swamp-automation/demo-connected.sh
+
+After each step, tell me what to inspect in ConfigHub and which proof boundary is still partial.
+```

--- a/internal/exampletruth/matrix.go
+++ b/internal/exampletruth/matrix.go
@@ -158,7 +158,14 @@ func Collect(root string) (Matrix, error) {
 			row.Notes = append(row.Notes, "Score now has example-owned local governed proof via ./examples/scoredev-paas/demo-governed-workload.sh for ALLOW versus ESCALATE, even though standalone live-cluster proof is still open.")
 		}
 
-		if _, ok := aiExplicit[slug]; ok {
+		if hasAIFirstBundle(root, slug) {
+			row.AIFirstSurface = AIFirstExplicit
+			row.ProofRefs.AIFirst = []string{
+				fmt.Sprintf("./examples/%s/AI_START_HERE.md", slug),
+				fmt.Sprintf("./examples/%s/prompts.md", slug),
+				fmt.Sprintf("./examples/%s/contracts.md", slug),
+			}
+		} else if _, ok := aiExplicit[slug]; ok {
 			row.AIFirstSurface = AIFirstExplicit
 			row.ProofRefs.AIFirst = []string{"examples/README.md#ai--automation-patterns"}
 		} else if _, ok := aiTrack[slug]; ok {
@@ -358,13 +365,17 @@ func trackingIssuesForExample(slug, aiSurface string) []string {
 	case "swamp-project":
 		issues = append(issues, "#180")
 	}
-	if aiSurface != AIFirstNone {
-		issues = append(issues, "#202")
-	}
 	if slug == "c3agent" {
 		issues = append(issues, "#216")
 	}
 	return uniqueStrings(issues)
+}
+
+func hasAIFirstBundle(root, slug string) bool {
+	exampleDir := filepath.Join(root, "examples", slug)
+	return fileExists(filepath.Join(exampleDir, "AI_START_HERE.md")) &&
+		fileExists(filepath.Join(exampleDir, "prompts.md")) &&
+		fileExists(filepath.Join(exampleDir, "contracts.md"))
 }
 
 func hasAll(values []string, wanted ...string) bool {


### PR DESCRIPTION
## Summary
- add AI-first operator bundles for the four flagship examples: `AI_START_HERE.md`, `prompts.md`, and `contracts.md`
- link those bundles from the flagship READMEs and top-level repo/example/demo surfaces
- teach the generated truth matrix to detect explicit AI-first bundles directly and remove stale `#202` tracking from generated/example metadata

## Validation
- `go test ./...`
- `./test/checks/check-example-truth-matrix.sh`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`

Closes #202