### PR TITLE
examples: add swamp workflow proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,10 @@ Both prove create, update, and drift-correction on a real cluster.
 | Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
-| Example quality | `#177`, `#180`, `#187` |
+| Example quality | `#177`, `#187` |
 | CLI/docs follow-on | `#238`, `#239`, `#240`, `#241`, `#242` |
 | Release gate | Secrets-backed ConfigHub smoke is green on `main`; rerun it in the release environment before tagging |
-| Actively tracked | `#173`, `#177`, `#180`, `#187`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#187`, `#238`-`#242` |
 
 For exact per-example counts and classifications, use the generated [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is derived from the runnable catalog, source-side tests, the connected smoke lane, and real live-proof harnesses.
 

--- a/docs/releases/v0.2-preview.2-plan.md
+++ b/docs/releases/v0.2-preview.2-plan.md
@@ -49,7 +49,6 @@ only the flagship path.
 Current open issues:
 
 - [#177](https://github.com/confighub/cub-gen/issues/177) Helm flagship
-- [#180](https://github.com/confighub/cub-gen/issues/180) workflow examples
 - [#187](https://github.com/confighub/cub-gen/issues/187) Kubara-like layered provenance
 
 Landed on `main`:
@@ -58,6 +57,7 @@ Landed on `main`:
 - [#185](https://github.com/confighub/cub-gen/issues/185) custom-generator onboarding
 - [#200](https://github.com/confighub/cub-gen/issues/200) AI best-practice alignment
 - [#202](https://github.com/confighub/cub-gen/issues/202) AI-first flagship surfaces
+- [#180](https://github.com/confighub/cub-gen/issues/180) workflow examples now meet the preview bar with example-owned local ALLOW/BLOCK proofs plus connected workflow paths
 - [#178](https://github.com/confighub/cub-gen/issues/178) Score standalone runtime proof
 - [#207](https://github.com/confighub/cub-gen/issues/207) Spring block/escalate proof
 - [#208](https://github.com/confighub/cub-gen/issues/208) Spring embedded-config mutation support

--- a/docs/releases/v0.2-preview.2-ship-checklist.md
+++ b/docs/releases/v0.2-preview.2-ship-checklist.md
@@ -66,7 +66,6 @@ exit-bar rationale still live in
 ### Still true release blockers
 
 - [ ] `#177` Helm flagship example
-- [ ] `#180` workflow example upgrade
 - [ ] `#187` layered provenance across overlays/ApplicationSet/labels
 
 For this preview, "all examples working well" means each featured example has:

--- a/docs/releases/v0.2-preview.2.md
+++ b/docs/releases/v0.2-preview.2.md
@@ -74,9 +74,10 @@ release-facing proof.
    - more complete multi-layer trace stories
    Refs: `#177`, `#187`
 
-2. Workflow surfaces are clearer, but still need deeper runnable
-   platform-story completion beyond the current workflow governance bundles.
-   Refs: `#180`
+2. Workflow examples now have example-owned local `ALLOW`/`BLOCK` proofs,
+   stronger AI-first workflow entrypoints, and connected paths that match the
+   preview release bar. Runtime execution is still presented honestly as a
+   companion story rather than in-repo live proof.
 
 3. The release environment still needs the final secrets-backed connected smoke
    confirmation for the intended tag environment.

--- a/examples/README.md
+++ b/examples/README.md
@@ -127,7 +127,7 @@ Start with the example that matches how your team already thinks:
 | Helm/Flux/Argo platform team (umbrella charts, overlays) | [`helm-paas`](./helm-paas/) | Ownership + field trace map without chart archaeology |
 | Score.dev platform team | [`scoredev-paas`](./scoredev-paas/) | Visibility from `score.yaml` intent to rendered runtime fields |
 | Ops/SRE workflow owner | [`ops-workflow`](./ops-workflow/) | Governed schedule/action changes with explicit ALLOW/BLOCK outcomes |
-| AI workflow / Swamp-style team | [`swamp-automation`](./swamp-automation/) | Structural workflow-change classification and policy-ready evidence |
+| AI workflow / Swamp-style team | [`swamp-automation`](./swamp-automation/) | Structural workflow-change classification with explicit ALLOW/BLOCK workflow evidence |
 | AI fleet platform owner | [`c3agent`](./c3agent/) or [`ai-ops-paas`](./ai-ops-paas/) | Model/budget/credential governance over fleet config changes |
 | Backstage catalog owner | [`backstage-idp`](./backstage-idp/) | Catalog ownership/lifecycle changes become traceable and reviewable |
 | Reconciler reliability owner | [`live-reconcile`](./live-reconcile/) | Real Flux+Argo create/update/drift-correction proof harness |
@@ -260,7 +260,7 @@ When you run `cub-gen attest --verifier <name>`, the verifier name records who/w
 | Ops workflow/SRE automation team | [ops-workflow](ops-workflow/) | [If you already run operational workflows at scale](ops-workflow/README.md#if-you-already-run-operational-workflows-at-scale) | `./examples/ops-workflow/demo-local.sh` |
 | AI agent fleet platform team | [c3agent](c3agent/) | [If you already run agent fleets operationally](c3agent/README.md#if-you-already-run-agent-fleets-operationally) | `./examples/c3agent/demo-local.sh` |
 | Full AI PaaS builder | [ai-ops-paas](ai-ops-paas/) | [If you already run AI/ops platforms on Kubernetes](ai-ops-paas/README.md#if-you-already-run-aiops-platforms-on-kubernetes) | `./examples/ai-ops-paas/demo-local.sh` |
-| Workflow automation platform team | [swamp-automation](swamp-automation/) | [If you already build workflow automation systems](swamp-automation/README.md#if-you-already-build-workflow-automation-systems) | `./examples/swamp-automation/demo-local.sh` |
+| Workflow automation platform team | [swamp-automation](swamp-automation/) | [If you already build workflow automation systems](swamp-automation/README.md#if-you-already-build-workflow-automation-systems) | `./examples/swamp-automation/demo-governed-structure.sh` |
 | Helm-based AI runtime team | [swamp-project](swamp-project/) | [If you already operate Helm-based AI runtimes](swamp-project/README.md#if-you-already-operate-helm-based-ai-runtimes) | `./examples/swamp-project/demo-local.sh` |
 | Reconciler/platform reliability engineer | [live-reconcile](live-reconcile/) | [If you already operate Flux/Argo at scale](live-reconcile/README.md#if-you-already-operate-fluxargo-at-scale) | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` |
 
@@ -281,8 +281,7 @@ If your users mostly run workflows (not app manifests), start with these two:
 
 # Swamp workflows: model/method/required-step structural governance
 ./examples/swamp-automation/demo-local.sh
-./cub-gen gitops import --space platform --json ./examples/swamp-automation \
-  | jq '.provenance[0].swamp_workflow_analysis'
+./examples/swamp-automation/demo-governed-structure.sh
 ```
 
 Operation-registry walkthrough (AI Ops + Ops Workflow + Swamp):

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -66,8 +66,8 @@ when you want to inspect what is actually running after reconciliation.
 | **Spring app/platform team** | `module-3-spring-ownership.sh` | App-vs-platform ownership boundaries |
 | **Backstage catalog admin** | [`backstage-idp`](../backstage-idp/) demo | Owner/lifecycle governance |
 | **AI fleet operator** | `ai-work-platform/scenario-1-c3agent.sh` | 30 DRY lines → 11 governed WET targets |
-| **Swamp/workflow maintainer** | `ai-work-platform/scenario-2-swamp.sh` | Structural workflow-change classification |
-| **Ops/SRE workflow owner** | `ai-work-platform/scenario-4-operations.sh` | Governed workflow mutation path |
+| **Swamp/workflow maintainer** | `ai-work-platform/scenario-2-swamp.sh` | Structural workflow-change classification with explicit ALLOW/BLOCK proof |
+| **Ops/SRE workflow owner** | `ai-work-platform/scenario-4-operations.sh` | Governed workflow mutation path with explicit ALLOW/BLOCK proof |
 | **Platform control-plane operator** | `ai-work-platform/scenario-3-confighub-actions.sh` | Recursive governance |
 | **Reconciler reliability owner** | `e2e-live-reconcile-flux.sh` | Real create/update/drift correction |
 | **App team (no platform layer)** | `module-5-no-config-platform.sh` | Provider config governance |
@@ -124,9 +124,10 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 | Script | Example | What it demonstrates |
 |--------|---------|---------------------|
 | `ai-work-platform/scenario-1-c3agent.sh` | [`c3agent`](../c3agent/) + [`ai-ops-paas`](../ai-ops-paas/) | c3agent 11-target coverage |
-| `ai-work-platform/scenario-2-swamp.sh` | [`swamp-automation`](../swamp-automation/) | Swamp workflow/model governance |
+| `ai-work-platform/scenario-2-swamp.sh` | [`swamp-automation`](../swamp-automation/) | Swamp workflow/model governance with example-owned local ALLOW/BLOCK proof |
 | `ai-work-platform/scenario-3-confighub-actions.sh` | [`confighub-actions`](../confighub-actions/) | Recursive governance |
-| `ai-work-platform/scenario-4-operations.sh` | [`ops-workflow`](../ops-workflow/) | Operations workflow governance |
+| `ai-work-platform/scenario-4-operations.sh` | [`ops-workflow`](../ops-workflow/) | Operations workflow governance with example-owned local ALLOW/BLOCK proof |
+| `../swamp-automation/demo-governed-structure.sh` | [`swamp-automation`](../swamp-automation/) | Approved model-method ALLOW versus unapproved model plus missing `validate` BLOCK |
 | `../ops-workflow/demo-governed-policy.sh` | [`ops-workflow`](../ops-workflow/) | Example-owned local ALLOW/BLOCK workflow policy proof |
 | `ai-work-platform/run-all.sh` | All above | Run all AI platform scenarios |
 
@@ -137,13 +138,11 @@ If your platform is workflow-heavy, start here before app-manifest demos:
 ```bash
 # Swamp workflow graph governance (models/methods/required steps)
 ./examples/demo/ai-work-platform/scenario-2-swamp.sh
-./cub-gen gitops import --space platform --json ./examples/swamp-automation ./examples/swamp-automation \
-  | jq '.provenance[0].swamp_workflow_analysis'
+./examples/swamp-automation/demo-governed-structure.sh
 
 # Ops workflow governance (actions/schedules/approval gates)
 ./examples/demo/ai-work-platform/scenario-4-operations.sh
-./cub-gen gitops import --space platform --json ./examples/ops-workflow ./examples/ops-workflow \
-  | jq '.provenance[0].ops_workflow_analysis'
+./examples/ops-workflow/demo-governed-policy.sh
 ```
 
 ## 6. Connected mode (ConfigHub)
@@ -398,7 +397,7 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
 | In progress | The flagship examples still need contract-based proof for real-cluster outcome, two-audience onboarding, visible ConfigHub value, and governed `ALLOW` plus `ESCALATE`/`BLOCK` paths |
-| Actively tracked | `#173`, `#177`, `#180`, `#187`, `#238`-`#242` |
+| Actively tracked | `#173`, `#177`, `#187`, `#238`-`#242` |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 

--- a/examples/demo/ai-work-platform/scenario-2-swamp.sh
+++ b/examples/demo/ai-work-platform/scenario-2-swamp.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT_DIR"
 
-echo "[ai-demo-2] Swamp Automation: AI-native workflow import"
-./examples/demo/simulate-repo-wizard.sh ./examples/swamp-automation ./examples/swamp-automation swamp
+echo "[ai-demo-2] Swamp Automation: governed ALLOW/BLOCK workflow proof"
+./examples/swamp-automation/demo-governed-structure.sh

--- a/examples/demo/ai-work-platform/scenario-4-operations.sh
+++ b/examples/demo/ai-work-platform/scenario-4-operations.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT_DIR"
 
-echo "[ai-demo-4] Operations workflow: existing operations example"
-./examples/demo/simulate-repo-wizard.sh ./examples/ops-workflow ./examples/ops-workflow ops-workflow
+echo "[ai-demo-4] Operations workflow: governed ALLOW/BLOCK policy proof"
+./examples/ops-workflow/demo-governed-policy.sh

--- a/examples/swamp-automation/AI_START_HERE.md
+++ b/examples/swamp-automation/AI_START_HERE.md
@@ -24,6 +24,7 @@ authoring surface is prompt/context plus a workflow spec.
 | `go build -o ./cub-gen ./cmd/cub-gen` | local source | `./cub-gen` binary | local binary only |
 | `gitops import --json` | `workflow-deploy.yaml`, `.swamp.yaml`, `platform/registry.yaml`, `platform/swamp-constraints.yaml` | stdout JSON only | no |
 | `prompt-as-dry-local.sh` | workflow files + AI-only guardrails | `.tmp/app-ai-change-run/<repo>-<timestamp>/...` | no repo/backend/live mutation |
+| `demo-governed-structure.sh` | scratch clone + workflow files + Swamp constraints | `.tmp/swamp-governed-structure/<run>/...` | scratch clone only |
 | `demo-local.sh` | example repo | temporary lifecycle simulation artifacts | no live/backend mutation |
 | `run-connected-smoke.sh` | repo + ConfigHub auth/context | `.tmp/connected-smoke/<run>/...` | backend evidence only |
 | `prompt-as-dry-connected.sh` | workflow files + ConfigHub auth/context | temporary connected lifecycle artifacts unless `OUTPUT_DIR` is set | backend evidence only |
@@ -70,19 +71,22 @@ That path still avoids repo, backend, and live mutation; it writes only local
    `./cub-gen gitops import --space platform --json ./examples/swamp-automation`
 2. AI-safe local loop:
    `./examples/demo/prompt-as-dry-local.sh ./examples/swamp-automation`
-3. Local structural walkthrough:
+3. Local governed ALLOW/BLOCK proof:
+   `./examples/swamp-automation/demo-governed-structure.sh`
+4. Local structural walkthrough:
    `./examples/swamp-automation/demo-local.sh`
-4. Connected environment check:
+5. Connected environment check:
    `cub auth login && ./examples/demo/run-connected-smoke.sh`
-5. AI-safe connected loop:
+6. AI-safe connected loop:
    `cub auth login && ./examples/demo/prompt-as-dry-connected.sh ./examples/swamp-automation`
-6. Deep connected example walkthrough:
+7. Deep connected example walkthrough:
    `cub auth login && ./examples/swamp-automation/demo-connected.sh`
 
 ## What to verify after each major step
 
 - Repo-only provenance: the import JSON includes workflow provenance and inverse-edit hints.
 - AI-safe local loop: `.tmp/app-ai-change-run/.../mutation-card.json` exists and verification is true.
+- Local governed proof: `.tmp/swamp-governed-structure/.../allow-summary.json` reports `ALLOW` and `block-summary.json` reports `BLOCK`.
 - Local structural walkthrough: the create/update lifecycle completes with valid attestation outputs.
 - Connected smoke: ConfigHub auth/context is valid and the smoke summaries include a non-empty `change_id`.
 - AI-safe connected loop: the same prompt-as-DRY path reaches a connected decision state.

--- a/examples/swamp-automation/README.md
+++ b/examples/swamp-automation/README.md
@@ -12,6 +12,7 @@ slowing down the agent iteration loop.
 | Slice | Status | How to prove it now |
 |-------|--------|---------------------|
 | Source-side structural workflow governance | Real | `./examples/swamp-automation/demo-local.sh` |
+| Local governed ALLOW + BLOCK structural proof | Real | `./examples/swamp-automation/demo-governed-structure.sh` |
 | Deep connected bridge path | Real | `./examples/swamp-automation/demo-connected.sh` |
 | AI-first prompt-as-DRY story | Strongest current lane | `./examples/demo/prompt-as-dry-local.sh` then `./examples/demo/prompt-as-dry-connected.sh` |
 | Standalone live workflow runtime or task artifact | Not yet | current example proves structural governance more than runtime execution |
@@ -36,6 +37,9 @@ go build -o ./cub-gen ./cmd/cub-gen
 
 # Local source-side path
 ./examples/swamp-automation/demo-local.sh
+
+# Local governed ALLOW/BLOCK proof
+./examples/swamp-automation/demo-governed-structure.sh
 
 # AI-first prompt-as-DRY path
 ./examples/demo/prompt-as-dry-local.sh
@@ -372,6 +376,17 @@ After running discover/import, inspect:
 
 ## 7. Try one governed change
 
+Use the example-owned wrapper when you want this proven end to end:
+
+```bash
+./examples/swamp-automation/demo-governed-structure.sh
+```
+
+That writes paired summaries under `.tmp/swamp-governed-structure/<run>/` for:
+
+- one `ALLOW` path where an approved model-method is added
+- one `BLOCK` path where the required `validate` step disappears and an unapproved model-method is introduced
+
 **ALLOW path**: Agent adds step using approved model:
 
 ```yaml
@@ -407,6 +422,7 @@ From repo root:
 ```bash
 # Local/offline
 ./examples/swamp-automation/demo-local.sh
+./examples/swamp-automation/demo-governed-structure.sh
 
 # Connected (requires ConfigHub auth)
 cub auth login

--- a/examples/swamp-automation/contracts.md
+++ b/examples/swamp-automation/contracts.md
@@ -47,6 +47,29 @@ inspect_with:
   - jq '{change, edit_recommendation, verification}' .tmp/swamp-prompt-local/mutation-card.json
 ```
 
+## Local governed structure proof
+
+```yaml
+id: swamp_local_governed_structure
+command: ./examples/swamp-automation/demo-governed-structure.sh
+mutates:
+  repo: scratch_clone_only
+  backend: false
+  live: false
+expects:
+  stdout_contains:
+    - "[swamp-governed] success"
+  files_exist:
+    - ".tmp/swamp-governed-structure/<run>/allow-summary.json"
+    - ".tmp/swamp-governed-structure/<run>/block-summary.json"
+  evidence:
+    allow_path: "approved model-method addition stays ALLOW"
+    block_path: "missing validate step plus unapproved model-method becomes BLOCK"
+inspect_with:
+  - jq '{decision_state, inverse_hint, policy}' .tmp/swamp-governed-structure/<run>/allow-summary.json
+  - jq '{decision_state, policy}' .tmp/swamp-governed-structure/<run>/block-summary.json
+```
+
 ## Local structural walkthrough
 
 ```yaml

--- a/examples/swamp-automation/demo-governed-structure.sh
+++ b/examples/swamp-automation/demo-governed-structure.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/swamp-governed-structure}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="$OUT_ROOT/$RUN_ID"
+WORK_REPO="$OUT_DIR/repo"
+ALLOW_MODEL="${ALLOW_MODEL:-app-healthcheck}"
+ALLOW_METHOD="${ALLOW_METHOD:-verify}"
+ALLOW_STEP_NAME="${ALLOW_STEP_NAME:-healthcheck}"
+BLOCK_MODEL="${BLOCK_MODEL:-untrusted-model}"
+BLOCK_METHOD="${BLOCK_METHOD:-do_something}"
+BLOCK_STEP_NAME="${BLOCK_STEP_NAME:-risky-step}"
+REQUIRED_STEP="${REQUIRED_STEP:-validate}"
+
+mkdir -p "$OUT_DIR"
+rm -rf "$WORK_REPO"
+
+echo "[swamp-governed] cloning repo into $WORK_REPO"
+git clone --quiet "$ROOT_DIR" "$WORK_REPO"
+
+cd "$WORK_REPO"
+git config user.name "cub-gen demo"
+git config user.email "cub-gen-demo@example.invalid"
+
+echo "[swamp-governed] build cub-gen once for both workflow policy checks"
+go build -o ./cub-gen ./cmd/cub-gen
+
+BASE_SHA="$(git rev-parse HEAD)"
+WORKFLOW_PATH="./examples/swamp-automation/workflow-deploy.yaml"
+
+echo "[swamp-governed] proof 1/2: approved model-method addition stays inside policy"
+git checkout --quiet -b demo-allow "$BASE_SHA"
+perl -0pi -e 's/(      - name: apply\n)/      - name: '"$ALLOW_STEP_NAME"'\n        task:\n          type: model_method\n          modelIdOrName: '"$ALLOW_MODEL"'\n          methodName: '"$ALLOW_METHOD"'\n$1/' "$WORKFLOW_PATH"
+git add "$WORKFLOW_PATH"
+git commit --quiet -m "demo: add approved healthcheck step"
+
+./cub-gen gitops import --space platform --json ./examples/swamp-automation ./examples/swamp-automation > "$OUT_DIR/allow-import.json"
+
+allow_model_method="$ALLOW_MODEL.$ALLOW_METHOD"
+if ! jq -e \
+  --arg step "$ALLOW_STEP_NAME" \
+  --arg model_method "$allow_model_method" \
+  '.provenance[0].swamp_workflow_analysis
+  | (.missing_required_steps | length == 0)
+    and (.unapproved_models | length == 0)
+    and (.unapproved_model_methods | length == 0)
+    and (.step_names | index($step) != null)
+    and (.model_method_refs | index($model_method) != null)' \
+  "$OUT_DIR/allow-import.json" >/dev/null; then
+  echo "error: expected approved workflow addition to stay inside policy." >&2
+  exit 1
+fi
+
+jq '{
+  decision_state: "ALLOW",
+  inverse_hint: (.provenance[0].inverse_edit_pointers[] | select(.dry_path == "jobs[].steps[].task.modelIdOrName")),
+  policy: (.provenance[0].swamp_workflow_analysis | {
+    required_steps,
+    missing_required_steps,
+    approved_models,
+    approved_model_methods,
+    step_names,
+    model_method_refs,
+    unapproved_models,
+    unapproved_model_methods
+  })
+}' "$OUT_DIR/allow-import.json" > "$OUT_DIR/allow-summary.json"
+
+echo "[swamp-governed][allow] policy summary"
+cat "$OUT_DIR/allow-summary.json"
+
+echo "[swamp-governed] proof 2/2: unapproved model and missing required step are surfaced immediately"
+git checkout --quiet -B demo-block "$BASE_SHA"
+perl -0pi -e 's/- name: validate\n        task:\n          type: model_method\n          modelIdOrName: app-validator\n          methodName: check\n        retries: 2/- name: '"$BLOCK_STEP_NAME"'\n        task:\n          type: model_method\n          modelIdOrName: '"$BLOCK_MODEL"'\n          methodName: '"$BLOCK_METHOD"'\n        retries: 2/' "$WORKFLOW_PATH"
+git add "$WORKFLOW_PATH"
+git commit --quiet -m "demo: add unapproved workflow step and remove validate"
+
+./cub-gen gitops import --space platform --json ./examples/swamp-automation ./examples/swamp-automation > "$OUT_DIR/block-import.json"
+
+block_model_method="$BLOCK_MODEL.$BLOCK_METHOD"
+if ! jq -e \
+  --arg required_step "$REQUIRED_STEP" \
+  --arg model "$BLOCK_MODEL" \
+  --arg model_method "$block_model_method" \
+  '.provenance[0].swamp_workflow_analysis
+  | (.missing_required_steps | index($required_step) != null)
+    and (.unapproved_models | index($model) != null)
+    and (.unapproved_model_methods | index($model_method) != null)' \
+  "$OUT_DIR/block-import.json" >/dev/null; then
+  echo "error: expected blocked workflow mutation to surface missing required step and unapproved model metadata." >&2
+  exit 1
+fi
+
+jq '{
+  decision_state: "BLOCK",
+  policy: (.provenance[0].swamp_workflow_analysis | {
+    required_steps,
+    missing_required_steps,
+    forbidden_step_names,
+    forbidden_steps_present,
+    step_names,
+    model_method_refs,
+    unapproved_models,
+    unapproved_model_methods
+  })
+}' "$OUT_DIR/block-import.json" > "$OUT_DIR/block-summary.json"
+
+echo "[swamp-governed][block] policy summary"
+cat "$OUT_DIR/block-summary.json"
+
+cat <<EOF
+
+[swamp-governed] success
+  allowed path: approved model-method '$allow_model_method' is added while required step '$REQUIRED_STEP' stays present
+  blocked path: missing required step '$REQUIRED_STEP' and unapproved model-method '$block_model_method' are surfaced together
+  artifacts: $OUT_DIR
+EOF

--- a/examples/swamp-automation/prompts.md
+++ b/examples/swamp-automation/prompts.md
@@ -46,6 +46,25 @@ Run the AI-safe local prompt-as-DRY loop for ./examples/swamp-automation.
 Do not run connected steps in this prompt.
 ```
 
+## Local governed structure prompt
+
+```text
+Run the example-owned local governed proof for ./examples/swamp-automation.
+
+1. Use:
+   ./examples/swamp-automation/demo-governed-structure.sh
+2. Capture the artifact directory from the script output.
+3. Summarize:
+   - which approved model-method change stayed ALLOW
+   - which missing-step/unapproved-model change was BLOCKED
+   - the key files created under the artifact directory
+4. Show me the most important evidence from:
+   - allow-summary.json
+   - block-summary.json
+
+Do not run connected or live steps in this prompt.
+```
+
 ## Connected workflow prompt
 
 ```text


### PR DESCRIPTION
## Summary
- add an example-owned local ALLOW/BLOCK proof for `swamp-automation`
- make the workflow-track demo scripts run the real governed proof wrappers for Swamp and ops-workflow
- update the AI bundle, examples index, demo index, and release trackers so `#180` stops showing up as an active preview blocker

## Testing
- `go test ./...`
- `bash -n examples/swamp-automation/demo-governed-structure.sh examples/demo/ai-work-platform/scenario-2-swamp.sh examples/demo/ai-work-platform/scenario-4-operations.sh`
- `./examples/swamp-automation/demo-governed-structure.sh`
- `./examples/demo/ai-work-platform/scenario-2-swamp.sh`
- `./examples/demo/ai-work-platform/scenario-4-operations.sh`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`

Closes #180.