### PR TITLE
Close AI and custom generator release blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ assistants:
 - [springboot-paas](examples/springboot-paas/) -> [AI_START_HERE](examples/springboot-paas/AI_START_HERE.md), [prompts](examples/springboot-paas/prompts.md), [contracts](examples/springboot-paas/contracts.md)
 - [swamp-automation](examples/swamp-automation/) -> [AI_START_HERE](examples/swamp-automation/AI_START_HERE.md), [prompts](examples/swamp-automation/prompts.md), [contracts](examples/swamp-automation/contracts.md)
 
+Use [AI Example Hygiene Checklist](docs/workflows/ai-example-hygiene-checklist.md)
+for the current repo bar on safe AI-assisted example design, and
+[Prompt as DRY](docs/workflows/prompt-as-dry.md) for the worked governance
+story behind those bundles.
+
+If your platform has its own generator and you are thinking "where is mine?",
+start with [Custom Generator Onboarding](docs/workflows/custom-generator-onboarding.md).
+
 ## What it looks like
 
 ```bash
@@ -192,6 +200,9 @@ Docs currently live in this repo:
 - [Examples](examples/README.md) — complete runnable scenarios for every generator
 - [Platform](docs/platform.md) — how cub-gen connects to ConfigHub
 - [Persona 5-minute runbooks](docs/workflows/persona-5-minute-runbooks.md) — stack-specific entry paths
+- [AI Example Hygiene Checklist](docs/workflows/ai-example-hygiene-checklist.md) — the current repo bar for safe AI-assisted example design
+- [Prompt as DRY](docs/workflows/prompt-as-dry.md) — worked AI-assisted governance story
+- [Custom Generator Onboarding](docs/workflows/custom-generator-onboarding.md) — how to add support for your own platform framework
 - [Change CLI contract](docs/contracts/change-cli-v1.md) — change preview/run/explain specification
 - [Operation registry for real apps](docs/workflows/operation-registry-real-apps.md) — registry-backed platform governance
 
@@ -214,10 +225,10 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
-| Example quality | `#177`, `#178`, `#180`, `#185`, `#187`, `#200` |
+| Example quality | `#177`, `#178`, `#180`, `#187` |
 | CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
 | Release gate | `#218` |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#218`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#187`, `#218`, `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,11 +130,25 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 
     [Confidence Scores](workflows/confidence-scores.md)
 
+-   **Run AI-First Safely**
+
+    Use the current checklist and worked prompt-as-DRY story for safe
+    AI-assisted change.
+
+    [AI Example Hygiene Checklist](workflows/ai-example-hygiene-checklist.md) · [Prompt as DRY](workflows/prompt-as-dry.md)
+
 -   **Check what is really proven**
 
     Use the derived example matrix to see which examples are source-chain verified, in the connected smoke lane, AI-first, or backed by real live proof.
 
     [Example Truth Matrix](testing/example-truth-matrix.md)
+
+-   **Add Your Generator**
+
+    If your platform has its own framework or layered generator chain, start
+    with the user-facing onboarding path.
+
+    [Custom Generator Onboarding](workflows/custom-generator-onboarding.md)
 
 -   **Start with workflows (Ops + Swamp)**
 

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -51,13 +51,13 @@ Current open issues:
 - [#177](https://github.com/confighub/cub-gen/issues/177) Helm flagship
 - [#178](https://github.com/confighub/cub-gen/issues/178) Score flagship remaining standalone live proof
 - [#180](https://github.com/confighub/cub-gen/issues/180) workflow examples
-- [#185](https://github.com/confighub/cub-gen/issues/185) custom-generator onboarding
 - [#187](https://github.com/confighub/cub-gen/issues/187) Kubara-like layered provenance
-- [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
 
 Landed on `main`:
 
 - [#182](https://github.com/confighub/cub-gen/issues/182) entrypoint redesign
+- [#185](https://github.com/confighub/cub-gen/issues/185) custom-generator onboarding
+- [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
 - [#202](https://github.com/confighub/cub-gen/issues/202) AI-first flagship surfaces
 - [#207](https://github.com/confighub/cub-gen/issues/207) Spring block/escalate proof
 - [#208](https://github.com/confighub/cub-gen/issues/208) Spring embedded-config mutation support

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -54,6 +54,8 @@ exit-bar rationale still live in
 - [x] `#226` standard ConfigHub API/CLI over custom bridge endpoints
 - [x] `#227` rethink the size and purpose of `ci-connected`
 - [x] `#202` AI-first flagship surfaces
+- [x] `#185` custom-generator onboarding
+- [x] `#200` AI best-practice alignment across examples
 - [x] `#232` README structure
 - [x] `#233` help-text duplication
 - [x] `#234` remove stale prototype framing
@@ -64,9 +66,7 @@ exit-bar rationale still live in
 - [ ] `#177` Helm flagship example
 - [ ] `#178` Score flagship remaining standalone live proof
 - [ ] `#180` workflow example upgrade
-- [ ] `#185` custom-generator onboarding
 - [ ] `#187` layered provenance across overlays/ApplicationSet/labels
-- [ ] `#200` AI best-practice alignment across examples
 - [ ] `#218` release-environment ConfigHub smoke reliability
 
 For this preview, "all examples working well" means each featured example has:

--- a/docs/releases/v0.2-preview.2.md
+++ b/docs/releases/v0.2-preview.2.md
@@ -77,9 +77,9 @@ release-facing proof.
    - standalone live-cluster proof from `score.yaml`
    Ref: `#178`
 
-3. Workflow and AI surfaces are clearer, but still need deeper runnable
-   platform-story completion beyond the new flagship AI bundles.
-   Refs: `#180`, `#200`
+3. Workflow surfaces are clearer, but still need deeper runnable
+   platform-story completion beyond the current workflow governance bundles.
+   Refs: `#180`
 
 4. The release environment still needs the final secrets-backed connected smoke
    confirmation for the intended tag environment.

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -397,7 +397,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#185`, `#187`, `#200`, `#218`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#187`, `#218`, `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -468,6 +468,10 @@ The key question: "Why does this cluster have this addon enabled?"
 
 Answer: Trace from cluster labels through overlay selection to the deployed field.
 
+If this is the section where you start thinking "where is my framework or
+generator?", use [Custom Generator Onboarding](../../docs/workflows/custom-generator-onboarding.md)
+for the user-facing extension path and Kubara-like layered requirements.
+
 ```bash
 # Show rendered lineage
 ./cub-gen gitops import --space platform --json ./examples/helm-paas \


### PR DESCRIPTION
## Summary
- make AI best-practice guidance and custom-generator onboarding discoverable from the root product surfaces
- link the Helm flagship directly to the custom-generator path for Kubara-like readers asking where their framework fits
- remove `#185` and `#200` from the active v0.2-preview.2 blockers and sync the release notes/trackers

## Validation
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`

Closes #185
Closes #200