### PR TITLE
Add ApplicationSet family and remote-store model docs

### DIFF
--- a/AI-README-FIRST.md
+++ b/AI-README-FIRST.md
@@ -60,13 +60,13 @@ Together: `cub-gen` knows source → rendered, `cub-scout` knows cluster → own
 
 As of 2026-04-09:
 
-- 8 generator profiles supported (Helm, Score.dev, Spring Boot, Backstage, No-Config-Platform, Ops Workflow, C3 Agent, Swamp)
+- 9 generator profiles supported (ApplicationSet, Helm, Score.dev, Spring Boot, Backstage, No-Config-Platform, Ops Workflow, C3 Agent, Swamp)
 - Local field-origin tracing with confidence scores
 - Inverse-edit pointers for safe DRY edits
 - Provenance bundles with publish/verify/attest pipeline
 - Change CLI: preview, run, explain (local + connected modes)
 - Bridge workflow: ingest → decision → promote
-- ApplicationSet generator support upstream of cub-scout
+- First-class ApplicationSet generator support for standalone deterministic repos, with layered Helm/ApplicationSet provenance still covered separately
 - Live reconciler proofs against Flux and ArgoCD on kind
 
 ## Verification rule

--- a/README.md
+++ b/README.md
@@ -226,10 +226,10 @@ Both prove create, update, and drift-correction on a real cluster.
 
 | Status | What is true today |
 |---|---|
-| Latest shipped | `v0.2-preview.1` was released on 2026-03-06 |
+| Latest shipped | `v0.2-preview.2` was released on 2026-04-11 |
 | Strong now | Dual-mode example entrypoints exist across the main catalog; a smaller ConfigHub smoke lane covers the flagship examples; Flux and Argo live reconciler proofs run on real clusters |
 | In progress | Follow-on depth is now mostly Helm-specific: umbrella/subchart support, richer provenance honesty, render-diff depth, multi-stage chaining, and CLI override capture |
-| Current release target | `v0.2-preview.2` focuses on all featured examples working well, CLI/docs trust, and a credible connected release signal |
+| Current release target | Post-preview follow-on depth: Helm/ApplicationSet richness, remote-store modeling, packaging, and product polish |
 | Current plan | See [docs/releases/v0.2-preview.2-plan.md](docs/releases/v0.2-preview.2-plan.md) |
 | Current ship checklist | See [docs/releases/v0.2-preview.2-ship-checklist.md](docs/releases/v0.2-preview.2-ship-checklist.md) |
 | Example quality | Flagship example blockers are resolved on this branch; deeper Helm follow-on depth is `#238`-`#242` |

--- a/cmd/cub-gen-style-sync/main.go
+++ b/cmd/cub-gen-style-sync/main.go
@@ -198,6 +198,9 @@ func renderYAML(entry styleModel) string {
 			if len(rule.ExactBasenames) > 0 {
 				w.stringSlice(3, "exact_basenames", rule.ExactBasenames)
 			}
+			if len(rule.PathPrefixes) > 0 {
+				w.stringSlice(3, "path_prefixes", rule.PathPrefixes)
+			}
 			if len(rule.Prefixes) > 0 {
 				w.stringSlice(3, "prefixes", rule.Prefixes)
 			}
@@ -326,12 +329,13 @@ func renderMarkdown(entry styleModel) string {
 	fmt.Fprintf(&b, "- Default input role: `%s`\n", entry.Contract.DefaultInputRole)
 	fmt.Fprintf(&b, "- Default owner: `%s`\n\n", entry.Contract.DefaultOwner)
 	b.WriteString("### Input role rules\n\n")
-	b.WriteString("| Role | Exact basenames | Prefixes | Extensions |\n")
-	b.WriteString("| --- | --- | --- | --- |\n")
+	b.WriteString("| Role | Exact basenames | Path prefixes | Prefixes | Extensions |\n")
+	b.WriteString("| --- | --- | --- | --- | --- |\n")
 	for _, rule := range entry.Contract.InputRoleRules {
-		fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n",
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s | %s |\n",
 			rule.Role,
 			mdCell(strings.Join(rule.ExactBasenames, ", ")),
+			mdCell(strings.Join(rule.PathPrefixes, ", ")),
 			mdCell(strings.Join(rule.Prefixes, ", ")),
 			mdCell(strings.Join(rule.Extensions, ", ")),
 		)

--- a/cmd/cub-gen/gitops_parity_test.go
+++ b/cmd/cub-gen/gitops_parity_test.go
@@ -193,6 +193,30 @@ func TestGitOpsParityGoldenDiscoverSwamp(t *testing.T) {
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gitops-discover-swamp.golden.json"), got)
 }
 
+func TestGitOpsParityGoldenDiscoverApplicationSet(t *testing.T) {
+	repoPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "applicationset-standalone"))
+	if err != nil {
+		t.Fatalf("resolve applicationset path: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{"gitops", "discover", "--space", "platform", "--json", repoPath})
+	if err != nil {
+		t.Fatalf("run applicationset discover returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %s", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal applicationset discover json: %v\noutput=%s", err, out)
+	}
+	normalizeDiscover(got)
+	got["target_path_expected_suffix"] = filepath.ToSlash(filepath.Join("testdata", "applicationset-standalone"))
+
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gitops-discover-applicationset.golden.json"), got)
+}
+
 func TestGitOpsParityGoldenImport(t *testing.T) {
 	setupAliases(t)
 
@@ -377,6 +401,31 @@ func TestGitOpsParityGoldenImportSwamp(t *testing.T) {
 	normalizeImport(got)
 
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gitops-import-swamp.golden.json"), got)
+}
+
+func TestGitOpsParityGoldenImportApplicationSet(t *testing.T) {
+	repoPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "applicationset-standalone"))
+	if err != nil {
+		t.Fatalf("resolve applicationset path: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{"gitops", "import", "--space", "platform", "--json", repoPath})
+	if err != nil {
+		t.Fatalf("run applicationset import returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %s", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal applicationset import json: %v\noutput=%s", err, out)
+	}
+	normalizeImport(got)
+	got["target_path_expected_suffix"] = filepath.ToSlash(filepath.Join("testdata", "applicationset-standalone"))
+	got["render_target_path_expected_suffix"] = filepath.ToSlash(filepath.Join("testdata", "applicationset-standalone"))
+
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gitops-import-applicationset.golden.json"), got)
 }
 
 func TestGitOpsParityGoldenCleanup(t *testing.T) {

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -106,6 +106,7 @@ type inversePointerTemplateRecord struct {
 type inputRoleRuleRecord struct {
 	Role           string   `json:"role"`
 	ExactBasenames []string `json:"exact_basenames,omitempty"`
+	PathPrefixes   []string `json:"path_prefixes,omitempty"`
 	Prefixes       []string `json:"prefixes,omitempty"`
 	Extensions     []string `json:"extensions,omitempty"`
 }
@@ -234,12 +235,13 @@ func writeGeneratorsMarkdown(out io.Writer, records []generatorFamilyRecord, det
 		if len(policies.InputRoleRules) > 0 {
 			fmt.Fprintln(out)
 			fmt.Fprintln(out, "### Input Role Rules")
-			fmt.Fprintln(out, "| Role | Exact basenames | Prefixes | Extensions |")
-			fmt.Fprintln(out, "| --- | --- | --- | --- |")
+			fmt.Fprintln(out, "| Role | Exact basenames | Path prefixes | Prefixes | Extensions |")
+			fmt.Fprintln(out, "| --- | --- | --- | --- | --- |")
 			for _, rule := range policies.InputRoleRules {
-				fmt.Fprintf(out, "| `%s` | %s | %s | %s |\n",
+				fmt.Fprintf(out, "| `%s` | %s | %s | %s | %s |\n",
 					markdownCell(rule.Role),
 					markdownCell(strings.Join(rule.ExactBasenames, ", ")),
+					markdownCell(strings.Join(rule.PathPrefixes, ", ")),
 					markdownCell(strings.Join(rule.Prefixes, ", ")),
 					markdownCell(strings.Join(rule.Extensions, ", ")),
 				)
@@ -488,6 +490,7 @@ func generatorPolicyRecord(spec registry.FamilySpec) *generatorFamilyPolicyRecor
 		policies.InputRoleRules = append(policies.InputRoleRules, inputRoleRuleRecord{
 			Role:           rule.Role,
 			ExactBasenames: append([]string(nil), rule.ExactBasenames...),
+			PathPrefixes:   append([]string(nil), rule.PathPrefixes...),
 			Prefixes:       append([]string(nil), rule.Prefixes...),
 			Extensions:     append([]string(nil), rule.Extensions...),
 		})

--- a/cmd/cub-gen/testdata/parity/generators-details.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators-details.golden.json
@@ -1,6 +1,103 @@
 {
-  "count": 8,
+  "count": 9,
   "families": [
+    {
+      "capabilities": [
+        "observed-expansion",
+        "authoritative-list-expansion",
+        "authoritative-clusters-expansion",
+        "graceful-degradation"
+      ],
+      "kind": "applicationset",
+      "policies": {
+        "default_input_role": "applicationset-input",
+        "default_owner": "platform-engineer",
+        "field_origin_confidences": {
+          "child_name": 0.89,
+          "source_path": 0.86
+        },
+        "field_origin_transform": "applicationset-template",
+        "hint_defaults": {
+          "application_set_path": "applicationset.yaml"
+        },
+        "input_role_rules": [
+          {
+            "exact_basenames": [
+              "applicationset.yaml",
+              "applicationset.yml"
+            ],
+            "role": "application-set"
+          },
+          {
+            "extensions": [
+              ".yaml",
+              ".yml",
+              ".json"
+            ],
+            "path_prefixes": [
+              "clusters/",
+              "inventory/clusters/",
+              "platform/clusters/"
+            ],
+            "role": "cluster-inventory"
+          }
+        ],
+        "inverse_edit_hints": {
+          "child_name": "Edit spec.template.metadata.name in {{application_set_path}}.",
+          "source_path": "Edit spec.template.spec.source.path in {{application_set_path}}."
+        },
+        "inverse_patch_reasons": {
+          "child_name": "Child Application identity is generated from the parent ApplicationSet template.",
+          "source_path": "Child Application source path is generated from the parent ApplicationSet template."
+        },
+        "inverse_patch_templates": {
+          "child_name": {
+            "confidence": 0.89,
+            "editable_by": "platform-engineer",
+            "requires_review": false
+          },
+          "source_path": {
+            "confidence": 0.86,
+            "editable_by": "platform-engineer",
+            "requires_review": true
+          }
+        },
+        "inverse_pointer_templates": {
+          "child_name": {
+            "confidence": 0.89,
+            "owner": "platform-engineer"
+          },
+          "source_path": {
+            "confidence": 0.86,
+            "owner": "platform-engineer"
+          }
+        },
+        "rendered_lineage_templates": [
+          {
+            "kind": "ApplicationSet",
+            "name_template": "{{name}}",
+            "namespace": "argocd",
+            "source_dry_path_template": "spec",
+            "source_path_hint": "application_set_path"
+          }
+        ],
+        "role_owners": {
+          "application-set": "platform-engineer",
+          "cluster-inventory": "platform-engineer"
+        },
+        "wet_targets": [
+          {
+            "kind": "ApplicationSet",
+            "name_template": "{{name}}",
+            "namespace": "argocd",
+            "owner": "platform-runtime"
+          }
+        ]
+      },
+      "profile": "applicationset",
+      "resource_kind": "ApplicationSet",
+      "resource_type": "argoproj.io/v1alpha1/ApplicationSet"
+    },
     {
       "capabilities": [
         "catalog-metadata",
@@ -440,6 +537,9 @@
               ".yml",
               ".json"
             ],
+            "path_prefixes": [
+              "platform/clusters/"
+            ],
             "role": "cluster-inventory"
           },
           {
@@ -448,6 +548,9 @@
               ".yml",
               ".json"
             ],
+            "path_prefixes": [
+              "platform/catalogs/managed-service-catalog/"
+            ],
             "role": "managed-service-catalog"
           },
           {
@@ -455,6 +558,9 @@
               ".yaml",
               ".yml",
               ".json"
+            ],
+            "path_prefixes": [
+              "platform/catalogs/customer-service-catalog/"
             ],
             "role": "customer-service-catalog"
           },

--- a/cmd/cub-gen/testdata/parity/generators-details.markdown.golden.md
+++ b/cmd/cub-gen/testdata/parity/generators-details.markdown.golden.md
@@ -1,9 +1,10 @@
 # Generator Families
 
-Total: 8
+Total: 9
 
 | Kind | Profile | Resource Kind | Resource Type | Capabilities |
 | --- | --- | --- | --- | --- |
+| `applicationset` | `applicationset` | `ApplicationSet` | `argoproj.io/v1alpha1/ApplicationSet` | observed-expansion, authoritative-list-expansion, authoritative-clusters-expansion, graceful-degradation |
 | `backstage` | `backstage-idp` | `Component` | `backstage.io/v1alpha1/Component` | catalog-metadata, render-manifests, inverse-catalog-patch |
 | `c3agent` | `c3agent` | `ConfigMap` | `v1/ConfigMap` | fleet-config, agent-orchestration, inverse-fleet-config-patch |
 | `helm` | `helm-paas` | `HelmRelease` | `helm.toolkit.fluxcd.io/v2/HelmRelease` | render-manifests, values-overrides, inverse-values-patch |
@@ -12,6 +13,72 @@ Total: 8
 | `score` | `scoredev-paas` | `Application` | `argoproj.io/v1alpha1/Application` | render-manifests, workload-spec, inverse-score-patch |
 | `springboot` | `springboot-paas` | `Kustomization` | `kustomize.toolkit.fluxcd.io/v1/Kustomization` | render-app-config, profile-overrides, inverse-app-config-patch |
 | `swamp` | `swamp` | `Workflow` | `swamp.dev/v1/Workflow` | workflow-automation, model-orchestration, inverse-workflow-patch |
+
+## `applicationset`
+
+- Profile: `applicationset`
+- Resource: `ApplicationSet` (`argoproj.io/v1alpha1/ApplicationSet`)
+- Capabilities: observed-expansion, authoritative-list-expansion, authoritative-clusters-expansion, graceful-degradation
+- Default input role: `applicationset-input`
+- Default owner: `platform-engineer`
+- Field-origin transform: `applicationset-template`
+
+### Input Role Rules
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `application-set` | applicationset.yaml, applicationset.yml | - | - | - |
+| `cluster-inventory` | - | clusters/, inventory/clusters/, platform/clusters/ | - | .yaml, .yml, .json |
+
+### Role Owners
+| Role | Owner |
+| --- | --- |
+| `application-set` | `platform-engineer` |
+| `cluster-inventory` | `platform-engineer` |
+
+### Inverse Patch Templates
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `child_name` | `platform-engineer` | 0.89 | `false` |
+| `source_path` | `platform-engineer` | 0.86 | `true` |
+
+### Inverse Pointer Templates
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `child_name` | `platform-engineer` | 0.89 |
+| `source_path` | `platform-engineer` | 0.86 |
+
+### Field Origin Confidences
+| Key | Confidence |
+| --- | --- |
+| `child_name` | 0.89 |
+| `source_path` | 0.86 |
+
+### Hint Defaults
+| Key | Value |
+| --- | --- |
+| `application_set_path` | `applicationset.yaml` |
+
+### Inverse Patch Reasons
+| Key | Reason |
+| --- | --- |
+| `child_name` | Child Application identity is generated from the parent ApplicationSet template. |
+| `source_path` | Child Application source path is generated from the parent ApplicationSet template. |
+
+### Inverse Edit Hints
+| Key | Hint |
+| --- | --- |
+| `child_name` | Edit spec.template.metadata.name in {{application_set_path}}. |
+| `source_path` | Edit spec.template.spec.source.path in {{application_set_path}}. |
+
+### WET Targets
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `ApplicationSet` | `{{name}}` | `platform-runtime` | `argocd` | `-` |
+
+### Rendered Lineage Templates
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ApplicationSet` | `{{name}}` | `argocd` | `application_set_path` | `-` | `false` | `spec` | `false` |
 
 ## `backstage`
 
@@ -23,10 +90,10 @@ Total: 8
 - Field-origin transform: `backstage-component-to-application`
 
 ### Input Role Rules
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `catalog-spec` | catalog-info.yaml, catalog-info.yml | - | - |
-| `app-config` | app-config.yaml, app-config.yml | - | - |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `catalog-spec` | catalog-info.yaml, catalog-info.yml | - | - | - |
+| `app-config` | app-config.yaml, app-config.yml | - | - | - |
 
 ### Role Owners
 | Role | Owner |
@@ -91,10 +158,10 @@ Total: 8
 - Field-origin overlay transform: `c3agent-overlay-merge`
 
 ### Input Role Rules
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `fleet-config-base` | c3agent.yaml, c3agent.yml, c3agent.json | - | - |
-| `fleet-config-overlay` | - | c3agent- | .yaml, .yml, .json |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `fleet-config-base` | c3agent.yaml, c3agent.yml, c3agent.json | - | - | - |
+| `fleet-config-overlay` | - | - | c3agent- | .yaml, .yml, .json |
 
 ### Inverse Patch Templates
 | Key | Editable by | Confidence | Requires review |
@@ -201,14 +268,14 @@ Total: 8
 - Field-origin overlay transform: `helm-values-overlay`
 
 ### Input Role Rules
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `chart` | chart.yaml | - | - |
-| `application-set` | applicationset.yaml, applicationset.yml | - | - |
-| `cluster-inventory` | - | - | .yaml, .yml, .json |
-| `managed-service-catalog` | - | - | .yaml, .yml, .json |
-| `customer-service-catalog` | - | - | .yaml, .yml, .json |
-| `values` | - | values | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `chart` | chart.yaml | - | - | - |
+| `application-set` | applicationset.yaml, applicationset.yml | - | - | - |
+| `cluster-inventory` | - | platform/clusters/ | - | .yaml, .yml, .json |
+| `managed-service-catalog` | - | platform/catalogs/managed-service-catalog/ | - | .yaml, .yml, .json |
+| `customer-service-catalog` | - | platform/catalogs/customer-service-catalog/ | - | .yaml, .yml, .json |
+| `values` | - | - | values | .yaml, .yml |
 
 ### Role Owners
 | Role | Owner |
@@ -276,10 +343,10 @@ Total: 8
 - Field-origin overlay transform: `no-config-platform-overlay-merge`
 
 ### Input Role Rules
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `provider-config-base` | no-config-platform.yaml, no-config-platform.yml, no-config-platform.json | - | - |
-| `provider-config-overlay` | - | no-config-platform- | .yaml, .yml, .json |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `provider-config-base` | no-config-platform.yaml, no-config-platform.yml, no-config-platform.json | - | - | - |
+| `provider-config-overlay` | - | - | no-config-platform- | .yaml, .yml, .json |
 
 ### Inverse Patch Templates
 | Key | Editable by | Confidence | Requires review |
@@ -342,10 +409,10 @@ Total: 8
 - Field-origin overlay transform: `ops-workflow-overlay-merge`
 
 ### Input Role Rules
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `operations-base` | operations.yaml, operations.yml, workflow.yaml, workflow.yml | - | - |
-| `operations-overlay` | - | operations-, workflow- | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `operations-base` | operations.yaml, operations.yml, workflow.yaml, workflow.yml | - | - | - |
+| `operations-overlay` | - | - | operations-, workflow- | .yaml, .yml |
 
 ### Inverse Patch Templates
 | Key | Editable by | Confidence | Requires review |
@@ -407,9 +474,9 @@ Total: 8
 - Field-origin transform: `score-to-k8s`
 
 ### Input Role Rules
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `score-spec` | score.yaml, score.yml | - | - |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `score-spec` | score.yaml, score.yml | - | - | - |
 
 ### Inverse Patch Templates
 | Key | Editable by | Confidence | Requires review |
@@ -475,11 +542,11 @@ Total: 8
 - Field-origin overlay transform: `spring-profile-overlay`
 
 ### Input Role Rules
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `build-config` | pom.xml, build.gradle, build.gradle.kts | - | - |
-| `app-config-base` | application.yaml, application.yml | - | - |
-| `app-config-profile` | - | application- | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `build-config` | pom.xml, build.gradle, build.gradle.kts | - | - | - |
+| `app-config-base` | application.yaml, application.yml | - | - | - |
+| `app-config-profile` | - | - | application- | .yaml, .yml |
 
 ### Role Owners
 | Role | Owner |
@@ -556,10 +623,10 @@ Total: 8
 - Field-origin overlay transform: `swamp-overlay-merge`
 
 ### Input Role Rules
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `swamp-config-base` | .swamp.yaml, .swamp.yml | - | - |
-| `swamp-workflow` | - | workflow- | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `swamp-config-base` | .swamp.yaml, .swamp.yml | - | - | - |
+| `swamp-workflow` | - | - | workflow- | .yaml, .yml |
 
 ### Inverse Patch Templates
 | Key | Editable by | Confidence | Requires review |

--- a/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators-help.stderr.golden.txt
@@ -4,6 +4,6 @@ Usage:
   use --strict-filters to fail on unknown filter values
   use --details with --json or --markdown to include policy/provenance templates
 
-Supported kinds: backstage, c3agent, helm, no-config-platform, opsworkflow, score, springboot, swamp
-Supported profiles: backstage-idp, c3agent, helm-paas, no-config-platform, ops-workflow, scoredev-paas, springboot-paas, swamp
-Supported capabilities: agent-orchestration, app-config-only, catalog-metadata, fleet-config, governed-execution-intent, inverse-app-config-patch, inverse-catalog-patch, inverse-fleet-config-patch, inverse-provider-config-patch, inverse-score-patch, inverse-values-patch, inverse-workflow-patch, model-orchestration, profile-overrides, provider-config, render-app-config, render-manifests, values-overrides, workflow-automation, workflow-plan, workload-spec
+Supported kinds: applicationset, backstage, c3agent, helm, no-config-platform, opsworkflow, score, springboot, swamp
+Supported profiles: applicationset, backstage-idp, c3agent, helm-paas, no-config-platform, ops-workflow, scoredev-paas, springboot-paas, swamp
+Supported capabilities: agent-orchestration, app-config-only, authoritative-clusters-expansion, authoritative-list-expansion, catalog-metadata, fleet-config, governed-execution-intent, graceful-degradation, inverse-app-config-patch, inverse-catalog-patch, inverse-fleet-config-patch, inverse-provider-config-patch, inverse-score-patch, inverse-values-patch, inverse-workflow-patch, model-orchestration, observed-expansion, profile-overrides, provider-config, render-app-config, render-manifests, values-overrides, workflow-automation, workflow-plan, workload-spec

--- a/cmd/cub-gen/testdata/parity/generators.golden.json
+++ b/cmd/cub-gen/testdata/parity/generators.golden.json
@@ -1,6 +1,18 @@
 {
-  "count": 8,
+  "count": 9,
   "families": [
+    {
+      "capabilities": [
+        "observed-expansion",
+        "authoritative-list-expansion",
+        "authoritative-clusters-expansion",
+        "graceful-degradation"
+      ],
+      "kind": "applicationset",
+      "profile": "applicationset",
+      "resource_kind": "ApplicationSet",
+      "resource_type": "argoproj.io/v1alpha1/ApplicationSet"
+    },
     {
       "capabilities": [
         "catalog-metadata",

--- a/cmd/cub-gen/testdata/parity/generators.markdown.golden.md
+++ b/cmd/cub-gen/testdata/parity/generators.markdown.golden.md
@@ -1,9 +1,10 @@
 # Generator Families
 
-Total: 8
+Total: 9
 
 | Kind | Profile | Resource Kind | Resource Type | Capabilities |
 | --- | --- | --- | --- | --- |
+| `applicationset` | `applicationset` | `ApplicationSet` | `argoproj.io/v1alpha1/ApplicationSet` | observed-expansion, authoritative-list-expansion, authoritative-clusters-expansion, graceful-degradation |
 | `backstage` | `backstage-idp` | `Component` | `backstage.io/v1alpha1/Component` | catalog-metadata, render-manifests, inverse-catalog-patch |
 | `c3agent` | `c3agent` | `ConfigMap` | `v1/ConfigMap` | fleet-config, agent-orchestration, inverse-fleet-config-patch |
 | `helm` | `helm-paas` | `HelmRelease` | `helm.toolkit.fluxcd.io/v2/HelmRelease` | render-manifests, values-overrides, inverse-values-patch |

--- a/cmd/cub-gen/testdata/parity/generators.table.golden.txt
+++ b/cmd/cub-gen/testdata/parity/generators.table.golden.txt
@@ -1,4 +1,5 @@
 Kind	Profile	Resource Kind	Resource Type	Capabilities
+applicationset	applicationset	ApplicationSet	argoproj.io/v1alpha1/ApplicationSet	observed-expansion,authoritative-list-expansion,authoritative-clusters-expansion,graceful-degradation
 backstage	backstage-idp	Component	backstage.io/v1alpha1/Component	catalog-metadata,render-manifests,inverse-catalog-patch
 c3agent	c3agent	ConfigMap	v1/ConfigMap	fleet-config,agent-orchestration,inverse-fleet-config-patch
 helm	helm-paas	HelmRelease	helm.toolkit.fluxcd.io/v2/HelmRelease	render-manifests,values-overrides,inverse-values-patch

--- a/cmd/cub-gen/testdata/parity/gitops-discover-applicationset.golden.json
+++ b/cmd/cub-gen/testdata/parity/gitops-discover-applicationset.golden.json
@@ -1,0 +1,42 @@
+{
+  "detections": [
+    {
+      "confidence": 0.95,
+      "id": "gen_e1966fdc610ceae8",
+      "inputs": [
+        "applicationset.yaml",
+        "clusters/prod-eu.yaml",
+        "clusters/stage-eu.yaml"
+      ],
+      "kind": "applicationset",
+      "name": "platform-apps",
+      "profile": "applicationset",
+      "root": ""
+    }
+  ],
+  "discover_file": "\u003cdiscover_file\u003e",
+  "discover_unit_slug": "\u003cdiscover_unit_slug\u003e",
+  "discovered_at": "\u003ctimestamp\u003e",
+  "ref": "HEAD",
+  "resources": [
+    {
+      "generator_id": "gen_e1966fdc610ceae8",
+      "generator_kind": "applicationset",
+      "generator_profile": "applicationset",
+      "inputs": [
+        "applicationset.yaml",
+        "clusters/prod-eu.yaml",
+        "clusters/stage-eu.yaml"
+      ],
+      "resource_body": "kind: ApplicationSet\nmetadata:\n  name: platform-apps\nspec:\n  root: \n",
+      "resource_kind": "ApplicationSet",
+      "resource_name": "platform-apps",
+      "resource_type": "argoproj.io/v1alpha1/ApplicationSet",
+      "root": ""
+    }
+  ],
+  "space": "platform",
+  "target_path": "\u003ctarget_path\u003e",
+  "target_path_expected_suffix": "testdata/applicationset-standalone",
+  "target_slug": "applicationset-standalone"
+}

--- a/cmd/cub-gen/testdata/parity/gitops-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/gitops-help.stdout.golden.txt
@@ -9,8 +9,8 @@ Usage:
   cub-gen gitops cleanup [--space SPACE] [--json] <target-path>
 
 Supported where-resource clauses:
-  kind = 'Application' | kind = 'Component' | kind = 'ConfigMap' | kind = 'HelmRelease' | kind = 'Kustomization' | kind = 'Workflow'
-  kind IN ('Application','Component','ConfigMap','HelmRelease','Kustomization','Workflow')
+  kind = 'Application' | kind = 'ApplicationSet' | kind = 'Component' | kind = 'ConfigMap' | kind = 'HelmRelease' | kind = 'Kustomization' | kind = 'Workflow'
+  kind IN ('Application','ApplicationSet','Component','ConfigMap','HelmRelease','Kustomization','Workflow')
   name = 'checkout-api' | resource_name LIKE '<contains-api>' | root LIKE '<contains-prod>'
   combine clauses with AND
 

--- a/cmd/cub-gen/testdata/parity/gitops-import-applicationset.golden.json
+++ b/cmd/cub-gen/testdata/parity/gitops-import-applicationset.golden.json
@@ -1,0 +1,288 @@
+{
+  "contracts": [
+    {
+      "capabilities": [
+        "observed-expansion",
+        "authoritative-list-expansion",
+        "authoritative-clusters-expansion",
+        "graceful-degradation"
+      ],
+      "deterministic": true,
+      "generator_id": "gen_e1966fdc610ceae8",
+      "inputs": [
+        {
+          "name": "input_01",
+          "required": true,
+          "schema_ref": "https://schema.confighub.dev/generators/applicationset-v1"
+        },
+        {
+          "name": "input_02",
+          "required": true,
+          "schema_ref": "https://schema.confighub.dev/generators/cluster-inventory-v1"
+        },
+        {
+          "name": "input_03",
+          "required": true,
+          "schema_ref": "https://schema.confighub.dev/generators/cluster-inventory-v1"
+        }
+      ],
+      "kind": "applicationset",
+      "name": "platform-apps",
+      "output_format": "kubernetes/yaml",
+      "profile": "applicationset",
+      "schema_version": "cub.confighub.io/generator-contract/v1",
+      "source_path": "",
+      "source_ref": "HEAD",
+      "source_repo": "\u003ctarget_path\u003e",
+      "transport": "oci+git",
+      "version": "0.1.0"
+    }
+  ],
+  "discover_unit_slug": "\u003cdiscover_unit_slug\u003e",
+  "discovered": [
+    {
+      "generator_id": "gen_e1966fdc610ceae8",
+      "generator_kind": "applicationset",
+      "generator_profile": "applicationset",
+      "inputs": [
+        "applicationset.yaml",
+        "clusters/prod-eu.yaml",
+        "clusters/stage-eu.yaml"
+      ],
+      "resource_body": "kind: ApplicationSet\nmetadata:\n  name: platform-apps\nspec:\n  root: \n",
+      "resource_kind": "ApplicationSet",
+      "resource_name": "platform-apps",
+      "resource_type": "argoproj.io/v1alpha1/ApplicationSet",
+      "root": ""
+    }
+  ],
+  "dry_inputs": [
+    {
+      "generator_id": "gen_e1966fdc610ceae8",
+      "owner": "platform-engineer",
+      "path": "applicationset.yaml",
+      "profile": "applicationset",
+      "required": true,
+      "role": "application-set"
+    },
+    {
+      "generator_id": "gen_e1966fdc610ceae8",
+      "owner": "platform-engineer",
+      "path": "clusters/prod-eu.yaml",
+      "profile": "applicationset",
+      "required": true,
+      "role": "cluster-inventory"
+    },
+    {
+      "generator_id": "gen_e1966fdc610ceae8",
+      "owner": "platform-engineer",
+      "path": "clusters/stage-eu.yaml",
+      "profile": "applicationset",
+      "required": true,
+      "role": "cluster-inventory"
+    }
+  ],
+  "dry_units": [
+    {
+      "id": "dry_d63e402db3c718e6",
+      "kind": "dry-unit",
+      "layer": "dry",
+      "name": "platform-apps-dry"
+    }
+  ],
+  "generator_units": [
+    {
+      "id": "gen_7769bb923c4c0945",
+      "kind": "generator-unit",
+      "layer": "generator",
+      "name": "platform-apps-generator"
+    }
+  ],
+  "imported_at": "\u003ctimestamp\u003e",
+  "inverse_transform_plans": [
+    {
+      "change_id": "\u003cchange_id\u003e",
+      "created_at": "\u003ctimestamp\u003e",
+      "patches": [
+        {
+          "confidence": 0.89,
+          "dry_path": "spec.template.metadata.name",
+          "editable_by": "platform-engineer",
+          "op": "replace",
+          "reason": "Child Application identity is generated from the parent ApplicationSet template.",
+          "requires_review": false,
+          "wet_path": "Application/metadata/name"
+        },
+        {
+          "confidence": 0.86,
+          "dry_path": "spec.template.spec.source.path",
+          "editable_by": "platform-engineer",
+          "op": "replace",
+          "reason": "Child Application source path is generated from the parent ApplicationSet template.",
+          "requires_review": true,
+          "wet_path": "Application/spec/source/path"
+        }
+      ],
+      "plan_id": "\u003cplan_id\u003e",
+      "schema_version": "cub.confighub.io/inverse-transform-plan/v1",
+      "source_kind": "applicationset",
+      "source_ref": "",
+      "status": "draft",
+      "target_unit_id": "dry_d63e402db3c718e6"
+    }
+  ],
+  "links": [
+    {
+      "dry_unit_id": "dry_d63e402db3c718e6",
+      "generator_unit_id": "gen_7769bb923c4c0945",
+      "wet_unit_id": "wet_be67b94a60379410"
+    }
+  ],
+  "provenance": [
+    {
+      "application_set_analysis": {
+        "application_set_path": "applicationset.yaml",
+        "cluster_inventory_paths": [
+          "clusters/prod-eu.yaml",
+          "clusters/stage-eu.yaml"
+        ],
+        "generated_applications": [
+          {
+            "cluster": "prod-eu",
+            "generator_type": "clusters",
+            "inventory_path": "clusters/prod-eu.yaml",
+            "name": "prod-eu-inventory",
+            "reason": "generated from cluster inventory prod-eu matching selector env=prod, region=eu",
+            "source_path": "applicationset.yaml"
+          }
+        ],
+        "generator_types": [
+          "clusters"
+        ],
+        "matched_clusters": [
+          "prod-eu"
+        ],
+        "mode": "authoritative",
+        "mode_reason": "Authoritative expansion produced 1 child Application(s) from explicit repo inputs."
+      },
+      "change_id": "\u003cchange_id\u003e",
+      "field_origin_map": [
+        {
+          "confidence": 0.89,
+          "dry_path": "spec.template.metadata.name",
+          "source_path": "applicationset.yaml",
+          "transform": "applicationset-template",
+          "wet_path": "Application/metadata/name"
+        },
+        {
+          "confidence": 0.86,
+          "dry_path": "spec.template.spec.source.path",
+          "source_path": "applicationset.yaml",
+          "transform": "applicationset-template",
+          "wet_path": "Application/spec/source/path"
+        }
+      ],
+      "generator_id": "gen_e1966fdc610ceae8",
+      "generator_name": "platform-apps",
+      "generator_profile": "applicationset",
+      "input_digest": "sha256:bac410d03ded81864397dd58a5fccff71ac501e7bc516e3b747d84fec7c5d354",
+      "inverse_edit_pointers": [
+        {
+          "confidence": 0.89,
+          "dry_path": "spec.template.metadata.name",
+          "edit_hint": "Edit spec.template.metadata.name in applicationset.yaml.",
+          "owner": "platform-engineer",
+          "wet_path": "Application/metadata/name"
+        },
+        {
+          "confidence": 0.86,
+          "dry_path": "spec.template.spec.source.path",
+          "edit_hint": "Edit spec.template.spec.source.path in applicationset.yaml.",
+          "owner": "platform-engineer",
+          "wet_path": "Application/spec/source/path"
+        }
+      ],
+      "outputs": [
+        {
+          "digest": "\u003cdigest\u003e",
+          "role": "rendered-manifests",
+          "uri": "oci://example.local/platform/platform-apps:latest"
+        }
+      ],
+      "provenance_id": "\u003cprovenance_id\u003e",
+      "rendered_at": "\u003ctimestamp\u003e",
+      "rendered_object_lineage": [
+        {
+          "kind": "ApplicationSet",
+          "name": "platform-apps",
+          "namespace": "argocd",
+          "source_dry_path": "spec",
+          "source_path": "applicationset.yaml"
+        },
+        {
+          "kind": "Application",
+          "name": "prod-eu-inventory",
+          "namespace": "argocd",
+          "source_dry_path": "spec.template.metadata.name",
+          "source_path": "applicationset.yaml"
+        }
+      ],
+      "schema_version": "cub.confighub.io/provenance/v1",
+      "sources": [
+        {
+          "path": "applicationset.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "clusters/prod-eu.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        },
+        {
+          "path": "clusters/stage-eu.yaml",
+          "revision": "HEAD",
+          "role": "generator-input",
+          "uri": "\u003csource_uri\u003e"
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "ref": "HEAD",
+  "render_target_path": "\u003crender_target_path\u003e",
+  "render_target_path_expected_suffix": "testdata/applicationset-standalone",
+  "render_target_slug": "applicationset-standalone",
+  "space": "platform",
+  "target_path": "\u003ctarget_path\u003e",
+  "target_path_expected_suffix": "testdata/applicationset-standalone",
+  "target_slug": "applicationset-standalone",
+  "wet_manifest_targets": [
+    {
+      "generator_id": "gen_e1966fdc610ceae8",
+      "kind": "ApplicationSet",
+      "name": "platform-apps",
+      "namespace": "argocd",
+      "owner": "platform-runtime",
+      "source_dry_path": "spec"
+    },
+    {
+      "generator_id": "gen_e1966fdc610ceae8",
+      "kind": "Application",
+      "name": "prod-eu-inventory",
+      "namespace": "argocd",
+      "owner": "platform-runtime",
+      "source_dry_path": "spec.template.metadata.name"
+    }
+  ],
+  "wet_units": [
+    {
+      "id": "wet_be67b94a60379410",
+      "kind": "wet-unit",
+      "layer": "wet",
+      "name": "platform-apps-wet"
+    }
+  ]
+}

--- a/docs/contracts/applicationset-generator-boundary.md
+++ b/docs/contracts/applicationset-generator-boundary.md
@@ -1,0 +1,101 @@
+# ApplicationSet Generator Boundary
+
+`cub-gen` now models Argo `ApplicationSet` as a first-class generator family
+when the repo itself is ApplicationSet-centric and the child expansion can be
+explained from explicit inputs.
+
+This is intentionally narrower than the broader layered Helm/ApplicationSet work
+from `#187`.
+
+## What is in scope
+
+First milestone support is:
+
+1. **Authoritative list expansion**
+   If the `ApplicationSet` uses a `list` generator, `cub-gen` expands child
+   `Application` names from the explicit list elements in the repo.
+2. **Authoritative clusters expansion**
+   If the `ApplicationSet` uses a `clusters` generator and the repo includes a
+   pinned cluster inventory snapshot, `cub-gen` expands child `Application`
+   names from that inventory.
+3. **Explicit degraded states**
+   If the child set cannot be reproduced from repo inputs alone, `cub-gen`
+   reports a deterministic degraded mode instead of pretending the expansion is
+   authoritative.
+
+## Modes
+
+`application_set_analysis.mode` in `provenance[]` is the contract surface for
+the boundary:
+
+1. `authoritative`
+   The repo contains enough explicit inputs to explain the child `Application`
+   set deterministically.
+2. `authoritative-expansion-unavailable`
+   The parent `ApplicationSet` spec is governed, but deterministic child
+   expansion is unavailable because a required inventory input is missing.
+3. `observed-only`
+   `cub-gen` recognizes the `ApplicationSet` boundary, but unsupported
+   generator types such as `git`, `matrix`, or `merge` keep child expansion in
+   observation mode.
+
+## What the importer records
+
+For `applicationset` generators, `cub-gen gitops import --json` now records:
+
+1. a first-class `applicationset` generator contract
+2. `rendered_object_lineage[]` entries for the parent `ApplicationSet` and any
+   deterministically generated child `Application` objects
+3. `field_origin_map[]` and `inverse_edit_pointers[]` that route child
+   `Application` edits back to `spec.template.*` in the parent
+4. `application_set_analysis` metadata with:
+   - `generator_types`
+   - `unsupported_generator_types`
+   - `cluster_inventory_paths`
+   - `matched_clusters`
+   - `list_element_names`
+   - `generated_applications`
+   - `mode` / `mode_reason`
+
+That means the repo can answer both:
+
+1. "Why does this child `Application` exist?"
+2. "Where do I edit to change it safely?"
+
+## Relation to layered Helm work
+
+The standalone `applicationset` family does **not** replace the existing layered
+Helm provenance path.
+
+Today the split is:
+
+1. **Standalone ApplicationSet repo**
+   detect/import as `applicationset`
+2. **Helm repo with ApplicationSet as a layered input**
+   keep the primary family as `helm`, and record the selector/inventory/overlay
+   chain under `helm_layered_analysis`
+
+That keeps this issue focused on the generator boundary itself while `#187`
+continues to own the deeper Kubara-like multi-layer story.
+
+## Proof commands
+
+Deterministic standalone fixture:
+
+```bash
+./cub-gen gitops discover --space platform --json ./testdata/applicationset-standalone
+./cub-gen gitops import --space platform --json ./testdata/applicationset-standalone
+```
+
+Look for:
+
+1. `generator_kind = "applicationset"`
+2. `resource_kind = "ApplicationSet"`
+3. `provenance[0].application_set_analysis.mode = "authoritative"`
+4. generated child `Application` lineage tied back to `applicationset.yaml`
+
+Graceful degradation proof:
+
+```bash
+go test ./internal/importer -run '^TestImportRepoApplicationSetGracefulDegradationWithoutClusterInventory$' -count=1 -v
+```

--- a/docs/contracts/canonical-triple-and-storage-boundary.md
+++ b/docs/contracts/canonical-triple-and-storage-boundary.md
@@ -66,6 +66,11 @@ Deterministic blocker messages are locked by tests in:
 3. Render lineage: `rendered_object_lineage[]`
 4. Editability trace: `field_origin_map[]`, `inverse_edit_pointers[]`
 5. Helm-specialized source hints: `chart_path`, `values_paths`
+6. Optional generator-family analysis blocks such as:
+   - `helm_layered_analysis`
+   - `application_set_analysis`
+   - `ops_workflow_analysis`
+   - `swamp_workflow_analysis`
 
 `InverseTransformPlan` (`inverse_transform_plans[]`) captures governed reverse-edit plan:
 
@@ -92,6 +97,11 @@ ConfigHub side (bridge path, intentionally separate):
 1. Governed WET unit state and approval/attestation authority.
 2. Decision path and execution rights after policy gates.
 3. Not a reconciler; Flux/Argo remain runtime reconciliation engines.
+
+Related contract notes:
+
+1. [ApplicationSet Generator Boundary](applicationset-generator-boundary.md)
+2. [Remote Stores And Projection Targets](remote-stores-and-projection-targets.md)
 
 Operational rule:
 

--- a/docs/contracts/remote-stores-and-projection-targets.md
+++ b/docs/contracts/remote-stores-and-projection-targets.md
@@ -1,0 +1,150 @@
+# Remote Stores And Projection Targets
+
+This document is the written model for `#221`.
+
+The short version:
+
+1. many systems can produce or own operational config
+2. ConfigHub is the governed operational authority layer across them
+3. some approved values should route back out to downstream systems explicitly
+
+## The model
+
+A remote system may play one or more roles:
+
+1. **authoring source**
+   where compact human intent starts
+2. **upstream producer**
+   a system that currently emits the config we ingest
+3. **narrow authority**
+   a system that remains authoritative for a defined field/object scope
+4. **governed operational authority**
+   the normalized, reviewable ConfigHub state we mutate and approve
+5. **downstream projection target**
+   a system that should receive approved fresh config after policy checks
+6. **evidence source**
+   a system we observe for rendered/live proof
+
+Git is only one member of that set.
+
+## Why this matters to cub-gen
+
+`cub-gen` already has the right primitives:
+
+1. `GeneratorContract` tells us what deterministic generator boundary ran
+2. `ProvenanceRecord` tells us where fields and outputs came from
+3. `InverseTransformPlan` tells us where a safe upstream edit should go
+4. route language already distinguishes "apply here", "lift upstream", and
+   "block/escalate"
+
+The missing product language was how to talk about remote systems that are not
+just files in Git.
+
+## Decided route language
+
+`project downstream` should be treated as a first-class route beside:
+
+1. `apply here`
+2. `lift upstream`
+3. `block/escalate`
+4. `project downstream`
+
+Meaning:
+
+1. the governed value is approved in ConfigHub
+2. publication to the downstream remote store is explicit
+3. publication is policy-checked and auditable
+4. publication does not erase the upstream provenance chain
+
+## Minimum metadata we need
+
+For any remote store / external authority / projection target, the minimum model
+needs to capture:
+
+1. system identity
+2. system type
+   Examples: `git`, `helm`, `vault`, `aws`, `gcp`, `saas`, `custom-api`
+3. authority scope
+   Which fields or object domains it actually owns
+4. import mode
+   Snapshot, pull, event-driven, generated, observed-only
+5. publish mode
+   Manual, policy-gated push, controller-managed, unsupported
+6. freshness reference
+   Revision, resource version, watermark, timestamp, or equivalent
+7. publish receipts
+   What was written, where, and under which approved decision
+8. loop-prevention linkage
+   Enough identity to detect "same system came back around as fresh input"
+
+## How this interacts with the contract triple
+
+### GeneratorContract
+
+`GeneratorContract` remains the deterministic DRY -> WET contract.
+
+Remote-store implications:
+
+1. a contract may declare that some upstream authority is outside Git
+2. a contract may state whether downstream projection is allowed for a given
+   family
+3. deterministic local generation and remote projection remain separate phases
+
+### ProvenanceRecord
+
+`ProvenanceRecord` is where remote-store reality should accumulate.
+
+It should carry:
+
+1. imported source references from remote producers
+2. authority annotations for fields or objects
+3. freshness/watermark evidence
+4. downstream publish receipts
+5. projection provenance linking approved state to actual remote publication
+
+### InverseTransformPlan
+
+`InverseTransformPlan` remains the safe-edit plan.
+
+With remote stores in the model, a plan can now route to:
+
+1. local governed mutation
+2. lift upstream to Git or another producer
+3. block/escalate
+4. project downstream to an allowed target
+
+## Freshness and loop prevention
+
+If the same remote system can both feed ConfigHub and receive updates back from
+ConfigHub, we need explicit loop controls:
+
+1. store the imported revision/watermark
+2. store the publish receipt for the downstream write
+3. compare fresh imports against the last published revision
+4. suppress or flag loops when the same publication echoes back as a new import
+5. escalate when a stale import collides with a fresher approved publish
+
+## Concrete example path in this repo
+
+The best current in-repo example path is the Spring platform story:
+
+1. source stays partly in Git
+2. operational state is governed locally/through ConfigHub concepts
+3. route language already distinguishes app-owned, upstream-owned, and
+   platform-owned fields
+
+That makes Spring the right first candidate for an eventual mocked non-Git
+remote store example where an approved value is explicitly `project downstream`.
+
+## Scope call for this issue
+
+This issue is satisfied by:
+
+1. a written conceptual model
+2. an explicit decision that `project downstream` is first-class route language
+3. documented interaction with contracts, provenance, inverse plans, and route
+   semantics
+4. minimum metadata for freshness, publish receipts, and loop prevention
+
+Implementation of real remote-store projection flows can stay incremental after
+the model is agreed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ DRY→WET is a one-way deterministic transform. There is no automatic LIVE→DRY
 | Generator | Profile | DRY source | Status |
 |-----------|---------|------------|--------|
 | Helm | `helm-paas` | `Chart.yaml` + `values.yaml` | Stable |
+| ApplicationSet | `applicationset` | `applicationset.yaml` + pinned inventory | v0.2 preview |
 | Score.dev | `scoredev-paas` | `score.yaml` | Stable |
 | Spring Boot | `springboot-paas` | `application.yaml` | Stable |
 | Backstage IDP | `backstage-idp` | `catalog-info.yaml` | v0.2 preview |
@@ -193,16 +194,16 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 
 ## Current status
 
-**Latest shipped:** `v0.2-preview.1` (2026-03-06)
+**Latest shipped:** `v0.2-preview.2` (2026-04-11)
 
-**Current target:** `v0.2-preview.2`
+**Current target:** post-preview backlog and productization follow-ups
 
 - repo-first CLI and contract coverage remain green,
-- current release work is focused on full example-catalog quality,
-- CLI/help/docs must match clean-checkout behavior,
-- flagship Helm, Score, Spring, and Swamp examples now carry explicit
+- the shipped preview now includes a first-class standalone `applicationset`
+  generator family,
+- flagship Helm, Score, Spring, and Swamp examples carry explicit
   `AI_START_HERE.md`, `prompts.md`, and `contracts.md` bundles,
-- connected release status must be backed by a credible lane the team actually runs.
+- connected release status is backed by the repo's `ConfigHub Smoke` lane.
 
 See the [v0.2-preview.2 Release Plan](releases/v0.2-preview.2-plan.md) for the
 current must-ship and post-release split, and the
@@ -212,6 +213,6 @@ what is already landed on `main` versus what still blocks the tag. The current
 the final tag write-up can be tightened from the eventual green `main`.
 
 - Core flow commands (`discover`, `import`, `cleanup`) frozen and golden-tested
-- Bridge artifacts (`publish`, `verify`, `attest`, `verify-attestation`) symmetric across all 8 generators
+- Bridge artifacts (`publish`, `verify`, `attest`, `verify-attestation`) symmetric across all 9 generators
 - Generator catalog (`generators`) with filtering, details, and markdown output
 - Local-first: works standalone, connects to [ConfigHub](platform.md) for governed execution

--- a/docs/triple-styles/README.md
+++ b/docs/triple-styles/README.md
@@ -10,6 +10,7 @@ Canonical runtime source remains Go registry specs in `internal/registry/registr
 
 | Kind | Style A | Style B | Style C |
 | --- | --- | --- | --- |
+| `applicationset` | [yaml](style-a-yaml/applicationset.yaml) | [markdown](style-b-markdown/applicationset.md) | [pair](style-c-yaml-plus-docs/applicationset/) |
 | `backstage` | [yaml](style-a-yaml/backstage.yaml) | [markdown](style-b-markdown/backstage.md) | [pair](style-c-yaml-plus-docs/backstage/) |
 | `c3agent` | [yaml](style-a-yaml/c3agent.yaml) | [markdown](style-b-markdown/c3agent.md) | [pair](style-c-yaml-plus-docs/c3agent/) |
 | `helm` | [yaml](style-a-yaml/helm.yaml) | [markdown](style-b-markdown/helm.md) | [pair](style-c-yaml-plus-docs/helm/) |

--- a/docs/triple-styles/style-a-yaml/applicationset.yaml
+++ b/docs/triple-styles/style-a-yaml/applicationset.yaml
@@ -1,0 +1,73 @@
+kind: "applicationset"
+profile: "applicationset"
+resource_kind: "ApplicationSet"
+resource_type: "argoproj.io/v1alpha1/ApplicationSet"
+capabilities:
+  - "observed-expansion"
+  - "authoritative-list-expansion"
+  - "authoritative-clusters-expansion"
+  - "graceful-degradation"
+contract:
+  default_input_role: "applicationset-input"
+  default_owner: "platform-engineer"
+  input_role_rules:
+    - role: "application-set"
+      exact_basenames:
+        - "applicationset.yaml"
+        - "applicationset.yml"
+    - role: "cluster-inventory"
+      path_prefixes:
+        - "clusters/"
+        - "inventory/clusters/"
+        - "platform/clusters/"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
+  role_owners:
+    application-set: "platform-engineer"
+    cluster-inventory: "platform-engineer"
+  role_schema_refs:
+    application-set: "https://schema.confighub.dev/generators/applicationset-v1"
+    cluster-inventory: "https://schema.confighub.dev/generators/cluster-inventory-v1"
+  wet_targets:
+    - kind: "ApplicationSet"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "argocd"
+provenance:
+  field_origin_transform: "applicationset-template"
+  field_origin_confidences:
+    child_name: 0.89
+    source_path: 0.86
+  rendered_lineage_templates:
+    - kind: "ApplicationSet"
+      name_template: "{{name}}"
+      namespace: "argocd"
+      source_path_hint: "application_set_path"
+      source_dry_path_template: "spec"
+inverse:
+  inverse_patch_templates:
+    child_name:
+      editable_by: "platform-engineer"
+      confidence: 0.89
+    source_path:
+      editable_by: "platform-engineer"
+      confidence: 0.86
+      requires_review: true
+  inverse_pointer_templates:
+    child_name:
+      owner: "platform-engineer"
+      confidence: 0.89
+    source_path:
+      owner: "platform-engineer"
+      confidence: 0.86
+  inverse_patch_reasons:
+    child_name: "Child Application identity is generated from the parent ApplicationSet template."
+    source_path: "Child Application source path is generated from the parent ApplicationSet template."
+  inverse_edit_hints:
+    child_name: "Edit spec.template.metadata.name in {{application_set_path}}."
+    source_path: "Edit spec.template.spec.source.path in {{application_set_path}}."
+hints:
+  defaults:
+    application_set_path: "applicationset.yaml"

--- a/docs/triple-styles/style-a-yaml/helm.yaml
+++ b/docs/triple-styles/style-a-yaml/helm.yaml
@@ -18,16 +18,22 @@ contract:
         - "applicationset.yaml"
         - "applicationset.yml"
     - role: "cluster-inventory"
+      path_prefixes:
+        - "platform/clusters/"
       extensions:
         - ".yaml"
         - ".yml"
         - ".json"
     - role: "managed-service-catalog"
+      path_prefixes:
+        - "platform/catalogs/managed-service-catalog/"
       extensions:
         - ".yaml"
         - ".yml"
         - ".json"
     - role: "customer-service-catalog"
+      path_prefixes:
+        - "platform/catalogs/customer-service-catalog/"
       extensions:
         - ".yaml"
         - ".yml"

--- a/docs/triple-styles/style-b-markdown/applicationset.md
+++ b/docs/triple-styles/style-b-markdown/applicationset.md
@@ -1,0 +1,106 @@
+# applicationset Triple
+
+- Profile: `applicationset`
+- Resource: `ApplicationSet` (`argoproj.io/v1alpha1/ApplicationSet`)
+- Capabilities: observed-expansion, authoritative-list-expansion, authoritative-clusters-expansion, graceful-degradation
+
+```mermaid
+flowchart LR
+  subgraph DRY["DRY Inputs"]
+    d1["application-set: applicationset.yaml, applicationset.yml<br/>owner: platform-engineer"]
+    d2["cluster-inventory: *.yaml | *.yml | *.json<br/>owner: platform-engineer"]
+  end
+  gen["applicationset (applicationset)<br/>capabilities: observed-expansion, authoritative-list-expansion, authoritative-clusters-expansion, graceful-degradation"]
+  subgraph WET["WET Targets"]
+    w1["ApplicationSet {{name}}<br/>owner: platform-runtime<br/>namespace: argocd"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+```
+
+## Contract
+
+- Default input role: `applicationset-input`
+- Default owner: `platform-engineer`
+
+### Input role rules
+
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `application-set` | applicationset.yaml, applicationset.yml | - | - | - |
+| `cluster-inventory` | - | clusters/, inventory/clusters/, platform/clusters/ | - | .yaml, .yml, .json |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+| `application-set` | `platform-engineer` |
+| `cluster-inventory` | `platform-engineer` |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `application-set` | `https://schema.confighub.dev/generators/applicationset-v1` |
+| `cluster-inventory` | `https://schema.confighub.dev/generators/cluster-inventory-v1` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `ApplicationSet` | `{{name}}` | `platform-runtime` | `argocd` | `` |
+
+## Provenance
+
+- Field-origin transform: `applicationset-template`
+- Field-origin overlay transform: ``
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `child_name` | 0.89 |
+| `source_path` | 0.86 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ApplicationSet` | `{{name}}` | `argocd` | `application_set_path` | `` | `false` | `spec` | `false` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `child_name` | `platform-engineer` | 0.89 | `false` |
+| `source_path` | `platform-engineer` | 0.86 | `true` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `child_name` | `platform-engineer` | 0.89 |
+| `source_path` | `platform-engineer` | 0.86 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `child_name` | Child Application identity is generated from the parent ApplicationSet template. |
+| `source_path` | Child Application source path is generated from the parent ApplicationSet template. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `child_name` | Edit spec.template.metadata.name in {{application_set_path}}. |
+| `source_path` | Edit spec.template.spec.source.path in {{application_set_path}}. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `application_set_path` | `applicationset.yaml` |

--- a/docs/triple-styles/style-b-markdown/backstage.md
+++ b/docs/triple-styles/style-b-markdown/backstage.md
@@ -28,10 +28,10 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `catalog-spec` | catalog-info.yaml, catalog-info.yml | - | - |
-| `app-config` | app-config.yaml, app-config.yml | - | - |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `catalog-spec` | catalog-info.yaml, catalog-info.yml | - | - | - |
+| `app-config` | app-config.yaml, app-config.yml | - | - | - |
 
 ### Role owners
 

--- a/docs/triple-styles/style-b-markdown/c3agent.md
+++ b/docs/triple-styles/style-b-markdown/c3agent.md
@@ -46,10 +46,10 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `fleet-config-base` | c3agent.yaml, c3agent.yml, c3agent.json | - | - |
-| `fleet-config-overlay` | - | c3agent- | .yaml, .yml, .json |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `fleet-config-base` | c3agent.yaml, c3agent.yml, c3agent.json | - | - | - |
+| `fleet-config-overlay` | - | - | c3agent- | .yaml, .yml, .json |
 
 ### Role owners
 

--- a/docs/triple-styles/style-b-markdown/helm.md
+++ b/docs/triple-styles/style-b-markdown/helm.md
@@ -38,14 +38,14 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `chart` | chart.yaml | - | - |
-| `application-set` | applicationset.yaml, applicationset.yml | - | - |
-| `cluster-inventory` | - | - | .yaml, .yml, .json |
-| `managed-service-catalog` | - | - | .yaml, .yml, .json |
-| `customer-service-catalog` | - | - | .yaml, .yml, .json |
-| `values` | - | values | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `chart` | chart.yaml | - | - | - |
+| `application-set` | applicationset.yaml, applicationset.yml | - | - | - |
+| `cluster-inventory` | - | platform/clusters/ | - | .yaml, .yml, .json |
+| `managed-service-catalog` | - | platform/catalogs/managed-service-catalog/ | - | .yaml, .yml, .json |
+| `customer-service-catalog` | - | platform/catalogs/customer-service-catalog/ | - | .yaml, .yml, .json |
+| `values` | - | - | values | .yaml, .yml |
 
 ### Role owners
 

--- a/docs/triple-styles/style-b-markdown/no-config-platform.md
+++ b/docs/triple-styles/style-b-markdown/no-config-platform.md
@@ -28,10 +28,10 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `provider-config-base` | no-config-platform.yaml, no-config-platform.yml, no-config-platform.json | - | - |
-| `provider-config-overlay` | - | no-config-platform- | .yaml, .yml, .json |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `provider-config-base` | no-config-platform.yaml, no-config-platform.yml, no-config-platform.json | - | - | - |
+| `provider-config-overlay` | - | - | no-config-platform- | .yaml, .yml, .json |
 
 ### Role owners
 

--- a/docs/triple-styles/style-b-markdown/opsworkflow.md
+++ b/docs/triple-styles/style-b-markdown/opsworkflow.md
@@ -28,10 +28,10 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `operations-base` | operations.yaml, operations.yml, workflow.yaml, workflow.yml | - | - |
-| `operations-overlay` | - | operations-, workflow- | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `operations-base` | operations.yaml, operations.yml, workflow.yaml, workflow.yml | - | - | - |
+| `operations-overlay` | - | - | operations-, workflow- | .yaml, .yml |
 
 ### Role owners
 

--- a/docs/triple-styles/style-b-markdown/score.md
+++ b/docs/triple-styles/style-b-markdown/score.md
@@ -28,9 +28,9 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `score-spec` | score.yaml, score.yml | - | - |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `score-spec` | score.yaml, score.yml | - | - | - |
 
 ### Role owners
 

--- a/docs/triple-styles/style-b-markdown/springboot.md
+++ b/docs/triple-styles/style-b-markdown/springboot.md
@@ -32,11 +32,11 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `build-config` | pom.xml, build.gradle, build.gradle.kts | - | - |
-| `app-config-base` | application.yaml, application.yml | - | - |
-| `app-config-profile` | - | application- | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `build-config` | pom.xml, build.gradle, build.gradle.kts | - | - | - |
+| `app-config-base` | application.yaml, application.yml | - | - | - |
+| `app-config-profile` | - | - | application- | .yaml, .yml |
 
 ### Role owners
 

--- a/docs/triple-styles/style-b-markdown/swamp.md
+++ b/docs/triple-styles/style-b-markdown/swamp.md
@@ -28,10 +28,10 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `swamp-config-base` | .swamp.yaml, .swamp.yml | - | - |
-| `swamp-workflow` | - | workflow- | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `swamp-config-base` | .swamp.yaml, .swamp.yml | - | - | - |
+| `swamp-workflow` | - | - | workflow- | .yaml, .yml |
 
 ### Role owners
 

--- a/docs/triple-styles/style-c-yaml-plus-docs/applicationset/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/applicationset/triple.md
@@ -1,0 +1,106 @@
+# applicationset Triple
+
+- Profile: `applicationset`
+- Resource: `ApplicationSet` (`argoproj.io/v1alpha1/ApplicationSet`)
+- Capabilities: observed-expansion, authoritative-list-expansion, authoritative-clusters-expansion, graceful-degradation
+
+```mermaid
+flowchart LR
+  subgraph DRY["DRY Inputs"]
+    d1["application-set: applicationset.yaml, applicationset.yml<br/>owner: platform-engineer"]
+    d2["cluster-inventory: *.yaml | *.yml | *.json<br/>owner: platform-engineer"]
+  end
+  gen["applicationset (applicationset)<br/>capabilities: observed-expansion, authoritative-list-expansion, authoritative-clusters-expansion, graceful-degradation"]
+  subgraph WET["WET Targets"]
+    w1["ApplicationSet {{name}}<br/>owner: platform-runtime<br/>namespace: argocd"]
+  end
+  d1 --> gen
+  d2 --> gen
+  gen --> w1
+```
+
+## Contract
+
+- Default input role: `applicationset-input`
+- Default owner: `platform-engineer`
+
+### Input role rules
+
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `application-set` | applicationset.yaml, applicationset.yml | - | - | - |
+| `cluster-inventory` | - | clusters/, inventory/clusters/, platform/clusters/ | - | .yaml, .yml, .json |
+
+### Role owners
+
+| Role | Owner |
+| --- | --- |
+| `application-set` | `platform-engineer` |
+| `cluster-inventory` | `platform-engineer` |
+
+### Role schema refs
+
+| Role | Schema ref |
+| --- | --- |
+| `application-set` | `https://schema.confighub.dev/generators/applicationset-v1` |
+| `cluster-inventory` | `https://schema.confighub.dev/generators/cluster-inventory-v1` |
+
+### WET targets
+
+| Kind | Name template | Owner | Namespace | Source DRY path template |
+| --- | --- | --- | --- | --- |
+| `ApplicationSet` | `{{name}}` | `platform-runtime` | `argocd` | `` |
+
+## Provenance
+
+- Field-origin transform: `applicationset-template`
+- Field-origin overlay transform: ``
+
+### Field-origin confidences
+
+| Key | Confidence |
+| --- | --- |
+| `child_name` | 0.89 |
+| `source_path` | 0.86 |
+
+### Rendered lineage templates
+
+| Kind | Name template | Namespace | Source path hint | Hint fallback | Multi hint | Source DRY path template | Optional |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ApplicationSet` | `{{name}}` | `argocd` | `application_set_path` | `` | `false` | `spec` | `false` |
+
+## Inverse
+
+### Inverse patch templates
+
+| Key | Editable by | Confidence | Requires review |
+| --- | --- | --- | --- |
+| `child_name` | `platform-engineer` | 0.89 | `false` |
+| `source_path` | `platform-engineer` | 0.86 | `true` |
+
+### Inverse pointer templates
+
+| Key | Owner | Confidence |
+| --- | --- | --- |
+| `child_name` | `platform-engineer` | 0.89 |
+| `source_path` | `platform-engineer` | 0.86 |
+
+### Inverse patch reasons
+
+| Key | Reason |
+| --- | --- |
+| `child_name` | Child Application identity is generated from the parent ApplicationSet template. |
+| `source_path` | Child Application source path is generated from the parent ApplicationSet template. |
+
+### Inverse edit hints
+
+| Key | Hint |
+| --- | --- |
+| `child_name` | Edit spec.template.metadata.name in {{application_set_path}}. |
+| `source_path` | Edit spec.template.spec.source.path in {{application_set_path}}. |
+
+### Hint defaults
+
+| Key | Value |
+| --- | --- |
+| `application_set_path` | `applicationset.yaml` |

--- a/docs/triple-styles/style-c-yaml-plus-docs/applicationset/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/applicationset/triple.yaml
@@ -1,0 +1,73 @@
+kind: "applicationset"
+profile: "applicationset"
+resource_kind: "ApplicationSet"
+resource_type: "argoproj.io/v1alpha1/ApplicationSet"
+capabilities:
+  - "observed-expansion"
+  - "authoritative-list-expansion"
+  - "authoritative-clusters-expansion"
+  - "graceful-degradation"
+contract:
+  default_input_role: "applicationset-input"
+  default_owner: "platform-engineer"
+  input_role_rules:
+    - role: "application-set"
+      exact_basenames:
+        - "applicationset.yaml"
+        - "applicationset.yml"
+    - role: "cluster-inventory"
+      path_prefixes:
+        - "clusters/"
+        - "inventory/clusters/"
+        - "platform/clusters/"
+      extensions:
+        - ".yaml"
+        - ".yml"
+        - ".json"
+  role_owners:
+    application-set: "platform-engineer"
+    cluster-inventory: "platform-engineer"
+  role_schema_refs:
+    application-set: "https://schema.confighub.dev/generators/applicationset-v1"
+    cluster-inventory: "https://schema.confighub.dev/generators/cluster-inventory-v1"
+  wet_targets:
+    - kind: "ApplicationSet"
+      name_template: "{{name}}"
+      owner: "platform-runtime"
+      namespace: "argocd"
+provenance:
+  field_origin_transform: "applicationset-template"
+  field_origin_confidences:
+    child_name: 0.89
+    source_path: 0.86
+  rendered_lineage_templates:
+    - kind: "ApplicationSet"
+      name_template: "{{name}}"
+      namespace: "argocd"
+      source_path_hint: "application_set_path"
+      source_dry_path_template: "spec"
+inverse:
+  inverse_patch_templates:
+    child_name:
+      editable_by: "platform-engineer"
+      confidence: 0.89
+    source_path:
+      editable_by: "platform-engineer"
+      confidence: 0.86
+      requires_review: true
+  inverse_pointer_templates:
+    child_name:
+      owner: "platform-engineer"
+      confidence: 0.89
+    source_path:
+      owner: "platform-engineer"
+      confidence: 0.86
+  inverse_patch_reasons:
+    child_name: "Child Application identity is generated from the parent ApplicationSet template."
+    source_path: "Child Application source path is generated from the parent ApplicationSet template."
+  inverse_edit_hints:
+    child_name: "Edit spec.template.metadata.name in {{application_set_path}}."
+    source_path: "Edit spec.template.spec.source.path in {{application_set_path}}."
+hints:
+  defaults:
+    application_set_path: "applicationset.yaml"

--- a/docs/triple-styles/style-c-yaml-plus-docs/backstage/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/backstage/triple.md
@@ -28,10 +28,10 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `catalog-spec` | catalog-info.yaml, catalog-info.yml | - | - |
-| `app-config` | app-config.yaml, app-config.yml | - | - |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `catalog-spec` | catalog-info.yaml, catalog-info.yml | - | - | - |
+| `app-config` | app-config.yaml, app-config.yml | - | - | - |
 
 ### Role owners
 

--- a/docs/triple-styles/style-c-yaml-plus-docs/c3agent/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/c3agent/triple.md
@@ -46,10 +46,10 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `fleet-config-base` | c3agent.yaml, c3agent.yml, c3agent.json | - | - |
-| `fleet-config-overlay` | - | c3agent- | .yaml, .yml, .json |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `fleet-config-base` | c3agent.yaml, c3agent.yml, c3agent.json | - | - | - |
+| `fleet-config-overlay` | - | - | c3agent- | .yaml, .yml, .json |
 
 ### Role owners
 

--- a/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.md
@@ -38,14 +38,14 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `chart` | chart.yaml | - | - |
-| `application-set` | applicationset.yaml, applicationset.yml | - | - |
-| `cluster-inventory` | - | - | .yaml, .yml, .json |
-| `managed-service-catalog` | - | - | .yaml, .yml, .json |
-| `customer-service-catalog` | - | - | .yaml, .yml, .json |
-| `values` | - | values | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `chart` | chart.yaml | - | - | - |
+| `application-set` | applicationset.yaml, applicationset.yml | - | - | - |
+| `cluster-inventory` | - | platform/clusters/ | - | .yaml, .yml, .json |
+| `managed-service-catalog` | - | platform/catalogs/managed-service-catalog/ | - | .yaml, .yml, .json |
+| `customer-service-catalog` | - | platform/catalogs/customer-service-catalog/ | - | .yaml, .yml, .json |
+| `values` | - | - | values | .yaml, .yml |
 
 ### Role owners
 

--- a/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.yaml
+++ b/docs/triple-styles/style-c-yaml-plus-docs/helm/triple.yaml
@@ -18,16 +18,22 @@ contract:
         - "applicationset.yaml"
         - "applicationset.yml"
     - role: "cluster-inventory"
+      path_prefixes:
+        - "platform/clusters/"
       extensions:
         - ".yaml"
         - ".yml"
         - ".json"
     - role: "managed-service-catalog"
+      path_prefixes:
+        - "platform/catalogs/managed-service-catalog/"
       extensions:
         - ".yaml"
         - ".yml"
         - ".json"
     - role: "customer-service-catalog"
+      path_prefixes:
+        - "platform/catalogs/customer-service-catalog/"
       extensions:
         - ".yaml"
         - ".yml"

--- a/docs/triple-styles/style-c-yaml-plus-docs/no-config-platform/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/no-config-platform/triple.md
@@ -28,10 +28,10 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `provider-config-base` | no-config-platform.yaml, no-config-platform.yml, no-config-platform.json | - | - |
-| `provider-config-overlay` | - | no-config-platform- | .yaml, .yml, .json |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `provider-config-base` | no-config-platform.yaml, no-config-platform.yml, no-config-platform.json | - | - | - |
+| `provider-config-overlay` | - | - | no-config-platform- | .yaml, .yml, .json |
 
 ### Role owners
 

--- a/docs/triple-styles/style-c-yaml-plus-docs/opsworkflow/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/opsworkflow/triple.md
@@ -28,10 +28,10 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `operations-base` | operations.yaml, operations.yml, workflow.yaml, workflow.yml | - | - |
-| `operations-overlay` | - | operations-, workflow- | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `operations-base` | operations.yaml, operations.yml, workflow.yaml, workflow.yml | - | - | - |
+| `operations-overlay` | - | - | operations-, workflow- | .yaml, .yml |
 
 ### Role owners
 

--- a/docs/triple-styles/style-c-yaml-plus-docs/score/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/score/triple.md
@@ -28,9 +28,9 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `score-spec` | score.yaml, score.yml | - | - |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `score-spec` | score.yaml, score.yml | - | - | - |
 
 ### Role owners
 

--- a/docs/triple-styles/style-c-yaml-plus-docs/springboot/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/springboot/triple.md
@@ -32,11 +32,11 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `build-config` | pom.xml, build.gradle, build.gradle.kts | - | - |
-| `app-config-base` | application.yaml, application.yml | - | - |
-| `app-config-profile` | - | application- | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `build-config` | pom.xml, build.gradle, build.gradle.kts | - | - | - |
+| `app-config-base` | application.yaml, application.yml | - | - | - |
+| `app-config-profile` | - | - | application- | .yaml, .yml |
 
 ### Role owners
 

--- a/docs/triple-styles/style-c-yaml-plus-docs/swamp/triple.md
+++ b/docs/triple-styles/style-c-yaml-plus-docs/swamp/triple.md
@@ -28,10 +28,10 @@ flowchart LR
 
 ### Input role rules
 
-| Role | Exact basenames | Prefixes | Extensions |
-| --- | --- | --- | --- |
-| `swamp-config-base` | .swamp.yaml, .swamp.yml | - | - |
-| `swamp-workflow` | - | workflow- | .yaml, .yml |
+| Role | Exact basenames | Path prefixes | Prefixes | Extensions |
+| --- | --- | --- | --- | --- |
+| `swamp-config-base` | .swamp.yaml, .swamp.yml | - | - | - |
+| `swamp-workflow` | - | - | workflow- | .yaml, .yml |
 
 ### Role owners
 

--- a/internal/applicationset/applicationset.go
+++ b/internal/applicationset/applicationset.go
@@ -1,0 +1,499 @@
+package applicationset
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	ModeAuthoritative                     = "authoritative"
+	ModeObservedOnly                      = "observed-only"
+	ModeAuthoritativeExpansionUnavailable = "authoritative-expansion-unavailable"
+)
+
+type ListElement struct {
+	Name   string
+	Values map[string]string
+}
+
+type Document struct {
+	Path                      string
+	Name                      string
+	TemplateName              string
+	TemplateSourcePath        string
+	GeneratorTypes            []string
+	UnsupportedGeneratorTypes []string
+	ListElements              []ListElement
+	ClusterSelector           map[string]string
+}
+
+type ClusterInventory struct {
+	Path   string
+	Name   string
+	Server string
+	Labels map[string]string
+}
+
+type GeneratedApplication struct {
+	Name          string
+	GeneratorType string
+	Reason        string
+	InventoryPath string
+	Cluster       string
+	ListElement   string
+	SourcePath    string
+}
+
+type Analysis struct {
+	ApplicationSetPath        string
+	GeneratorTypes            []string
+	UnsupportedGeneratorTypes []string
+	ClusterInventoryPaths     []string
+	MatchedClusters           []string
+	ListElementNames          []string
+	Mode                      string
+	ModeReason                string
+	GeneratedApplications     []GeneratedApplication
+}
+
+func IsApplicationSetFile(repo, path string) bool {
+	doc, err := ParseFile(repo, path)
+	return err == nil && strings.TrimSpace(doc.Path) != ""
+}
+
+func ParseFile(repo, path string) (Document, error) {
+	type rawApplicationSet struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+		Spec struct {
+			Generators []map[string]any `yaml:"generators"`
+			Template   struct {
+				Metadata struct {
+					Name string `yaml:"name"`
+				} `yaml:"metadata"`
+				Spec struct {
+					Source struct {
+						Path string `yaml:"path"`
+					} `yaml:"source"`
+				} `yaml:"spec"`
+			} `yaml:"template"`
+		} `yaml:"spec"`
+	}
+
+	content, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(path)))
+	if err != nil {
+		return Document{}, err
+	}
+
+	var raw rawApplicationSet
+	if err := yaml.Unmarshal(content, &raw); err != nil {
+		return Document{}, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(raw.Kind), "ApplicationSet") {
+		return Document{}, fmt.Errorf("%s is not an ApplicationSet", path)
+	}
+
+	out := Document{
+		Path:               filepath.ToSlash(path),
+		Name:               strings.TrimSpace(raw.Metadata.Name),
+		TemplateName:       strings.TrimSpace(raw.Spec.Template.Metadata.Name),
+		TemplateSourcePath: strings.TrimSpace(raw.Spec.Template.Spec.Source.Path),
+	}
+	if out.Name == "" {
+		out.Name = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	}
+
+	generatorTypeSet := map[string]struct{}{}
+	unsupportedSet := map[string]struct{}{}
+	for _, generator := range raw.Spec.Generators {
+		switch {
+		case hasGeneratorKey(generator, "list"):
+			generatorTypeSet["list"] = struct{}{}
+			out.ListElements = append(out.ListElements, parseListElements(generator["list"])...)
+		case hasGeneratorKey(generator, "clusters"):
+			generatorTypeSet["clusters"] = struct{}{}
+			if selector := parseClusterSelector(generator["clusters"]); len(selector) > 0 {
+				out.ClusterSelector = selector
+			}
+		case hasGeneratorKey(generator, "git"):
+			generatorTypeSet["git"] = struct{}{}
+			unsupportedSet["git"] = struct{}{}
+		case hasGeneratorKey(generator, "matrix"):
+			generatorTypeSet["matrix"] = struct{}{}
+			unsupportedSet["matrix"] = struct{}{}
+		case hasGeneratorKey(generator, "merge"):
+			generatorTypeSet["merge"] = struct{}{}
+			unsupportedSet["merge"] = struct{}{}
+		default:
+			for key := range generator {
+				key = strings.TrimSpace(strings.ToLower(key))
+				if key == "" {
+					continue
+				}
+				generatorTypeSet[key] = struct{}{}
+				unsupportedSet[key] = struct{}{}
+			}
+		}
+	}
+	out.GeneratorTypes = sortedKeys(generatorTypeSet)
+	out.UnsupportedGeneratorTypes = sortedKeys(unsupportedSet)
+	return out, nil
+}
+
+func ParseClusterInventoryFile(repo, path string) (ClusterInventory, error) {
+	type rawInventory struct {
+		Metadata struct {
+			Name   string            `yaml:"name"`
+			Labels map[string]string `yaml:"labels"`
+		} `yaml:"metadata"`
+		Spec struct {
+			Server string `yaml:"server"`
+		} `yaml:"spec"`
+	}
+
+	content, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(path)))
+	if err != nil {
+		return ClusterInventory{}, err
+	}
+
+	var raw rawInventory
+	if err := yaml.Unmarshal(content, &raw); err != nil {
+		return ClusterInventory{}, err
+	}
+
+	return ClusterInventory{
+		Path:   filepath.ToSlash(path),
+		Name:   strings.TrimSpace(raw.Metadata.Name),
+		Server: strings.TrimSpace(raw.Spec.Server),
+		Labels: raw.Metadata.Labels,
+	}, nil
+}
+
+func Analyze(repo, appsetPath string, clusterPaths []string) (Analysis, error) {
+	doc, err := ParseFile(repo, appsetPath)
+	if err != nil {
+		return Analysis{}, err
+	}
+
+	analysis := Analysis{
+		ApplicationSetPath:        doc.Path,
+		GeneratorTypes:            append([]string(nil), doc.GeneratorTypes...),
+		UnsupportedGeneratorTypes: append([]string(nil), doc.UnsupportedGeneratorTypes...),
+		ClusterInventoryPaths:     uniqueSorted(clusterPaths),
+	}
+
+	for _, element := range doc.ListElements {
+		if element.Name != "" {
+			analysis.ListElementNames = append(analysis.ListElementNames, element.Name)
+		}
+	}
+	analysis.ListElementNames = uniqueSorted(analysis.ListElementNames)
+
+	generated := make([]GeneratedApplication, 0, len(doc.ListElements)+len(clusterPaths))
+	if len(doc.ListElements) > 0 {
+		for _, element := range doc.ListElements {
+			name := renderTemplate(doc.TemplateName, element.Values)
+			if name == "" {
+				continue
+			}
+			reason := "generated from list element"
+			if element.Name != "" {
+				reason = fmt.Sprintf("generated from list element %s", element.Name)
+			}
+			generated = append(generated, GeneratedApplication{
+				Name:          name,
+				GeneratorType: "list",
+				Reason:        reason,
+				ListElement:   element.Name,
+				SourcePath:    doc.Path,
+			})
+		}
+	}
+
+	clusterGeneratorPresent := stringSliceContains(doc.GeneratorTypes, "clusters")
+	if clusterGeneratorPresent {
+		if len(clusterPaths) == 0 {
+			analysis.Mode = ModeAuthoritativeExpansionUnavailable
+			analysis.ModeReason = "ApplicationSet uses the clusters generator, but no pinned cluster inventory inputs were found in the repo."
+		} else {
+			clusters := loadClusterInventories(repo, clusterPaths)
+			for _, cluster := range clusters {
+				if cluster.Name == "" {
+					continue
+				}
+				if len(doc.ClusterSelector) > 0 && !labelsMatch(cluster.Labels, doc.ClusterSelector) {
+					continue
+				}
+				analysis.MatchedClusters = append(analysis.MatchedClusters, cluster.Name)
+				values := map[string]string{
+					"name":   cluster.Name,
+					"server": cluster.Server,
+				}
+				name := renderTemplate(doc.TemplateName, values)
+				if name == "" {
+					name = cluster.Name
+				}
+				reason := "generated from pinned cluster inventory"
+				if len(doc.ClusterSelector) > 0 {
+					reason = fmt.Sprintf("generated from cluster inventory %s matching selector %s", cluster.Name, selectorString(doc.ClusterSelector))
+				}
+				generated = append(generated, GeneratedApplication{
+					Name:          name,
+					GeneratorType: "clusters",
+					Reason:        reason,
+					InventoryPath: cluster.Path,
+					Cluster:       cluster.Name,
+					SourcePath:    doc.Path,
+				})
+			}
+			analysis.MatchedClusters = uniqueSorted(analysis.MatchedClusters)
+			if analysis.Mode == "" {
+				if len(analysis.MatchedClusters) == 0 {
+					analysis.Mode = ModeAuthoritative
+					if len(doc.ClusterSelector) == 0 {
+						analysis.ModeReason = "Pinned cluster inventory is present, but no clusters were expanded into child Applications."
+					} else {
+						analysis.ModeReason = fmt.Sprintf("Pinned cluster inventory is present, but no clusters match selector %s.", selectorString(doc.ClusterSelector))
+					}
+				}
+			}
+		}
+	}
+
+	generated = dedupeGenerated(generated)
+	analysis.GeneratedApplications = generated
+
+	switch {
+	case len(doc.UnsupportedGeneratorTypes) > 0:
+		analysis.Mode = ModeObservedOnly
+		analysis.ModeReason = fmt.Sprintf("ApplicationSet uses unsupported generator types %s, so cub-gen keeps the parent spec in observed-only mode.", strings.Join(doc.UnsupportedGeneratorTypes, ", "))
+	case analysis.Mode != "":
+		// Keep the earlier explicit degraded mode/reason.
+	case len(generated) > 0:
+		analysis.Mode = ModeAuthoritative
+		analysis.ModeReason = fmt.Sprintf("Authoritative expansion produced %d child Application(s) from explicit repo inputs.", len(generated))
+	case len(doc.GeneratorTypes) == 0:
+		analysis.Mode = ModeObservedOnly
+		analysis.ModeReason = "ApplicationSet generator inputs were not recognized deterministically, so cub-gen keeps the parent spec in observed-only mode."
+	default:
+		analysis.Mode = ModeObservedOnly
+		analysis.ModeReason = "ApplicationSet did not include enough explicit repo inputs for authoritative child expansion."
+	}
+
+	return analysis, nil
+}
+
+func hasGeneratorKey(generator map[string]any, key string) bool {
+	if generator == nil {
+		return false
+	}
+	_, ok := generator[strings.TrimSpace(key)]
+	return ok
+}
+
+func parseListElements(raw any) []ListElement {
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	items, ok := obj["elements"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]ListElement, 0, len(items))
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		values := make(map[string]string, len(m))
+		name := ""
+		for key, value := range m {
+			str := scalarString(value)
+			if strings.TrimSpace(str) == "" {
+				continue
+			}
+			values[key] = str
+			if strings.EqualFold(key, "name") {
+				name = str
+			}
+		}
+		out = append(out, ListElement{Name: name, Values: values})
+	}
+	return out
+}
+
+func parseClusterSelector(raw any) map[string]string {
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	selector, ok := obj["selector"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	matchLabels, ok := selector["matchLabels"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(matchLabels))
+	for key, value := range matchLabels {
+		str := scalarString(value)
+		if strings.TrimSpace(str) == "" {
+			continue
+		}
+		out[key] = str
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func scalarString(v any) string {
+	switch x := v.(type) {
+	case string:
+		return strings.TrimSpace(x)
+	case fmt.Stringer:
+		return strings.TrimSpace(x.String())
+	case int, int8, int16, int32, int64, float32, float64, bool:
+		return fmt.Sprint(x)
+	default:
+		return ""
+	}
+}
+
+func loadClusterInventories(repo string, paths []string) []ClusterInventory {
+	out := make([]ClusterInventory, 0, len(paths))
+	for _, path := range uniqueSorted(paths) {
+		cluster, err := ParseClusterInventoryFile(repo, path)
+		if err != nil {
+			continue
+		}
+		out = append(out, cluster)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out
+}
+
+func renderTemplate(template string, values map[string]string) string {
+	out := strings.TrimSpace(template)
+	if out == "" {
+		return ""
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		out = strings.ReplaceAll(out, "{{"+key+"}}", values[key])
+	}
+	if strings.Contains(out, "{{") {
+		return ""
+	}
+	return out
+}
+
+func labelsMatch(labels, selector map[string]string) bool {
+	if len(selector) == 0 {
+		return true
+	}
+	for key, expected := range selector {
+		if labels[key] != expected {
+			return false
+		}
+	}
+	return true
+}
+
+func selectorString(selector map[string]string) string {
+	keys := make([]string, 0, len(selector))
+	for key := range selector {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+selector[key])
+	}
+	return strings.Join(parts, ", ")
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func uniqueSorted(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func dedupeGenerated(values []GeneratedApplication) []GeneratedApplication {
+	seen := map[string]struct{}{}
+	out := make([]GeneratedApplication, 0, len(values))
+	for _, value := range values {
+		key := strings.Join([]string{
+			value.Name,
+			value.GeneratorType,
+			value.InventoryPath,
+			value.Cluster,
+			value.ListElement,
+			value.SourcePath,
+		}, "|")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		if out[i].GeneratorType != out[j].GeneratorType {
+			return out[i].GeneratorType < out[j].GeneratorType
+		}
+		return out[i].Reason < out[j].Reason
+	})
+	return out
+}

--- a/internal/applicationset/applicationset_test.go
+++ b/internal/applicationset/applicationset_test.go
@@ -1,0 +1,85 @@
+package applicationset
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAnalyzeListGeneratorAuthoritative(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "applicationset.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: list-demo
+spec:
+  generators:
+    - list:
+        elements:
+          - name: dev
+            server: https://dev.example.invalid
+          - name: prod
+            server: https://prod.example.invalid
+  template:
+    metadata:
+      name: "{{name}}-inventory"
+    spec:
+      source:
+        path: apps/inventory
+`)
+
+	analysis, err := Analyze(repo, "applicationset.yaml", nil)
+	if err != nil {
+		t.Fatalf("Analyze returned error: %v", err)
+	}
+	if analysis.Mode != ModeAuthoritative {
+		t.Fatalf("expected authoritative mode, got %+v", analysis)
+	}
+	if len(analysis.GeneratedApplications) != 2 {
+		t.Fatalf("expected two generated applications, got %+v", analysis.GeneratedApplications)
+	}
+	if analysis.GeneratedApplications[0].Name != "dev-inventory" || analysis.GeneratedApplications[1].Name != "prod-inventory" {
+		t.Fatalf("unexpected generated applications: %+v", analysis.GeneratedApplications)
+	}
+}
+
+func TestAnalyzeUnsupportedGeneratorObservedOnly(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "applicationset.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: git-demo
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/example/platform-apps.git
+        revision: HEAD
+        directories:
+          - path: apps/*
+  template:
+    metadata:
+      name: "{{path.basename}}"
+`)
+
+	analysis, err := Analyze(repo, "applicationset.yaml", nil)
+	if err != nil {
+		t.Fatalf("Analyze returned error: %v", err)
+	}
+	if analysis.Mode != ModeObservedOnly {
+		t.Fatalf("expected observed-only mode, got %+v", analysis)
+	}
+	if !strings.Contains(analysis.ModeReason, "unsupported generator types git") {
+		t.Fatalf("expected explicit unsupported reason, got %+v", analysis)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/contracts/schemas/provenance.v1.schema.json
+++ b/internal/contracts/schemas/provenance.v1.schema.json
@@ -303,6 +303,99 @@
         }
       }
     },
+    "application_set_analysis": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "application_set_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generator_types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "unsupported_generator_types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "cluster_inventory_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "matched_clusters": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "list_element_names": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mode_reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generated_applications": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "generator_type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1
+              },
+              "inventory_path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "cluster": {
+                "type": "string",
+                "minLength": 1
+              },
+              "list_element": {
+                "type": "string",
+                "minLength": 1
+              },
+              "source_path": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    },
     "ops_workflow_analysis": {
       "type": "object",
       "additionalProperties": false,

--- a/internal/contracts/triple_conformance_fixtures_test.go
+++ b/internal/contracts/triple_conformance_fixtures_test.go
@@ -86,6 +86,7 @@ func TestContractTripleConformanceFixtures(t *testing.T) {
 
 func allFamilyFixtures() []familyFixture {
 	return []familyFixture{
+		{Name: "applicationset", RepoDir: filepath.Join("..", "testdata", "applicationset-standalone"), Kind: model.GeneratorApplicationSet, Profile: "applicationset"},
 		{Name: "helm", RepoDir: "helm-paas", Kind: model.GeneratorHelm, Profile: "helm-paas"},
 		{Name: "score", RepoDir: "scoredev-paas", Kind: model.GeneratorScore, Profile: "scoredev-paas"},
 		{Name: "spring", RepoDir: "springboot-paas", Kind: model.GeneratorSpringBoot, Profile: "springboot-paas"},

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/confighub/cub-gen/internal/applicationset"
 	"github.com/confighub/cub-gen/internal/model"
 	"github.com/confighub/cub-gen/internal/registry"
 )
@@ -76,6 +77,13 @@ func ScanRepo(repoPath, ref string) (model.DetectionResult, error) {
 	all = append(all, opsDetections...)
 	all = append(all, c3agentDetections...)
 	all = append(all, swampDetections...)
+	if len(all) == 0 {
+		applicationSetDetections, err := detectApplicationSet(absRepo)
+		if err != nil {
+			return model.DetectionResult{}, err
+		}
+		all = append(all, applicationSetDetections...)
+	}
 	sort.Slice(all, func(i, j int) bool {
 		if all[i].Kind != all[j].Kind {
 			return all[i].Kind < all[j].Kind
@@ -161,6 +169,90 @@ func existingHelmAuxiliaryInputs(repo, root string) []string {
 		filepath.Join(root, "platform", "catalogs", "customer-service-catalog", "*.yaml"),
 		filepath.Join(root, "platform", "catalogs", "customer-service-catalog", "*.yml"),
 		filepath.Join(root, "platform", "catalogs", "customer-service-catalog", "*.json"),
+	}
+	for _, pattern := range globs {
+		matches, _ := filepath.Glob(pattern)
+		for _, match := range matches {
+			rel, err := filepath.Rel(repo, match)
+			if err != nil {
+				continue
+			}
+			candidates = append(candidates, filepath.ToSlash(rel))
+		}
+	}
+	return uniqueSortedStrings(candidates)
+}
+
+func detectApplicationSet(repo string) ([]model.GeneratorDetection, error) {
+	detected := make(map[string]model.GeneratorDetection)
+	err := filepath.WalkDir(repo, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() && shouldSkipDir(d.Name()) {
+			return filepath.SkipDir
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := strings.ToLower(d.Name())
+		if name != "applicationset.yaml" && name != "applicationset.yml" {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(repo, path)
+		if err != nil {
+			return err
+		}
+		relPath = filepath.ToSlash(relPath)
+		if !applicationset.IsApplicationSetFile(repo, relPath) {
+			return nil
+		}
+
+		doc, err := applicationset.ParseFile(repo, relPath)
+		if err != nil {
+			return nil
+		}
+		root := filepath.ToSlash(filepath.Dir(relPath))
+		if root == "." {
+			root = ""
+		}
+
+		inputs := []string{doc.Path}
+		inputs = append(inputs, existingApplicationSetAuxiliaryInputs(repo)...)
+		inputs = uniqueSortedStrings(inputs)
+
+		id := shortID("applicationset:" + relPath)
+		key := "applicationset:" + relPath
+		detected[key] = model.GeneratorDetection{
+			ID:         "gen_" + id,
+			Kind:       model.GeneratorApplicationSet,
+			Profile:    profileForKind(model.GeneratorApplicationSet),
+			Name:       doc.Name,
+			Root:       root,
+			Inputs:     inputs,
+			Confidence: 0.95,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("detect applicationset: %w", err)
+	}
+	return mapValuesSorted(detected), nil
+}
+
+func existingApplicationSetAuxiliaryInputs(repo string) []string {
+	candidates := make([]string, 0, 8)
+	globs := []string{
+		filepath.Join(repo, "clusters", "*.yaml"),
+		filepath.Join(repo, "clusters", "*.yml"),
+		filepath.Join(repo, "clusters", "*.json"),
+		filepath.Join(repo, "inventory", "clusters", "*.yaml"),
+		filepath.Join(repo, "inventory", "clusters", "*.yml"),
+		filepath.Join(repo, "inventory", "clusters", "*.json"),
+		filepath.Join(repo, "platform", "clusters", "*.yaml"),
+		filepath.Join(repo, "platform", "clusters", "*.yml"),
+		filepath.Join(repo, "platform", "clusters", "*.json"),
 	}
 	for _, pattern := range globs {
 		matches, _ := filepath.Glob(pattern)

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -169,6 +169,36 @@ func TestScanRepoHelmIncludesLayeredAuxiliaryInputs(t *testing.T) {
 	}
 }
 
+func TestScanRepoApplicationSetStandalone(t *testing.T) {
+	t.Parallel()
+
+	repo := filepath.Join("..", "..", "testdata", "applicationset-standalone")
+	result, err := ScanRepo(repo, "main")
+	if err != nil {
+		t.Fatalf("ScanRepo returned error: %v", err)
+	}
+	if len(result.Generators) != 1 {
+		t.Fatalf("expected 1 generator, got %d", len(result.Generators))
+	}
+
+	g := result.Generators[0]
+	if g.Kind != model.GeneratorApplicationSet {
+		t.Fatalf("expected kind %q, got %q", model.GeneratorApplicationSet, g.Kind)
+	}
+	if g.Profile != "applicationset" {
+		t.Fatalf("expected profile applicationset, got %q", g.Profile)
+	}
+	for _, expected := range []string{
+		"applicationset.yaml",
+		"clusters/prod-eu.yaml",
+		"clusters/stage-eu.yaml",
+	} {
+		if !contains(g.Inputs, expected) {
+			t.Fatalf("expected applicationset inputs to contain %q; got %v", expected, g.Inputs)
+		}
+	}
+}
+
 func TestScanRepoC3AgentStructuralDetection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/exampletruth/bridge_matrix.go
+++ b/internal/exampletruth/bridge_matrix.go
@@ -14,6 +14,12 @@ type FamilyFixture struct {
 func BridgeSymmetryMatrix() []FamilyFixture {
 	return []FamilyFixture{
 		{
+			Name:            "applicationset",
+			RepoSuffix:      filepath.Join("testdata", "applicationset-standalone"),
+			ExpectedProfile: "applicationset",
+			ExpectedKind:    "applicationset",
+		},
+		{
 			Name:            "helm",
 			RepoSuffix:      filepath.Join("examples", "helm-paas"),
 			ExpectedProfile: "helm-paas",

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/confighub/cub-gen/internal/applicationset"
 	"github.com/confighub/cub-gen/internal/contracts"
 	"github.com/confighub/cub-gen/internal/detect"
 	"github.com/confighub/cub-gen/internal/model"
@@ -172,6 +173,7 @@ func buildProvenance(changeID, space string, detection model.DetectionResult, g 
 		FieldOriginMap:      fieldOriginsForGenerator(detection, g),
 		InverseEditPointers: inversePointersForGenerator(detection, g),
 		HelmLayeredAnalysis: helmLayeredAnalysisForGenerator(detection, g),
+		ApplicationSet:      applicationSetAnalysisForGenerator(detection, g),
 		OpsWorkflow:         opsWorkflowAnalysisForGenerator(detection, g),
 		SwampWorkflow:       swampWorkflowAnalysisForGenerator(detection, g),
 		RenderedAt:          renderedAt,
@@ -233,6 +235,40 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 			RequiresReview: policy.RequiresReview,
 			Reason:         registry.InversePatchReason(g.Kind, "image_tag", "Container image tag maps cleanly to helm values."),
 		}}
+	case model.GeneratorApplicationSet:
+		hints := applicationSetHintsFromInputs(detection.Repo, g.Inputs)
+		namePolicy := registry.InversePatchTemplateFor(g.Kind, "child_name", registry.InversePatchTemplate{
+			EditableBy: "platform-engineer", Confidence: 0.89, RequiresReview: false,
+		})
+		sourcePathPolicy := registry.InversePatchTemplateFor(g.Kind, "source_path", registry.InversePatchTemplate{
+			EditableBy: "platform-engineer", Confidence: 0.86, RequiresReview: true,
+		})
+		return []model.InversePatch{
+			{
+				Operation:      "replace",
+				DryPath:        "spec.template.metadata.name",
+				WetPath:        "Application/metadata/name",
+				EditableBy:     namePolicy.EditableBy,
+				Confidence:     namePolicy.Confidence,
+				RequiresReview: namePolicy.RequiresReview,
+				Reason: renderTargetTemplate(
+					registry.InversePatchReason(g.Kind, "child_name", "Child Application identity is generated from the parent ApplicationSet template."),
+					map[string]string{"application_set_path": hints.ApplicationSetPath},
+				),
+			},
+			{
+				Operation:      "replace",
+				DryPath:        "spec.template.spec.source.path",
+				WetPath:        "Application/spec/source/path",
+				EditableBy:     sourcePathPolicy.EditableBy,
+				Confidence:     sourcePathPolicy.Confidence,
+				RequiresReview: sourcePathPolicy.RequiresReview,
+				Reason: renderTargetTemplate(
+					registry.InversePatchReason(g.Kind, "source_path", "Child Application source path is generated from the parent ApplicationSet template."),
+					map[string]string{"application_set_path": hints.ApplicationSetPath},
+				),
+			},
+		}
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
 		policy := registry.InversePatchTemplateFor(g.Kind, "env_var", registry.InversePatchTemplate{
@@ -539,6 +575,27 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				SourcePath: sourcePath,
 				Transform:  transform,
 				Confidence: registry.FieldOriginConfidenceFor(g.Kind, confidenceKey, confidenceFallback),
+			})
+		}
+		return origins
+	case model.GeneratorApplicationSet:
+		hints := applicationSetHintsFromInputs(detection.Repo, g.Inputs)
+		origins := []model.FieldOrigin{
+			{
+				DryPath:    "spec.template.metadata.name",
+				WetPath:    "Application/metadata/name",
+				SourcePath: hints.ApplicationSetPath,
+				Transform:  registry.FieldOriginTransform(g.Kind),
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "child_name", 0.89),
+			},
+		}
+		if strings.TrimSpace(hints.TemplateSourcePath) != "" {
+			origins = append(origins, model.FieldOrigin{
+				DryPath:    "spec.template.spec.source.path",
+				WetPath:    "Application/spec/source/path",
+				SourcePath: hints.ApplicationSetPath,
+				Transform:  registry.FieldOriginTransform(g.Kind),
+				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "source_path", 0.86),
 			})
 		}
 		return origins
@@ -856,6 +913,34 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 				Confidence: policy.Confidence,
 			},
 		}
+	case model.GeneratorApplicationSet:
+		hints := applicationSetHintsFromInputs(detection.Repo, g.Inputs)
+		namePolicy := registry.InversePointerTemplateFor(g.Kind, "child_name", registry.InversePointerTemplate{
+			Owner: "platform-engineer", Confidence: 0.89,
+		})
+		sourcePathPolicy := registry.InversePointerTemplateFor(g.Kind, "source_path", registry.InversePointerTemplate{
+			Owner: "platform-engineer", Confidence: 0.86,
+		})
+		vars := map[string]string{"application_set_path": hints.ApplicationSetPath}
+		out := []model.InverseEditPointer{
+			{
+				WetPath:    "Application/metadata/name",
+				DryPath:    "spec.template.metadata.name",
+				Owner:      namePolicy.Owner,
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "child_name", "Edit spec.template.metadata.name in {{application_set_path}}."), vars),
+				Confidence: namePolicy.Confidence,
+			},
+		}
+		if strings.TrimSpace(hints.TemplateSourcePath) != "" {
+			out = append(out, model.InverseEditPointer{
+				WetPath:    "Application/spec/source/path",
+				DryPath:    "spec.template.spec.source.path",
+				Owner:      sourcePathPolicy.Owner,
+				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "source_path", "Edit spec.template.spec.source.path in {{application_set_path}}."), vars),
+				Confidence: sourcePathPolicy.Confidence,
+			})
+		}
+		return out
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
 		imagePolicy := registry.InversePointerTemplateFor(g.Kind, "image", registry.InversePointerTemplate{
@@ -1170,6 +1255,25 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 	}
 }
 
+type applicationSetHints struct {
+	ApplicationSetPath string
+	TemplateSourcePath string
+}
+
+func applicationSetHintsFromInputs(repo string, inputs []string) applicationSetHints {
+	h := applicationSetHints{
+		ApplicationSetPath: registry.HintDefault(model.GeneratorApplicationSet, "application_set_path", "applicationset.yaml"),
+	}
+	appsetPath := firstInputPathForRole(model.GeneratorApplicationSet, inputs, "application-set")
+	if appsetPath != "" {
+		h.ApplicationSetPath = appsetPath
+		if doc, err := applicationset.ParseFile(repo, appsetPath); err == nil {
+			h.TemplateSourcePath = doc.TemplateSourcePath
+		}
+	}
+	return h
+}
+
 type scoreHints struct {
 	SourcePath      string
 	ContainerName   string
@@ -1295,6 +1399,32 @@ func dryInputsForGenerator(g model.GeneratorDetection) []model.DryInputRef {
 }
 
 func wetManifestTargetsForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.WetManifestTarget {
+	if g.Kind == model.GeneratorApplicationSet {
+		analysis := applicationSetAnalysisForGenerator(detection, g)
+		out := []model.WetManifestTarget{{
+			GeneratorID:   g.ID,
+			Kind:          "ApplicationSet",
+			Name:          g.Name,
+			Owner:         "platform-runtime",
+			Namespace:     "argocd",
+			SourceDryPath: "spec",
+		}}
+		if analysis == nil {
+			return out
+		}
+		for _, child := range analysis.GeneratedApplications {
+			out = append(out, model.WetManifestTarget{
+				GeneratorID:   g.ID,
+				Kind:          "Application",
+				Name:          child.Name,
+				Owner:         "platform-runtime",
+				Namespace:     "argocd",
+				SourceDryPath: "spec.template.metadata.name",
+			})
+		}
+		return out
+	}
+
 	templates := registry.WetTargetTemplates(g.Kind)
 	if len(templates) == 0 {
 		return []model.WetManifestTarget{}
@@ -1505,6 +1635,51 @@ func firstDistinctPath(paths []string, primary string) string {
 		}
 	}
 	return ""
+}
+
+func applicationSetAnalysisForGenerator(detection model.DetectionResult, g model.GeneratorDetection) *model.ApplicationSetAnalysis {
+	if g.Kind != model.GeneratorApplicationSet {
+		return nil
+	}
+
+	appsetPath := firstInputPathForRole(g.Kind, g.Inputs, "application-set")
+	if appsetPath == "" {
+		return nil
+	}
+
+	clusterPaths := inputPathsForRole(g.Kind, g.Inputs, "cluster-inventory")
+	analysis, err := applicationset.Analyze(detection.Repo, appsetPath, clusterPaths)
+	if err != nil {
+		return &model.ApplicationSetAnalysis{
+			ApplicationSetPath:    appsetPath,
+			ClusterInventoryPaths: append([]string(nil), clusterPaths...),
+			Mode:                  applicationset.ModeObservedOnly,
+			ModeReason:            fmt.Sprintf("ApplicationSet input %s was observed, but cub-gen could not parse it deterministically yet.", appsetPath),
+		}
+	}
+
+	out := &model.ApplicationSetAnalysis{
+		ApplicationSetPath:        analysis.ApplicationSetPath,
+		GeneratorTypes:            append([]string(nil), analysis.GeneratorTypes...),
+		UnsupportedGeneratorTypes: append([]string(nil), analysis.UnsupportedGeneratorTypes...),
+		ClusterInventoryPaths:     append([]string(nil), analysis.ClusterInventoryPaths...),
+		MatchedClusters:           append([]string(nil), analysis.MatchedClusters...),
+		ListElementNames:          append([]string(nil), analysis.ListElementNames...),
+		Mode:                      analysis.Mode,
+		ModeReason:                analysis.ModeReason,
+	}
+	for _, child := range analysis.GeneratedApplications {
+		out.GeneratedApplications = append(out.GeneratedApplications, model.ApplicationSetGeneratedApplication{
+			Name:          child.Name,
+			GeneratorType: child.GeneratorType,
+			Reason:        child.Reason,
+			InventoryPath: child.InventoryPath,
+			Cluster:       child.Cluster,
+			ListElement:   child.ListElement,
+			SourcePath:    child.SourcePath,
+		})
+	}
+	return out
 }
 
 type helmApplicationSetDoc struct {
@@ -1835,6 +2010,31 @@ func uniqueStringsInOrder(values []string) []string {
 }
 
 func renderedLineageForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.RenderedObjectLineage {
+	if g.Kind == model.GeneratorApplicationSet {
+		analysis := applicationSetAnalysisForGenerator(detection, g)
+		hints := applicationSetHintsFromInputs(detection.Repo, g.Inputs)
+		lineage := []model.RenderedObjectLineage{{
+			Kind:          "ApplicationSet",
+			Name:          g.Name,
+			Namespace:     "argocd",
+			SourcePath:    hints.ApplicationSetPath,
+			SourceDryPath: "spec",
+		}}
+		if analysis == nil {
+			return lineage
+		}
+		for _, child := range analysis.GeneratedApplications {
+			lineage = append(lineage, model.RenderedObjectLineage{
+				Kind:          "Application",
+				Name:          child.Name,
+				Namespace:     "argocd",
+				SourcePath:    hints.ApplicationSetPath,
+				SourceDryPath: "spec.template.metadata.name",
+			})
+		}
+		return lineage
+	}
+
 	templates := registry.RenderedLineageTemplates(g.Kind)
 	if len(templates) == 0 {
 		return nil

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/confighub/cub-gen/internal/applicationset"
 	"github.com/confighub/cub-gen/internal/model"
 )
 
@@ -350,6 +351,89 @@ func TestImportRepoHelmDryWetContract(t *testing.T) {
 	}
 	if !wetTargetHasKindOwner(result.WetManifestTargets, "HelmRelease", "platform-runtime") {
 		t.Fatalf("expected HelmRelease owner to be platform-runtime, got %+v", result.WetManifestTargets)
+	}
+}
+
+func TestImportRepoApplicationSetDryWetContract(t *testing.T) {
+	repo := filepath.Join("..", "..", "testdata", "applicationset-standalone")
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+
+	if len(result.Provenance) != 1 {
+		t.Fatalf("expected single provenance record, got %d", len(result.Provenance))
+	}
+	prov := result.Provenance[0]
+	if prov.ApplicationSet == nil {
+		t.Fatalf("expected applicationset analysis, got nil")
+	}
+	if prov.ApplicationSet.Mode != applicationset.ModeAuthoritative {
+		t.Fatalf("expected authoritative mode, got %+v", prov.ApplicationSet)
+	}
+	if !containsString(prov.ApplicationSet.MatchedClusters, "prod-eu") {
+		t.Fatalf("expected matched cluster prod-eu, got %+v", prov.ApplicationSet)
+	}
+	if len(prov.ApplicationSet.GeneratedApplications) != 1 {
+		t.Fatalf("expected one generated application, got %+v", prov.ApplicationSet.GeneratedApplications)
+	}
+	if prov.ApplicationSet.GeneratedApplications[0].Name != "prod-eu-inventory" {
+		t.Fatalf("expected generated application prod-eu-inventory, got %+v", prov.ApplicationSet.GeneratedApplications)
+	}
+	if !renderedLineageHasKind(prov.RenderedLineage, "ApplicationSet") || !renderedLineageHasKind(prov.RenderedLineage, "Application") {
+		t.Fatalf("expected rendered lineage to include ApplicationSet and Application, got %+v", prov.RenderedLineage)
+	}
+	if !fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "spec.template.metadata.name", "applicationset.yaml") {
+		t.Fatalf("expected template name field origin to resolve to applicationset.yaml, got %+v", prov.FieldOriginMap)
+	}
+	if !inversePointerHintContains(prov.InverseEditPointers, "spec.template.metadata.name", "applicationset.yaml") {
+		t.Fatalf("expected inverse pointer to route back to applicationset.yaml, got %+v", prov.InverseEditPointers)
+	}
+
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "application-set", "platform-engineer", "applicationset.yaml") {
+		t.Fatalf("expected applicationset dry input, got %+v", result.DryInputs)
+	}
+	if !dryInputHasRoleOwnerPath(result.DryInputs, "cluster-inventory", "platform-engineer", "clusters/prod-eu.yaml") {
+		t.Fatalf("expected cluster inventory dry input, got %+v", result.DryInputs)
+	}
+	if !wetTargetHasKind(result.WetManifestTargets, "ApplicationSet") || !wetTargetHasKind(result.WetManifestTargets, "Application") {
+		t.Fatalf("expected ApplicationSet/Application wet targets, got %+v", result.WetManifestTargets)
+	}
+}
+
+func TestImportRepoApplicationSetGracefulDegradationWithoutClusterInventory(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "applicationset.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: platform-apps
+spec:
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            env: prod
+  template:
+    metadata:
+      name: "{{name}}-inventory"
+    spec:
+      source:
+        path: apps/inventory
+`)
+
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+	if len(result.Provenance) != 1 || result.Provenance[0].ApplicationSet == nil {
+		t.Fatalf("expected applicationset analysis, got %+v", result.Provenance)
+	}
+	got := result.Provenance[0].ApplicationSet
+	if got.Mode != applicationset.ModeAuthoritativeExpansionUnavailable {
+		t.Fatalf("expected authoritative-expansion-unavailable, got %+v", got)
+	}
+	if !strings.Contains(got.ModeReason, "no pinned cluster inventory inputs") {
+		t.Fatalf("expected explicit degraded reason, got %+v", got)
 	}
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -4,6 +4,7 @@ type GeneratorKind string
 
 const (
 	GeneratorHelm             GeneratorKind = "helm"
+	GeneratorApplicationSet   GeneratorKind = "applicationset"
 	GeneratorScore            GeneratorKind = "score"
 	GeneratorSpringBoot       GeneratorKind = "springboot"
 	GeneratorBackstage        GeneratorKind = "backstage"
@@ -112,6 +113,28 @@ type HelmLayeredAnalysis struct {
 	SecurityDecisionReason   string   `json:"security_decision_reason,omitempty"`
 }
 
+type ApplicationSetGeneratedApplication struct {
+	Name          string `json:"name"`
+	GeneratorType string `json:"generator_type,omitempty"`
+	Reason        string `json:"reason,omitempty"`
+	InventoryPath string `json:"inventory_path,omitempty"`
+	Cluster       string `json:"cluster,omitempty"`
+	ListElement   string `json:"list_element,omitempty"`
+	SourcePath    string `json:"source_path,omitempty"`
+}
+
+type ApplicationSetAnalysis struct {
+	ApplicationSetPath        string                               `json:"application_set_path,omitempty"`
+	GeneratorTypes            []string                             `json:"generator_types,omitempty"`
+	UnsupportedGeneratorTypes []string                             `json:"unsupported_generator_types,omitempty"`
+	ClusterInventoryPaths     []string                             `json:"cluster_inventory_paths,omitempty"`
+	MatchedClusters           []string                             `json:"matched_clusters,omitempty"`
+	ListElementNames          []string                             `json:"list_element_names,omitempty"`
+	Mode                      string                               `json:"mode,omitempty"`
+	ModeReason                string                               `json:"mode_reason,omitempty"`
+	GeneratedApplications     []ApplicationSetGeneratedApplication `json:"generated_applications,omitempty"`
+}
+
 type InverseEditPointer struct {
 	WetPath    string  `json:"wet_path"`
 	DryPath    string  `json:"dry_path"`
@@ -183,6 +206,7 @@ type ProvenanceRecord struct {
 	FieldOriginMap      []FieldOrigin           `json:"field_origin_map"`
 	InverseEditPointers []InverseEditPointer    `json:"inverse_edit_pointers"`
 	HelmLayeredAnalysis *HelmLayeredAnalysis    `json:"helm_layered_analysis,omitempty"`
+	ApplicationSet      *ApplicationSetAnalysis `json:"application_set_analysis,omitempty"`
 	OpsWorkflow         *OpsWorkflowAnalysis    `json:"ops_workflow_analysis,omitempty"`
 	SwampWorkflow       *SwampWorkflowAnalysis  `json:"swamp_workflow_analysis,omitempty"`
 	RenderedAt          string                  `json:"rendered_at"`

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -72,6 +72,57 @@ type FamilySpec struct {
 }
 
 var familySpecs = map[model.GeneratorKind]FamilySpec{
+	model.GeneratorApplicationSet: {
+		Kind:         model.GeneratorApplicationSet,
+		Profile:      "applicationset",
+		ResourceKind: "ApplicationSet",
+		ResourceType: "argoproj.io/v1alpha1/ApplicationSet",
+		Capabilities: []string{"observed-expansion", "authoritative-list-expansion", "authoritative-clusters-expansion", "graceful-degradation"},
+		RoleSchemaRefs: map[string]string{
+			"application-set":   "https://schema.confighub.dev/generators/applicationset-v1",
+			"cluster-inventory": "https://schema.confighub.dev/generators/cluster-inventory-v1",
+		},
+		HintDefaults: map[string]string{
+			"application_set_path": "applicationset.yaml",
+		},
+		InversePatchReasons: map[string]string{
+			"child_name":  "Child Application identity is generated from the parent ApplicationSet template.",
+			"source_path": "Child Application source path is generated from the parent ApplicationSet template.",
+		},
+		InverseEditHints: map[string]string{
+			"child_name":  "Edit spec.template.metadata.name in {{application_set_path}}.",
+			"source_path": "Edit spec.template.spec.source.path in {{application_set_path}}.",
+		},
+		InversePatchTemplates: map[string]InversePatchTemplate{
+			"child_name":  {EditableBy: "platform-engineer", Confidence: 0.89, RequiresReview: false},
+			"source_path": {EditableBy: "platform-engineer", Confidence: 0.86, RequiresReview: true},
+		},
+		InversePointerTemplates: map[string]InversePointerTemplate{
+			"child_name":  {Owner: "platform-engineer", Confidence: 0.89},
+			"source_path": {Owner: "platform-engineer", Confidence: 0.86},
+		},
+		FieldOriginConfidences: map[string]float64{
+			"child_name":  0.89,
+			"source_path": 0.86,
+		},
+		RenderedLineageTemplates: []RenderedLineageTemplate{
+			{Kind: "ApplicationSet", NameTemplate: "{{name}}", Namespace: "argocd", SourcePathHint: "application_set_path", SourceDryPathTemplate: "spec"},
+		},
+		FieldOriginTransform: "applicationset-template",
+		InputRoleRules: []InputRoleRule{
+			{Role: "application-set", ExactBasenames: []string{"applicationset.yaml", "applicationset.yml"}},
+			{Role: "cluster-inventory", PathPrefixes: []string{"clusters/", "inventory/clusters/", "platform/clusters/"}, Extensions: []string{".yaml", ".yml", ".json"}},
+		},
+		DefaultInputRole: "applicationset-input",
+		RoleOwners: map[string]string{
+			"application-set":   "platform-engineer",
+			"cluster-inventory": "platform-engineer",
+		},
+		DefaultOwner: "platform-engineer",
+		WetTargets: []WetTargetTemplate{
+			{Kind: "ApplicationSet", NameTemplate: "{{name}}", Owner: "platform-runtime", Namespace: "argocd"},
+		},
+	},
 	model.GeneratorHelm: {
 		Kind:         model.GeneratorHelm,
 		Profile:      "helm-paas",

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestRegistryHasSpecForAllKinds(t *testing.T) {
 	expected := []model.GeneratorKind{
+		model.GeneratorApplicationSet,
 		model.GeneratorBackstage,
 		model.GeneratorC3Agent,
 		model.GeneratorHelm,
@@ -41,6 +42,7 @@ func TestRegistryHasSpecForAllKinds(t *testing.T) {
 
 	expectedResourceKinds := []string{
 		"Application",
+		"ApplicationSet",
 		"Component",
 		"ConfigMap",
 		"HelmRelease",
@@ -115,6 +117,8 @@ func TestRegistryInputRoleAndOwnerClassification(t *testing.T) {
 		expectedOwner string
 	}{
 		{name: "helm-chart", kind: model.GeneratorHelm, path: "Chart.yaml", expectedRole: "chart", expectedOwner: "platform-engineer"},
+		{name: "applicationset-spec", kind: model.GeneratorApplicationSet, path: "applicationset.yaml", expectedRole: "application-set", expectedOwner: "platform-engineer"},
+		{name: "applicationset-cluster-inventory", kind: model.GeneratorApplicationSet, path: "clusters/prod-eu.yaml", expectedRole: "cluster-inventory", expectedOwner: "platform-engineer"},
 		{name: "helm-values", kind: model.GeneratorHelm, path: "values-prod.yaml", expectedRole: "values", expectedOwner: "app-team"},
 		{name: "helm-applicationset", kind: model.GeneratorHelm, path: "gitops/argo/applicationset.yaml", expectedRole: "application-set", expectedOwner: "platform-engineer"},
 		{name: "helm-cluster-inventory", kind: model.GeneratorHelm, path: "platform/clusters/prod-eu.yaml", expectedRole: "cluster-inventory", expectedOwner: "platform-engineer"},
@@ -153,6 +157,7 @@ func TestRegistrySchemaRef(t *testing.T) {
 		expected string
 	}{
 		{name: "helm-chart", kind: model.GeneratorHelm, path: "Chart.yaml", expected: "https://json.schemastore.org/chart"},
+		{name: "applicationset", kind: model.GeneratorApplicationSet, path: "applicationset.yaml", expected: "https://schema.confighub.dev/generators/applicationset-v1"},
 		{name: "score", kind: model.GeneratorScore, path: "score.yaml", expected: "https://docs.score.dev/schemas/score-v1b1.json"},
 		{name: "spring-app", kind: model.GeneratorSpringBoot, path: "application.yaml", expected: "https://json.schemastore.org/spring-configuration-metadata"},
 		{name: "backstage-catalog", kind: model.GeneratorBackstage, path: "catalog-info.yaml", expected: "https://json.schemastore.org/backstage-catalog-info"},

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,8 @@ nav:
 
   - Contracts:
       - "Canonical Triple & Storage": contracts/canonical-triple-and-storage-boundary.md
+      - "ApplicationSet Boundary": contracts/applicationset-generator-boundary.md
+      - "Remote Stores & Projection Targets": contracts/remote-stores-and-projection-targets.md
       - "Decision & Attestation State": contracts/decision-and-attestation-state.md
       - "PR/MR Linkage & Promotion": contracts/pr-mr-linkage-and-dry-promotion.md
       - "Checkpoint Schemas": agentic-gitops/04-schemas/00-gitops-checkpoint-schemas.md
@@ -135,6 +137,7 @@ nav:
   - Generators:
       - "Overview": triple-styles/README.md
       - Style B (Markdown):
+          - "ApplicationSet": triple-styles/style-b-markdown/applicationset.md
           - "Helm": triple-styles/style-b-markdown/helm.md
           - "Score.dev": triple-styles/style-b-markdown/score.md
           - "Spring Boot": triple-styles/style-b-markdown/springboot.md
@@ -144,6 +147,7 @@ nav:
           - "C3 Agent": triple-styles/style-b-markdown/c3agent.md
           - "Swamp": triple-styles/style-b-markdown/swamp.md
       - Style C (YAML + Docs):
+          - "ApplicationSet": triple-styles/style-c-yaml-plus-docs/applicationset/triple.md
           - "Helm": triple-styles/style-c-yaml-plus-docs/helm/triple.md
           - "Score.dev": triple-styles/style-c-yaml-plus-docs/score/triple.md
           - "Spring Boot": triple-styles/style-c-yaml-plus-docs/springboot/triple.md

--- a/testdata/applicationset-standalone/applicationset.yaml
+++ b/testdata/applicationset-standalone/applicationset.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: platform-apps
+spec:
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            env: prod
+            region: eu
+  template:
+    metadata:
+      name: "{{name}}-inventory"
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/confighub/cub-gen.git
+        targetRevision: HEAD
+        path: examples/springboot-paas
+      destination:
+        server: "{{server}}"
+        namespace: apps

--- a/testdata/applicationset-standalone/clusters/prod-eu.yaml
+++ b/testdata/applicationset-standalone/clusters/prod-eu.yaml
@@ -1,0 +1,9 @@
+apiVersion: cubgen.confighub.dev/v1alpha1
+kind: ClusterInventory
+metadata:
+  name: prod-eu
+  labels:
+    env: prod
+    region: eu
+spec:
+  server: https://prod-eu.example.invalid

--- a/testdata/applicationset-standalone/clusters/stage-eu.yaml
+++ b/testdata/applicationset-standalone/clusters/stage-eu.yaml
@@ -1,0 +1,9 @@
+apiVersion: cubgen.confighub.dev/v1alpha1
+kind: ClusterInventory
+metadata:
+  name: stage-eu
+  labels:
+    env: stage
+    region: eu
+spec:
+  server: https://stage-eu.example.invalid


### PR DESCRIPTION
## Summary

Closes #214
Closes #221

This adds a first-class `applicationset` generator family for standalone deterministic repos and lands the written remote-store / projection-target model.

## What changed

- added `applicationset` as a registry-backed generator family with:
  - standalone detection
  - deterministic import/provenance support
  - authoritative `list` / pinned-`clusters` expansion
  - explicit degraded modes for unsupported or missing-input cases
- added a standalone fixture at `testdata/applicationset-standalone`
- added importer/model/schema support for `application_set_analysis`
- updated generator details surfaces to include `path_prefixes` so input-role rules stay inspectable
- regenerated parity goldens and triple-style projections for the new family
- documented the ApplicationSet boundary relative to layered Helm work
- documented the remote-store / external-authority / projection-target model and made `project downstream` explicit route language
- refreshed top-level status/docs to reflect `v0.2-preview.2` and 9 generator families

## Proof

- `go test ./...`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`
- `go run ./cmd/cub-gen gitops discover --space platform --json ./testdata/applicationset-standalone`
- `go run ./cmd/cub-gen gitops import --space platform --json ./testdata/applicationset-standalone`

## Notes

- This keeps the layered Helm/ApplicationSet story explicit: standalone ApplicationSet repos detect/import as `applicationset`, while the existing Helm layered provenance path remains the current shape for mixed Helm/ApplicationSet repos.
- `mkdocs build --strict` was not run here because `mkdocs` is not installed in this shell.
