### PR TITLE
Add standalone live runtime proof for scoredev-paas

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ to source file, line, and owner before anything reaches the cluster.
 | If you already run... | Start here | First useful answer |
 |-----------|-----------|---------------------|
 | Helm plus Flux/Argo platform repos | [helm-paas](examples/helm-paas/) | Which values file owns this rendered field? |
+| Score.dev workloads | [scoredev-paas](examples/scoredev-paas/) | Which `score.yaml` field produced this runtime value, and does the workload stay inside contract? |
 | Spring Boot services in GitOps | [springboot-paas](examples/springboot-paas/) | Which `application.yaml` setting or platform file should I edit? |
 | Cluster-first GitOps operations | ConfigHub GitOps import + [cub-scout](https://github.com/confighub/cub-scout) + then `cub-gen` | What is running, and what source produced it? |
 
@@ -92,6 +93,9 @@ go build -o ./cub-gen ./cmd/cub-gen
 # Platform-first: existing Helm + Flux/Argo team
 ./examples/helm-paas/demo-local.sh
 
+# Score-first: existing Score.dev team
+./examples/scoredev-paas/demo-local.sh
+
 # App-first: existing Spring Boot team
 ./examples/springboot-paas/demo-local.sh
 ```
@@ -113,6 +117,9 @@ cub auth login
 
 # Platform-first connected path
 ./examples/helm-paas/demo-connected.sh
+
+# Score-first connected path
+./examples/scoredev-paas/demo-connected.sh
 
 # App-first connected path
 ./examples/springboot-paas/demo-connected.sh
@@ -225,10 +232,10 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
-| Example quality | `#177`, `#178`, `#180`, `#187` |
+| Example quality | `#177`, `#180`, `#187` |
 | CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
 | Release gate | `#218` |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#187`, `#218`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#180`, `#187`, `#218`, `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -49,7 +49,6 @@ only the flagship path.
 Current open issues:
 
 - [#177](https://github.com/confighub/cub-gen/issues/177) Helm flagship
-- [#178](https://github.com/confighub/cub-gen/issues/178) Score flagship remaining standalone live proof
 - [#180](https://github.com/confighub/cub-gen/issues/180) workflow examples
 - [#187](https://github.com/confighub/cub-gen/issues/187) Kubara-like layered provenance
 
@@ -59,6 +58,7 @@ Landed on `main`:
 - [#185](https://github.com/confighub/cub-gen/issues/185) custom-generator onboarding
 - [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
 - [#202](https://github.com/confighub/cub-gen/issues/202) AI-first flagship surfaces
+- [#178](https://github.com/confighub/cub-gen/issues/178) Score standalone runtime proof
 - [#207](https://github.com/confighub/cub-gen/issues/207) Spring block/escalate proof
 - [#208](https://github.com/confighub/cub-gen/issues/208) Spring embedded-config mutation support
 

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -18,7 +18,7 @@ exit-bar rationale still live in
   - `8` source-chain verified
   - `12` with connected mode entrypoints
   - `2` covered by the connected smoke lane
-  - real live proof: `none=9`, `paired-harness=1`, `standalone=2`
+  - real live proof: `none=8`, `paired-harness=1`, `standalone=3`
   - AI-first surface: `none=3`, `partial=2`, `explicit=7`
 
 ## Landed on `main` already
@@ -30,8 +30,8 @@ exit-bar rationale still live in
 - Example READMEs and central docs now say what is proven today, what to run
   first, and what is still partial.
 - `scoredev-paas` now has an example-owned local governed proof path with
-  `ALLOW` versus `ESCALATE`; the remaining Score gap is standalone live-cluster
-  proof.
+  `ALLOW` versus `ESCALATE`, plus a standalone runtime proof from the merged
+  Score inputs on kind.
 - The change API and demo flows now prefer repo paths over parity-era slug-only
   inputs.
 
@@ -54,6 +54,7 @@ exit-bar rationale still live in
 - [x] `#226` standard ConfigHub API/CLI over custom bridge endpoints
 - [x] `#227` rethink the size and purpose of `ci-connected`
 - [x] `#202` AI-first flagship surfaces
+- [x] `#178` Score flagship remaining standalone live proof
 - [x] `#185` custom-generator onboarding
 - [x] `#200` AI best-practice alignment across examples
 - [x] `#232` README structure
@@ -64,7 +65,6 @@ exit-bar rationale still live in
 ### Still true release blockers
 
 - [ ] `#177` Helm flagship example
-- [ ] `#178` Score flagship remaining standalone live proof
 - [ ] `#180` workflow example upgrade
 - [ ] `#187` layered provenance across overlays/ApplicationSet/labels
 - [ ] `#218` release-environment ConfigHub smoke reliability

--- a/docs/releases/v0.2-preview.2.md
+++ b/docs/releases/v0.2-preview.2.md
@@ -45,9 +45,10 @@ release-facing proof.
      the repo, and now has direct embedded ConfigHub payload mutation proof for
      the app-owned Spring config path.
    - `scoredev-paas` now has an example-owned local governed workload proof for
-     `ALLOW` versus `ESCALATE`, and workflow examples and AI-adjacent examples
-     now have clearer entry surfaces even where deeper acceptance work is still
-     open.
+     `ALLOW` versus `ESCALATE`, plus a standalone live `checkout-api` proof on
+     kind from the merged `score.yaml` and `score-prod.yaml` inputs.
+   - workflow examples and AI-adjacent examples now have clearer entry surfaces
+     even where deeper acceptance work is still open.
 
 5. The change surface is easier to consume.
    - change CLI and change API flows now prefer repo paths over parity-era
@@ -73,15 +74,11 @@ release-facing proof.
    - more complete multi-layer trace stories
    Refs: `#177`, `#187`
 
-2. Score still needs its strongest end state:
-   - standalone live-cluster proof from `score.yaml`
-   Ref: `#178`
-
-3. Workflow surfaces are clearer, but still need deeper runnable
+2. Workflow surfaces are clearer, but still need deeper runnable
    platform-story completion beyond the current workflow governance bundles.
    Refs: `#180`
 
-4. The release environment still needs the final secrets-backed connected smoke
+3. The release environment still needs the final secrets-backed connected smoke
    confirmation for the intended tag environment.
    Refs: `#218`, `#226`
 

--- a/docs/testing/example-truth-matrix.json
+++ b/docs/testing/example-truth-matrix.json
@@ -256,10 +256,14 @@
       "source_chain_verified": true,
       "connected_mode_present": true,
       "connected_release_gated": false,
-      "real_live_proof": "none",
+      "real_live_proof": "standalone",
       "ai_first_surface": "explicit",
       "proof_commands": [
+        "./examples/scoredev-paas/bin/build-image",
+        "./examples/scoredev-paas/bin/create-cluster",
         "./examples/scoredev-paas/demo-connected.sh",
+        "./examples/scoredev-paas/demo-runtime.sh",
+        "./examples/scoredev-paas/verify-e2e.sh",
         "go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v"
       ],
       "proof_refs": {
@@ -269,6 +273,12 @@
         "connected_mode": [
           "./examples/scoredev-paas/demo-connected.sh"
         ],
+        "real_live": [
+          "./examples/scoredev-paas/demo-runtime.sh",
+          "./examples/scoredev-paas/verify-e2e.sh",
+          "./examples/scoredev-paas/bin/create-cluster",
+          "./examples/scoredev-paas/bin/build-image"
+        ],
         "ai_first": [
           "./examples/scoredev-paas/AI_START_HERE.md",
           "./examples/scoredev-paas/prompts.md",
@@ -277,11 +287,10 @@
       },
       "tracking_issues": [
         "#173",
-        "#178",
         "#183"
       ],
       "notes": [
-        "Score now has example-owned local governed proof via ./examples/scoredev-paas/demo-governed-workload.sh for ALLOW versus ESCALATE, even though standalone live-cluster proof is still open."
+        "Standalone real-cluster proof: merged score.yaml + score-prod.yaml rendered into a live checkout-api deployment on kind."
       ]
     },
     {
@@ -400,9 +409,9 @@
     "connected_mode_present": 12,
     "connected_release_gated": 2,
     "real_live_proof": {
-      "none": 9,
+      "none": 8,
       "paired-harness": 1,
-      "standalone": 2
+      "standalone": 3
     },
     "ai_first_surface": {
       "explicit": 7,

--- a/docs/testing/example-truth-matrix.md
+++ b/docs/testing/example-truth-matrix.md
@@ -9,7 +9,7 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Source-chain verified: `8`
 - Connected mode present: `12`
 - Connected smoke gated: `2`
-- Real live proof: `none=9`, `paired-harness=1`, `standalone=2`
+- Real live proof: `none=8`, `paired-harness=1`, `standalone=3`
 - AI-first surface: `none=3`, `partial=2`, `explicit=7`
 
 ## Matrix
@@ -24,7 +24,7 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 | `just-apps-no-platform-config` | yes | yes | yes | no | `none` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
 | `live-reconcile` | no | no | yes | no | `standalone` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
 | `ops-workflow` | yes | yes | yes | no | `none` | `partial` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `scoredev-paas` | yes | yes | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#178](https://github.com/confighub/cub-gen/issues/178), [#183](https://github.com/confighub/cub-gen/issues/183) |
+| `scoredev-paas` | yes | yes | yes | no | `standalone` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#183](https://github.com/confighub/cub-gen/issues/183) |
 | `springboot-paas` | yes | yes | yes | yes | `standalone` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#179](https://github.com/confighub/cub-gen/issues/179), [#183](https://github.com/confighub/cub-gen/issues/183) |
 | `swamp-automation` | yes | yes | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183) |
 | `swamp-project` | no | no | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183) |
@@ -102,9 +102,9 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Source chain: `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v`
 - Connected mode: `./examples/scoredev-paas/demo-connected.sh`
 - Connected smoke lane: --
-- Real live: --
+- Real live: `./examples/scoredev-paas/demo-runtime.sh`, `./examples/scoredev-paas/verify-e2e.sh`, `./examples/scoredev-paas/bin/create-cluster`, `./examples/scoredev-paas/bin/build-image`
 - AI-first: `./examples/scoredev-paas/AI_START_HERE.md`, `./examples/scoredev-paas/prompts.md`, `./examples/scoredev-paas/contracts.md`
-- Notes: Score now has example-owned local governed proof via ./examples/scoredev-paas/demo-governed-workload.sh for ALLOW versus ESCALATE, even though standalone live-cluster proof is still open.
+- Notes: Standalone real-cluster proof: merged score.yaml + score-prod.yaml rendered into a live checkout-api deployment on kind.
 
 ### `springboot-paas`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ what you already run:
 |---|---|---|---|---|
 | Helm plus Argo/Flux platform repos | `./examples/demo/start-platform-first.sh` | `./examples/helm-paas/demo-governed-change.sh`, then `cub auth login && RECONCILER=argo ./examples/helm-paas/demo-runtime.sh` | values ownership now, local ALLOW/BLOCK proof next, and live Argo/Flux proof from the Helm flagship itself after | Strongest platform-first source-side path today |
 | Spring Boot app repos | `./examples/demo/start-app-first.sh` | `./examples/springboot-paas/demo-embedded-config-mutation.sh`, then `cub auth login && ./examples/springboot-paas/demo-connected.sh` | config ownership now, direct embedded apply-here proof next, live `inventory-api` proof after | Strongest standalone end-to-end example in the repo today |
-| Score.dev workloads | `./examples/demo/start-score-first.sh` | `./examples/scoredev-paas/demo-governed-workload.sh`, then `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field origin now, local ALLOW/ESCALATE proof next, governed connected output after | Strongest Score source-side path today; standalone live Score proof is still open work |
+| Score.dev workloads | `./examples/demo/start-score-first.sh` | `./examples/scoredev-paas/demo-governed-workload.sh`, then `./examples/scoredev-paas/demo-runtime.sh` | `score.yaml` field origin now, local ALLOW/ESCALATE proof next, live `checkout-api` proof after | Strongest Score end-to-end path for source, governance, and standalone runtime now |
 | A running cluster and GitOps controller | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | trace one chosen field back to source | live cluster state first, source provenance second | Best when the cluster is already the urgent source of truth |
 
 ## Flagship AI bundles
@@ -40,7 +40,7 @@ The four flagship examples now carry the same AI-first operator bundle:
 |---|---|---|---|
 | [`springboot-paas`](./springboot-paas/) | real `inventory-api` app on a kind cluster | `./examples/springboot-paas/verify-e2e.sh` | Standalone live app proof is real |
 | [`helm-paas`](./helm-paas/) | Flux and Argo reconciliation of rendered Helm output plus connected governance evidence | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | Example-owned wrapper, with the shared live-reconcile harness beneath it |
-| [`scoredev-paas`](./scoredev-paas/) | local governed contract proof plus connected governed output | `./examples/scoredev-paas/demo-governed-workload.sh` | Standalone Score live proof is still open |
+| [`scoredev-paas`](./scoredev-paas/) | `checkout-api` on kind from merged `score.yaml` + `score-prod.yaml` | `./examples/scoredev-paas/verify-e2e.sh` | Standalone live Score proof is real |
 
 ## Two audiences, one set of wrappers
 
@@ -83,7 +83,7 @@ That split is especially important for:
 |---|---|---|
 | [`helm-paas`](./helm-paas/) | Helm + Argo/Flux + values ownership | Strongest platform-first source-side path, with example-owned ALLOW/BLOCK and runtime wrappers |
 | [`springboot-paas`](./springboot-paas/) | Real app-team + platform-team config ownership | Strongest standalone end-to-end example in the repo today, now with direct embedded ConfigHub payload mutation proof |
-| [`scoredev-paas`](./scoredev-paas/) | Score intent to rendered runtime fields plus workload-contract escalation | Strongest Score source-side path today, now with example-owned ALLOW/ESCALATE proof; runtime proof still needs its own standalone finish |
+| [`scoredev-paas`](./scoredev-paas/) | Score intent to rendered runtime fields plus workload-contract escalation | Strongest Score end-to-end path today, now with example-owned ALLOW/ESCALATE proof and standalone runtime verification |
 
 ## What happens after import? (Day-2 stories)
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -42,7 +42,7 @@ The flagship examples also now publish an explicit AI-first bundle:
 |---|---|---|---|
 | Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then the example-owned governed-change proof and live wrapper | values ownership now, local ALLOW/BLOCK proof next, connected + live proof after |
 | Spring Boot app repos | `./examples/demo/start-app-first.sh` | local lifecycle for `springboot-paas`, then the example-owned embedded payload mutation proof | app-vs-platform config ownership now, direct embedded apply-here proof next, standalone live app proof after |
-| Score.dev workloads | `./examples/demo/start-score-first.sh` | Score field trace, inverse edit map, and governed workload-contract proof | `score.yaml` to runtime-field mapping now, local ALLOW/ESCALATE proof next, connected governed output after |
+| Score.dev workloads | `./examples/demo/start-score-first.sh` | Score field trace, inverse edit map, governed workload-contract proof, and standalone runtime proof | `score.yaml` to runtime-field mapping now, local ALLOW/ESCALATE proof next, live `checkout-api` proof after |
 | Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | real Flux and Argo reconciliation on kind | pods, rollout, and drift correction |
 
 Cluster-side follow-on: pair the above with [`cub-scout`](https://github.com/confighub/cub-scout)
@@ -55,7 +55,7 @@ when you want to inspect what is actually running after reconciliation.
 | Spring standalone app path | `inventory-api` on kind plus HTTP verification | `./examples/springboot-paas/verify-e2e.sh` | Strongest standalone app proof |
 | Helm flagship live path | Argo and Flux reconciliation of Helm-derived manifests plus connected governance evidence | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | Example-owned wrapper over the shared live-reconcile harness |
 | Connected smoke | ConfigHub-authenticated flagship bundle/attestation chain | `./examples/demo/run-connected-smoke.sh` | Release-facing connected proof lane |
-| Score path | governed workload-contract proof plus connected output, but no standalone live-cluster Score proof yet | `./examples/scoredev-paas/demo-governed-workload.sh` | Honest flagship with local ALLOW/ESCALATE proof and connected next step |
+| Score standalone path | `checkout-api` on kind plus HTTP verification from merged Score inputs | `./examples/scoredev-paas/verify-e2e.sh` | Standalone Score live proof is now real |
 
 ## 3. Pick your demo by persona
 
@@ -110,7 +110,7 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 | `start-app-first.sh` | [`springboot-paas`](../springboot-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated app-first starter path |
 | `../springboot-paas/demo-governed-routes.sh` | [`springboot-paas`](../springboot-paas/) | App-owned field ALLOW versus platform-owned field BLOCKED with `springboot validate-mutation` |
 | `../springboot-paas/demo-embedded-config-mutation.sh` | [`springboot-paas`](../springboot-paas/) | Direct embedded `application.yaml` mutation in the ConfigHub payload plus blocked datasource proof |
-| `start-score-first.sh` | [`scoredev-paas`](../scoredev-paas/) | Opinionated Score-first starter path with honest runtime-gap handoff |
+| `start-score-first.sh` | [`scoredev-paas`](../scoredev-paas/) | Opinionated Score-first starter path with local governance and standalone runtime proof |
 | `../scoredev-paas/demo-governed-workload.sh` | [`scoredev-paas`](../scoredev-paas/) | App-owned image change ALLOW versus unapproved resource type ESCALATE with `score validate-workload` |
 | `module-1-helm-import.sh` | [`helm-paas`](../helm-paas/) | Helm detection, values ownership, field-origin tracing |
 | `module-2-score-field-map.sh` | [`scoredev-paas`](../scoredev-paas/) | Score field-origin and inverse edit mapping |
@@ -397,7 +397,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#178`, `#180`, `#187`, `#218`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#180`, `#187`, `#218`, `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 

--- a/examples/demo/start-score-first.sh
+++ b/examples/demo/start-score-first.sh
@@ -11,6 +11,10 @@ echo
 echo "[start-score] step 2: prove app-owned workload changes stay allowed and new resource types escalate"
 ./examples/scoredev-paas/demo-governed-workload.sh
 
+echo
+echo "[start-score] step 3: run the merged Score workload as a real app on a local cluster"
+./examples/scoredev-paas/demo-runtime.sh
+
 cat <<'EOF'
 
 [start-score] next steps
@@ -21,10 +25,10 @@ cat <<'EOF'
   what to inspect:
     - local output: score.yaml field origin + inverse edit map
     - governed output: ALLOW for safe image change, ESCALATE for unapproved resource type
+    - runtime output: live checkout-api Deployment + Service on kind with /healthz and / verified
     - connected output: change_id, bundle digest, and decision/query evidence
 
-  runtime proof today:
-    standalone Score live-cluster proof is still open work
-    use RECONCILER=both ./examples/live-reconcile/demo-local.sh for reconciler proof
-    and ./examples/scoredev-paas/README.md for the current Score-specific truth
+  cleanup when finished:
+    kind delete cluster --name scoredev-runtime
+    or set CLUSTER_NAME to keep this proof separate from other examples
 EOF

--- a/examples/scoredev-paas/AI_START_HERE.md
+++ b/examples/scoredev-paas/AI_START_HERE.md
@@ -7,12 +7,15 @@ you need to explain how that intent becomes governed runtime config.
 
 - Score field-origin tracing from `score.yaml` to rendered runtime fields
 - a local `ALLOW` path and a local `ESCALATE` path for workload contracts
+- a standalone live `checkout-api` runtime on kind from the merged Score inputs
 - a deeper connected ConfigHub walkthrough
-- honest current limit: no standalone live Score runtime proof yet
 
 ## What you need installed
 
 - Go 1.22+
+- Docker
+- kind
+- kubectl
 - `jq`
 - `cub` only for connected mode
 
@@ -24,6 +27,7 @@ you need to explain how that intent becomes governed runtime config.
 | `gitops discover/import` | `score.yaml`, `platform/contracts`, `platform/policies`, `gitops/` | stdout JSON only | no |
 | `score validate-workload` | `score.yaml`, workload class contract | stdout only | no |
 | `demo-governed-workload.sh` | example repo + contract | `.tmp/scoredev-governed-workload/<run>/...` | scratch clone only |
+| `demo-runtime.sh` | example repo + Docker + kind | `var/runtime-manifests.yaml`, kind cluster state | live cluster only |
 | `run-connected-smoke.sh` | repo + ConfigHub auth/context | `.tmp/connected-smoke/<run>/...` | backend evidence only |
 | `demo-connected.sh` | repo + ConfigHub auth/context | temporary connected lifecycle artifacts unless `OUTPUT_DIR` is set | backend evidence only |
 
@@ -64,9 +68,11 @@ Success looks like:
    `./cub-gen score validate-workload --score ./examples/scoredev-paas/score.yaml --contract ./examples/scoredev-paas/platform/contracts/workload-class.yaml`
 3. Local governed proof:
    `./examples/scoredev-paas/demo-governed-workload.sh`
-4. Connected environment check:
+4. Standalone runtime proof:
+   `./examples/scoredev-paas/demo-runtime.sh`
+5. Connected environment check:
    `cub auth login && ./examples/demo/run-connected-smoke.sh`
-5. Deep connected walkthrough:
+6. Deep connected walkthrough:
    `cub auth login && ./examples/scoredev-paas/demo-connected.sh`
 
 ## What to verify after each major step
@@ -74,13 +80,14 @@ Success looks like:
 - Repo-only preview: the import JSON includes `score.yaml` lineage and inverse-edit hints.
 - Read-only contract check: the current example returns an allowed result without mutating anything.
 - Local governed proof: the image update stays allowed and the unapproved resource type escalates; artifacts land under `.tmp/scoredev-governed-workload/...`.
+- Standalone runtime proof: the kind cluster runs `checkout-api`, `/healthz` returns `ok`, `/` returns `service=checkout-api`, and `logLevel=warn` from the prod overlay.
 - Connected smoke: ConfigHub auth/context is valid and the smoke summaries include a non-empty `change_id`.
 - Deep connected walkthrough: a terminal connected decision state is returned for the same `change_id`.
 
 ## GUI checkpoints
 
 - ConfigHub GUI: inspect the change referenced by `change_id` after smoke or deep connected mode.
-- Runtime note: use `springboot-paas` or `live-reconcile` if you specifically need an in-repo live runtime proof today.
+- Runtime note: the standalone live Score proof is local cluster evidence, not a ConfigHub-connected apply path.
 
 ## Trust order when outputs disagree
 
@@ -91,3 +98,4 @@ Success looks like:
 ## Cleanup
 
 - Remove local proof artifacts with `rm -rf .tmp/scoredev-governed-workload .tmp/connected-smoke`
+- Remove the local kind cluster with `kind delete cluster --name scoredev-runtime`

--- a/examples/scoredev-paas/Dockerfile
+++ b/examples/scoredev-paas/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY app/package.json ./package.json
+COPY app/src ./src
+
+EXPOSE 8080
+
+CMD ["node", "src/server.js"]

--- a/examples/scoredev-paas/README.md
+++ b/examples/scoredev-paas/README.md
@@ -17,13 +17,13 @@ inverse-edit guidance.
 | Source-side Score provenance | Real | `./examples/scoredev-paas/demo-local.sh` |
 | Local governed Score contract proof | Real | `./examples/scoredev-paas/demo-governed-workload.sh` |
 | Deep connected bridge path | Real | `./examples/scoredev-paas/demo-connected.sh` |
-| Standalone Score live app proof | Not yet | still open work in [#178](https://github.com/confighub/cub-gen/issues/178) |
+| Standalone Score live app proof | Real | `./examples/scoredev-paas/demo-runtime.sh` |
 
-This README is intentionally honest: today the strongest Score proof in this
-repo is source-side tracing plus connected governance output. If you need real
-runtime proof elsewhere in the repo right now, use [`springboot-paas`](../springboot-paas/)
-or [`live-reconcile`](../live-reconcile/) as the current runtime companions
-while the Score-specific live path is being finished.
+This README is intentionally honest: the strongest Score proof in this repo is
+now example-owned end to end. You can start with source-side tracing, prove a
+governed ALLOW versus ESCALATE boundary locally, and then run the same Score
+workload as a real app on a kind cluster from the merged `score.yaml` plus
+`score-prod.yaml` inputs.
 
 ## AI-first bundle
 
@@ -39,7 +39,7 @@ safe, step-by-step handoff:
 | If you are... | First command | Then do this | What you can inspect |
 |---|---|---|---|
 | Existing Score.dev user | `./examples/scoredev-paas/demo-local.sh` | `./examples/scoredev-paas/demo-governed-workload.sh`, then `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `score.yaml` field trace now, local ALLOW/ESCALATE proof next, connected governed output after |
-| Existing ConfigHub user adding Score governance | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `./examples/demo/start-score-first.sh` for the repo-side first-run story | bundle, attestation, and decision evidence plus source mapping |
+| Existing ConfigHub user adding Score governance | `cub auth login && ./examples/scoredev-paas/demo-connected.sh` | `./examples/demo/start-score-first.sh` for the repo-side first-run story, then `./examples/scoredev-paas/demo-runtime.sh` for the standalone runtime proof | bundle, attestation, decision evidence, then a real `checkout-api` deployment |
 | Existing cluster-first operator | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) first | come back to `./examples/scoredev-paas/demo-local.sh` for source provenance | live workload first, Score contract trace second |
 
 Both paths lead to the same outcome: governed Score workloads with field-origin tracing.
@@ -51,7 +51,7 @@ Both paths lead to the same outcome: governed Score workloads with field-origin 
 | Local source-side proof | `./examples/scoredev-paas/demo-local.sh` | `score.yaml` field origin, inverse edit pointers, and rendered targets |
 | Local governed contract proof | `./examples/scoredev-paas/demo-governed-workload.sh` | app-owned image change returns `ALLOW`, unapproved resource type returns `ESCALATE` |
 | Deep connected bridge proof | `./examples/scoredev-paas/demo-connected.sh` | change ID, bundle digest, attestation, and connected decision/query output |
-| Runtime companion today | [`springboot-paas`](../springboot-paas/) or [`live-reconcile`](../live-reconcile/) | current standalone live app proof elsewhere in the repo while Score runtime proof is being finished |
+| Standalone runtime proof | `./examples/scoredev-paas/demo-runtime.sh` | a live `checkout-api` Deployment and Service on kind, with `/healthz` and `/` verified from the merged Score inputs |
 
 ## 1. Who this is for
 
@@ -65,7 +65,7 @@ Both paths lead to the same outcome: governed Score workloads with field-origin 
 | Component | What it is |
 |-----------|------------|
 | **Real app** | Node.js checkout API defined in `score.yaml` |
-| **Real cluster objects** | Kubernetes Deployment, Service, ConfigMap |
+| **Real cluster objects** | Kubernetes Deployment and Service |
 | **Real inspection target** | `kubectl get deployment checkout-api -o yaml` |
 | **GitOps transport** | Argo CD Application or Flux Kustomization |
 
@@ -124,7 +124,7 @@ So the recommended path is:
 ┌─────────────────────┐          ┌──────────────────────┐         ┌─────────────────┐
 │ score.yaml          │          │ Deployment           │         │ Running pods     │
 │ app/src/server.js   │──import─▶│ Service              │──sync──▶│ Live service     │
-│ platform/contracts/ │          │ ConfigMap            │         │ Cluster state    │
+│ platform/contracts/ │          │ runtime policy trace │         │ Cluster state    │
 │ platform/policies/  │          │ Kustomization (Flux) │         │                 │
 └─────────────────────┘          └──────────────────────┘         └─────────────────┘
   App team: score.yaml.            Rendered K8s manifests            What's actually
@@ -135,9 +135,10 @@ So the recommended path is:
 containers, env vars, ports, and resource dependencies (Postgres, Redis). This
 is platform-agnostic intent.
 
-**WET** is what cub-gen produces: Kubernetes Deployments, Services, and ConfigMaps
-with every field traced back to Score. The platform's workload class contract
-validates that the rendered output meets requirements.
+**WET** is what cub-gen produces: Kubernetes Deployments, Services, and the
+transport/policy metadata around them, with every field traced back to Score.
+The platform's workload class contract validates that the rendered output meets
+requirements.
 
 **LIVE** is what's running. Flux or ArgoCD reconciles WET to LIVE. Your
 reconciler stays in control.
@@ -209,6 +210,9 @@ go build -o ./cub-gen ./cmd/cub-gen
 
 # Local governed contract path
 ./examples/scoredev-paas/demo-governed-workload.sh
+
+# Standalone live runtime path
+./examples/scoredev-paas/demo-runtime.sh
 
 # Connected ConfigHub path
 cub auth login

--- a/examples/scoredev-paas/bin/build-image
+++ b/examples/scoredev-paas/bin/build-image
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "${SCRIPT_DIR}")"
+CLUSTER_NAME="${1:-scoredev-runtime}"
+IMAGE_TAG="${2:-}"
+
+if [[ -z "${IMAGE_TAG}" ]]; then
+  IMAGE_TAG="$(go run "${PROJECT_DIR}/bin/render_runtime.go" \
+    --score "${PROJECT_DIR}/score.yaml" \
+    --overlay "${PROJECT_DIR}/score-prod.yaml" \
+    --print-image)"
+fi
+
+echo "Building Docker image ${IMAGE_TAG}..."
+docker build -t "${IMAGE_TAG}" "${PROJECT_DIR}"
+echo "  Image built."
+
+echo "Loading image into Kind cluster '${CLUSTER_NAME}'..."
+kind load docker-image "${IMAGE_TAG}" --name "${CLUSTER_NAME}"
+echo "  Image loaded."
+
+echo ""
+echo "====================================="
+echo "Image ${IMAGE_TAG} ready in cluster."
+echo "====================================="

--- a/examples/scoredev-paas/bin/create-cluster
+++ b/examples/scoredev-paas/bin/create-cluster
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "${SCRIPT_DIR}")"
+CLUSTER_NAME="${1:-scoredev-runtime}"
+KUBECONFIG_PATH="${PROJECT_DIR}/var/${CLUSTER_NAME}.kubeconfig"
+
+mkdir -p "${PROJECT_DIR}/var"
+
+echo "Creating Kind cluster '${CLUSTER_NAME}'..."
+
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  echo "Cluster '${CLUSTER_NAME}' already exists."
+  kind get kubeconfig --name "${CLUSTER_NAME}" > "${KUBECONFIG_PATH}"
+  echo "Kubeconfig written to ${KUBECONFIG_PATH}"
+  exit 0
+fi
+
+kind create cluster --name "${CLUSTER_NAME}" --wait 60s
+kind get kubeconfig --name "${CLUSTER_NAME}" > "${KUBECONFIG_PATH}"
+
+echo ""
+echo "====================================="
+echo "Cluster '${CLUSTER_NAME}' is ready."
+echo "KUBECONFIG=${KUBECONFIG_PATH}"
+echo "====================================="

--- a/examples/scoredev-paas/bin/render-runtime
+++ b/examples/scoredev-paas/bin/render-runtime
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "${SCRIPT_DIR}")"
+OUTPUT_PATH="${1:-${PROJECT_DIR}/var/runtime-manifests.yaml}"
+NAMESPACE="${NAMESPACE:-checkout-api}"
+
+mkdir -p "${PROJECT_DIR}/var"
+
+go run "${PROJECT_DIR}/bin/render_runtime.go" \
+  --score "${PROJECT_DIR}/score.yaml" \
+  --overlay "${PROJECT_DIR}/score-prod.yaml" \
+  --namespace "${NAMESPACE}" \
+  --output "${OUTPUT_PATH}"
+
+echo "Runtime manifests written to ${OUTPUT_PATH}"

--- a/examples/scoredev-paas/bin/render_runtime.go
+++ b/examples/scoredev-paas/bin/render_runtime.go
@@ -1,0 +1,439 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type workloadDocument struct {
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Containers map[string]workloadContainer `yaml:"containers"`
+	Service    struct {
+		Ports map[string]servicePort `yaml:"ports"`
+	} `yaml:"service"`
+	Resources map[string]workloadResource `yaml:"resources"`
+}
+
+type workloadContainer struct {
+	Image     string            `yaml:"image"`
+	Variables map[string]string `yaml:"variables"`
+}
+
+type workloadResource struct {
+	Type string `yaml:"type"`
+}
+
+type servicePort struct {
+	Port       int `yaml:"port"`
+	TargetPort int `yaml:"targetPort"`
+}
+
+type runtimeManifests struct {
+	Image     string
+	Namespace string
+	Content   []byte
+}
+
+var resourcePattern = regexp.MustCompile(`^\$\{resources\.([^.]+)\.(host|port)\}$`)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	scorePath := flag.String("score", "", "Path to base score.yaml")
+	overlayPath := flag.String("overlay", "", "Path to overlay YAML")
+	namespace := flag.String("namespace", "", "Runtime namespace")
+	outputPath := flag.String("output", "", "Write rendered YAML to this path instead of stdout")
+	printImage := flag.Bool("print-image", false, "Print the resolved image tag only")
+	flag.Parse()
+
+	if strings.TrimSpace(*scorePath) == "" {
+		return errors.New("--score is required")
+	}
+	if strings.TrimSpace(*overlayPath) == "" {
+		return errors.New("--overlay is required")
+	}
+
+	manifests, err := renderRuntime(*scorePath, *overlayPath, *namespace)
+	if err != nil {
+		return err
+	}
+
+	if *printImage {
+		fmt.Println(manifests.Image)
+		return nil
+	}
+
+	if strings.TrimSpace(*outputPath) == "" {
+		_, err = os.Stdout.Write(manifests.Content)
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*outputPath), 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	return os.WriteFile(*outputPath, manifests.Content, 0o644)
+}
+
+func renderRuntime(scorePath, overlayPath, namespace string) (runtimeManifests, error) {
+	workload, err := loadMergedWorkload(scorePath, overlayPath)
+	if err != nil {
+		return runtimeManifests{}, err
+	}
+
+	resolvedNamespace := strings.TrimSpace(namespace)
+	if resolvedNamespace == "" {
+		resolvedNamespace = strings.TrimSpace(workload.Metadata.Name)
+	}
+	if resolvedNamespace == "" {
+		return runtimeManifests{}, errors.New("metadata.name or --namespace is required")
+	}
+
+	containerName, containerSpec, err := primaryContainer(workload.Containers)
+	if err != nil {
+		return runtimeManifests{}, err
+	}
+	if strings.TrimSpace(containerSpec.Image) == "" {
+		return runtimeManifests{}, errors.New("resolved Score runtime image is empty")
+	}
+
+	portName, portSpec, err := primaryServicePort(workload.Service.Ports)
+	if err != nil {
+		return runtimeManifests{}, err
+	}
+
+	env := envVars(resolveVariables(containerSpec.Variables, workload.Resources))
+	content, err := marshalManifestSet(manifestSetInput{
+		Name:          workload.Metadata.Name,
+		Namespace:     resolvedNamespace,
+		ContainerName: containerName,
+		Image:         containerSpec.Image,
+		ServiceName:   portName,
+		ServicePort:   portSpec.Port,
+		TargetPort:    portSpec.targetPort(),
+		Env:           env,
+	})
+	if err != nil {
+		return runtimeManifests{}, err
+	}
+
+	return runtimeManifests{
+		Image:     containerSpec.Image,
+		Namespace: resolvedNamespace,
+		Content:   content,
+	}, nil
+}
+
+func loadMergedWorkload(scorePath, overlayPath string) (workloadDocument, error) {
+	baseData, err := os.ReadFile(scorePath)
+	if err != nil {
+		return workloadDocument{}, fmt.Errorf("read base score file: %w", err)
+	}
+	overlayData, err := os.ReadFile(overlayPath)
+	if err != nil {
+		return workloadDocument{}, fmt.Errorf("read overlay file: %w", err)
+	}
+
+	var base workloadDocument
+	if err := yaml.Unmarshal(baseData, &base); err != nil {
+		return workloadDocument{}, fmt.Errorf("parse base score file: %w", err)
+	}
+	var overlay workloadDocument
+	if err := yaml.Unmarshal(overlayData, &overlay); err != nil {
+		return workloadDocument{}, fmt.Errorf("parse overlay file: %w", err)
+	}
+
+	mergeWorkload(&base, overlay)
+	return base, nil
+}
+
+func mergeWorkload(base *workloadDocument, overlay workloadDocument) {
+	if strings.TrimSpace(overlay.Metadata.Name) != "" {
+		base.Metadata.Name = overlay.Metadata.Name
+	}
+
+	if base.Containers == nil {
+		base.Containers = map[string]workloadContainer{}
+	}
+	for name, overlayContainer := range overlay.Containers {
+		current := base.Containers[name]
+		if strings.TrimSpace(overlayContainer.Image) != "" {
+			current.Image = overlayContainer.Image
+		}
+		current.Variables = mergeStringMap(current.Variables, overlayContainer.Variables)
+		base.Containers[name] = current
+	}
+
+	if base.Service.Ports == nil {
+		base.Service.Ports = map[string]servicePort{}
+	}
+	for name, overlayPort := range overlay.Service.Ports {
+		current := base.Service.Ports[name]
+		if overlayPort.Port != 0 {
+			current.Port = overlayPort.Port
+		}
+		if overlayPort.TargetPort != 0 {
+			current.TargetPort = overlayPort.TargetPort
+		}
+		base.Service.Ports[name] = current
+	}
+
+	if base.Resources == nil {
+		base.Resources = map[string]workloadResource{}
+	}
+	for name, overlayResource := range overlay.Resources {
+		current := base.Resources[name]
+		if strings.TrimSpace(overlayResource.Type) != "" {
+			current.Type = overlayResource.Type
+		}
+		base.Resources[name] = current
+	}
+}
+
+func mergeStringMap(base, overlay map[string]string) map[string]string {
+	if base == nil && overlay == nil {
+		return nil
+	}
+	merged := make(map[string]string, len(base)+len(overlay))
+	for key, value := range base {
+		merged[key] = value
+	}
+	for key, value := range overlay {
+		merged[key] = value
+	}
+	return merged
+}
+
+func primaryContainer(containers map[string]workloadContainer) (string, workloadContainer, error) {
+	if len(containers) == 0 {
+		return "", workloadContainer{}, errors.New("no containers declared in Score workload")
+	}
+	names := make([]string, 0, len(containers))
+	for name := range containers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if name == "main" {
+			return name, containers[name], nil
+		}
+	}
+	name := names[0]
+	return name, containers[name], nil
+}
+
+func primaryServicePort(ports map[string]servicePort) (string, servicePort, error) {
+	if len(ports) == 0 {
+		return "", servicePort{}, errors.New("no service ports declared in Score workload")
+	}
+	names := make([]string, 0, len(ports))
+	for name := range ports {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if name == "web" {
+			return name, ports[name], nil
+		}
+	}
+	name := names[0]
+	return name, ports[name], nil
+}
+
+func resolveVariables(variables map[string]string, resources map[string]workloadResource) map[string]string {
+	if len(variables) == 0 {
+		return nil
+	}
+	resolved := make(map[string]string, len(variables))
+	for key, value := range variables {
+		matches := resourcePattern.FindStringSubmatch(strings.TrimSpace(value))
+		if len(matches) != 3 {
+			resolved[key] = value
+			continue
+		}
+
+		resourceName := matches[1]
+		field := matches[2]
+		resourceSpec := resources[resourceName]
+		resolved[key] = resourceValue(resourceName, resourceSpec.Type, field, value)
+	}
+	return resolved
+}
+
+func resourceValue(resourceName, resourceType, field, fallback string) string {
+	resourceType = strings.TrimSpace(resourceType)
+	switch field {
+	case "host":
+		switch resourceType {
+		case "postgres":
+			return "postgres.platform.svc.cluster.local"
+		case "redis":
+			return "redis.platform.svc.cluster.local"
+		case "dns":
+			return "dns.platform.svc.cluster.local"
+		}
+		return fmt.Sprintf("%s.platform.svc.cluster.local", resourceName)
+	case "port":
+		switch resourceType {
+		case "postgres":
+			return "5432"
+		case "redis":
+			return "6379"
+		}
+	}
+	return fallback
+}
+
+type envVar struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+func envVars(values map[string]string) []envVar {
+	if len(values) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]envVar, 0, len(names)+1)
+	for _, name := range names {
+		out = append(out, envVar{Name: name, Value: values[name]})
+	}
+	return out
+}
+
+type manifestSetInput struct {
+	Name          string
+	Namespace     string
+	ContainerName string
+	Image         string
+	ServiceName   string
+	ServicePort   int
+	TargetPort    int
+	Env           []envVar
+}
+
+func marshalManifestSet(input manifestSetInput) ([]byte, error) {
+	labels := map[string]string{
+		"app.kubernetes.io/name": input.Name,
+		"app.kubernetes.io/part-of": "scoredev-paas",
+	}
+
+	objects := []any{
+		map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]any{
+				"name": input.Namespace,
+			},
+		},
+		map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name":      input.Name,
+				"namespace": input.Namespace,
+				"labels":    labels,
+			},
+			"spec": map[string]any{
+				"replicas": 1,
+				"selector": map[string]any{
+					"matchLabels": labels,
+				},
+				"template": map[string]any{
+					"metadata": map[string]any{
+						"labels": labels,
+					},
+					"spec": map[string]any{
+						"containers": []any{
+							map[string]any{
+								"name":            input.ContainerName,
+								"image":           input.Image,
+								"imagePullPolicy": "IfNotPresent",
+								"ports": []any{
+									map[string]any{
+										"containerPort": input.TargetPort,
+										"name":          input.ServiceName,
+									},
+								},
+								"env": input.Env,
+								"readinessProbe": map[string]any{
+									"httpGet": map[string]any{
+										"path": "/healthz",
+										"port": input.TargetPort,
+									},
+									"initialDelaySeconds": 2,
+									"periodSeconds":       3,
+								},
+								"livenessProbe": map[string]any{
+									"httpGet": map[string]any{
+										"path": "/healthz",
+										"port": input.TargetPort,
+									},
+									"initialDelaySeconds": 5,
+									"periodSeconds":       5,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]any{
+				"name":      input.Name,
+				"namespace": input.Namespace,
+				"labels":    labels,
+			},
+			"spec": map[string]any{
+				"selector": labels,
+				"ports": []any{
+					map[string]any{
+						"name":       input.ServiceName,
+						"port":       input.ServicePort,
+						"targetPort": input.TargetPort,
+					},
+				},
+			},
+		},
+	}
+
+	var out strings.Builder
+	for i, object := range objects {
+		rendered, err := yaml.Marshal(object)
+		if err != nil {
+			return nil, fmt.Errorf("marshal manifest %d: %w", i, err)
+		}
+		if i > 0 {
+			out.WriteString("---\n")
+		}
+		out.Write(rendered)
+	}
+	return []byte(out.String()), nil
+}
+
+func (p servicePort) targetPort() int {
+	if p.TargetPort != 0 {
+		return p.TargetPort
+	}
+	return p.Port
+}

--- a/examples/scoredev-paas/bin/render_runtime.go
+++ b/examples/scoredev-paas/bin/render_runtime.go
@@ -332,7 +332,7 @@ type manifestSetInput struct {
 
 func marshalManifestSet(input manifestSetInput) ([]byte, error) {
 	labels := map[string]string{
-		"app.kubernetes.io/name": input.Name,
+		"app.kubernetes.io/name":    input.Name,
 		"app.kubernetes.io/part-of": "scoredev-paas",
 	}
 

--- a/examples/scoredev-paas/bin/render_runtime_test.go
+++ b/examples/scoredev-paas/bin/render_runtime_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderRuntimeMergesOverlayAndResolvesResources(t *testing.T) {
+	dir := t.TempDir()
+	scorePath := filepath.Join(dir, "score.yaml")
+	overlayPath := filepath.Join(dir, "score-prod.yaml")
+
+	if err := os.WriteFile(scorePath, []byte(`apiVersion: score.dev/v1b1
+kind: Workload
+metadata:
+  name: checkout-api
+containers:
+  main:
+    image: ghcr.io/example/checkout-api:v1.0.0
+    variables:
+      LOG_LEVEL: info
+      DB_HOST: ${resources.db.host}
+      DB_PORT: ${resources.db.port}
+service:
+  ports:
+    web:
+      port: 8080
+resources:
+  db:
+    type: postgres
+`), 0o644); err != nil {
+		t.Fatalf("write score.yaml: %v", err)
+	}
+
+	if err := os.WriteFile(overlayPath, []byte(`apiVersion: score.dev/v1b1
+metadata:
+  name: checkout-api
+containers:
+  main:
+    image: ghcr.io/example/checkout-api:v2.1.0
+    variables:
+      LOG_LEVEL: warn
+      NODE_ENV: production
+`), 0o644); err != nil {
+		t.Fatalf("write score-prod.yaml: %v", err)
+	}
+
+	manifests, err := renderRuntime(scorePath, overlayPath, "")
+	if err != nil {
+		t.Fatalf("render runtime: %v", err)
+	}
+
+	if manifests.Image != "ghcr.io/example/checkout-api:v2.1.0" {
+		t.Fatalf("resolved image = %q, want overlay image", manifests.Image)
+	}
+	text := string(manifests.Content)
+	for _, want := range []string{
+		"namespace: checkout-api",
+		"image: ghcr.io/example/checkout-api:v2.1.0",
+		"name: LOG_LEVEL",
+		"value: warn",
+		"name: NODE_ENV",
+		"value: production",
+		"value: postgres.platform.svc.cluster.local",
+		"value: \"5432\"",
+		"path: /healthz",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("rendered manifests missing %q\n%s", want, text)
+		}
+	}
+}

--- a/examples/scoredev-paas/contracts.md
+++ b/examples/scoredev-paas/contracts.md
@@ -67,6 +67,31 @@ inspect_with:
   - cat escalate.txt
 ```
 
+## Standalone runtime proof
+
+```yaml
+id: score_standalone_runtime
+command: ./examples/scoredev-paas/demo-runtime.sh
+mutates:
+  repo: false
+  backend: false
+  live: kind_cluster_only
+expects:
+  stdout_contains:
+    - "E2E verification PASSED"
+    - "[score-runtime] success"
+  files_exist:
+    - "examples/scoredev-paas/var/runtime-manifests.yaml"
+  live_checks:
+    - "checkout-api deployment has a ready replica"
+    - "/healthz returns ok"
+    - "/ returns service=checkout-api and logLevel=warn"
+inspect_with:
+  - kubectl -n checkout-api get deployment checkout-api -o yaml
+  - kubectl -n checkout-api get service checkout-api -o yaml
+  - ./examples/scoredev-paas/verify-e2e.sh
+```
+
 ## Connected preflight
 
 ```yaml
@@ -100,7 +125,7 @@ expects:
     - ".tmp/scoredev-connected/create/summary.json"
     - ".tmp/scoredev-connected/update/summary.json"
   decision_state: terminal_allow_escalate_or_block
-  note: "standalone live-cluster Score proof is still out of scope for this contract"
+  note: "connected proof complements the standalone live-cluster proof; it does not replace it"
 inspect_with:
   - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/scoredev-connected/create/summary.json
   - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/scoredev-connected/update/summary.json

--- a/examples/scoredev-paas/demo-runtime.sh
+++ b/examples/scoredev-paas/demo-runtime.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER_NAME="${CLUSTER_NAME:-scoredev-runtime}"
+KUBECONFIG_PATH="${ROOT_DIR}/var/${CLUSTER_NAME}.kubeconfig"
+NAMESPACE="${NAMESPACE:-checkout-api}"
+MANIFESTS_PATH="${MANIFESTS_PATH:-${ROOT_DIR}/var/runtime-manifests.yaml}"
+DEPLOYMENT_NAME="checkout-api"
+
+"${ROOT_DIR}/bin/create-cluster" "${CLUSTER_NAME}"
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+"${ROOT_DIR}/bin/build-image" "${CLUSTER_NAME}"
+"${ROOT_DIR}/bin/render-runtime" "${MANIFESTS_PATH}"
+
+echo "Applying rendered runtime manifests..."
+kubectl apply -f "${MANIFESTS_PATH}" >/dev/null
+
+echo "Waiting for deployment/${DEPLOYMENT_NAME} to become ready..."
+kubectl -n "${NAMESPACE}" rollout status deployment/"${DEPLOYMENT_NAME}" --timeout=180s
+
+"${ROOT_DIR}/verify-e2e.sh"
+
+echo
+echo "[score-runtime] success"
+echo "  cluster: ${CLUSTER_NAME}"
+echo "  kubeconfig: ${KUBECONFIG_PATH}"
+echo "  manifests: ${MANIFESTS_PATH}"

--- a/examples/scoredev-paas/prompts.md
+++ b/examples/scoredev-paas/prompts.md
@@ -52,12 +52,31 @@ Help me run the connected Score walkthrough for ./examples/scoredev-paas.
 Safety rules:
 - Start with the shared connected smoke check even though Score is not in the smoke lane.
 - Stop if cub auth/context is missing.
-- Be explicit that this example still does not claim standalone live-cluster Score proof.
 
 Sequence:
 1. cub auth login
 2. ./examples/demo/run-connected-smoke.sh
 3. OUTPUT_DIR=.tmp/scoredev-connected ./examples/scoredev-paas/demo-connected.sh
 
-After each step, tell me what to inspect in ConfigHub and what the remaining proof gap is.
+After each step, tell me what to inspect in ConfigHub and how this differs from the standalone local runtime proof.
+```
+
+## Standalone runtime prompt
+
+```text
+Help me run the standalone live Score runtime proof for ./examples/scoredev-paas.
+
+Safety rules:
+- Explain that this uses a local kind cluster and Docker image only.
+- Stop if Docker, kind, or kubectl are missing.
+- Keep the cluster name and kubeconfig path visible in your summary.
+
+Sequence:
+1. ./examples/scoredev-paas/demo-runtime.sh
+2. Summarize:
+   - the resolved runtime image tag
+   - the namespace, deployment, and service that were created
+   - the /healthz result
+   - the JSON response from /
+3. Tell me how to inspect the live deployment with kubectl and how to tear the cluster down when I'm done.
 ```

--- a/examples/scoredev-paas/var/.gitignore
+++ b/examples/scoredev-paas/var/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/examples/scoredev-paas/verify-e2e.sh
+++ b/examples/scoredev-paas/verify-e2e.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER_NAME="${CLUSTER_NAME:-scoredev-runtime}"
+KUBECONFIG="${KUBECONFIG:-$ROOT_DIR/var/${CLUSTER_NAME}.kubeconfig}"
+NAMESPACE="${NAMESPACE:-checkout-api}"
+DEPLOYMENT="${DEPLOYMENT:-checkout-api}"
+SERVICE="${SERVICE:-checkout-api}"
+LOCAL_PORT="${LOCAL_PORT:-18081}"
+EXPECTED_IMAGE="${EXPECTED_IMAGE:-ghcr.io/example/checkout-api:v2.1.0}"
+
+export KUBECONFIG
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo "Checking cluster..."
+kubectl cluster-info >/dev/null 2>&1 || fail "Cluster is not reachable"
+echo "  OK: Cluster is reachable"
+
+echo "Checking namespace..."
+kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1 || fail "Namespace ${NAMESPACE} does not exist"
+echo "  OK: Namespace ${NAMESPACE} exists"
+
+echo "Checking deployment..."
+kubectl -n "${NAMESPACE}" get deployment "${DEPLOYMENT}" >/dev/null 2>&1 || fail "Deployment ${DEPLOYMENT} not found"
+READY="$(kubectl -n "${NAMESPACE}" get deployment "${DEPLOYMENT}" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")"
+[[ "${READY:-0}" -ge 1 ]] || fail "Deployment ${DEPLOYMENT} has no ready replicas"
+echo "  OK: Deployment ${DEPLOYMENT} has ${READY} ready replica(s)"
+
+echo "Checking image..."
+IMAGE="$(kubectl -n "${NAMESPACE}" get deployment "${DEPLOYMENT}" -o jsonpath='{.spec.template.spec.containers[0].image}')"
+[[ "${IMAGE}" == "${EXPECTED_IMAGE}" ]] || fail "Expected image ${EXPECTED_IMAGE}, got ${IMAGE}"
+echo "  OK: Deployment image is ${IMAGE}"
+
+echo "Checking pods..."
+POD="$(kubectl -n "${NAMESPACE}" get pods -l "app.kubernetes.io/name=${DEPLOYMENT}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)"
+[[ -n "${POD}" ]] || fail "No pods found for ${DEPLOYMENT}"
+PHASE="$(kubectl -n "${NAMESPACE}" get pod "${POD}" -o jsonpath='{.status.phase}')"
+[[ "${PHASE}" == "Running" ]] || fail "Pod ${POD} is ${PHASE}, expected Running"
+echo "  OK: Pod ${POD} is Running"
+
+echo "Port-forwarding to ${LOCAL_PORT}..."
+kubectl -n "${NAMESPACE}" port-forward "svc/${SERVICE}" "${LOCAL_PORT}:8080" >/dev/null 2>&1 &
+PF_PID=$!
+trap 'kill ${PF_PID} 2>/dev/null || true' EXIT
+sleep 3
+
+echo "Checking /healthz..."
+HEALTHZ="$(curl -sf "http://localhost:${LOCAL_PORT}/healthz" 2>/dev/null)" || fail "Could not reach /healthz"
+[[ "${HEALTHZ}" == "ok" ]] || fail "Expected /healthz to return ok, got ${HEALTHZ}"
+echo "  OK: /healthz returned ok"
+
+echo "Checking /..."
+ROOT_JSON="$(curl -sf "http://localhost:${LOCAL_PORT}/" 2>/dev/null)" || fail "Could not reach /"
+echo "  Response: ${ROOT_JSON}"
+
+SERVICE_NAME="$(echo "${ROOT_JSON}" | jq -r '.service')"
+[[ "${SERVICE_NAME}" == "checkout-api" ]] || fail "Expected service=checkout-api, got ${SERVICE_NAME}"
+echo "  OK: service=${SERVICE_NAME}"
+
+LOG_LEVEL="$(echo "${ROOT_JSON}" | jq -r '.logLevel')"
+[[ "${LOG_LEVEL}" == "warn" ]] || fail "Expected logLevel=warn, got ${LOG_LEVEL}"
+echo "  OK: logLevel=${LOG_LEVEL}"
+
+echo
+echo "====================================="
+echo "E2E verification PASSED"
+echo "====================================="

--- a/internal/exampletruth/matrix.go
+++ b/internal/exampletruth/matrix.go
@@ -155,7 +155,14 @@ func Collect(root string) (Matrix, error) {
 			}
 			row.Notes = append(row.Notes, "Runtime harness for WET->LIVE proof; source-side generator proof lives in paired examples.")
 		case "scoredev-paas":
-			row.Notes = append(row.Notes, "Score now has example-owned local governed proof via ./examples/scoredev-paas/demo-governed-workload.sh for ALLOW versus ESCALATE, even though standalone live-cluster proof is still open.")
+			row.RealLiveProof = RealLiveStandalone
+			row.ProofRefs.RealLive = []string{
+				"./examples/scoredev-paas/demo-runtime.sh",
+				"./examples/scoredev-paas/verify-e2e.sh",
+				"./examples/scoredev-paas/bin/create-cluster",
+				"./examples/scoredev-paas/bin/build-image",
+			}
+			row.Notes = append(row.Notes, "Standalone real-cluster proof: merged score.yaml + score-prod.yaml rendered into a live checkout-api deployment on kind.")
 		}
 
 		if hasAIFirstBundle(root, slug) {
@@ -354,8 +361,6 @@ func trackingIssuesForExample(slug, aiSurface string) []string {
 	switch slug {
 	case "helm-paas":
 		issues = append(issues, "#177", "#187")
-	case "scoredev-paas":
-		issues = append(issues, "#178")
 	case "springboot-paas":
 		issues = append(issues, "#179")
 	case "ops-workflow", "swamp-automation":


### PR DESCRIPTION
## Summary
- add an example-owned Score runtime path with a small renderer, Docker image build/load helpers, kind cluster setup, and HTTP verification
- prove the full Score-first starter flow end to end, including local ALLOW/ESCALATE governance and standalone live `checkout-api` runtime verification
- update the truth matrix, flagship docs, AI bundle, and release trackers so `scoredev-paas` is treated as a standalone live-proof example and remove `#178` from the active blocker list

## Validation
- `go test ./...`
- `bash -n examples/scoredev-paas/bin/render-runtime examples/scoredev-paas/bin/create-cluster examples/scoredev-paas/bin/build-image examples/scoredev-paas/demo-runtime.sh examples/scoredev-paas/verify-e2e.sh examples/demo/start-score-first.sh`
- `./examples/scoredev-paas/demo-runtime.sh`
- `./examples/demo/start-score-first.sh`
- `./test/checks/check-example-truth-matrix.sh`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`

Closes #178
