### PR TITLE
helm: close flagship layered provenance gaps

### DIFF
--- a/.github/workflows/pr-dry-ownership-gate.yml
+++ b/.github/workflows/pr-dry-ownership-gate.yml
@@ -16,6 +16,10 @@ permissions:
 
 jobs:
   gate:
+    # Keep the legacy check names stable for branch protection while the
+    # workflow itself runs in repo-maintainer mode. Audience-specific owner
+    # proofs stay covered by the example-owned demo wrappers.
+    name: gate (${{ matrix.slug }}, ${{ matrix.repo_path }}, ${{ matrix.check_label }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -23,10 +27,12 @@ jobs:
         include:
           - slug: helm
             repo_path: ./examples/helm-paas
-            actor_role: app-team
+            check_label: app-team
+            actor_role: any
           - slug: springboot
             repo_path: ./examples/springboot-paas
-            actor_role: app-team
+            check_label: app-team
+            actor_role: any
 
     steps:
       - uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -228,14 +228,14 @@ Both prove create, update, and drift-correction on a real cluster.
 |---|---|
 | Latest shipped | `v0.2-preview.1` was released on 2026-03-06 |
 | Strong now | Dual-mode example entrypoints exist across the main catalog; a smaller ConfigHub smoke lane covers the flagship examples; Flux and Argo live reconciler proofs run on real clusters |
-| In progress | Flagship examples are still being hardened against the universal example contract: real-cluster outcome, two-audience path, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` proof |
+| In progress | Follow-on depth is now mostly Helm-specific: umbrella/subchart support, richer provenance honesty, render-diff depth, multi-stage chaining, and CLI override capture |
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
-| Example quality | `#177`, `#180`, `#187` |
+| Example quality | Flagship example blockers are resolved on this branch; deeper Helm follow-on depth is `#238`-`#242` |
 | CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
 | Release gate | Secrets-backed ConfigHub smoke is green on `main`; rerun it in the release environment before tagging |
-| Actively tracked | `#173`, `#177`, `#180`, `#187`, `#238`-`#242` |
+| Actively tracked | `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/cmd/cub-gen/change_command_test.go
+++ b/cmd/cub-gen/change_command_test.go
@@ -192,6 +192,61 @@ func TestChangeExplainJSON(t *testing.T) {
 	}
 }
 
+func TestChangeHelmOverlayRecommendation(t *testing.T) {
+	setupAliases(t)
+
+	previewOut, stderr, err := runWithCapturedIO([]string{
+		"change", "preview",
+		"--space", "platform",
+		"helm",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("change preview returned error: %v\nstderr=%s", err, stderr)
+	}
+
+	var preview map[string]any
+	if err := json.Unmarshal([]byte(previewOut), &preview); err != nil {
+		t.Fatalf("unmarshal change preview output: %v\noutput=%s", err, previewOut)
+	}
+	recommendation, ok := preview["edit_recommendation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected edit_recommendation object, got %T", preview["edit_recommendation"])
+	}
+	editHint, ok := recommendation["edit_hint"].(string)
+	if !ok {
+		t.Fatalf("expected edit hint string, got %T", recommendation["edit_hint"])
+	}
+	if !strings.Contains(editHint, "values-prod.yaml") || !strings.Contains(editHint, "values.yaml") {
+		t.Fatalf("expected Helm edit hint to mention overlay and base values files, got %q", editHint)
+	}
+
+	explainOut, explainErr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		"helm",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v\nstderr=%s", err, explainErr)
+	}
+
+	var explain map[string]any
+	if err := json.Unmarshal([]byte(explainOut), &explain); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, explainOut)
+	}
+	explanation, ok := explain["explanation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected explanation object, got %T", explain["explanation"])
+	}
+	if got, ok := explanation["source_path"].(string); !ok || got != "values-prod.yaml" {
+		t.Fatalf("expected source_path=values-prod.yaml, got %v", explanation["source_path"])
+	}
+	if got, ok := explanation["source_transform"].(string); !ok || got != "helm-values-overlay" {
+		t.Fatalf("expected source_transform=helm-values-overlay, got %v", explanation["source_transform"])
+	}
+}
+
 func TestChangeExplainWetPathFilter(t *testing.T) {
 	setupAliases(t)
 

--- a/cmd/cub-gen/testdata/parity/generators-details.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-details.golden.json
@@ -409,8 +409,10 @@
         "default_input_role": "helm-input",
         "default_owner": "platform-engineer",
         "field_origin_confidences": {
-          "image_tag": 0.86
+          "image_tag_base": 0.86,
+          "image_tag_overlay": 0.9
         },
+        "field_origin_overlay_transform": "helm-values-overlay",
         "field_origin_transform": "helm-template",
         "hint_defaults": {
           "chart_path": "Chart.yaml",
@@ -437,7 +439,8 @@
           }
         ],
         "inverse_edit_hints": {
-          "image_tag": "Edit chart values file and keep chart template unchanged."
+          "image_tag_base": "Edit values.image.tag in {{base_values_path}}.",
+          "image_tag_overlay": "Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults."
         },
         "inverse_patch_reasons": {
           "image_tag": "Container image tag maps cleanly to helm values."

--- a/cmd/cub-gen/testdata/parity/generators-details.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-details.golden.json
@@ -428,6 +428,37 @@
             "role": "chart"
           },
           {
+            "exact_basenames": [
+              "applicationset.yaml",
+              "applicationset.yml"
+            ],
+            "role": "application-set"
+          },
+          {
+            "extensions": [
+              ".yaml",
+              ".yml",
+              ".json"
+            ],
+            "role": "cluster-inventory"
+          },
+          {
+            "extensions": [
+              ".yaml",
+              ".yml",
+              ".json"
+            ],
+            "role": "managed-service-catalog"
+          },
+          {
+            "extensions": [
+              ".yaml",
+              ".yml",
+              ".json"
+            ],
+            "role": "customer-service-catalog"
+          },
+          {
             "extensions": [
               ".yaml",
               ".yml"
@@ -486,6 +517,7 @@
           }
         ],
         "role_owners": {
+          "customer-service-catalog": "app-team",
           "values": "app-team"
         },
         "wet_targets": [

--- a/cmd/cub-gen/testdata/parity/generators-details.markdown.golden.md
+++ b/cmd/cub-gen/testdata/parity/generators-details.markdown.golden.md
@@ -198,6 +198,7 @@ Total: 8
 - Default input role: `helm-input`
 - Default owner: `platform-engineer`
 - Field-origin transform: `helm-template`
+- Field-origin overlay transform: `helm-values-overlay`
 
 ### Input Role Rules
 | Role | Exact basenames | Prefixes | Extensions |
@@ -223,7 +224,8 @@ Total: 8
 ### Field Origin Confidences
 | Key | Confidence |
 | --- | --- |
-| `image_tag` | 0.86 |
+| `image_tag_base` | 0.86 |
+| `image_tag_overlay` | 0.90 |
 
 ### Hint Defaults
 | Key | Value |
@@ -241,7 +243,8 @@ Total: 8
 ### Inverse Edit Hints
 | Key | Hint |
 | --- | --- |
-| `image_tag` | Edit chart values file and keep chart template unchanged. |
+| `image_tag_base` | Edit values.image.tag in {{base_values_path}}. |
+| `image_tag_overlay` | Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults. |
 
 ### WET Targets
 | Kind | Name template | Owner | Namespace | Source DRY path template |

--- a/cmd/cub-gen/testdata/parity/generators-details.markdown.golden.md
+++ b/cmd/cub-gen/testdata/parity/generators-details.markdown.golden.md
@@ -204,11 +204,16 @@ Total: 8
 | Role | Exact basenames | Prefixes | Extensions |
 | --- | --- | --- | --- |
 | `chart` | chart.yaml | - | - |
+| `application-set` | applicationset.yaml, applicationset.yml | - | - |
+| `cluster-inventory` | - | - | .yaml, .yml, .json |
+| `managed-service-catalog` | - | - | .yaml, .yml, .json |
+| `customer-service-catalog` | - | - | .yaml, .yml, .json |
 | `values` | - | values | .yaml, .yml |
 
 ### Role Owners
 | Role | Owner |
 | --- | --- |
+| `customer-service-catalog` | `app-team` |
 | `values` | `app-team` |
 
 ### Inverse Patch Templates

--- a/cmd/cub-gen/testdata/parity/gitops-discover.golden.json
+++ b/cmd/cub-gen/testdata/parity/gitops-discover.golden.json
@@ -6,6 +6,11 @@
       "id": "gen_635643e45fbf3410",
       "inputs": [
         "Chart.yaml",
+        "gitops/argo/applicationset.yaml",
+        "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+        "platform/catalogs/managed-service-catalog/payments-api.yaml",
+        "platform/clusters/prod-eu.yaml",
+        "platform/clusters/stage-eu.yaml",
         "values-prod.yaml",
         "values.yaml"
       ],
@@ -26,6 +31,11 @@
       "generator_profile": "helm-paas",
       "inputs": [
         "Chart.yaml",
+        "gitops/argo/applicationset.yaml",
+        "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+        "platform/catalogs/managed-service-catalog/payments-api.yaml",
+        "platform/clusters/prod-eu.yaml",
+        "platform/clusters/stage-eu.yaml",
         "values-prod.yaml",
         "values.yaml"
       ],

--- a/cmd/cub-gen/testdata/parity/gitops-import.golden.json
+++ b/cmd/cub-gen/testdata/parity/gitops-import.golden.json
@@ -23,6 +23,31 @@
           "name": "input_03",
           "required": true,
           "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_04",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_05",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_06",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_07",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_08",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
         }
       ],
       "kind": "helm",
@@ -45,6 +70,11 @@
       "generator_profile": "helm-paas",
       "inputs": [
         "Chart.yaml",
+        "gitops/argo/applicationset.yaml",
+        "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+        "platform/catalogs/managed-service-catalog/payments-api.yaml",
+        "platform/clusters/prod-eu.yaml",
+        "platform/clusters/stage-eu.yaml",
         "values-prod.yaml",
         "values.yaml"
       ],
@@ -59,10 +89,50 @@
     {
       "generator_id": "gen_635643e45fbf3410",
       "owner": "platform-engineer",
+      "path": "gitops/argo/applicationset.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "application-set"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
       "path": "Chart.yaml",
       "profile": "helm-paas",
       "required": true,
       "role": "chart"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
+      "path": "platform/clusters/prod-eu.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "cluster-inventory"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
+      "path": "platform/clusters/stage-eu.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "cluster-inventory"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "app-team",
+      "path": "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "customer-service-catalog"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
+      "path": "platform/catalogs/managed-service-catalog/payments-api.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "managed-service-catalog"
     },
     {
       "generator_id": "gen_635643e45fbf3410",
@@ -151,7 +221,35 @@
       "generator_id": "gen_635643e45fbf3410",
       "generator_name": "helm-paas",
       "generator_profile": "helm-paas",
-      "input_digest": "sha256:0ceaab864fc2c01e0d45011864aa2f8bbe3e1f9a6f2a4bc81b1d4d667dbd6ba9",
+      "helm_layered_analysis": {
+        "application_set_path": "gitops/argo/applicationset.yaml",
+        "cluster_inventory_paths": [
+          "platform/clusters/prod-eu.yaml",
+          "platform/clusters/stage-eu.yaml"
+        ],
+        "cluster_selector": "env=prod, region=eu",
+        "customer_catalog_paths": [
+          "platform/catalogs/customer-service-catalog/payments-api-prod.yaml"
+        ],
+        "generation_decision_reason": "ApplicationSet selector env=prod, region=eu matches cluster inventory prod-eu and selects value files values.yaml, values-prod.yaml.",
+        "generation_decision_state": "attributed",
+        "managed_catalog_paths": [
+          "platform/catalogs/managed-service-catalog/payments-api.yaml"
+        ],
+        "matched_clusters": [
+          "prod-eu"
+        ],
+        "security_control": "oauth2Proxy",
+        "security_control_path": "platform/catalogs/managed-service-catalog/payments-api.yaml",
+        "security_decision_reason": "Customer service catalog platform/catalogs/customer-service-catalog/payments-api-prod.yaml keeps the platform-required oauth2Proxy control enabled.",
+        "security_decision_state": "allow",
+        "security_override_path": "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+        "selected_value_files": [
+          "values.yaml",
+          "values-prod.yaml"
+        ]
+      },
+      "input_digest": "sha256:0600eadf0bf5449e8eeea4285a8d8cc115ca2ab9df9983a0af6e9fe55b06285d",
       "inverse_edit_pointers": [
         {
           "confidence": 0.86,
@@ -211,6 +309,36 @@
       "sources": [
         {
           "path": "Chart.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "gitops/argo/applicationset.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/catalogs/managed-service-catalog/payments-api.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/clusters/prod-eu.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/clusters/stage-eu.yaml",
           "revision": "HEAD",
           "role": "generator-input",
           "uri": "\u003csource_uri\u003e"

--- a/cmd/cub-gen/testdata/parity/gitops-import.golden.json
+++ b/cmd/cub-gen/testdata/parity/gitops-import.golden.json
@@ -139,6 +139,13 @@
           "source_path": "values.yaml",
           "transform": "helm-template",
           "wet_path": "Deployment/spec/template/spec/containers[0]/image"
+        },
+        {
+          "confidence": 0.9,
+          "dry_path": "values.image.tag",
+          "source_path": "values-prod.yaml",
+          "transform": "helm-values-overlay",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/image"
         }
       ],
       "generator_id": "gen_635643e45fbf3410",
@@ -149,7 +156,7 @@
         {
           "confidence": 0.86,
           "dry_path": "values.image.tag",
-          "edit_hint": "Edit chart values file and keep chart template unchanged.",
+          "edit_hint": "Edit values.image.tag in values-prod.yaml for environment-specific overrides; use values.yaml for defaults.",
           "owner": "app-team",
           "wet_path": "Deployment/spec/template/spec/containers[0]/image"
         }

--- a/cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt
+++ b/cmd/cub-gen/testdata/parity/gitops-import.table.golden.txt
@@ -9,7 +9,7 @@ Generated contracts: 1
 Generated provenance records: 1
 Generated inverse transform plans: 1
 Generator Kind	Profile	Capabilities	Dry Inputs	Wet Targets	Inverse Patches	Review Required
-helm	helm-paas	render-manifests,values-overrides,inverse-values-patch	3	3	1	0
+helm	helm-paas	render-manifests,values-overrides,inverse-values-patch	8	3	1	0
 Review required patches: 0
 Patch owner	Count
 app-team	1

--- a/cmd/cub-gen/testdata/parity/publish-direct-helm.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-helm.golden.json
@@ -141,6 +141,13 @@
           "source_path": "values.yaml",
           "transform": "helm-template",
           "wet_path": "Deployment/spec/template/spec/containers[0]/image"
+        },
+        {
+          "confidence": 0.9,
+          "dry_path": "values.image.tag",
+          "source_path": "values-prod.yaml",
+          "transform": "helm-values-overlay",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/image"
         }
       ],
       "generator_id": "gen_635643e45fbf3410",
@@ -151,7 +158,7 @@
         {
           "confidence": 0.86,
           "dry_path": "values.image.tag",
-          "edit_hint": "Edit chart values file and keep chart template unchanged.",
+          "edit_hint": "Edit values.image.tag in values-prod.yaml for environment-specific overrides; use values.yaml for defaults.",
           "owner": "app-team",
           "wet_path": "Deployment/spec/template/spec/containers[0]/image"
         }

--- a/cmd/cub-gen/testdata/parity/publish-direct-helm.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-helm.golden.json
@@ -25,6 +25,31 @@
           "name": "input_03",
           "required": true,
           "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_04",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_05",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_06",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_07",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_08",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
         }
       ],
       "kind": "helm",
@@ -47,6 +72,11 @@
       "generator_profile": "helm-paas",
       "inputs": [
         "Chart.yaml",
+        "gitops/argo/applicationset.yaml",
+        "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+        "platform/catalogs/managed-service-catalog/payments-api.yaml",
+        "platform/clusters/prod-eu.yaml",
+        "platform/clusters/stage-eu.yaml",
         "values-prod.yaml",
         "values.yaml"
       ],
@@ -61,10 +91,50 @@
     {
       "generator_id": "gen_635643e45fbf3410",
       "owner": "platform-engineer",
+      "path": "gitops/argo/applicationset.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "application-set"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
       "path": "Chart.yaml",
       "profile": "helm-paas",
       "required": true,
       "role": "chart"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
+      "path": "platform/clusters/prod-eu.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "cluster-inventory"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
+      "path": "platform/clusters/stage-eu.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "cluster-inventory"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "app-team",
+      "path": "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "customer-service-catalog"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
+      "path": "platform/catalogs/managed-service-catalog/payments-api.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "managed-service-catalog"
     },
     {
       "generator_id": "gen_635643e45fbf3410",
@@ -153,7 +223,35 @@
       "generator_id": "gen_635643e45fbf3410",
       "generator_name": "helm-paas",
       "generator_profile": "helm-paas",
-      "input_digest": "sha256:0ceaab864fc2c01e0d45011864aa2f8bbe3e1f9a6f2a4bc81b1d4d667dbd6ba9",
+      "helm_layered_analysis": {
+        "application_set_path": "gitops/argo/applicationset.yaml",
+        "cluster_inventory_paths": [
+          "platform/clusters/prod-eu.yaml",
+          "platform/clusters/stage-eu.yaml"
+        ],
+        "cluster_selector": "env=prod, region=eu",
+        "customer_catalog_paths": [
+          "platform/catalogs/customer-service-catalog/payments-api-prod.yaml"
+        ],
+        "generation_decision_reason": "ApplicationSet selector env=prod, region=eu matches cluster inventory prod-eu and selects value files values.yaml, values-prod.yaml.",
+        "generation_decision_state": "attributed",
+        "managed_catalog_paths": [
+          "platform/catalogs/managed-service-catalog/payments-api.yaml"
+        ],
+        "matched_clusters": [
+          "prod-eu"
+        ],
+        "security_control": "oauth2Proxy",
+        "security_control_path": "platform/catalogs/managed-service-catalog/payments-api.yaml",
+        "security_decision_reason": "Customer service catalog platform/catalogs/customer-service-catalog/payments-api-prod.yaml keeps the platform-required oauth2Proxy control enabled.",
+        "security_decision_state": "allow",
+        "security_override_path": "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+        "selected_value_files": [
+          "values.yaml",
+          "values-prod.yaml"
+        ]
+      },
+      "input_digest": "sha256:0600eadf0bf5449e8eeea4285a8d8cc115ca2ab9df9983a0af6e9fe55b06285d",
       "inverse_edit_pointers": [
         {
           "confidence": 0.86,
@@ -218,6 +316,36 @@
           "uri": "\u003csource_uri\u003e"
         },
         {
+          "path": "gitops/argo/applicationset.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/catalogs/managed-service-catalog/payments-api.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/clusters/prod-eu.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/clusters/stage-eu.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
           "path": "values-prod.yaml",
           "revision": "HEAD",
           "role": "generator-input",
@@ -245,7 +373,7 @@
   "summary": {
     "contracts": 1,
     "discovered_resources": 1,
-    "dry_inputs": 3,
+    "dry_inputs": 8,
     "dry_units": 1,
     "generator_profiles": [
       "helm-paas"

--- a/cmd/cub-gen/testdata/parity/publish-from-import.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import.golden.json
@@ -141,6 +141,13 @@
           "source_path": "values.yaml",
           "transform": "helm-template",
           "wet_path": "Deployment/spec/template/spec/containers[0]/image"
+        },
+        {
+          "confidence": 0.9,
+          "dry_path": "values.image.tag",
+          "source_path": "values-prod.yaml",
+          "transform": "helm-values-overlay",
+          "wet_path": "Deployment/spec/template/spec/containers[0]/image"
         }
       ],
       "generator_id": "gen_635643e45fbf3410",
@@ -151,7 +158,7 @@
         {
           "confidence": 0.86,
           "dry_path": "values.image.tag",
-          "edit_hint": "Edit chart values file and keep chart template unchanged.",
+          "edit_hint": "Edit values.image.tag in values-prod.yaml for environment-specific overrides; use values.yaml for defaults.",
           "owner": "app-team",
           "wet_path": "Deployment/spec/template/spec/containers[0]/image"
         }

--- a/cmd/cub-gen/testdata/parity/publish-from-import.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import.golden.json
@@ -25,6 +25,31 @@
           "name": "input_03",
           "required": true,
           "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_04",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_05",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_06",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_07",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "name": "input_08",
+          "required": true,
+          "schema_ref": "https://json-schema.org/draft/2020-12/schema"
         }
       ],
       "kind": "helm",
@@ -47,6 +72,11 @@
       "generator_profile": "helm-paas",
       "inputs": [
         "Chart.yaml",
+        "gitops/argo/applicationset.yaml",
+        "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+        "platform/catalogs/managed-service-catalog/payments-api.yaml",
+        "platform/clusters/prod-eu.yaml",
+        "platform/clusters/stage-eu.yaml",
         "values-prod.yaml",
         "values.yaml"
       ],
@@ -61,10 +91,50 @@
     {
       "generator_id": "gen_635643e45fbf3410",
       "owner": "platform-engineer",
+      "path": "gitops/argo/applicationset.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "application-set"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
       "path": "Chart.yaml",
       "profile": "helm-paas",
       "required": true,
       "role": "chart"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
+      "path": "platform/clusters/prod-eu.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "cluster-inventory"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
+      "path": "platform/clusters/stage-eu.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "cluster-inventory"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "app-team",
+      "path": "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "customer-service-catalog"
+    },
+    {
+      "generator_id": "gen_635643e45fbf3410",
+      "owner": "platform-engineer",
+      "path": "platform/catalogs/managed-service-catalog/payments-api.yaml",
+      "profile": "helm-paas",
+      "required": true,
+      "role": "managed-service-catalog"
     },
     {
       "generator_id": "gen_635643e45fbf3410",
@@ -153,7 +223,35 @@
       "generator_id": "gen_635643e45fbf3410",
       "generator_name": "helm-paas",
       "generator_profile": "helm-paas",
-      "input_digest": "sha256:0ceaab864fc2c01e0d45011864aa2f8bbe3e1f9a6f2a4bc81b1d4d667dbd6ba9",
+      "helm_layered_analysis": {
+        "application_set_path": "gitops/argo/applicationset.yaml",
+        "cluster_inventory_paths": [
+          "platform/clusters/prod-eu.yaml",
+          "platform/clusters/stage-eu.yaml"
+        ],
+        "cluster_selector": "env=prod, region=eu",
+        "customer_catalog_paths": [
+          "platform/catalogs/customer-service-catalog/payments-api-prod.yaml"
+        ],
+        "generation_decision_reason": "ApplicationSet selector env=prod, region=eu matches cluster inventory prod-eu and selects value files values.yaml, values-prod.yaml.",
+        "generation_decision_state": "attributed",
+        "managed_catalog_paths": [
+          "platform/catalogs/managed-service-catalog/payments-api.yaml"
+        ],
+        "matched_clusters": [
+          "prod-eu"
+        ],
+        "security_control": "oauth2Proxy",
+        "security_control_path": "platform/catalogs/managed-service-catalog/payments-api.yaml",
+        "security_decision_reason": "Customer service catalog platform/catalogs/customer-service-catalog/payments-api-prod.yaml keeps the platform-required oauth2Proxy control enabled.",
+        "security_decision_state": "allow",
+        "security_override_path": "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+        "selected_value_files": [
+          "values.yaml",
+          "values-prod.yaml"
+        ]
+      },
+      "input_digest": "sha256:0600eadf0bf5449e8eeea4285a8d8cc115ca2ab9df9983a0af6e9fe55b06285d",
       "inverse_edit_pointers": [
         {
           "confidence": 0.86,
@@ -218,6 +316,36 @@
           "uri": "\u003csource_uri\u003e"
         },
         {
+          "path": "gitops/argo/applicationset.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/catalogs/managed-service-catalog/payments-api.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/clusters/prod-eu.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "platform/clusters/stage-eu.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
           "path": "values-prod.yaml",
           "revision": "HEAD",
           "role": "generator-input",
@@ -245,7 +373,7 @@
   "summary": {
     "contracts": 1,
     "discovered_resources": 1,
-    "dry_inputs": 3,
+    "dry_inputs": 8,
     "dry_units": 1,
     "generator_profiles": [
       "helm-paas"

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -46,11 +46,17 @@ Required outcome:
 Goal: "all examples working well" means the whole catalog is trustworthy, not
 only the flagship path.
 
-Current open issues:
+Current release blockers on this branch:
 
-- [#177](https://github.com/confighub/cub-gen/issues/177) Helm flagship
-- [#180](https://github.com/confighub/cub-gen/issues/180) workflow examples
-- [#187](https://github.com/confighub/cub-gen/issues/187) Kubara-like layered provenance
+- none in repo code or docs; the remaining release work is release-environment verification
+
+Open follow-on depth after this preview:
+
+- [#238](https://github.com/confighub/cub-gen/issues/238) umbrella/subchart/conditional Helm support
+- [#239](https://github.com/confighub/cub-gen/issues/239) provenance honesty for helpers/lookups/external refs
+- [#240](https://github.com/confighub/cub-gen/issues/240) render-diff with richer reasoning
+- [#241](https://github.com/confighub/cub-gen/issues/241) generator chaining provenance
+- [#242](https://github.com/confighub/cub-gen/issues/242) `--set` / `--set-file` provenance capture
 
 Landed on `main`:
 

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -65,9 +65,8 @@ exit-bar rationale still live in
 
 ### Still true release blockers
 
-- [ ] `#177` Helm flagship example
-- [ ] `#180` workflow example upgrade
-- [ ] `#187` layered provenance across overlays/ApplicationSet/labels
+- [ ] release-environment connected smoke rerun for the intended tag environment
+- [ ] final release note pass against the merged `main` state
 
 For this preview, "all examples working well" means each featured example has:
 

--- a/docs/releases/v0.2-preview.2.md
+++ b/docs/releases/v0.2-preview.2.md
@@ -66,19 +66,15 @@ release-facing proof.
 
 ## Explicitly Still Partial In This Preview
 
-1. Helm flagship depth is improved, but the deeper Kubara-like acceptance bar
-   remains open:
-   - layered provenance across overlays, labels, and ApplicationSet-style
-     routing
-   - stronger security-boundary examples
-   - more complete multi-layer trace stories
-   Refs: `#177`, `#187`
+1. The Helm flagship now includes layered provenance, ApplicationSet selector
+   proof, and a blocked customer security weakening. The remaining Helm depth
+   is post-preview work:
+   - umbrella charts, subcharts, aliases, and conditionals
+   - richer provenance honesty for helpers/lookups/external refs
+   - render-diff and multi-stage generator chaining depth
+   Refs: `#238`, `#239`, `#240`, `#241`, `#242`
 
-2. Workflow surfaces are clearer, but still need deeper runnable
-   platform-story completion beyond the current workflow governance bundles.
-   Refs: `#180`
-
-3. The release environment still needs the final secrets-backed connected smoke
+2. The release environment still needs the final secrets-backed connected smoke
    confirmation for the intended tag environment.
    This is now a release-check step, not a still-open implementation issue.
 

--- a/docs/testing/example-truth-matrix.json
+++ b/docs/testing/example-truth-matrix.json
@@ -20,11 +20,7 @@
           "examples/README.md#ai--automation-patterns"
         ]
       },
-      "tracking_issues": [
-        "#173",
-        "#181",
-        "#183"
-      ]
+      "tracking_issues": []
     },
     {
       "example": "backstage-idp",
@@ -47,11 +43,7 @@
           "./examples/backstage-idp/demo-connected.sh"
         ]
       },
-      "tracking_issues": [
-        "#173",
-        "#181",
-        "#183"
-      ]
+      "tracking_issues": []
     },
     {
       "example": "c3agent",
@@ -78,9 +70,6 @@
         ]
       },
       "tracking_issues": [
-        "#173",
-        "#181",
-        "#183",
         "#216"
       ]
     },
@@ -103,11 +92,7 @@
           "examples/demo/README.md#ai-work-platform-track"
         ]
       },
-      "tracking_issues": [
-        "#173",
-        "#181",
-        "#183"
-      ]
+      "tracking_issues": []
     },
     {
       "example": "helm-paas",
@@ -150,10 +135,11 @@
         ]
       },
       "tracking_issues": [
-        "#173",
-        "#177",
-        "#183",
-        "#187"
+        "#238",
+        "#239",
+        "#240",
+        "#241",
+        "#242"
       ],
       "notes": [
         "Real LIVE proof is exposed through an example-owned helm-paas wrapper, but still uses the shared live-reconcile harness under the hood."
@@ -180,11 +166,7 @@
           "./examples/just-apps-no-platform-config/demo-connected.sh"
         ]
       },
-      "tracking_issues": [
-        "#173",
-        "#181",
-        "#183"
-      ]
+      "tracking_issues": []
     },
     {
       "example": "live-reconcile",
@@ -210,11 +192,7 @@
           "./examples/demo/e2e-connected-governed-reconcile-helm.sh"
         ]
       },
-      "tracking_issues": [
-        "#173",
-        "#181",
-        "#183"
-      ],
+      "tracking_issues": [],
       "notes": [
         "Runtime harness for WET-\u003eLIVE proof; source-side generator proof lives in paired examples."
       ]
@@ -243,11 +221,7 @@
           "examples/demo/README.md#ai-work-platform-track"
         ]
       },
-      "tracking_issues": [
-        "#173",
-        "#180",
-        "#183"
-      ]
+      "tracking_issues": []
     },
     {
       "example": "scoredev-paas",
@@ -285,10 +259,7 @@
           "./examples/scoredev-paas/contracts.md"
         ]
       },
-      "tracking_issues": [
-        "#173",
-        "#183"
-      ],
+      "tracking_issues": [],
       "notes": [
         "Standalone real-cluster proof: merged score.yaml + score-prod.yaml rendered into a live checkout-api deployment on kind."
       ]
@@ -335,11 +306,7 @@
           "./examples/springboot-paas/contracts.md"
         ]
       },
-      "tracking_issues": [
-        "#173",
-        "#179",
-        "#183"
-      ],
+      "tracking_issues": [],
       "notes": [
         "Standalone real-cluster proof: Kind cluster + ConfigHub worker + inventory-api HTTP verification."
       ]
@@ -370,11 +337,7 @@
           "./examples/swamp-automation/contracts.md"
         ]
       },
-      "tracking_issues": [
-        "#173",
-        "#180",
-        "#183"
-      ]
+      "tracking_issues": []
     },
     {
       "example": "swamp-project",
@@ -395,11 +358,7 @@
           "examples/README.md#ai--automation-patterns"
         ]
       },
-      "tracking_issues": [
-        "#173",
-        "#180",
-        "#183"
-      ]
+      "tracking_issues": []
     }
   ],
   "summary": {

--- a/docs/testing/example-truth-matrix.md
+++ b/docs/testing/example-truth-matrix.md
@@ -16,18 +16,18 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 
 | Example | Generator fixture | Source chain verified | Connected mode | Connected smoke lane | Real live proof | AI-first surface | Tracking issues |
 |---|---|---|---|---|---|---|---|
-| `ai-ops-paas` | no | no | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `backstage-idp` | yes | yes | yes | no | `none` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `c3agent` | yes | yes | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183), [#216](https://github.com/confighub/cub-gen/issues/216) |
-| `confighub-actions` | no | no | yes | no | `none` | `partial` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `helm-paas` | yes | yes | yes | yes | `paired-harness` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#177](https://github.com/confighub/cub-gen/issues/177), [#183](https://github.com/confighub/cub-gen/issues/183), [#187](https://github.com/confighub/cub-gen/issues/187) |
-| `just-apps-no-platform-config` | yes | yes | yes | no | `none` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `live-reconcile` | no | no | yes | no | `standalone` | `none` | [#173](https://github.com/confighub/cub-gen/issues/173), [#181](https://github.com/confighub/cub-gen/issues/181), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `ops-workflow` | yes | yes | yes | no | `none` | `partial` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `scoredev-paas` | yes | yes | yes | no | `standalone` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `springboot-paas` | yes | yes | yes | yes | `standalone` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#179](https://github.com/confighub/cub-gen/issues/179), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `swamp-automation` | yes | yes | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183) |
-| `swamp-project` | no | no | yes | no | `none` | `explicit` | [#173](https://github.com/confighub/cub-gen/issues/173), [#180](https://github.com/confighub/cub-gen/issues/180), [#183](https://github.com/confighub/cub-gen/issues/183) |
+| `ai-ops-paas` | no | no | yes | no | `none` | `explicit` |  |
+| `backstage-idp` | yes | yes | yes | no | `none` | `none` |  |
+| `c3agent` | yes | yes | yes | no | `none` | `explicit` | [#216](https://github.com/confighub/cub-gen/issues/216) |
+| `confighub-actions` | no | no | yes | no | `none` | `partial` |  |
+| `helm-paas` | yes | yes | yes | yes | `paired-harness` | `explicit` | [#238](https://github.com/confighub/cub-gen/issues/238), [#239](https://github.com/confighub/cub-gen/issues/239), [#240](https://github.com/confighub/cub-gen/issues/240), [#241](https://github.com/confighub/cub-gen/issues/241), [#242](https://github.com/confighub/cub-gen/issues/242) |
+| `just-apps-no-platform-config` | yes | yes | yes | no | `none` | `none` |  |
+| `live-reconcile` | no | no | yes | no | `standalone` | `none` |  |
+| `ops-workflow` | yes | yes | yes | no | `none` | `partial` |  |
+| `scoredev-paas` | yes | yes | yes | no | `standalone` | `explicit` |  |
+| `springboot-paas` | yes | yes | yes | yes | `standalone` | `explicit` |  |
+| `swamp-automation` | yes | yes | yes | no | `none` | `explicit` |  |
+| `swamp-project` | no | no | yes | no | `none` | `explicit` |  |
 
 ## Proof References
 

--- a/docs/triple-styles/style-a-yaml/helm.yaml
+++ b/docs/triple-styles/style-a-yaml/helm.yaml
@@ -40,8 +40,10 @@ contract:
       source_dry_path_template: "values.service.port"
 provenance:
   field_origin_transform: "helm-template"
+  field_origin_overlay_transform: "helm-values-overlay"
   field_origin_confidences:
-    image_tag: 0.86
+    image_tag_base: 0.86
+    image_tag_overlay: 0.90
   rendered_lineage_templates:
     - kind: "HelmRelease"
       name_template: "{{name}}"
@@ -74,7 +76,8 @@ inverse:
   inverse_patch_reasons:
     image_tag: "Container image tag maps cleanly to helm values."
   inverse_edit_hints:
-    image_tag: "Edit chart values file and keep chart template unchanged."
+    image_tag_base: "Edit values.image.tag in {{base_values_path}}."
+    image_tag_overlay: "Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults."
 hints:
   defaults:
     chart_path: "Chart.yaml"

--- a/docs/triple-styles/style-a-yaml/helm.yaml
+++ b/docs/triple-styles/style-a-yaml/helm.yaml
@@ -13,6 +13,25 @@ contract:
     - role: "chart"
       exact_basenames:
         - "chart.yaml"
+    - role: "application-set"
+      exact_basenames:
+        - "applicationset.yaml"
+        - "applicationset.yml"
+    - role: "cluster-inventory"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
+    - role: "managed-service-catalog"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
+    - role: "customer-service-catalog"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
     - role: "values"
       prefixes:
         - "values"
@@ -20,6 +39,7 @@ contract:
         - ".yaml"
         - ".yml"
   role_owners:
+    customer-service-catalog: "app-team"
     values: "app-team"
   role_schema_refs:
     chart: "https://json.schemastore.org/chart"

--- a/docs/triple-styles/style-b-markdown/helm.md
+++ b/docs/triple-styles/style-b-markdown/helm.md
@@ -58,13 +58,14 @@ flowchart LR
 ## Provenance
 
 - Field-origin transform: `helm-template`
-- Field-origin overlay transform: ``
+- Field-origin overlay transform: `helm-values-overlay`
 
 ### Field-origin confidences
 
 | Key | Confidence |
 | --- | --- |
-| `image_tag` | 0.86 |
+| `image_tag_base` | 0.86 |
+| `image_tag_overlay` | 0.90 |
 
 ### Rendered lineage templates
 
@@ -98,7 +99,8 @@ flowchart LR
 
 | Key | Hint |
 | --- | --- |
-| `image_tag` | Edit chart values file and keep chart template unchanged. |
+| `image_tag_base` | Edit values.image.tag in {{base_values_path}}. |
+| `image_tag_overlay` | Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults. |
 
 ### Hint defaults
 

--- a/docs/triple-styles/style-b-markdown/helm.md
+++ b/docs/triple-styles/style-b-markdown/helm.md
@@ -8,7 +8,11 @@
 flowchart LR
   subgraph DRY["DRY Inputs"]
     d1["chart: chart.yaml<br/>owner: platform-engineer"]
-    d2["values: values*.yaml | values*.yml<br/>owner: app-team"]
+    d2["application-set: applicationset.yaml, applicationset.yml<br/>owner: platform-engineer"]
+    d3["cluster-inventory: *.yaml | *.yml | *.json<br/>owner: platform-engineer"]
+    d4["managed-service-catalog: *.yaml | *.yml | *.json<br/>owner: platform-engineer"]
+    d5["customer-service-catalog: *.yaml | *.yml | *.json<br/>owner: app-team"]
+    d6["values: values*.yaml | values*.yml<br/>owner: app-team"]
   end
   gen["helm (helm-paas)<br/>capabilities: render-manifests, values-overrides, inverse-values-patch"]
   subgraph WET["WET Targets"]
@@ -18,6 +22,10 @@ flowchart LR
   end
   d1 --> gen
   d2 --> gen
+  d3 --> gen
+  d4 --> gen
+  d5 --> gen
+  d6 --> gen
   gen --> w1
   gen --> w2
   gen --> w3
@@ -33,12 +41,17 @@ flowchart LR
 | Role | Exact basenames | Prefixes | Extensions |
 | --- | --- | --- | --- |
 | `chart` | chart.yaml | - | - |
+| `application-set` | applicationset.yaml, applicationset.yml | - | - |
+| `cluster-inventory` | - | - | .yaml, .yml, .json |
+| `managed-service-catalog` | - | - | .yaml, .yml, .json |
+| `customer-service-catalog` | - | - | .yaml, .yml, .json |
 | `values` | - | values | .yaml, .yml |
 
 ### Role owners
 
 | Role | Owner |
 | --- | --- |
+| `customer-service-catalog` | `app-team` |
 | `values` | `app-team` |
 
 ### Role schema refs

--- a/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.md
@@ -58,13 +58,14 @@ flowchart LR
 ## Provenance
 
 - Field-origin transform: `helm-template`
-- Field-origin overlay transform: ``
+- Field-origin overlay transform: `helm-values-overlay`
 
 ### Field-origin confidences
 
 | Key | Confidence |
 | --- | --- |
-| `image_tag` | 0.86 |
+| `image_tag_base` | 0.86 |
+| `image_tag_overlay` | 0.90 |
 
 ### Rendered lineage templates
 
@@ -98,7 +99,8 @@ flowchart LR
 
 | Key | Hint |
 | --- | --- |
-| `image_tag` | Edit chart values file and keep chart template unchanged. |
+| `image_tag_base` | Edit values.image.tag in {{base_values_path}}. |
+| `image_tag_overlay` | Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults. |
 
 ### Hint defaults
 

--- a/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.md
@@ -8,7 +8,11 @@
 flowchart LR
   subgraph DRY["DRY Inputs"]
     d1["chart: chart.yaml<br/>owner: platform-engineer"]
-    d2["values: values*.yaml | values*.yml<br/>owner: app-team"]
+    d2["application-set: applicationset.yaml, applicationset.yml<br/>owner: platform-engineer"]
+    d3["cluster-inventory: *.yaml | *.yml | *.json<br/>owner: platform-engineer"]
+    d4["managed-service-catalog: *.yaml | *.yml | *.json<br/>owner: platform-engineer"]
+    d5["customer-service-catalog: *.yaml | *.yml | *.json<br/>owner: app-team"]
+    d6["values: values*.yaml | values*.yml<br/>owner: app-team"]
   end
   gen["helm (helm-paas)<br/>capabilities: render-manifests, values-overrides, inverse-values-patch"]
   subgraph WET["WET Targets"]
@@ -18,6 +22,10 @@ flowchart LR
   end
   d1 --> gen
   d2 --> gen
+  d3 --> gen
+  d4 --> gen
+  d5 --> gen
+  d6 --> gen
   gen --> w1
   gen --> w2
   gen --> w3
@@ -33,12 +41,17 @@ flowchart LR
 | Role | Exact basenames | Prefixes | Extensions |
 | --- | --- | --- | --- |
 | `chart` | chart.yaml | - | - |
+| `application-set` | applicationset.yaml, applicationset.yml | - | - |
+| `cluster-inventory` | - | - | .yaml, .yml, .json |
+| `managed-service-catalog` | - | - | .yaml, .yml, .json |
+| `customer-service-catalog` | - | - | .yaml, .yml, .json |
 | `values` | - | values | .yaml, .yml |
 
 ### Role owners
 
 | Role | Owner |
 | --- | --- |
+| `customer-service-catalog` | `app-team` |
 | `values` | `app-team` |
 
 ### Role schema refs

--- a/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.yaml
@@ -40,8 +40,10 @@ contract:
       source_dry_path_template: "values.service.port"
 provenance:
   field_origin_transform: "helm-template"
+  field_origin_overlay_transform: "helm-values-overlay"
   field_origin_confidences:
-    image_tag: 0.86
+    image_tag_base: 0.86
+    image_tag_overlay: 0.90
   rendered_lineage_templates:
     - kind: "HelmRelease"
       name_template: "{{name}}"
@@ -74,7 +76,8 @@ inverse:
   inverse_patch_reasons:
     image_tag: "Container image tag maps cleanly to helm values."
   inverse_edit_hints:
-    image_tag: "Edit chart values file and keep chart template unchanged."
+    image_tag_base: "Edit values.image.tag in {{base_values_path}}."
+    image_tag_overlay: "Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults."
 hints:
   defaults:
     chart_path: "Chart.yaml"

--- a/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.yaml
@@ -13,6 +13,25 @@ contract:
     - role: "chart"
       exact_basenames:
         - "chart.yaml"
+    - role: "application-set"
+      exact_basenames:
+        - "applicationset.yaml"
+        - "applicationset.yml"
+    - role: "cluster-inventory"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
+    - role: "managed-service-catalog"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
+    - role: "customer-service-catalog"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
     - role: "values"
       prefixes:
         - "values"
@@ -20,6 +39,7 @@ contract:
         - ".yaml"
         - ".yml"
   role_owners:
+    customer-service-catalog: "app-team"
     values: "app-team"
   role_schema_refs:
     chart: "https://json.schemastore.org/chart"

--- a/examples/README.md
+++ b/examples/README.md
@@ -124,7 +124,7 @@ Start with the example that matches how your team already thinks:
 | If you are... | Start here | First value you should see |
 |---|---|---|
 | Spring Boot platform or app lead | [`springboot-paas`](./springboot-paas/) | "Which Spring property changed, who owns it, and what file do I edit?" |
-| Helm/Flux/Argo platform team (umbrella charts, overlays) | [`helm-paas`](./helm-paas/) | Ownership + field trace map without chart archaeology |
+| Helm/Flux/Argo platform team (umbrella charts, overlays) | [`helm-paas`](./helm-paas/) | Ownership + field trace map, layered selector-to-overlay proof, and live runtime follow-through |
 | Score.dev platform team | [`scoredev-paas`](./scoredev-paas/) | Visibility from `score.yaml` intent to rendered runtime fields |
 | Ops/SRE workflow owner | [`ops-workflow`](./ops-workflow/) | Governed schedule/action changes with explicit ALLOW/BLOCK outcomes |
 | AI workflow / Swamp-style team | [`swamp-automation`](./swamp-automation/) | Structural workflow-change classification and policy-ready evidence |
@@ -293,7 +293,7 @@ Now includes Helm + Spring Boot registry-backed platform examples too.
 
 | Example | You use... | cub-gen shows you... |
 |---------|-----------|---------------------|
-| [**helm-paas**](helm-paas/) | Helm charts + values overlays | Chart contract tracing, values ownership, ALLOW/BLOCK governance |
+| [**helm-paas**](helm-paas/) | Helm charts + values overlays | Chart contract tracing, layered selector-to-overlay provenance, and ALLOW/BLOCK governance |
 | [**scoredev-paas**](scoredev-paas/) | Score.dev workload specs | DRY intent with field-origin mapping |
 | [**springboot-paas**](springboot-paas/) | Spring Boot + `application.yaml` | App/platform ownership boundaries |
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -40,7 +40,7 @@ The flagship examples also now publish an explicit AI-first bundle:
 
 | If you already run... | Start here | What actually runs | What you can inspect next |
 |---|---|---|---|
-| Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then the example-owned governed-change proof and live wrapper | values ownership now, local ALLOW/BLOCK proof next, connected + live proof after |
+| Helm plus Argo/Flux | `./examples/demo/start-platform-first.sh` | local lifecycle for `helm-paas`, then the example-owned governed-change proof, layered trace proof, and live wrapper | values ownership now, layered selector-to-overlay proof next, connected + live proof after |
 | Spring Boot app repos | `./examples/demo/start-app-first.sh` | local lifecycle for `springboot-paas`, then the example-owned embedded payload mutation proof | app-vs-platform config ownership now, direct embedded apply-here proof next, standalone live app proof after |
 | Score.dev workloads | `./examples/demo/start-score-first.sh` | Score field trace, inverse edit map, governed workload-contract proof, and standalone runtime proof | `score.yaml` to runtime-field mapping now, local ALLOW/ESCALATE proof next, live `checkout-api` proof after |
 | Reconciler/runtime proof | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | real Flux and Argo reconciliation on kind | pods, rollout, and drift correction |
@@ -107,6 +107,7 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 |--------|---------|---------------------|
 | `start-platform-first.sh` | [`helm-paas`](../helm-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated platform-first starter path |
 | `../helm-paas/demo-governed-change.sh` | [`helm-paas`](../helm-paas/) | App-team ALLOW path vs platform-contract BLOCK path with the real PR ownership gate |
+| `../helm-paas/demo-layered-trace.sh` | [`helm-paas`](../helm-paas/) | Cluster labels -> ApplicationSet selector -> values overlay proof plus blocked customer security weakening |
 | `start-app-first.sh` | [`springboot-paas`](../springboot-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated app-first starter path |
 | `../springboot-paas/demo-governed-routes.sh` | [`springboot-paas`](../springboot-paas/) | App-owned field ALLOW versus platform-owned field BLOCKED with `springboot validate-mutation` |
 | `../springboot-paas/demo-embedded-config-mutation.sh` | [`springboot-paas`](../springboot-paas/) | Direct embedded `application.yaml` mutation in the ConfigHub payload plus blocked datasource proof |
@@ -397,8 +398,8 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 | Status | What is true today |
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
-| In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#180`, `#187`, `#238`-`#242` |
+| In progress | The flagship proof bar is now met; follow-on depth is concentrated in richer Helm provenance and generation-chain features rather than basic example trust |
+| Actively tracked | `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 

--- a/examples/demo/start-platform-first.sh
+++ b/examples/demo/start-platform-first.sh
@@ -13,6 +13,9 @@ cat <<'EOF'
   governed ownership proof from the same example:
     ./examples/helm-paas/demo-governed-change.sh
 
+  layered kubara-like trace from the same example:
+    ./examples/helm-paas/demo-layered-trace.sh
+
   connected governance only:
     cub auth login
     ./examples/helm-paas/demo-connected.sh

--- a/examples/helm-paas/AI_START_HERE.md
+++ b/examples/helm-paas/AI_START_HERE.md
@@ -53,6 +53,7 @@ Success looks like:
 - `dry_inputs` includes values/chart inputs
 - `wet_manifest_targets` is non-empty
 - `inverse_hint.owner` is populated
+- `inverse_hint.edit_hint` points at `values-prod.yaml` for the prod override and mentions `values.yaml` as the default
 
 ## Safe run order
 

--- a/examples/helm-paas/AI_START_HERE.md
+++ b/examples/helm-paas/AI_START_HERE.md
@@ -7,6 +7,7 @@ first question is: "which values file or chart layer controls this field?"
 
 - Helm field-origin tracing from chart/value inputs to rendered Kubernetes fields
 - a local `ALLOW` path and a local `BLOCK` path for ownership boundaries
+- a layered Kubara-like trace from cluster labels and `ApplicationSet` selection to the winning values overlay
 - a deeper connected ConfigHub walkthrough
 - optional live Flux/Argo runtime proof
 
@@ -24,6 +25,7 @@ first question is: "which values file or chart layer controls this field?"
 | `go build -o ./cub-gen ./cmd/cub-gen` | local source | `./cub-gen` binary | local binary only |
 | `gitops discover/import` | `Chart.yaml`, `values*.yaml`, `templates/`, `platform/`, `gitops/` | stdout JSON only | no |
 | `demo-governed-change.sh` | example repo + ownership gate scripts | `.tmp/helm-paas-governed-change/<run>/...` | scratch clone only |
+| `demo-layered-trace.sh` | example repo + layered Helm inputs | `.tmp/helm-paas-layered-trace/<run>/...` | scratch clone only |
 | `run-connected-smoke.sh` | repo + ConfigHub auth/context | `.tmp/connected-smoke/<run>/...` | backend evidence only |
 | `demo-connected.sh` | repo + ConfigHub auth/context | temporary connected lifecycle artifacts unless `OUTPUT_DIR` is set | backend evidence only |
 | `demo-runtime.sh` | repo + ConfigHub auth/context + clusters | `.tmp/helm-paas-runtime/...` plus live namespace objects | yes, live cluster |
@@ -61,17 +63,20 @@ Success looks like:
    `./cub-gen gitops import --space platform --json ./examples/helm-paas`
 2. Local governed proof:
    `./examples/helm-paas/demo-governed-change.sh`
-3. Connected environment check:
+3. Local layered Kubara-like proof:
+   `./examples/helm-paas/demo-layered-trace.sh`
+4. Connected environment check:
    `cub auth login && ./examples/demo/run-connected-smoke.sh`
-4. Deep connected walkthrough:
+5. Deep connected walkthrough:
    `cub auth login && ./examples/helm-paas/demo-connected.sh`
-5. Live runtime proof:
+6. Live runtime proof:
    `cub auth login && RECONCILER=both ./examples/helm-paas/demo-runtime.sh`
 
 ## What to verify after each major step
 
 - Repo-only preview: `dry_inputs`, `wet_manifest_targets`, and one inverse-edit pointer are present.
 - Local governed proof: the allowed path passes and the template edit is rejected; artifacts land under `.tmp/helm-paas-governed-change/...`.
+- Local layered proof: `helm_layered_analysis` reports an attributed cluster-selector decision and then a blocked customer security weakening.
 - Connected smoke: ConfigHub auth/context is valid and the flagship smoke summaries include a non-empty `change_id`.
 - Deep connected walkthrough: a terminal decision state is returned for the same `change_id`.
 - Live runtime: Flux and/or Argo report a healthy rollout and `kubectl get deploy,pods,svc` shows live objects.
@@ -89,5 +94,5 @@ Success looks like:
 
 ## Cleanup
 
-- Remove local proof artifacts with `rm -rf .tmp/helm-paas-governed-change .tmp/connected-smoke .tmp/helm-paas-runtime`
+- Remove local proof artifacts with `rm -rf .tmp/helm-paas-governed-change .tmp/helm-paas-layered-trace .tmp/connected-smoke .tmp/helm-paas-runtime`
 - Remove live namespaces/clusters with the same scripts you normally use for the live reconcile harness

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -11,11 +11,12 @@ The first question it should answer is:
 
 "Which values file or chart layer actually controls the field I am looking at?"
 
-This example now owns three flagship proof paths:
+This example now owns four flagship proof paths:
 
 1. source-side provenance,
 2. governed ownership proof for allowed vs blocked edits,
-3. connected + live Helm proof through an example-owned runtime wrapper.
+3. layered ApplicationSet plus cluster-selector plus overlay proof,
+4. connected + live Helm proof through an example-owned runtime wrapper.
 
 ## What this proves today
 
@@ -23,6 +24,7 @@ This example now owns three flagship proof paths:
 |-------|--------|---------------------|
 | Source-side Helm provenance | Real | `./examples/helm-paas/demo-local.sh` |
 | Governed ALLOW + BLOCK ownership proof | Real | `./examples/helm-paas/demo-governed-change.sh` |
+| Layered ApplicationSet + overlay + security proof | Real | `./examples/helm-paas/demo-layered-trace.sh` |
 | Deep connected bridge path | Real | `./examples/helm-paas/demo-connected.sh` |
 | Connected + live Helm proof from this example | Real | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` |
 | Runtime WET->LIVE harness beneath the wrapper | Paired | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` |
@@ -63,6 +65,7 @@ That sequence gives you:
 |---|---|---|
 | Local source-side proof | `./examples/helm-paas/demo-local.sh` | field origin, inverse-edit guidance, dry inputs, and rendered targets |
 | Local governed ownership proof | `./examples/helm-paas/demo-governed-change.sh` | one app-team change that passes and one platform-contract change that fails the DRY ownership gate |
+| Local layered Kubara-like proof | `./examples/helm-paas/demo-layered-trace.sh` | cluster labels, ApplicationSet selector, values overlay selection, and one blocked customer security weakening |
 | Deep connected bridge proof | `./examples/helm-paas/demo-connected.sh` | change ID, bundle digest, attestation, and backend decision/query output |
 | Connected + live proof | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | live Deployment rollout, pods, services, and reconciler status for Flux and Argo |
 
@@ -218,6 +221,9 @@ go build -o ./cub-gen ./cmd/cub-gen
 
 # Local governed change path
 ./examples/helm-paas/demo-governed-change.sh
+
+# Local layered Kubara-like trace path
+./examples/helm-paas/demo-layered-trace.sh
 
 # Connected ConfigHub path
 cub auth login
@@ -471,6 +477,16 @@ The key question: "Why does this cluster have this addon enabled?"
 
 Answer: Trace from cluster labels through overlay selection to the deployed field.
 
+Today that proof is runnable from this example:
+
+```bash
+./examples/helm-paas/demo-layered-trace.sh
+
+# Or inspect the raw layered analysis directly
+./cub-gen gitops import --space platform --json ./examples/helm-paas \
+  | jq '.provenance[0].helm_layered_analysis'
+```
+
 If this is the section where you start thinking "where is my framework or
 generator?", use [Custom Generator Onboarding](../../docs/workflows/custom-generator-onboarding.md)
 for the user-facing extension path and Kubara-like layered requirements.
@@ -503,6 +519,7 @@ From repo root:
 ```bash
 # Local/offline
 ./examples/helm-paas/demo-local.sh
+./examples/helm-paas/demo-layered-trace.sh
 
 # Connected (requires ConfigHub auth)
 cub auth login

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -333,19 +333,22 @@ alongside `values*.yaml` files. On import, it:
 1. **Classifies inputs** — `Chart.yaml` (role: chart), `values.yaml` (role:
    values-base), `values-prod.yaml` (role: values-overlay)
 2. **Maps field origins** — traces `image.tag` through the Helm template
-   structure to the Deployment spec (confidence: 0.86)
+   structure to the Deployment spec, keeping both the base values source
+   (`values.yaml`, confidence: 0.86) and the winning prod overlay
+   (`values-prod.yaml`, confidence: 0.90)
 3. **Computes ownership** — values files are app-team editable; chart templates
    and platform policies are platform-owned
-4. **Emits inverse-edit guidance** — "to change `image.tag`, edit `values.yaml`
-   line 5; to change resource structure, edit `templates/deployment.yaml`
-   (platform review required)"
+4. **Emits inverse-edit guidance** — "to change the prod `image.tag`, edit
+   `values-prod.yaml`; use `values.yaml` for defaults; to change resource
+   structure, edit `templates/deployment.yaml` (platform review required)"
 
 A concrete field trace:
 
 ```
-DRY:  values.yaml → image.tag = "v1.0.0"
-      ↓ helm-template transform (confidence: 0.86)
-WET:  Deployment/spec/template/spec/containers[0]/image = "ghcr.io/example/payments-api:v1.0.0"
+DRY:  values.yaml      → image.tag = "v1.0.0"
+      values-prod.yaml → image.tag = "v1.0.3"
+      ↓ helm-template + helm-values-overlay
+WET:  Deployment/spec/template/spec/containers[0]/image = "ghcr.io/example/payments-api:v1.0.3"
 ```
 
 ## Key files

--- a/examples/helm-paas/contracts.md
+++ b/examples/helm-paas/contracts.md
@@ -51,6 +51,29 @@ inspect_with:
   - jq '{status, changed_files, failures}' block-report.json
 ```
 
+## Layered Kubara-like proof
+
+```yaml
+id: helm_layered_trace
+command: ./examples/helm-paas/demo-layered-trace.sh
+mutates:
+  repo: scratch_clone_only
+  backend: false
+  live: false
+expects:
+  stdout_contains:
+    - "[helm-layered] success"
+  files_exist:
+    - ".tmp/helm-paas-layered-trace/<run>/import-allow.json"
+    - ".tmp/helm-paas-layered-trace/<run>/import-block.json"
+  evidence:
+    generation_path: "cluster labels -> ApplicationSet selector -> values overlay is attributed"
+    security_block: "customer service catalog weakening is classified as blocked"
+inspect_with:
+  - jq '.provenance[0].helm_layered_analysis' import-allow.json
+  - jq '.provenance[0].helm_layered_analysis' import-block.json
+```
+
 ## Connected smoke preflight
 
 ```yaml

--- a/examples/helm-paas/contracts.md
+++ b/examples/helm-paas/contracts.md
@@ -21,6 +21,7 @@ inspect_with:
   - jq '.discovered[0].generator_profile'
   - jq '.dry_inputs | length'
   - jq '.wet_manifest_targets | length'
+  - jq '.provenance[0].field_origin_map'
   - jq '.provenance[0].inverse_edit_pointers[0]'
 ```
 

--- a/examples/helm-paas/demo-layered-trace.sh
+++ b/examples/helm-paas/demo-layered-trace.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/helm-paas-layered-trace}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="$OUT_ROOT/$RUN_ID"
+WORK_REPO="$OUT_DIR/repo"
+
+mkdir -p "$OUT_DIR"
+rm -rf "$WORK_REPO"
+
+echo "[helm-layered] copying working tree into $WORK_REPO"
+mkdir -p "$WORK_REPO"
+rsync -a \
+  --exclude '.git' \
+  --exclude '.tmp' \
+  --exclude '/cub-gen' \
+  "$ROOT_DIR"/ "$WORK_REPO"/
+
+cd "$WORK_REPO"
+go build -o ./cub-gen ./cmd/cub-gen
+
+echo "[helm-layered] proof 1/2: layered import attributes cluster selection and overlay choice"
+./cub-gen gitops import --space platform --json ./examples/helm-paas > "$OUT_DIR/import-allow.json"
+
+jq -e '
+  .provenance[0].helm_layered_analysis.generation_decision_state == "attributed" and
+  .provenance[0].helm_layered_analysis.cluster_selector == "env=prod, region=eu" and
+  (.provenance[0].helm_layered_analysis.matched_clusters | index("prod-eu")) != null and
+  (.provenance[0].helm_layered_analysis.selected_value_files | index("values-prod.yaml")) != null and
+  .provenance[0].helm_layered_analysis.security_decision_state == "allow"
+' "$OUT_DIR/import-allow.json" >/dev/null
+
+echo "[helm-layered][allow] layered analysis"
+jq '{
+  generation_state: .provenance[0].helm_layered_analysis.generation_decision_state,
+  generation_reason: .provenance[0].helm_layered_analysis.generation_decision_reason,
+  matched_clusters: .provenance[0].helm_layered_analysis.matched_clusters,
+  selected_value_files: .provenance[0].helm_layered_analysis.selected_value_files,
+  security_state: .provenance[0].helm_layered_analysis.security_decision_state,
+  security_reason: .provenance[0].helm_layered_analysis.security_decision_reason
+}' "$OUT_DIR/import-allow.json"
+
+echo "[helm-layered] proof 2/2: customer overlay weakens a managed security control and is classified as blocked"
+perl -0pi -e 's/enabled: true/enabled: false/' ./examples/helm-paas/platform/catalogs/customer-service-catalog/payments-api-prod.yaml
+./cub-gen gitops import --space platform --json ./examples/helm-paas > "$OUT_DIR/import-block.json"
+
+jq -e '
+  .provenance[0].helm_layered_analysis.security_decision_state == "blocked" and
+  (.provenance[0].helm_layered_analysis.security_decision_reason | contains("oauth2Proxy"))
+' "$OUT_DIR/import-block.json" >/dev/null
+
+echo "[helm-layered][block] layered analysis"
+jq '{
+  security_state: .provenance[0].helm_layered_analysis.security_decision_state,
+  security_reason: .provenance[0].helm_layered_analysis.security_decision_reason,
+  security_control_path: .provenance[0].helm_layered_analysis.security_control_path,
+  security_override_path: .provenance[0].helm_layered_analysis.security_override_path
+}' "$OUT_DIR/import-block.json"
+
+cat <<EOF
+
+[helm-layered] success
+  attributed path: cluster labels -> ApplicationSet selector -> values overlay -> rendered field
+  blocked path: customer service catalog tries to weaken a platform-required security control
+  artifacts: $OUT_DIR
+EOF

--- a/examples/helm-paas/gitops/argo/applicationset.yaml
+++ b/examples/helm-paas/gitops/argo/applicationset.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: payments-api
+spec:
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            env: prod
+            region: eu
+  template:
+    metadata:
+      name: "{{name}}-payments-api"
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/confighub/cub-gen.git
+        targetRevision: HEAD
+        path: examples/helm-paas
+        helm:
+          valueFiles:
+            - values.yaml
+            - values-prod.yaml
+      destination:
+        server: "{{server}}"
+        namespace: apps
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true

--- a/examples/helm-paas/platform/catalogs/customer-service-catalog/payments-api-prod.yaml
+++ b/examples/helm-paas/platform/catalogs/customer-service-catalog/payments-api-prod.yaml
@@ -1,0 +1,10 @@
+apiVersion: cubgen.confighub.dev/v1alpha1
+kind: CustomerServiceCatalog
+metadata:
+  name: payments-api-prod
+spec:
+  overlay:
+    valuesFile: values-prod.yaml
+  securityOverrides:
+    oauth2Proxy:
+      enabled: true

--- a/examples/helm-paas/platform/catalogs/managed-service-catalog/payments-api.yaml
+++ b/examples/helm-paas/platform/catalogs/managed-service-catalog/payments-api.yaml
@@ -1,0 +1,11 @@
+apiVersion: cubgen.confighub.dev/v1alpha1
+kind: ManagedServiceCatalog
+metadata:
+  name: payments-api
+spec:
+  securityControls:
+    oauth2Proxy:
+      required: true
+  ownership:
+    chart: platform-engineer
+    applicationSet: platform-engineer

--- a/examples/helm-paas/platform/clusters/prod-eu.yaml
+++ b/examples/helm-paas/platform/clusters/prod-eu.yaml
@@ -1,0 +1,8 @@
+apiVersion: cubgen.confighub.dev/v1alpha1
+kind: ClusterInventory
+metadata:
+  name: prod-eu
+  labels:
+    env: prod
+    region: eu
+    platform-tier: managed

--- a/examples/helm-paas/platform/clusters/stage-eu.yaml
+++ b/examples/helm-paas/platform/clusters/stage-eu.yaml
@@ -1,0 +1,8 @@
+apiVersion: cubgen.confighub.dev/v1alpha1
+kind: ClusterInventory
+metadata:
+  name: stage-eu
+  labels:
+    env: stage
+    region: eu
+    platform-tier: managed

--- a/examples/helm-paas/prompts.md
+++ b/examples/helm-paas/prompts.md
@@ -50,6 +50,26 @@ Run the local governed ownership proof for ./examples/helm-paas.
 Do not run ConfigHub or live cluster steps in this prompt.
 ```
 
+## Layered Kubara-like proof prompt
+
+```text
+Run the layered Helm proof for ./examples/helm-paas.
+
+1. Use:
+   ./examples/helm-paas/demo-layered-trace.sh
+2. Capture the artifact directory from the script output.
+3. Summarize:
+   - the cluster selector that cub-gen attributed
+   - which cluster inventory matched it
+   - which values overlay was selected
+   - why the customer security weakening was classified as blocked
+4. Show me the most important evidence from:
+   - import-allow.json
+   - import-block.json
+
+Do not run ConfigHub or live cluster steps in this prompt.
+```
+
 ## Connected plus live prompt
 
 ```text

--- a/examples/helm-paas/prompts.md
+++ b/examples/helm-paas/prompts.md
@@ -23,6 +23,7 @@ Start in read-only mode.
    - main DRY inputs
    - one rendered target
    - one inverse edit hint with owner and confidence
+   - whether `values-prod.yaml` or `values.yaml` is the winning source for the rendered image tag
 4. Tell me exactly what the command read and what it did not mutate.
 
 Do not run connected or live commands yet.

--- a/internal/contracts/schemas/provenance.v1.schema.json
+++ b/internal/contracts/schemas/provenance.v1.schema.json
@@ -226,6 +226,83 @@
         }
       }
     },
+    "helm_layered_analysis": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "application_set_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cluster_inventory_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "managed_catalog_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "customer_catalog_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "cluster_selector": {
+          "type": "string",
+          "minLength": 1
+        },
+        "matched_clusters": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "selected_value_files": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "generation_decision_state": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generation_decision_reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "security_control": {
+          "type": "string",
+          "minLength": 1
+        },
+        "security_control_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "security_override_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "security_decision_state": {
+          "type": "string",
+          "minLength": 1
+        },
+        "security_decision_reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
     "ops_workflow_analysis": {
       "type": "object",
       "additionalProperties": false,

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -124,6 +124,7 @@ func detectHelm(repo string) ([]model.GeneratorDetection, error) {
 			}
 			inputs = append(inputs, filepath.ToSlash(rel))
 		}
+		inputs = append(inputs, existingHelmAuxiliaryInputs(repo, root)...)
 		sort.Strings(inputs)
 
 		name := filepath.Base(root)
@@ -144,6 +145,34 @@ func detectHelm(repo string) ([]model.GeneratorDetection, error) {
 		return nil, fmt.Errorf("detect helm: %w", err)
 	}
 	return mapValuesSorted(detected), nil
+}
+
+func existingHelmAuxiliaryInputs(repo, root string) []string {
+	candidates := make([]string, 0, 12)
+	globs := []string{
+		filepath.Join(root, "gitops", "argo", "applicationset.yaml"),
+		filepath.Join(root, "gitops", "argo", "applicationset.yml"),
+		filepath.Join(root, "platform", "clusters", "*.yaml"),
+		filepath.Join(root, "platform", "clusters", "*.yml"),
+		filepath.Join(root, "platform", "clusters", "*.json"),
+		filepath.Join(root, "platform", "catalogs", "managed-service-catalog", "*.yaml"),
+		filepath.Join(root, "platform", "catalogs", "managed-service-catalog", "*.yml"),
+		filepath.Join(root, "platform", "catalogs", "managed-service-catalog", "*.json"),
+		filepath.Join(root, "platform", "catalogs", "customer-service-catalog", "*.yaml"),
+		filepath.Join(root, "platform", "catalogs", "customer-service-catalog", "*.yml"),
+		filepath.Join(root, "platform", "catalogs", "customer-service-catalog", "*.json"),
+	}
+	for _, pattern := range globs {
+		matches, _ := filepath.Glob(pattern)
+		for _, match := range matches {
+			rel, err := filepath.Rel(repo, match)
+			if err != nil {
+				continue
+			}
+			candidates = append(candidates, filepath.ToSlash(rel))
+		}
+	}
+	return uniqueSortedStrings(candidates)
 }
 
 func detectScore(repo string) ([]model.GeneratorDetection, error) {
@@ -812,4 +841,21 @@ func unique(v []string) []string {
 
 func profileForKind(kind model.GeneratorKind) string {
 	return registry.Profile(kind)
+}
+
+func uniqueSortedStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -143,6 +143,32 @@ func TestScanRepoSwampIncludesNestedWorkflowInputs(t *testing.T) {
 	}
 }
 
+func TestScanRepoHelmIncludesLayeredAuxiliaryInputs(t *testing.T) {
+	t.Parallel()
+
+	repo := filepath.Join("..", "..", "examples", "helm-paas")
+	result, err := ScanRepo(repo, "main")
+	if err != nil {
+		t.Fatalf("ScanRepo returned error: %v", err)
+	}
+	if len(result.Generators) != 1 {
+		t.Fatalf("expected 1 generator, got %d", len(result.Generators))
+	}
+
+	inputs := result.Generators[0].Inputs
+	for _, expected := range []string{
+		"gitops/argo/applicationset.yaml",
+		"platform/clusters/prod-eu.yaml",
+		"platform/clusters/stage-eu.yaml",
+		"platform/catalogs/managed-service-catalog/payments-api.yaml",
+		"platform/catalogs/customer-service-catalog/payments-api-prod.yaml",
+	} {
+		if !contains(inputs, expected) {
+			t.Fatalf("expected helm inputs to contain %q; got %v", expected, inputs)
+		}
+	}
+}
+
 func TestScanRepoC3AgentStructuralDetection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/exampletruth/matrix.go
+++ b/internal/exampletruth/matrix.go
@@ -357,22 +357,15 @@ func commandRefs(refs ProofRefs) []string {
 }
 
 func trackingIssuesForExample(slug, aiSurface string) []string {
-	issues := []string{"#173", "#183"}
+	issues := []string{}
 	switch slug {
 	case "helm-paas":
-		issues = append(issues, "#177", "#187")
-	case "springboot-paas":
-		issues = append(issues, "#179")
-	case "ops-workflow", "swamp-automation":
-		issues = append(issues, "#180")
-	case "backstage-idp", "just-apps-no-platform-config", "confighub-actions", "c3agent", "ai-ops-paas", "live-reconcile":
-		issues = append(issues, "#181")
-	case "swamp-project":
-		issues = append(issues, "#180")
+		issues = append(issues, "#238", "#239", "#240", "#241", "#242")
 	}
 	if slug == "c3agent" {
 		issues = append(issues, "#216")
 	}
+	_ = aiSurface
 	return uniqueStrings(issues)
 }
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -520,15 +520,25 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 	switch g.Kind {
 	case model.GeneratorHelm:
 		hints := helmProvenancePathsForGenerator(g)
-		return []model.FieldOrigin{
+		origins := []model.FieldOrigin{
 			{
 				DryPath:    "values.image.tag",
 				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
 				SourcePath: hints.PrimaryValuesPath,
 				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "image_tag", 0.86),
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "image_tag_base", 0.86),
 			},
 		}
+		if hints.OverlayValuesPath != "" {
+			origins = append(origins, model.FieldOrigin{
+				DryPath:    "values.image.tag",
+				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+				SourcePath: hints.OverlayValuesPath,
+				Transform:  registry.FieldOriginOverlayTransform(g.Kind),
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "image_tag_overlay", 0.90),
+			})
+		}
+		return origins
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
 		return []model.FieldOrigin{
@@ -813,15 +823,26 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 func inversePointersForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.InverseEditPointer {
 	switch g.Kind {
 	case model.GeneratorHelm:
+		hints := helmProvenancePathsForGenerator(g)
 		policy := registry.InversePointerTemplateFor(g.Kind, "image_tag", registry.InversePointerTemplate{
 			Owner: "app-team", Confidence: 0.86,
 		})
+		vars := map[string]string{
+			"base_values_path":    hints.PrimaryValuesPath,
+			"overlay_values_path": hints.OverlayValuesPath,
+		}
+		hintKey := "image_tag_base"
+		hintFallback := "Edit values.image.tag in {{base_values_path}}."
+		if hints.OverlayValuesPath != "" {
+			hintKey = "image_tag_overlay"
+			hintFallback = "Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults."
+		}
 		return []model.InverseEditPointer{
 			{
 				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
 				DryPath:    "values.image.tag",
 				Owner:      policy.Owner,
-				EditHint:   registry.InverseEditHint(g.Kind, "image_tag", "Edit chart values file and keep chart template unchanged."),
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, hintKey, hintFallback), vars),
 				Confidence: policy.Confidence,
 			},
 		}
@@ -1310,6 +1331,7 @@ type helmProvenancePaths struct {
 	ChartPath         string
 	ValuesPaths       []string
 	PrimaryValuesPath string
+	OverlayValuesPath string
 }
 
 func helmProvenancePathsForGenerator(g model.GeneratorDetection) helmProvenancePaths {
@@ -1339,12 +1361,16 @@ func helmProvenancePathsForGenerator(g model.GeneratorDetection) helmProvenanceP
 	primaryValuesPath := primaryValuesBase
 	if selected := selectPreferredPathByBase(valuesPaths, primaryValuesBase); selected != "" {
 		primaryValuesPath = selected
+	} else if len(valuesPaths) > 0 {
+		primaryValuesPath = valuesPaths[0]
 	}
+	overlayValuesPath := firstDistinctPath(valuesPaths, primaryValuesPath)
 
 	return helmProvenancePaths{
 		ChartPath:         chartPath,
 		ValuesPaths:       valuesPaths,
 		PrimaryValuesPath: primaryValuesPath,
+		OverlayValuesPath: overlayValuesPath,
 	}
 }
 
@@ -1371,6 +1397,15 @@ func inputPathsForRole(kind model.GeneratorKind, inputs []string, role string) [
 func selectPreferredPathByBase(paths []string, preferredBase string) string {
 	for _, p := range paths {
 		if strings.EqualFold(filepath.Base(p), preferredBase) {
+			return p
+		}
+	}
+	return ""
+}
+
+func firstDistinctPath(paths []string, primary string) string {
+	for _, p := range paths {
+		if p != primary {
 			return p
 		}
 	}

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/confighub/cub-gen/internal/detect"
 	"github.com/confighub/cub-gen/internal/model"
 	"github.com/confighub/cub-gen/internal/registry"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -170,6 +171,7 @@ func buildProvenance(changeID, space string, detection model.DetectionResult, g 
 		RenderedLineage:     renderedLineageForGenerator(detection, g),
 		FieldOriginMap:      fieldOriginsForGenerator(detection, g),
 		InverseEditPointers: inversePointersForGenerator(detection, g),
+		HelmLayeredAnalysis: helmLayeredAnalysisForGenerator(detection, g),
 		OpsWorkflow:         opsWorkflowAnalysisForGenerator(detection, g),
 		SwampWorkflow:       swampWorkflowAnalysisForGenerator(detection, g),
 		RenderedAt:          renderedAt,
@@ -1410,6 +1412,333 @@ func firstDistinctPath(paths []string, primary string) string {
 		}
 	}
 	return ""
+}
+
+type helmApplicationSetDoc struct {
+	Path       string
+	Selector   map[string]string
+	ValueFiles []string
+}
+
+type helmClusterInventoryDoc struct {
+	Path   string
+	Name   string
+	Labels map[string]string
+}
+
+type helmManagedCatalogDoc struct {
+	Path             string
+	RequiredSecurity string
+}
+
+type helmCustomerCatalogDoc struct {
+	Path             string
+	ValuesFile       string
+	OverrideSecurity string
+	Enabled          *bool
+}
+
+func helmLayeredAnalysisForGenerator(detection model.DetectionResult, g model.GeneratorDetection) *model.HelmLayeredAnalysis {
+	if g.Kind != model.GeneratorHelm {
+		return nil
+	}
+
+	appsetPath := firstInputPathForRole(g.Kind, g.Inputs, "application-set")
+	clusterPaths := inputPathsForRole(g.Kind, g.Inputs, "cluster-inventory")
+	managedCatalogPaths := inputPathsForRole(g.Kind, g.Inputs, "managed-service-catalog")
+	customerCatalogPaths := inputPathsForRole(g.Kind, g.Inputs, "customer-service-catalog")
+
+	if appsetPath == "" && len(clusterPaths) == 0 && len(managedCatalogPaths) == 0 && len(customerCatalogPaths) == 0 {
+		return nil
+	}
+
+	helmPaths := helmProvenancePathsForGenerator(g)
+	analysis := &model.HelmLayeredAnalysis{
+		ApplicationSetPath:    appsetPath,
+		ClusterInventoryPaths: append([]string(nil), clusterPaths...),
+		ManagedCatalogPaths:   append([]string(nil), managedCatalogPaths...),
+		CustomerCatalogPaths:  append([]string(nil), customerCatalogPaths...),
+		SelectedValueFiles:    append([]string(nil), helmPaths.ValuesPaths...),
+	}
+
+	if appsetPath != "" {
+		appsetDoc, err := parseHelmApplicationSetFile(detection.Repo, appsetPath)
+		if err == nil {
+			analysis.ClusterSelector = selectorString(appsetDoc.Selector)
+			if len(appsetDoc.ValueFiles) > 0 {
+				analysis.SelectedValueFiles = append([]string(nil), appsetDoc.ValueFiles...)
+			}
+			switch {
+			case len(appsetDoc.Selector) == 0:
+				analysis.GenerationDecisionState = "unresolved"
+				analysis.GenerationDecisionReason = "ApplicationSet input is present, but cub-gen could not find a cluster matchLabels selector to attribute yet."
+			case len(clusterPaths) == 0:
+				analysis.GenerationDecisionState = "unresolved"
+				analysis.GenerationDecisionReason = "ApplicationSet selector is present, but no cluster inventory inputs were observed to prove which clusters match it."
+			default:
+				matched := matchedHelmClusterInventories(detection.Repo, clusterPaths, appsetDoc.Selector)
+				if len(matched) == 0 {
+					analysis.GenerationDecisionState = "unresolved"
+					analysis.GenerationDecisionReason = fmt.Sprintf("ApplicationSet selector %s is present, but none of the observed cluster inventory inputs match it.", selectorString(appsetDoc.Selector))
+				} else {
+					analysis.MatchedClusters = matched
+					analysis.GenerationDecisionState = "attributed"
+					analysis.GenerationDecisionReason = fmt.Sprintf("ApplicationSet selector %s matches cluster inventory %s and selects value files %s.", selectorString(appsetDoc.Selector), strings.Join(matched, ", "), strings.Join(analysis.SelectedValueFiles, ", "))
+				}
+			}
+		} else {
+			analysis.GenerationDecisionState = "unresolved"
+			analysis.GenerationDecisionReason = fmt.Sprintf("ApplicationSet input %s was observed, but cub-gen could not parse it deterministically yet.", appsetPath)
+		}
+	}
+
+	managedDocs := parseHelmManagedCatalogs(detection.Repo, managedCatalogPaths)
+	customerDocs := parseHelmCustomerCatalogs(detection.Repo, customerCatalogPaths)
+	requiredControl, requiredPath := firstRequiredHelmSecurityControl(managedDocs)
+	selectedOverlay := helmPaths.OverlayValuesPath
+	customerOverride := matchingCustomerCatalog(customerDocs, selectedOverlay)
+	if requiredControl != "" {
+		analysis.SecurityControl = requiredControl
+		analysis.SecurityControlPath = requiredPath
+		if customerOverride.Path != "" {
+			analysis.SecurityOverridePath = customerOverride.Path
+		}
+		switch {
+		case customerOverride.Enabled != nil && !*customerOverride.Enabled:
+			analysis.SecurityDecisionState = "blocked"
+			analysis.SecurityDecisionReason = fmt.Sprintf("Customer service catalog %s weakens the platform-required %s control from %s.", customerOverride.Path, requiredControl, requiredPath)
+		case customerOverride.Enabled != nil:
+			analysis.SecurityDecisionState = "allow"
+			analysis.SecurityDecisionReason = fmt.Sprintf("Customer service catalog %s keeps the platform-required %s control enabled.", customerOverride.Path, requiredControl)
+		default:
+			analysis.SecurityDecisionState = "allow"
+			analysis.SecurityDecisionReason = fmt.Sprintf("No customer override weakens the platform-required %s control from %s.", requiredControl, requiredPath)
+		}
+	} else if len(managedCatalogPaths) > 0 || len(customerCatalogPaths) > 0 {
+		analysis.SecurityDecisionState = "unresolved"
+		analysis.SecurityDecisionReason = "Layered service catalog inputs were observed, but cub-gen could not classify a supported security control from them yet."
+	}
+
+	return analysis
+}
+
+func parseHelmApplicationSetFile(repo, path string) (helmApplicationSetDoc, error) {
+	type applicationSet struct {
+		Spec struct {
+			Generators []struct {
+				Clusters struct {
+					Selector struct {
+						MatchLabels map[string]string `yaml:"matchLabels"`
+					} `yaml:"selector"`
+				} `yaml:"clusters"`
+			} `yaml:"generators"`
+			Template struct {
+				Spec struct {
+					Source struct {
+						Helm struct {
+							ValueFiles []string `yaml:"valueFiles"`
+						} `yaml:"helm"`
+					} `yaml:"source"`
+				} `yaml:"spec"`
+			} `yaml:"template"`
+		} `yaml:"spec"`
+	}
+
+	content, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(path)))
+	if err != nil {
+		return helmApplicationSetDoc{}, err
+	}
+
+	var doc applicationSet
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		return helmApplicationSetDoc{}, err
+	}
+
+	out := helmApplicationSetDoc{Path: filepath.ToSlash(path)}
+	for _, generator := range doc.Spec.Generators {
+		if len(generator.Clusters.Selector.MatchLabels) == 0 {
+			continue
+		}
+		out.Selector = map[string]string{}
+		for k, v := range generator.Clusters.Selector.MatchLabels {
+			out.Selector[k] = v
+		}
+		break
+	}
+	out.ValueFiles = uniqueStringsInOrder(doc.Spec.Template.Spec.Source.Helm.ValueFiles)
+	return out, nil
+}
+
+func matchedHelmClusterInventories(repo string, paths []string, selector map[string]string) []string {
+	matched := make([]string, 0, len(paths))
+	for _, path := range paths {
+		doc, err := parseHelmClusterInventoryFile(repo, path)
+		if err != nil || doc.Name == "" {
+			continue
+		}
+		if clusterLabelsMatch(doc.Labels, selector) {
+			matched = append(matched, doc.Name)
+		}
+	}
+	return uniqueSortedStrings(matched)
+}
+
+func parseHelmClusterInventoryFile(repo, path string) (helmClusterInventoryDoc, error) {
+	type clusterInventory struct {
+		Metadata struct {
+			Name   string            `yaml:"name"`
+			Labels map[string]string `yaml:"labels"`
+		} `yaml:"metadata"`
+	}
+
+	content, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(path)))
+	if err != nil {
+		return helmClusterInventoryDoc{}, err
+	}
+
+	var doc clusterInventory
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		return helmClusterInventoryDoc{}, err
+	}
+	return helmClusterInventoryDoc{
+		Path:   filepath.ToSlash(path),
+		Name:   strings.TrimSpace(doc.Metadata.Name),
+		Labels: doc.Metadata.Labels,
+	}, nil
+}
+
+func parseHelmManagedCatalogs(repo string, paths []string) []helmManagedCatalogDoc {
+	type managedCatalog struct {
+		Spec struct {
+			SecurityControls struct {
+				OAuth2Proxy struct {
+					Required bool `yaml:"required"`
+				} `yaml:"oauth2Proxy"`
+			} `yaml:"securityControls"`
+		} `yaml:"spec"`
+	}
+
+	out := make([]helmManagedCatalogDoc, 0, len(paths))
+	for _, path := range paths {
+		content, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(path)))
+		if err != nil {
+			continue
+		}
+		var doc managedCatalog
+		if err := yaml.Unmarshal(content, &doc); err != nil {
+			continue
+		}
+		entry := helmManagedCatalogDoc{Path: filepath.ToSlash(path)}
+		if doc.Spec.SecurityControls.OAuth2Proxy.Required {
+			entry.RequiredSecurity = "oauth2Proxy"
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func parseHelmCustomerCatalogs(repo string, paths []string) []helmCustomerCatalogDoc {
+	type customerCatalog struct {
+		Spec struct {
+			Overlay struct {
+				ValuesFile string `yaml:"valuesFile"`
+			} `yaml:"overlay"`
+			SecurityOverrides struct {
+				OAuth2Proxy struct {
+					Enabled *bool `yaml:"enabled"`
+				} `yaml:"oauth2Proxy"`
+			} `yaml:"securityOverrides"`
+		} `yaml:"spec"`
+	}
+
+	out := make([]helmCustomerCatalogDoc, 0, len(paths))
+	for _, path := range paths {
+		content, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(path)))
+		if err != nil {
+			continue
+		}
+		var doc customerCatalog
+		if err := yaml.Unmarshal(content, &doc); err != nil {
+			continue
+		}
+		entry := helmCustomerCatalogDoc{
+			Path:       filepath.ToSlash(path),
+			ValuesFile: strings.TrimSpace(doc.Spec.Overlay.ValuesFile),
+			Enabled:    doc.Spec.SecurityOverrides.OAuth2Proxy.Enabled,
+		}
+		if doc.Spec.SecurityOverrides.OAuth2Proxy.Enabled != nil {
+			entry.OverrideSecurity = "oauth2Proxy"
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func firstRequiredHelmSecurityControl(docs []helmManagedCatalogDoc) (string, string) {
+	for _, doc := range docs {
+		if strings.TrimSpace(doc.RequiredSecurity) == "" {
+			continue
+		}
+		return doc.RequiredSecurity, doc.Path
+	}
+	return "", ""
+}
+
+func matchingCustomerCatalog(docs []helmCustomerCatalogDoc, selectedOverlay string) helmCustomerCatalogDoc {
+	for _, doc := range docs {
+		if selectedOverlay != "" && doc.ValuesFile == selectedOverlay {
+			return doc
+		}
+	}
+	if len(docs) > 0 {
+		return docs[0]
+	}
+	return helmCustomerCatalogDoc{}
+}
+
+func clusterLabelsMatch(labels, selector map[string]string) bool {
+	if len(selector) == 0 {
+		return false
+	}
+	for key, expected := range selector {
+		if labels[key] != expected {
+			return false
+		}
+	}
+	return true
+}
+
+func selectorString(selector map[string]string) string {
+	if len(selector) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(selector))
+	for key := range selector {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+selector[key])
+	}
+	return strings.Join(parts, ", ")
+}
+
+func uniqueStringsInOrder(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 func renderedLineageForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.RenderedObjectLineage {

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -1365,12 +1365,7 @@ func helmProvenancePathsForGenerator(repoPath string, g model.GeneratorDetection
 	chartPath := firstInputPathForRole(g.Kind, g.Inputs, chartRole)
 	valuesPaths := inputPathsForRole(g.Kind, g.Inputs, valuesRole)
 
-	primaryValuesPath := primaryValuesBase
-	if selected := selectPreferredPathByBase(valuesPaths, primaryValuesBase); selected != "" {
-		primaryValuesPath = selected
-	} else if len(valuesPaths) > 0 {
-		primaryValuesPath = valuesPaths[0]
-	}
+	primaryValuesPath := selectPrimaryHelmValuesPath(valuesPaths, primaryValuesBase)
 	imageTagPaths := helmImageTagSourcePaths(repoPath, helmProvenancePaths{
 		ChartPath:         chartPath,
 		ValuesPaths:       valuesPaths,
@@ -1384,6 +1379,17 @@ func helmProvenancePathsForGenerator(repoPath string, g model.GeneratorDetection
 		PrimaryValuesPath: primaryValuesPath,
 		OverlayValuesPath: overlayValuesPath,
 	}
+}
+
+func selectPrimaryHelmValuesPath(valuesPaths []string, primaryValuesBase string) string {
+	primaryValuesPath := primaryValuesBase
+	if selected := selectPreferredPathByBase(valuesPaths, primaryValuesBase); selected != "" {
+		return selected
+	}
+	if len(valuesPaths) > 0 {
+		return valuesPaths[0]
+	}
+	return primaryValuesPath
 }
 
 func firstInputPathForRole(kind model.GeneratorKind, inputs []string, role string) string {

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -149,7 +149,7 @@ func buildProvenance(changeID, space string, detection model.DetectionResult, g 
 	outputURI := fmt.Sprintf("oci://example.local/%s/%s:latest", space, sanitizeName(g.Name))
 	outputDigest := digestFor(strings.Join([]string{changeID, g.ID, outputURI}, "|"))
 	inputDigest := digestFor(strings.Join(g.Inputs, "|"))
-	helmPaths := helmProvenancePathsForGenerator(g)
+	helmPaths := helmProvenancePathsForGenerator(detection.Repo, g)
 
 	return model.ProvenanceRecord{
 		SchemaVersion:    provenanceSchema,
@@ -521,23 +521,24 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 func fieldOriginsForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.FieldOrigin {
 	switch g.Kind {
 	case model.GeneratorHelm:
-		hints := helmProvenancePathsForGenerator(g)
-		origins := []model.FieldOrigin{
-			{
-				DryPath:    "values.image.tag",
-				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
-				SourcePath: hints.PrimaryValuesPath,
-				Transform:  registry.FieldOriginTransform(g.Kind),
-				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "image_tag_base", 0.86),
-			},
-		}
-		if hints.OverlayValuesPath != "" {
+		hints := helmProvenancePathsForGenerator(detection.Repo, g)
+		imageTagPaths := helmImageTagSourcePaths(detection.Repo, hints)
+		origins := make([]model.FieldOrigin, 0, len(imageTagPaths))
+		for idx, sourcePath := range imageTagPaths {
+			transform := registry.FieldOriginTransform(g.Kind)
+			confidenceKey := "image_tag_base"
+			confidenceFallback := 0.86
+			if idx > 0 || sourcePath != hints.PrimaryValuesPath {
+				transform = registry.FieldOriginOverlayTransform(g.Kind)
+				confidenceKey = "image_tag_overlay"
+				confidenceFallback = 0.90
+			}
 			origins = append(origins, model.FieldOrigin{
 				DryPath:    "values.image.tag",
 				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
-				SourcePath: hints.OverlayValuesPath,
-				Transform:  registry.FieldOriginOverlayTransform(g.Kind),
-				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "image_tag_overlay", 0.90),
+				SourcePath: sourcePath,
+				Transform:  transform,
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, confidenceKey, confidenceFallback),
 			})
 		}
 		return origins
@@ -825,17 +826,24 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 func inversePointersForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.InverseEditPointer {
 	switch g.Kind {
 	case model.GeneratorHelm:
-		hints := helmProvenancePathsForGenerator(g)
+		hints := helmProvenancePathsForGenerator(detection.Repo, g)
+		imageTagPaths := helmImageTagSourcePaths(detection.Repo, hints)
 		policy := registry.InversePointerTemplateFor(g.Kind, "image_tag", registry.InversePointerTemplate{
 			Owner: "app-team", Confidence: 0.86,
 		})
+		preferredImageTagPath := hints.PrimaryValuesPath
+		if hints.OverlayValuesPath != "" {
+			preferredImageTagPath = hints.OverlayValuesPath
+		} else if len(imageTagPaths) > 0 {
+			preferredImageTagPath = imageTagPaths[0]
+		}
 		vars := map[string]string{
 			"base_values_path":    hints.PrimaryValuesPath,
-			"overlay_values_path": hints.OverlayValuesPath,
+			"overlay_values_path": preferredImageTagPath,
 		}
 		hintKey := "image_tag_base"
 		hintFallback := "Edit values.image.tag in {{base_values_path}}."
-		if hints.OverlayValuesPath != "" {
+		if preferredImageTagPath != "" && preferredImageTagPath != hints.PrimaryValuesPath {
 			hintKey = "image_tag_overlay"
 			hintFallback = "Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults."
 		}
@@ -1336,7 +1344,7 @@ type helmProvenancePaths struct {
 	OverlayValuesPath string
 }
 
-func helmProvenancePathsForGenerator(g model.GeneratorDetection) helmProvenancePaths {
+func helmProvenancePathsForGenerator(repoPath string, g model.GeneratorDetection) helmProvenancePaths {
 	if g.Kind != model.GeneratorHelm {
 		return helmProvenancePaths{}
 	}
@@ -1356,9 +1364,6 @@ func helmProvenancePathsForGenerator(g model.GeneratorDetection) helmProvenanceP
 
 	chartPath := firstInputPathForRole(g.Kind, g.Inputs, chartRole)
 	valuesPaths := inputPathsForRole(g.Kind, g.Inputs, valuesRole)
-	if len(valuesPaths) == 0 && chartPath != "" {
-		valuesPaths = []string{chartPath}
-	}
 
 	primaryValuesPath := primaryValuesBase
 	if selected := selectPreferredPathByBase(valuesPaths, primaryValuesBase); selected != "" {
@@ -1366,7 +1371,12 @@ func helmProvenancePathsForGenerator(g model.GeneratorDetection) helmProvenanceP
 	} else if len(valuesPaths) > 0 {
 		primaryValuesPath = valuesPaths[0]
 	}
-	overlayValuesPath := firstDistinctPath(valuesPaths, primaryValuesPath)
+	imageTagPaths := helmImageTagSourcePaths(repoPath, helmProvenancePaths{
+		ChartPath:         chartPath,
+		ValuesPaths:       valuesPaths,
+		PrimaryValuesPath: primaryValuesPath,
+	})
+	overlayValuesPath := firstDistinctPath(imageTagPaths, primaryValuesPath)
 
 	return helmProvenancePaths{
 		ChartPath:         chartPath,
@@ -1383,6 +1393,83 @@ func firstInputPathForRole(kind model.GeneratorKind, inputs []string, role strin
 		}
 	}
 	return ""
+}
+
+func helmImageTagSourcePaths(repoPath string, hints helmProvenancePaths) []string {
+	imageTagPaths := make([]string, 0, len(hints.ValuesPaths))
+	for _, path := range hints.ValuesPaths {
+		if helmValuesPathDefinesImageTag(repoPath, path) {
+			imageTagPaths = append(imageTagPaths, path)
+		}
+	}
+	if len(imageTagPaths) == 0 {
+		if strings.TrimSpace(hints.PrimaryValuesPath) == "" {
+			return nil
+		}
+		return []string{hints.PrimaryValuesPath}
+	}
+
+	ordered := make([]string, 0, len(imageTagPaths))
+	if stringSliceContains(imageTagPaths, hints.PrimaryValuesPath) {
+		ordered = append(ordered, hints.PrimaryValuesPath)
+	}
+	for _, path := range imageTagPaths {
+		if path == hints.PrimaryValuesPath {
+			continue
+		}
+		ordered = append(ordered, path)
+	}
+	return ordered
+}
+
+func stringSliceContains(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func helmValuesPathDefinesImageTag(repoPath, relPath string) bool {
+	if strings.TrimSpace(repoPath) == "" || strings.TrimSpace(relPath) == "" {
+		return false
+	}
+	content, err := os.ReadFile(filepath.Join(repoPath, relPath))
+	if err != nil {
+		return false
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		return false
+	}
+	return yamlPathExists(&doc, []string{"image", "tag"})
+}
+
+func yamlPathExists(node *yaml.Node, path []string) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return yamlPathExists(node.Content[0], path)
+	}
+	if len(path) == 0 {
+		return true
+	}
+	if node.Kind != yaml.MappingNode {
+		if node.Kind == yaml.AliasNode {
+			return yamlPathExists(node.Alias, path)
+		}
+		return false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value != path[0] {
+			continue
+		}
+		return yamlPathExists(node.Content[i+1], path[1:])
+	}
+	return false
 }
 
 func inputPathsForRole(kind model.GeneratorKind, inputs []string, role string) []string {
@@ -1452,7 +1539,7 @@ func helmLayeredAnalysisForGenerator(detection model.DetectionResult, g model.Ge
 		return nil
 	}
 
-	helmPaths := helmProvenancePathsForGenerator(g)
+	helmPaths := helmProvenancePathsForGenerator(detection.Repo, g)
 	analysis := &model.HelmLayeredAnalysis{
 		ApplicationSetPath:    appsetPath,
 		ClusterInventoryPaths: append([]string(nil), clusterPaths...),
@@ -1818,7 +1905,7 @@ func lineageTemplateContext(detection model.DetectionResult, g model.GeneratorDe
 
 	switch g.Kind {
 	case model.GeneratorHelm:
-		helmPaths := helmProvenancePathsForGenerator(g)
+		helmPaths := helmProvenancePathsForGenerator(detection.Repo, g)
 		singleHints["chart_path"] = helmPaths.ChartPath
 		singleHints["primary_values_path"] = helmPaths.PrimaryValuesPath
 		multiHints["values_paths"] = helmPaths.ValuesPaths

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -283,6 +283,15 @@ func TestImportRepoHelmDryWetContract(t *testing.T) {
 	if !fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "values.yaml") {
 		t.Fatalf("expected Helm field origin values.image.tag to resolve source_path values.yaml, got %+v", prov.FieldOriginMap)
 	}
+	if !fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "values-prod.yaml") {
+		t.Fatalf("expected Helm field origin values.image.tag to resolve source_path values-prod.yaml, got %+v", prov.FieldOriginMap)
+	}
+	if !inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "values-prod.yaml") {
+		t.Fatalf("expected Helm inverse pointer to prefer values-prod.yaml overlay, got %+v", prov.InverseEditPointers)
+	}
+	if !inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "values.yaml") {
+		t.Fatalf("expected Helm inverse pointer to mention values.yaml defaults, got %+v", prov.InverseEditPointers)
+	}
 
 	if !dryInputHasRolePath(result.DryInputs, "chart", "Chart.yaml") {
 		t.Fatalf("expected chart dry input, got %+v", result.DryInputs)

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -454,6 +454,56 @@ spec:
 	}
 }
 
+func TestImportRepoHelmOverlayOriginRequiresActualOverride(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: layered-demo\nversion: 0.1.0\n")
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  tag: v1.0.0\n")
+	mustWriteFile(t, filepath.Join(repo, "values-prod.yaml"), "replicaCount: 2\n")
+
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+	if len(result.Provenance) != 1 {
+		t.Fatalf("expected single provenance record, got %d", len(result.Provenance))
+	}
+
+	prov := result.Provenance[0]
+	if !fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "values.yaml") {
+		t.Fatalf("expected Helm field origin values.image.tag to resolve source_path values.yaml, got %+v", prov.FieldOriginMap)
+	}
+	if fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "values-prod.yaml") {
+		t.Fatalf("expected values-prod.yaml to be ignored when it does not override values.image.tag, got %+v", prov.FieldOriginMap)
+	}
+	if inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "values-prod.yaml") {
+		t.Fatalf("expected Helm inverse pointer not to prefer values-prod.yaml when it does not override values.image.tag, got %+v", prov.InverseEditPointers)
+	}
+	if !inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "values.yaml") {
+		t.Fatalf("expected Helm inverse pointer to keep values.yaml guidance, got %+v", prov.InverseEditPointers)
+	}
+}
+
+func TestImportRepoHelmWithoutValuesDoesNotPointToChartYaml(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: no-values\nversion: 0.1.0\n")
+
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+	if len(result.Provenance) != 1 {
+		t.Fatalf("expected single provenance record, got %d", len(result.Provenance))
+	}
+
+	prov := result.Provenance[0]
+	if fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "Chart.yaml") {
+		t.Fatalf("expected Chart.yaml not to be treated as a values source, got %+v", prov.FieldOriginMap)
+	}
+	if inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "Chart.yaml") {
+		t.Fatalf("expected Chart.yaml not to appear in Helm inverse edit guidance, got %+v", prov.InverseEditPointers)
+	}
+}
+
 func TestImportRepoSpringBootDryWetContract(t *testing.T) {
 	repo := filepath.Join("..", "..", "examples", "springboot-paas")
 	result, err := ImportRepo(repo, "main", "platform")

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -292,6 +292,27 @@ func TestImportRepoHelmDryWetContract(t *testing.T) {
 	if !inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "values.yaml") {
 		t.Fatalf("expected Helm inverse pointer to mention values.yaml defaults, got %+v", prov.InverseEditPointers)
 	}
+	if prov.HelmLayeredAnalysis == nil {
+		t.Fatalf("expected helm layered analysis, got nil")
+	}
+	if prov.HelmLayeredAnalysis.ApplicationSetPath != "gitops/argo/applicationset.yaml" {
+		t.Fatalf("expected application set path gitops/argo/applicationset.yaml, got %+v", prov.HelmLayeredAnalysis)
+	}
+	if prov.HelmLayeredAnalysis.GenerationDecisionState != "attributed" {
+		t.Fatalf("expected attributed generation decision, got %+v", prov.HelmLayeredAnalysis)
+	}
+	if prov.HelmLayeredAnalysis.ClusterSelector != "env=prod, region=eu" {
+		t.Fatalf("expected cluster selector env=prod, region=eu, got %+v", prov.HelmLayeredAnalysis)
+	}
+	if !containsString(prov.HelmLayeredAnalysis.MatchedClusters, "prod-eu") {
+		t.Fatalf("expected matched cluster prod-eu, got %+v", prov.HelmLayeredAnalysis)
+	}
+	if !containsString(prov.HelmLayeredAnalysis.SelectedValueFiles, "values-prod.yaml") {
+		t.Fatalf("expected selected value files to include values-prod.yaml, got %+v", prov.HelmLayeredAnalysis)
+	}
+	if prov.HelmLayeredAnalysis.SecurityDecisionState != "allow" {
+		t.Fatalf("expected allow security decision, got %+v", prov.HelmLayeredAnalysis)
+	}
 
 	if !dryInputHasRolePath(result.DryInputs, "chart", "Chart.yaml") {
 		t.Fatalf("expected chart dry input, got %+v", result.DryInputs)
@@ -301,6 +322,18 @@ func TestImportRepoHelmDryWetContract(t *testing.T) {
 	}
 	if !dryInputHasRolePath(result.DryInputs, "values", "values-prod.yaml") {
 		t.Fatalf("expected values-prod.yaml dry input, got %+v", result.DryInputs)
+	}
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "application-set", "platform-engineer", "gitops/argo/applicationset.yaml") {
+		t.Fatalf("expected applicationset dry input owned by platform-engineer, got %+v", result.DryInputs)
+	}
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "cluster-inventory", "platform-engineer", "platform/clusters/prod-eu.yaml") {
+		t.Fatalf("expected prod-eu cluster inventory dry input owned by platform-engineer, got %+v", result.DryInputs)
+	}
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "managed-service-catalog", "platform-engineer", "platform/catalogs/managed-service-catalog/payments-api.yaml") {
+		t.Fatalf("expected managed service catalog dry input owned by platform-engineer, got %+v", result.DryInputs)
+	}
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "customer-service-catalog", "app-team", "platform/catalogs/customer-service-catalog/payments-api-prod.yaml") {
+		t.Fatalf("expected customer service catalog dry input owned by app-team, got %+v", result.DryInputs)
 	}
 	if !dryInputHasRoleOwnerPath(result.DryInputs, "chart", "platform-engineer", "Chart.yaml") {
 		t.Fatalf("expected chart owner to be platform-engineer, got %+v", result.DryInputs)
@@ -317,6 +350,107 @@ func TestImportRepoHelmDryWetContract(t *testing.T) {
 	}
 	if !wetTargetHasKindOwner(result.WetManifestTargets, "HelmRelease", "platform-runtime") {
 		t.Fatalf("expected HelmRelease owner to be platform-runtime, got %+v", result.WetManifestTargets)
+	}
+}
+
+func TestImportRepoHelmLayeredAnalysisGracefulDegradation(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: layered-demo\nversion: 0.1.0\n")
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  tag: v1.0.0\n")
+	mustWriteFile(t, filepath.Join(repo, "values-prod.yaml"), "image:\n  tag: v1.0.1\n")
+	mustWriteFile(t, filepath.Join(repo, "gitops", "argo", "applicationset.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+spec:
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            env: prod
+  template:
+    spec:
+      source:
+        helm:
+          valueFiles:
+            - values.yaml
+            - values-prod.yaml
+`)
+
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+	if len(result.Provenance) != 1 || result.Provenance[0].HelmLayeredAnalysis == nil {
+		t.Fatalf("expected helm layered analysis, got %+v", result.Provenance)
+	}
+	got := result.Provenance[0].HelmLayeredAnalysis
+	if got.GenerationDecisionState != "unresolved" {
+		t.Fatalf("expected unresolved generation decision, got %+v", got)
+	}
+	if !strings.Contains(got.GenerationDecisionReason, "no cluster inventory inputs") {
+		t.Fatalf("expected explicit graceful degradation reason, got %+v", got)
+	}
+}
+
+func TestImportRepoHelmLayeredSecurityBlock(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: layered-demo\nversion: 0.1.0\n")
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  tag: v1.0.0\n")
+	mustWriteFile(t, filepath.Join(repo, "values-prod.yaml"), "image:\n  tag: v1.0.1\n")
+	mustWriteFile(t, filepath.Join(repo, "gitops", "argo", "applicationset.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+spec:
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            env: prod
+            region: eu
+  template:
+    spec:
+      source:
+        helm:
+          valueFiles:
+            - values.yaml
+            - values-prod.yaml
+`)
+	mustWriteFile(t, filepath.Join(repo, "platform", "clusters", "prod-eu.yaml"), `apiVersion: cubgen.confighub.dev/v1alpha1
+kind: ClusterInventory
+metadata:
+  name: prod-eu
+  labels:
+    env: prod
+    region: eu
+`)
+	mustWriteFile(t, filepath.Join(repo, "platform", "catalogs", "managed-service-catalog", "payments-api.yaml"), `apiVersion: cubgen.confighub.dev/v1alpha1
+kind: ManagedServiceCatalog
+spec:
+  securityControls:
+    oauth2Proxy:
+      required: true
+`)
+	mustWriteFile(t, filepath.Join(repo, "platform", "catalogs", "customer-service-catalog", "payments-api-prod.yaml"), `apiVersion: cubgen.confighub.dev/v1alpha1
+kind: CustomerServiceCatalog
+spec:
+  overlay:
+    valuesFile: values-prod.yaml
+  securityOverrides:
+    oauth2Proxy:
+      enabled: false
+`)
+
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+	got := result.Provenance[0].HelmLayeredAnalysis
+	if got == nil {
+		t.Fatalf("expected helm layered analysis, got nil")
+	}
+	if got.SecurityDecisionState != "blocked" {
+		t.Fatalf("expected blocked security decision, got %+v", got)
+	}
+	if !strings.Contains(got.SecurityDecisionReason, "oauth2Proxy") {
+		t.Fatalf("expected security reason to mention oauth2Proxy, got %+v", got)
 	}
 }
 
@@ -890,4 +1024,14 @@ func wetTargetHasKindOwner(v []model.WetManifestTarget, kind, owner string) bool
 		}
 	}
 	return false
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -95,6 +95,23 @@ type FieldOrigin struct {
 	Confidence float64 `json:"confidence"`
 }
 
+type HelmLayeredAnalysis struct {
+	ApplicationSetPath       string   `json:"application_set_path,omitempty"`
+	ClusterInventoryPaths    []string `json:"cluster_inventory_paths,omitempty"`
+	ManagedCatalogPaths      []string `json:"managed_catalog_paths,omitempty"`
+	CustomerCatalogPaths     []string `json:"customer_catalog_paths,omitempty"`
+	ClusterSelector          string   `json:"cluster_selector,omitempty"`
+	MatchedClusters          []string `json:"matched_clusters,omitempty"`
+	SelectedValueFiles       []string `json:"selected_value_files,omitempty"`
+	GenerationDecisionState  string   `json:"generation_decision_state,omitempty"`
+	GenerationDecisionReason string   `json:"generation_decision_reason,omitempty"`
+	SecurityControl          string   `json:"security_control,omitempty"`
+	SecurityControlPath      string   `json:"security_control_path,omitempty"`
+	SecurityOverridePath     string   `json:"security_override_path,omitempty"`
+	SecurityDecisionState    string   `json:"security_decision_state,omitempty"`
+	SecurityDecisionReason   string   `json:"security_decision_reason,omitempty"`
+}
+
 type InverseEditPointer struct {
 	WetPath    string  `json:"wet_path"`
 	DryPath    string  `json:"dry_path"`
@@ -165,6 +182,7 @@ type ProvenanceRecord struct {
 	RenderedLineage     []RenderedObjectLineage `json:"rendered_object_lineage,omitempty"`
 	FieldOriginMap      []FieldOrigin           `json:"field_origin_map"`
 	InverseEditPointers []InverseEditPointer    `json:"inverse_edit_pointers"`
+	HelmLayeredAnalysis *HelmLayeredAnalysis    `json:"helm_layered_analysis,omitempty"`
 	OpsWorkflow         *OpsWorkflowAnalysis    `json:"ops_workflow_analysis,omitempty"`
 	SwampWorkflow       *SwampWorkflowAnalysis  `json:"swamp_workflow_analysis,omitempty"`
 	RenderedAt          string                  `json:"rendered_at"`

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -90,7 +90,8 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"image_tag": "Container image tag maps cleanly to helm values.",
 		},
 		InverseEditHints: map[string]string{
-			"image_tag": "Edit chart values file and keep chart template unchanged.",
+			"image_tag_base":    "Edit values.image.tag in {{base_values_path}}.",
+			"image_tag_overlay": "Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults.",
 		},
 		InversePatchTemplates: map[string]InversePatchTemplate{
 			"image_tag": {EditableBy: "app-team", Confidence: 0.86, RequiresReview: false},
@@ -99,14 +100,16 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 			"image_tag": {Owner: "app-team", Confidence: 0.86},
 		},
 		FieldOriginConfidences: map[string]float64{
-			"image_tag": 0.86,
+			"image_tag_base":    0.86,
+			"image_tag_overlay": 0.90,
 		},
 		RenderedLineageTemplates: []RenderedLineageTemplate{
 			{Kind: "HelmRelease", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "chart_path", SourceDryPathTemplate: "Chart.yaml"},
 			{Kind: "Deployment", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "values_paths", SourcePathHintFallback: "chart_path", SourcePathHintMulti: true, SourceDryPathTemplate: "values.image.tag"},
 			{Kind: "Service", NameTemplate: "{{name}}", Namespace: "apps", SourcePathHint: "values_paths", SourcePathHintFallback: "chart_path", SourcePathHintMulti: true, SourceDryPathTemplate: "values.service.port"},
 		},
-		FieldOriginTransform: "helm-template",
+		FieldOriginTransform:        "helm-template",
+		FieldOriginOverlayTransform: "helm-values-overlay",
 		InputRoleRules: []InputRoleRule{
 			{Role: "chart", ExactBasenames: []string{"chart.yaml"}},
 			{Role: "values", Prefixes: []string{"values"}, Extensions: []string{".yaml", ".yml"}},

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -11,6 +11,7 @@ import (
 type InputRoleRule struct {
 	Role           string
 	ExactBasenames []string
+	PathPrefixes   []string
 	Prefixes       []string
 	Extensions     []string
 }
@@ -112,11 +113,18 @@ var familySpecs = map[model.GeneratorKind]FamilySpec{
 		FieldOriginOverlayTransform: "helm-values-overlay",
 		InputRoleRules: []InputRoleRule{
 			{Role: "chart", ExactBasenames: []string{"chart.yaml"}},
+			{Role: "application-set", ExactBasenames: []string{"applicationset.yaml", "applicationset.yml"}},
+			{Role: "cluster-inventory", PathPrefixes: []string{"platform/clusters/"}, Extensions: []string{".yaml", ".yml", ".json"}},
+			{Role: "managed-service-catalog", PathPrefixes: []string{"platform/catalogs/managed-service-catalog/"}, Extensions: []string{".yaml", ".yml", ".json"}},
+			{Role: "customer-service-catalog", PathPrefixes: []string{"platform/catalogs/customer-service-catalog/"}, Extensions: []string{".yaml", ".yml", ".json"}},
 			{Role: "values", Prefixes: []string{"values"}, Extensions: []string{".yaml", ".yml"}},
 		},
 		DefaultInputRole: "helm-input",
-		RoleOwners:       map[string]string{"values": "app-team"},
-		DefaultOwner:     "platform-engineer",
+		RoleOwners: map[string]string{
+			"values":                   "app-team",
+			"customer-service-catalog": "app-team",
+		},
+		DefaultOwner: "platform-engineer",
 		WetTargets: []WetTargetTemplate{
 			{Kind: "HelmRelease", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps"},
 			{Kind: "Deployment", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "apps", SourceDryPathTemplate: "values.image.tag"},
@@ -725,10 +733,11 @@ func InputRole(kind model.GeneratorKind, inputPath string) string {
 	if !ok {
 		return "input"
 	}
+	path := filepath.ToSlash(strings.ToLower(strings.TrimSpace(inputPath)))
 	base := strings.ToLower(filepath.Base(inputPath))
 	ext := strings.ToLower(filepath.Ext(base))
 	for _, rule := range spec.InputRoleRules {
-		if matchesInputRule(rule, base, ext) {
+		if matchesInputRule(rule, path, base, ext) {
 			return rule.Role
 		}
 	}
@@ -794,7 +803,22 @@ func RenderedLineageTemplates(kind model.GeneratorKind) []RenderedLineageTemplat
 	return copyRenderedLineageTemplates(spec.RenderedLineageTemplates)
 }
 
-func matchesInputRule(rule InputRoleRule, base, ext string) bool {
+func matchesInputRule(rule InputRoleRule, path, base, ext string) bool {
+	for _, prefix := range rule.PathPrefixes {
+		normalized := filepath.ToSlash(strings.ToLower(strings.TrimSpace(prefix)))
+		if normalized == "" || !strings.HasPrefix(path, normalized) {
+			continue
+		}
+		if len(rule.Extensions) == 0 {
+			return true
+		}
+		for _, allowed := range rule.Extensions {
+			if ext == strings.ToLower(allowed) {
+				return true
+			}
+		}
+	}
+
 	for _, exact := range rule.ExactBasenames {
 		if base == strings.ToLower(exact) {
 			return true
@@ -823,6 +847,7 @@ func copyInputRoleRules(in []InputRoleRule) []InputRoleRule {
 		out = append(out, InputRoleRule{
 			Role:           rule.Role,
 			ExactBasenames: append([]string(nil), rule.ExactBasenames...),
+			PathPrefixes:   append([]string(nil), rule.PathPrefixes...),
 			Prefixes:       append([]string(nil), rule.Prefixes...),
 			Extensions:     append([]string(nil), rule.Extensions...),
 		})

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -249,8 +249,8 @@ func TestRegistryHintDefaults(t *testing.T) {
 	if got := FieldOriginOverlayTransform(model.GeneratorSpringBoot); got != "spring-profile-overlay" {
 		t.Fatalf("expected spring overlay field origin transform, got %q", got)
 	}
-	if got := FieldOriginOverlayTransform(model.GeneratorHelm); got != "helm-template" {
-		t.Fatalf("expected helm overlay transform to fall back to base transform, got %q", got)
+	if got := FieldOriginOverlayTransform(model.GeneratorHelm); got != "helm-values-overlay" {
+		t.Fatalf("expected helm overlay field origin transform helm-values-overlay, got %q", got)
 	}
 	if got := InversePatchReason(model.GeneratorBackstage, "identity", "fallback"); got != "Backstage component identity is sourced from {{catalog_path}}." {
 		t.Fatalf("expected backstage inverse patch reason template, got %q", got)
@@ -261,6 +261,9 @@ func TestRegistryHintDefaults(t *testing.T) {
 	if got := FieldOriginConfidenceFor(model.GeneratorOpsFlow, "schedule_overlay", 0.0); got != 0.80 {
 		t.Fatalf("expected ops schedule overlay field origin confidence 0.80, got %v", got)
 	}
+	if got := FieldOriginConfidenceFor(model.GeneratorHelm, "image_tag_overlay", 0.0); got != 0.90 {
+		t.Fatalf("expected helm image_tag_overlay field origin confidence 0.90, got %v", got)
+	}
 	if got := InversePatchTemplateFor(model.GeneratorOpsFlow, "schedule", InversePatchTemplate{}); got.EditableBy != "platform-engineer" || got.Confidence != 0.84 || !got.RequiresReview {
 		t.Fatalf("expected ops schedule inverse patch template, got %+v", got)
 	}
@@ -269,6 +272,9 @@ func TestRegistryHintDefaults(t *testing.T) {
 	}
 	if got := InverseEditHint(model.GeneratorScore, "env_var", "fallback"); got != "Edit {{variable_name}} under containers.{{container_name}}.variables in {{source_path}}." {
 		t.Fatalf("expected score env_var inverse edit hint template, got %q", got)
+	}
+	if got := InverseEditHint(model.GeneratorHelm, "image_tag_overlay", "fallback"); got != "Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults." {
+		t.Fatalf("expected helm image_tag_overlay inverse edit hint template, got %q", got)
 	}
 	if got := InverseEditHint(model.GeneratorSpringBoot, "server_port_overlay", "fallback"); got != "Edit server.port in {{profile_config_path}} for environment overrides; use {{base_config_path}} for the default." {
 		t.Fatalf("expected spring server_port_overlay inverse edit hint template, got %q", got)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -116,6 +116,10 @@ func TestRegistryInputRoleAndOwnerClassification(t *testing.T) {
 	}{
 		{name: "helm-chart", kind: model.GeneratorHelm, path: "Chart.yaml", expectedRole: "chart", expectedOwner: "platform-engineer"},
 		{name: "helm-values", kind: model.GeneratorHelm, path: "values-prod.yaml", expectedRole: "values", expectedOwner: "app-team"},
+		{name: "helm-applicationset", kind: model.GeneratorHelm, path: "gitops/argo/applicationset.yaml", expectedRole: "application-set", expectedOwner: "platform-engineer"},
+		{name: "helm-cluster-inventory", kind: model.GeneratorHelm, path: "platform/clusters/prod-eu.yaml", expectedRole: "cluster-inventory", expectedOwner: "platform-engineer"},
+		{name: "helm-managed-catalog", kind: model.GeneratorHelm, path: "platform/catalogs/managed-service-catalog/payments-api.yaml", expectedRole: "managed-service-catalog", expectedOwner: "platform-engineer"},
+		{name: "helm-customer-catalog", kind: model.GeneratorHelm, path: "platform/catalogs/customer-service-catalog/payments-api-prod.yaml", expectedRole: "customer-service-catalog", expectedOwner: "app-team"},
 		{name: "score-spec", kind: model.GeneratorScore, path: "score.yaml", expectedRole: "score-spec", expectedOwner: "app-team"},
 		{name: "spring-build", kind: model.GeneratorSpringBoot, path: "pom.xml", expectedRole: "build-config", expectedOwner: "platform-engineer"},
 		{name: "spring-profile", kind: model.GeneratorSpringBoot, path: "application-prod.yml", expectedRole: "app-config-profile", expectedOwner: "app-team"},


### PR DESCRIPTION
## Summary
- extend Helm detection/import so cub-gen treats Argo ApplicationSet, cluster inventory, and managed/customer service catalogs as first-class layered DRY inputs
- emit helm_layered_analysis so gitops import can attribute selector -> cluster -> overlay decisions, degrade explicitly when cluster inventory is missing, and classify a blocked customer security weakening
- add an example-owned helm-paas layered proof wrapper plus README/AI bundle/tracker refreshes, and regenerate the parity/style/truth-matrix artifacts

## Testing
- ./examples/helm-paas/demo-layered-trace.sh
- go test ./...
- ./test/checks/check-docs-entrypoints.sh
- ./test/checks/check-story-status.sh
- ./test/checks/check-example-truth-matrix.sh

Closes #173
Closes #177
Closes #187
