### PR TITLE
Close connected smoke bootstrap blocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
 | Example quality | `#177`, `#180`, `#187` |
 | CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
-| Release gate | `#218` |
-| Actively tracked | `#173`, `#177`, `#180`, `#187`, `#218`, `#238`-`#242` |
+| Release gate | Secrets-backed ConfigHub smoke is green on `main`; rerun it in the release environment before tagging |
+| Actively tracked | `#173`, `#177`, `#180`, `#187`, `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -78,12 +78,9 @@ Required outcome:
 Goal: decide what the connected release gate really proves, then make it
 credible.
 
-Current open issues:
-
-- [#218](https://github.com/confighub/cub-gen/issues/218) provision secrets and get a green connected run
-
 Landed on `main`:
 
+- [#218](https://github.com/confighub/cub-gen/issues/218) provision secrets and get a green connected run
 - [#226](https://github.com/confighub/cub-gen/issues/226) standard ConfigHub API/CLI over custom bridge endpoints
 - [#227](https://github.com/confighub/cub-gen/issues/227) rethink the size and purpose of `ci-connected`
 
@@ -92,7 +89,7 @@ Required outcome:
 - the project deliberately replaces the old `ci-connected` release claim with a
   smaller connected smoke lane and updates docs/status claims to match,
 - the smaller smoke lane is something the team can actually run in the intended
-  release environment,
+  release environment, and it is already green on `main`,
 - deeper connected stories, flow proofs, and live reconcile checks remain
   available as an explicit non-release lane,
 - release notes and README wording stop implying that a skipped lane is an

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -53,6 +53,7 @@ exit-bar rationale still live in
 - [x] `#208` Spring embedded-config mutation support
 - [x] `#226` standard ConfigHub API/CLI over custom bridge endpoints
 - [x] `#227` rethink the size and purpose of `ci-connected`
+- [x] `#218` release-environment ConfigHub smoke bootstrap
 - [x] `#202` AI-first flagship surfaces
 - [x] `#178` Score flagship remaining standalone live proof
 - [x] `#185` custom-generator onboarding
@@ -67,7 +68,6 @@ exit-bar rationale still live in
 - [ ] `#177` Helm flagship example
 - [ ] `#180` workflow example upgrade
 - [ ] `#187` layered provenance across overlays/ApplicationSet/labels
-- [ ] `#218` release-environment ConfigHub smoke reliability
 
 For this preview, "all examples working well" means each featured example has:
 

--- a/docs/releases/v0.2-preview.2.md
+++ b/docs/releases/v0.2-preview.2.md
@@ -80,7 +80,7 @@ release-facing proof.
 
 3. The release environment still needs the final secrets-backed connected smoke
    confirmation for the intended tag environment.
-   Refs: `#218`, `#226`
+   This is now a release-check step, not a still-open implementation issue.
 
 This preview should be read as a trustworthy product-surface release, not as
 the final acceptance completion of every featured example.

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -397,7 +397,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#180`, `#187`, `#218`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#180`, `#187`, `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 


### PR DESCRIPTION
## Summary
- remove `#218` from the active v0.2-preview.2 blocker lists and treat it as landed bootstrap work
- keep the final release-environment smoke rerun as a checklist step instead of an open implementation issue
- sync README, demo status, release plan, ship checklist, and release notes to that current state

## Evidence
The merged `main` commit from #257 has green GitHub Actions checks for:
- `Build + Unit`
- `CLI Parity`
- `ConfigHub Smoke`

## Validation
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`

Closes #218