### PR TITLE
feat: capture Helm CLI overrides in provenance

### DIFF
--- a/cmd/cub-gen/change_api.go
+++ b/cmd/cub-gen/change_api.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	bridgeflow "github.com/confighub/cub-gen/internal/bridge"
+	"github.com/confighub/cub-gen/internal/importer"
 	"github.com/confighub/cub-gen/internal/model"
 )
 
@@ -21,6 +22,7 @@ type changeRunOptions struct {
 	Space            string
 	Ref              string
 	WhereResource    string
+	HelmCLIOverrides []model.HelmCLIOverride
 	Mode             string
 	BaseURL          string
 	Token            string
@@ -46,6 +48,7 @@ func executeChangeRun(targetSlug, renderTargetSlug string, opts changeRunOptions
 		opts.Ref,
 		opts.WhereResource,
 		verifier,
+		opts.HelmCLIOverrides,
 	)
 	if err != nil {
 		return changeRunResult{}, nil, err
@@ -121,13 +124,16 @@ func executeChangeRun(targetSlug, renderTargetSlug string, opts changeRunOptions
 }
 
 type changeAPIInput struct {
-	TargetSlug       string `json:"target_slug"`
-	TargetPath       string `json:"target_path,omitempty"`
-	RenderTargetSlug string `json:"render_target_slug"`
-	RenderTargetPath string `json:"render_target_path,omitempty"`
-	Space            string `json:"space,omitempty"`
-	Ref              string `json:"ref,omitempty"`
-	WhereResource    string `json:"where_resource,omitempty"`
+	TargetSlug       string   `json:"target_slug"`
+	TargetPath       string   `json:"target_path,omitempty"`
+	RenderTargetSlug string   `json:"render_target_slug"`
+	RenderTargetPath string   `json:"render_target_path,omitempty"`
+	Space            string   `json:"space,omitempty"`
+	Ref              string   `json:"ref,omitempty"`
+	WhereResource    string   `json:"where_resource,omitempty"`
+	HelmSet          []string `json:"helm_set,omitempty"`
+	HelmSetString    []string `json:"helm_set_string,omitempty"`
+	HelmSetFile      []string `json:"helm_set_file,omitempty"`
 }
 
 type changeAPIConnected struct {
@@ -300,9 +306,14 @@ func (s *changeAPIServer) handlePostChanges(w http.ResponseWriter, r *http.Reque
 		ref = s.defaultRef
 	}
 	whereResource := strings.TrimSpace(req.Input.WhereResource)
+	helmCLIOverrides, err := importer.ParseHelmCLIOverrides(req.Input.HelmSet, req.Input.HelmSetString, req.Input.HelmSetFile)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error(), map[string]any{"field": "input"})
+		return
+	}
 
 	if action == "preview" {
-		preview, _, imported, err := buildChangePreviewResult(targetSlug, renderTargetSlug, space, ref, whereResource, s.defaultVerifier)
+		preview, _, imported, err := buildChangePreviewResult(targetSlug, renderTargetSlug, space, ref, whereResource, s.defaultVerifier, helmCLIOverrides)
 		if err != nil {
 			writeAPIError(w, http.StatusUnprocessableEntity, "CHANGE_FAILED", err.Error(), nil)
 			return
@@ -336,6 +347,7 @@ func (s *changeAPIServer) handlePostChanges(w http.ResponseWriter, r *http.Reque
 		Space:            space,
 		Ref:              ref,
 		WhereResource:    whereResource,
+		HelmCLIOverrides: helmCLIOverrides,
 		Mode:             runMode,
 		BaseURL:          strings.TrimSpace(req.Connected.BaseURL),
 		Token:            strings.TrimSpace(req.Connected.Token),
@@ -532,5 +544,6 @@ func printChangeAPIUsage(out *os.File) {
 	fmt.Fprintln(out, "Request shape:")
 	fmt.Fprintln(out, "  input.target_path=<repo-path>")
 	fmt.Fprintln(out, "  input.render_target_path=<repo-path> (optional; defaults to target_path)")
+	fmt.Fprintln(out, "  input.helm_set[]=key=value | input.helm_set_string[]=key=value | input.helm_set_file[]=key=path (optional for Helm repos)")
 	fmt.Fprintln(out, "  legacy input.target_slug/render_target_slug still work for compatibility")
 }

--- a/cmd/cub-gen/flag_helpers.go
+++ b/cmd/cub-gen/flag_helpers.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/confighub/cub-gen/internal/importer"
+	"github.com/confighub/cub-gen/internal/model"
+)
+
+type multiStringFlag []string
+
+func (m *multiStringFlag) String() string {
+	if m == nil {
+		return ""
+	}
+	return strings.Join(*m, ",")
+}
+
+func (m *multiStringFlag) Set(value string) error {
+	*m = append(*m, value)
+	return nil
+}
+
+type helmCLIOverrideFlagSet struct {
+	set       multiStringFlag
+	setString multiStringFlag
+	setFile   multiStringFlag
+}
+
+func addHelmCLIOverrideFlags(fs *flag.FlagSet) *helmCLIOverrideFlagSet {
+	flags := &helmCLIOverrideFlagSet{}
+	fs.Var(&flags.set, "set", "Helm-style override (key=value); repeat or comma-separate entries")
+	fs.Var(&flags.setString, "set-string", "Helm-style string override (key=value); repeat or comma-separate entries")
+	fs.Var(&flags.setFile, "set-file", "Helm-style file override (key=path); repeat or comma-separate entries")
+	return flags
+}
+
+func (f *helmCLIOverrideFlagSet) parse() ([]model.HelmCLIOverride, error) {
+	if f == nil {
+		return nil, nil
+	}
+	return importer.ParseHelmCLIOverrides(f.set, f.setString, f.setFile)
+}

--- a/cmd/cub-gen/helm_override_command_test.go
+++ b/cmd/cub-gen/helm_override_command_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGitOpsImportHelmCLIOverridesJSON(t *testing.T) {
+	setupAliases(t)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"gitops", "import",
+		"--space", "platform",
+		"--json",
+		"--set", "image.tag=v9.9.9",
+		"helm",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("gitops import returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal import output: %v\noutput=%s", err, out)
+	}
+
+	overrides, ok := got["helm_cli_overrides"].([]any)
+	if !ok || len(overrides) != 1 {
+		t.Fatalf("expected top-level helm_cli_overrides, got %T %+v", got["helm_cli_overrides"], got["helm_cli_overrides"])
+	}
+
+	provenance, ok := got["provenance"].([]any)
+	if !ok || len(provenance) == 0 {
+		t.Fatalf("expected provenance records, got %T %+v", got["provenance"], got["provenance"])
+	}
+	record, ok := provenance[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected provenance record object, got %T", provenance[0])
+	}
+	fieldOrigins, ok := record["field_origin_map"].([]any)
+	if !ok || len(fieldOrigins) == 0 {
+		t.Fatalf("expected field_origin_map, got %T %+v", record["field_origin_map"], record["field_origin_map"])
+	}
+	firstOrigin, ok := fieldOrigins[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected field origin object, got %T", fieldOrigins[0])
+	}
+	if firstOrigin["transform"] != "helm-cli-override" {
+		t.Fatalf("expected helm-cli-override transform, got %v", firstOrigin["transform"])
+	}
+	if firstOrigin["source_path"] != "--set image.tag=v9.9.9" {
+		t.Fatalf("expected override source_path, got %v", firstOrigin["source_path"])
+	}
+}
+
+func TestChangeExplainHelmCLIOverrideWins(t *testing.T) {
+	setupAliases(t)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		"--set", "image.tag=v9.9.9",
+		"helm",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, out)
+	}
+	explanation, ok := got["explanation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected explanation object, got %T", got["explanation"])
+	}
+	if explanation["source_transform"] != "helm-cli-override" {
+		t.Fatalf("expected source_transform=helm-cli-override, got %v", explanation["source_transform"])
+	}
+	if explanation["source_path"] != "--set image.tag=v9.9.9" {
+		t.Fatalf("expected source_path override, got %v", explanation["source_path"])
+	}
+	if explanation["owner"] != "release-automation" {
+		t.Fatalf("expected owner release-automation, got %v", explanation["owner"])
+	}
+	editHint, _ := explanation["edit_hint"].(string)
+	if !strings.Contains(editHint, "Helm CLI override") {
+		t.Fatalf("expected override-aware edit hint, got %q", editHint)
+	}
+	warning, _ := explanation["warning"].(string)
+	if !strings.Contains(warning, "editing values files alone will not change") {
+		t.Fatalf("expected override warning, got %q", warning)
+	}
+}
+
+func TestChangeAPIHTTPPreviewWithHelmCLIOverride(t *testing.T) {
+	setupAliases(t)
+
+	srv := httptest.NewServer(newChangeAPIHandler("platform", "HEAD", "ci-bot"))
+	defer srv.Close()
+
+	req := map[string]any{
+		"action": "preview",
+		"input": map[string]any{
+			"target_slug": "helm",
+			"helm_set":    []string{"image.tag=v9.9.9"},
+		},
+	}
+	status, body := mustJSONRequest(t, http.MethodPost, srv.URL+"/v1/changes", req)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 from preview request, got %d body=%v", status, body)
+	}
+
+	input, ok := body["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected input object, got %T", body["input"])
+	}
+	overrides, ok := input["helm_cli_overrides"].([]any)
+	if !ok || len(overrides) != 1 {
+		t.Fatalf("expected echoed helm_cli_overrides, got %T %+v", input["helm_cli_overrides"], input["helm_cli_overrides"])
+	}
+}

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -19,6 +19,8 @@ import (
 	"github.com/confighub/cub-gen/internal/registry"
 )
 
+const helmCLIOverrideTransform = "helm-cli-override"
+
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
@@ -697,14 +699,21 @@ func runLegacyImport(args []string) error {
 	space := fs.String("space", "default", "Target ConfigHub space")
 	out := fs.String("out", "-", "Output file path, or '-' for stdout")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	overrideFlags := addHelmCLIOverrideFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
 		}
 		return err
 	}
+	helmCLIOverrides, err := overrideFlags.parse()
+	if err != nil {
+		return err
+	}
 
-	result, err := importer.ImportRepo(*repo, *ref, *space)
+	result, err := importer.ImportRepoWithOptions(*repo, *ref, *space, importer.ImportOptions{
+		HelmCLIOverrides: helmCLIOverrides,
+	})
 	if err != nil {
 		return err
 	}
@@ -736,18 +745,25 @@ func runPublish(args []string) error {
 	ref := fs.String("ref", "HEAD", "Git ref label to include in output (direct mode)")
 	whereResource := fs.String("where-resource", "", "Additional resource filter expression (direct mode)")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	overrideFlags := addHelmCLIOverrideFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
 		}
 		return err
 	}
+	helmCLIOverrides, err := overrideFlags.parse()
+	if err != nil {
+		return err
+	}
 
 	var imported gitopsflow.ImportFlowResult
 	switch fs.NArg() {
 	case 0:
+		if len(helmCLIOverrides) > 0 {
+			return errors.New("cannot combine Helm CLI override flags with --in pipe mode")
+		}
 		var inputBytes []byte
-		var err error
 		if *in == "-" {
 			inputBytes, err = io.ReadAll(os.Stdin)
 			if err != nil {
@@ -770,7 +786,9 @@ func runPublish(args []string) error {
 		if err != nil {
 			return err
 		}
-		imported, err = gitopsflow.Import(targetSlug, renderTargetSlug, *ref, *space, *whereResource)
+		imported, err = gitopsflow.ImportWithOptions(targetSlug, renderTargetSlug, *ref, *space, *whereResource, importer.ImportOptions{
+			HelmCLIOverrides: helmCLIOverrides,
+		})
 		if err != nil {
 			return err
 		}
@@ -972,13 +990,14 @@ func runVerifyAttestation(args []string) error {
 }
 
 type changePreviewInput struct {
-	TargetSlug       string `json:"target_slug"`
-	TargetPath       string `json:"target_path,omitempty"`
-	RenderTargetSlug string `json:"render_target_slug"`
-	RenderTargetPath string `json:"render_target_path,omitempty"`
-	Space            string `json:"space"`
-	Ref              string `json:"ref"`
-	WhereResource    string `json:"where_resource,omitempty"`
+	TargetSlug       string                  `json:"target_slug"`
+	TargetPath       string                  `json:"target_path,omitempty"`
+	RenderTargetSlug string                  `json:"render_target_slug"`
+	RenderTargetPath string                  `json:"render_target_path,omitempty"`
+	Space            string                  `json:"space"`
+	Ref              string                  `json:"ref"`
+	WhereResource    string                  `json:"where_resource,omitempty"`
+	HelmCLIOverrides []model.HelmCLIOverride `json:"helm_cli_overrides,omitempty"`
 }
 
 type changePreviewSummary struct {
@@ -1039,6 +1058,7 @@ type changeExplainSuggestion struct {
 	SourceTransform  string  `json:"source_transform,omitempty"`
 	GeneratorName    string  `json:"generator_name,omitempty"`
 	GeneratorProfile string  `json:"generator_profile,omitempty"`
+	Warning          string  `json:"warning,omitempty"`
 }
 
 type changeExplainResult struct {
@@ -1082,6 +1102,7 @@ func runChangePreview(args []string) error {
 	verifier := fs.String("verifier", "cub-gen", "Verifier identity label")
 	jsonOut := fs.Bool("json", true, "Output JSON")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	overrideFlags := addHelmCLIOverrideFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -1089,6 +1110,10 @@ func runChangePreview(args []string) error {
 		return err
 	}
 	_ = jsonOut
+	helmCLIOverrides, err := overrideFlags.parse()
+	if err != nil {
+		return err
+	}
 
 	targetSlug, renderTargetSlug, err := resolveTargetPairArgs(fs, "usage: cub-gen change preview [flags] <target-path> [<render-target-path>]")
 	if err != nil {
@@ -1102,6 +1127,7 @@ func runChangePreview(args []string) error {
 		*ref,
 		*whereResource,
 		*verifier,
+		helmCLIOverrides,
 	)
 	if err != nil {
 		return err
@@ -1136,6 +1162,7 @@ func runChangeRun(args []string) error {
 	verifier := fs.String("verifier", "cub-gen", "Verifier identity label")
 	jsonOut := fs.Bool("json", true, "Output JSON")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	overrideFlags := addHelmCLIOverrideFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -1143,6 +1170,10 @@ func runChangeRun(args []string) error {
 		return err
 	}
 	_ = jsonOut
+	helmCLIOverrides, err := overrideFlags.parse()
+	if err != nil {
+		return err
+	}
 
 	targetSlug, renderTargetSlug, err := resolveTargetPairArgs(fs, "usage: cub-gen change run [flags] <target-path> [<render-target-path>]")
 	if err != nil {
@@ -1163,6 +1194,7 @@ func runChangeRun(args []string) error {
 		IngestEndpoint:   *ingestEndpoint,
 		DecisionEndpoint: *decisionEndpoint,
 		Verifier:         *verifier,
+		HelmCLIOverrides: helmCLIOverrides,
 	})
 	if err != nil {
 		return err
@@ -1196,6 +1228,7 @@ func runChangeExplain(args []string) error {
 	out := fs.String("out", "-", "Output file path, or '-' for stdout")
 	jsonOut := fs.Bool("json", true, "Output JSON")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	overrideFlags := addHelmCLIOverrideFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -1203,6 +1236,10 @@ func runChangeExplain(args []string) error {
 		return err
 	}
 	_ = jsonOut
+	helmCLIOverrides, err := overrideFlags.parse()
+	if err != nil {
+		return err
+	}
 
 	wetFilter := strings.TrimSpace(*wetPath)
 	dryFilter := strings.TrimSpace(*dryPath)
@@ -1213,10 +1250,12 @@ func runChangeExplain(args []string) error {
 		input      changePreviewInput
 		change     changePreviewSummary
 		provenance []model.ProvenanceRecord
-		err        error
 	)
 
 	if changeIDFilter != "" {
+		if len(helmCLIOverrides) > 0 {
+			return errors.New("change explain --change-id/--bundle cannot be combined with Helm CLI override flags")
+		}
 		if fs.NArg() != 0 {
 			return errors.New("usage: cub-gen change explain --change-id ID --bundle FILE [flags]")
 		}
@@ -1269,6 +1308,7 @@ func runChangeExplain(args []string) error {
 			*ref,
 			*whereResource,
 			"cub-gen",
+			helmCLIOverrides,
 		)
 		if err != nil {
 			return err
@@ -1311,8 +1351,11 @@ func runChangeExplain(args []string) error {
 
 func buildChangePreviewResult(
 	targetSlug, renderTargetSlug, space, ref, whereResource, verifier string,
+	helmCLIOverrides []model.HelmCLIOverride,
 ) (changePreviewResult, publish.ChangeBundle, gitopsflow.ImportFlowResult, error) {
-	imported, err := gitopsflow.Import(targetSlug, renderTargetSlug, ref, space, whereResource)
+	imported, err := gitopsflow.ImportWithOptions(targetSlug, renderTargetSlug, ref, space, whereResource, importer.ImportOptions{
+		HelmCLIOverrides: helmCLIOverrides,
+	})
 	if err != nil {
 		return changePreviewResult{}, publish.ChangeBundle{}, gitopsflow.ImportFlowResult{}, err
 	}
@@ -1347,6 +1390,7 @@ func buildChangePreviewResult(
 			Space:            imported.Space,
 			Ref:              imported.Ref,
 			WhereResource:    strings.TrimSpace(whereResource),
+			HelmCLIOverrides: append([]model.HelmCLIOverride(nil), imported.HelmCLIOverrides...),
 		},
 		Change: changePreviewSummary{
 			ChangeID:          bundle.ChangeID,
@@ -1373,16 +1417,23 @@ func buildChangePreviewResult(
 
 func bestInverseEditPointer(provenance []model.ProvenanceRecord) (model.InverseEditPointer, bool) {
 	best := model.InverseEditPointer{}
-	found := false
+	bestConfidence := -1.0
 	for _, record := range provenance {
 		for _, pointer := range record.InverseEditPointers {
-			if !found || pointer.Confidence > best.Confidence {
-				best = pointer
-				found = true
+			candidate := pointer
+			if source, ok := bestFieldOrigin(record.FieldOriginMap, pointer.WetPath, pointer.DryPath); ok {
+				candidate = applyFieldOriginToPointer(candidate, source)
+			}
+			if candidate.Confidence > bestConfidence {
+				best = candidate
+				bestConfidence = candidate.Confidence
 			}
 		}
 	}
-	return best, found
+	if bestConfidence < 0 {
+		return model.InverseEditPointer{}, false
+	}
+	return best, true
 }
 
 func pickInverseSuggestion(
@@ -1408,9 +1459,11 @@ func pickInverseSuggestion(
 
 			sourcePath := ""
 			sourceTransform := ""
+			sourceConfidence := 0.0
 			if source, ok := bestFieldOrigin(record.FieldOriginMap, pointer.WetPath, pointer.DryPath); ok {
 				sourcePath = source.SourcePath
 				sourceTransform = source.Transform
+				sourceConfidence = source.Confidence
 			}
 
 			candidate := changeExplainSuggestion{
@@ -1423,6 +1476,14 @@ func pickInverseSuggestion(
 				SourceTransform:  sourceTransform,
 				GeneratorName:    record.GeneratorName,
 				GeneratorProfile: record.GeneratorProfile,
+			}
+			if sourceTransform == helmCLIOverrideTransform {
+				candidate.Owner = "release-automation"
+				candidate.EditHint = overrideAwareEditHint(sourcePath, pointer.EditHint)
+				candidate.Warning = overrideAwareWarning()
+				if sourceConfidence > candidate.Confidence {
+					candidate.Confidence = sourceConfidence
+				}
 			}
 			if candidate.Confidence > bestConfidence {
 				best = candidate
@@ -1483,6 +1544,29 @@ func bestFieldOrigin(origins []model.FieldOrigin, wetPath, dryPath string) (mode
 		return model.FieldOrigin{}, false
 	}
 	return best, true
+}
+
+func applyFieldOriginToPointer(pointer model.InverseEditPointer, origin model.FieldOrigin) model.InverseEditPointer {
+	if origin.Transform != helmCLIOverrideTransform {
+		return pointer
+	}
+	pointer.Owner = "release-automation"
+	pointer.EditHint = overrideAwareEditHint(origin.SourcePath, pointer.EditHint)
+	if origin.Confidence > pointer.Confidence {
+		pointer.Confidence = origin.Confidence
+	}
+	return pointer
+}
+
+func overrideAwareEditHint(sourcePath, fallback string) string {
+	if strings.TrimSpace(sourcePath) == "" {
+		return fallback
+	}
+	return fmt.Sprintf("This render used %s. Edit that Helm CLI override or the CI/pipeline step that passes it before changing values files.", sourcePath)
+}
+
+func overrideAwareWarning() string {
+	return "This field was overridden by the Helm CLI invocation for this run, so editing values files alone will not change the rendered output."
 }
 
 func discoveredProfiles(discovered []gitopsflow.DiscoveredResource) []string {
@@ -1593,6 +1677,7 @@ func runGitOpsImport(args []string) error {
 	wait := fs.Bool("wait", false, "Accepted for parity with cub gitops import")
 	jsonOut := fs.Bool("json", false, "Output JSON")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	overrideFlags := addHelmCLIOverrideFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -1600,13 +1685,19 @@ func runGitOpsImport(args []string) error {
 		return err
 	}
 	_ = wait
+	helmCLIOverrides, err := overrideFlags.parse()
+	if err != nil {
+		return err
+	}
 
 	targetSlug, renderTargetSlug, err := resolveTargetPairArgs(fs, "usage: cub-gen gitops import [flags] <target-path> [<render-target-path>]")
 	if err != nil {
 		return err
 	}
 
-	result, err := gitopsflow.Import(targetSlug, renderTargetSlug, *ref, *space, *whereResource)
+	result, err := gitopsflow.ImportWithOptions(targetSlug, renderTargetSlug, *ref, *space, *whereResource, importer.ImportOptions{
+		HelmCLIOverrides: helmCLIOverrides,
+	})
 	if err != nil {
 		return err
 	}
@@ -2052,9 +2143,9 @@ func printChangeUsage(out io.Writer) {
 		helpSection{
 			Title: "Usage",
 			Lines: []string{
-				"  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-path> [<render-target-path>]",
-				"  cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-path> [<render-target-path>]",
-				"  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-path> [<render-target-path>]",
+				"  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-path> [<render-target-path>]",
+				"  cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-path> [<render-target-path>]",
+				"  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-path> [<render-target-path>]",
 				"  cub-gen change explain --change-id ID --bundle FILE [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty]",
 				"  cub-gen change api serve [--listen ADDR] [--space SPACE] [--ref REF] [--verifier NAME]",
 			},
@@ -2063,6 +2154,7 @@ func printChangeUsage(out io.Writer) {
 			Title: "Examples",
 			Lines: []string{
 				"  cub-gen change preview --space my-space ./examples/helm-paas",
+				"  cub-gen change explain --space my-space --set image.tag=v1.2.4 ./examples/helm-paas",
 				"  cub-gen change run --mode local --space my-space ./examples/scoredev-paas",
 				"  cub-gen change explain --space my-space --wet-path \"Deployment/spec/template/spec/containers[0]/ports[0]/containerPort\" ./examples/springboot-paas",
 				"  cub-gen change explain --change-id chg_123 --bundle bundle.json --wet-path \"Deployment/spec/template/spec/containers[0]/image\"",
@@ -2074,6 +2166,7 @@ func printChangeUsage(out io.Writer) {
 			Lines: []string{
 				"  - Start with 'change explain' if you already know the rendered field you care about",
 				"  - Start with 'change preview' before 'change run'",
+				"  - Helm CLI overrides win over values-prod.yaml, values.yaml, and chart defaults",
 				"  - 'change run --mode connected' asks ConfigHub for a decision; it does not deploy",
 				"  - If omitted, <render-target-path> defaults to <target-path>",
 			},
@@ -2097,7 +2190,7 @@ func printGitOpsUsage(out io.Writer) {
 			Title: "Usage",
 			Lines: []string{
 				"  cub-gen gitops discover [--space SPACE] [--ref REF] [--where-resource EXPR] [--json] <target-path>",
-				"  cub-gen gitops import [--space SPACE] [--ref REF] [--where-resource EXPR] [--wait] [--json] <target-path> [<render-target-path>]",
+				"  cub-gen gitops import [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--wait] [--json] <target-path> [<render-target-path>]",
 				"  cub-gen gitops cleanup [--space SPACE] [--json] <target-path>",
 			},
 		},
@@ -2116,6 +2209,7 @@ func printGitOpsUsage(out io.Writer) {
 				"  cub-gen gitops discover --space my-space ./examples/scoredev-paas",
 				"  cub-gen gitops discover --where-resource \"kind IN ('HelmRelease') AND resource_name LIKE '<contains-payments>'\" ./examples/helm-paas",
 				"  cub-gen gitops import --space my-space ./examples/springboot-paas",
+				"  cub-gen gitops import --space my-space --set image.tag=v1.2.4 ./examples/helm-paas",
 				"  cub-gen gitops cleanup --space my-space ./examples/springboot-paas",
 			},
 		},
@@ -2124,6 +2218,7 @@ func printGitOpsUsage(out io.Writer) {
 			Lines: []string{
 				"  - Start with 'gitops import' if you want provenance immediately",
 				"  - Use 'gitops discover' first when you want to filter or explore a repo",
+				"  - Helm CLI overrides win over values-prod.yaml, values.yaml, and chart defaults",
 				"  - If omitted, <render-target-path> defaults to <target-path>",
 				"  - For cluster-side import, use 'cub gitops' instead of 'cub-gen gitops'",
 			},
@@ -2142,13 +2237,14 @@ func printPublishUsage(out io.Writer) {
 			Title: "Usage",
 			Lines: []string{
 				"  cub-gen publish [--in FILE|-] [--out FILE|-] [--pretty]",
-				"  cub-gen publish [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--pretty] <target-path> [<render-target-path>]",
+				"  cub-gen publish [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--out FILE|-] [--pretty] <target-path> [<render-target-path>]",
 			},
 		},
 		helpSection{
 			Title: "Examples",
 			Lines: []string{
 				"  cub-gen gitops import --space my-space ./examples/helm-paas | cub-gen publish --in - --out -",
+				"  cub-gen publish --space my-space --set image.tag=v1.2.4 ./examples/helm-paas > bundle.json",
 				"  cub-gen publish --space my-space ./examples/helm-paas > bundle.json",
 			},
 		},
@@ -2156,6 +2252,7 @@ func printPublishUsage(out io.Writer) {
 			Title: "Tips",
 			Lines: []string{
 				"  - If omitted, <render-target-path> defaults to <target-path>",
+				"  - Helm CLI overrides win over values-prod.yaml, values.yaml, and chart defaults",
 				"  - Pipe to 'cub-gen verify' and 'cub-gen attest' for release evidence",
 			},
 		},

--- a/cmd/cub-gen/testdata/parity/gitops-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/gitops-help.stdout.golden.txt
@@ -5,7 +5,7 @@ These commands read local repo paths. They do not import from a cluster or deplo
 
 Usage:
   cub-gen gitops discover [--space SPACE] [--ref REF] [--where-resource EXPR] [--json] <target-path>
-  cub-gen gitops import [--space SPACE] [--ref REF] [--where-resource EXPR] [--wait] [--json] <target-path> [<render-target-path>]
+  cub-gen gitops import [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--wait] [--json] <target-path> [<render-target-path>]
   cub-gen gitops cleanup [--space SPACE] [--json] <target-path>
 
 Supported where-resource clauses:
@@ -18,10 +18,12 @@ Examples:
   cub-gen gitops discover --space my-space ./examples/scoredev-paas
   cub-gen gitops discover --where-resource "kind IN ('HelmRelease') AND resource_name LIKE '<contains-payments>'" ./examples/helm-paas
   cub-gen gitops import --space my-space ./examples/springboot-paas
+  cub-gen gitops import --space my-space --set image.tag=v1.2.4 ./examples/helm-paas
   cub-gen gitops cleanup --space my-space ./examples/springboot-paas
 
 Tips:
   - Start with 'gitops import' if you want provenance immediately
   - Use 'gitops discover' first when you want to filter or explore a repo
+  - Helm CLI overrides win over values-prod.yaml, values.yaml, and chart defaults
   - If omitted, <render-target-path> defaults to <target-path>
   - For cluster-side import, use 'cub gitops' instead of 'cub-gen gitops'

--- a/cmd/cub-gen/testdata/parity/gitops-import-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/gitops-import-help.stderr.golden.txt
@@ -5,6 +5,12 @@ Usage of gitops import:
     	Pretty-print JSON output (default true)
   -ref string
     	Git ref label to include in output (default "HEAD")
+  -set value
+    	Helm-style override (key=value); repeat or comma-separate entries
+  -set-file value
+    	Helm-style file override (key=path); repeat or comma-separate entries
+  -set-string value
+    	Helm-style string override (key=value); repeat or comma-separate entries
   -space string
     	ConfigHub space label (default "default")
   -wait

--- a/cmd/cub-gen/testdata/parity/publish-help.stderr.golden.txt
+++ b/cmd/cub-gen/testdata/parity/publish-help.stderr.golden.txt
@@ -4,12 +4,14 @@ Use pipe mode when you already have gitops import JSON, or direct mode to import
 
 Usage:
   cub-gen publish [--in FILE|-] [--out FILE|-] [--pretty]
-  cub-gen publish [--space SPACE] [--ref REF] [--where-resource EXPR] [--out FILE|-] [--pretty] <target-path> [<render-target-path>]
+  cub-gen publish [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--out FILE|-] [--pretty] <target-path> [<render-target-path>]
 
 Examples:
   cub-gen gitops import --space my-space ./examples/helm-paas | cub-gen publish --in - --out -
+  cub-gen publish --space my-space --set image.tag=v1.2.4 ./examples/helm-paas > bundle.json
   cub-gen publish --space my-space ./examples/helm-paas > bundle.json
 
 Tips:
   - If omitted, <render-target-path> defaults to <target-path>
+  - Helm CLI overrides win over values-prod.yaml, values.yaml, and chart defaults
   - Pipe to 'cub-gen verify' and 'cub-gen attest' for release evidence

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -52,7 +52,7 @@ cub-gen gitops discover --space <space> [--json] [--where-resource <expr>] <targ
 Import DRY/WET classification with provenance and inverse-edit guidance.
 
 ```
-cub-gen gitops import --space <space> [--json] [--wait] <target-path> [<render-target-path>]
+cub-gen gitops import --space <space> [--json] [--wait] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] <target-path> [<render-target-path>]
 ```
 
 | Flag | Description |
@@ -60,6 +60,7 @@ cub-gen gitops import --space <space> [--json] [--wait] <target-path> [<render-t
 | `--space` | Space label (must match discover) |
 | `--json` | Emit JSON output with full provenance |
 | `--wait` | Accepted for connected-shape compatibility; no-op in local mode |
+| `--set` / `--set-string` / `--set-file` | Helm-style invocation overrides captured in provenance when Helm is the active generator |
 
 Arguments:
 
@@ -89,7 +90,7 @@ Generate a ConfigHub-ready change bundle from import output.
 cub-gen gitops import ... | cub-gen publish --in - --out -
 
 # Direct mode (import + bundle in one step)
-cub-gen publish --space <space> <target-path> [<render-target-path>]
+cub-gen publish --space <space> [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] <target-path> [<render-target-path>]
 ```
 
 Output includes `digest_algorithm` (sha256) and `bundle_digest` for verification.
@@ -306,6 +307,7 @@ What works today:
 
 - One `gitops import` / `publish` invocation works on one repo path pair.
 - Supported generators can pick up overlay files that already live in that repo, such as Helm `values-prod.yaml`, Spring `application-dev.yaml`, and generator-specific overlay files.
+- Helm flows also capture invocation-time `--set`, `--set-string`, and `--set-file` overrides and rank them above values files in provenance and `change explain`.
 - Provenance records include those generator inputs in `dry_inputs`, `values_paths`, and `field_origin_map` when the generator emits separate overlay transforms.
 - `change explain` can point to overlay-specific edit locations. For Spring Boot, the current edit hint routes `server.port` changes to `application-dev.yaml` for environment overrides while keeping `application.yaml` as the base.
 
@@ -330,6 +332,13 @@ Reality-check example:
 Use this section as the answer for "can cub-gen render N explicit variants from one generator in one command?":
 not yet. Today it can understand supported overlay files already present in a repo, but it does not fan out one invocation into N per-environment bundles.
 
+Helm precedence today is:
+
+1. `--set` / `--set-string` / `--set-file`
+2. overlay files such as `values-prod.yaml`
+3. base `values.yaml`
+4. chart defaults
+
 ---
 
 ## Generator quickstart recipes
@@ -346,6 +355,8 @@ go build -o ./cub-gen ./cmd/cub-gen
 ./cub-gen gitops discover --space platform ./examples/helm-paas
 ./cub-gen gitops import --space platform --json ./examples/helm-paas \
   | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets}'
+./cub-gen change explain --space platform --set image.tag=v1.2.4 \
+  ./examples/helm-paas
 ./cub-gen gitops cleanup --space platform ./examples/helm-paas
 ```
 

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -33,7 +33,7 @@ Known gaps still open:
 
 - umbrella/subchart/alias/conditional chart support is still open work ([#238](https://github.com/confighub/cub-gen/issues/238))
 - one-command multi-variant fan-out is not exposed yet ([#237](https://github.com/confighub/cub-gen/issues/237))
-- CLI override capture for `--set` / `--set-file` is not modeled yet ([#242](https://github.com/confighub/cub-gen/issues/242))
+- helper/template/builtin provenance honesty is still partial ([#239](https://github.com/confighub/cub-gen/issues/239))
 
 ## AI-first bundle
 
@@ -120,7 +120,8 @@ source won, and what to edit next.
 ## What you get
 
 - **Field-origin tracing**: every deployed field maps back to `values.yaml`,
-  `values-prod.yaml`, or a chart template — with owner and confidence score
+  `values-prod.yaml`, a Helm CLI override, or a chart template — with owner and
+  confidence score
 - **Inverse-edit guidance**: "to change the image tag in production, edit
   `values-prod.yaml`, not the chart template"
 - **Governance decisions**: ALLOW, ESCALATE, or BLOCK changes based on who
@@ -146,9 +147,10 @@ source won, and what to edit next.
 `Chart.yaml` + `templates/` (platform team). These are the source of truth for
 intent.
 
-**WET** is what generators produce: rendered Kubernetes manifests with every field
-traced back to its DRY source. cub-gen doesn't run `helm template` — it reads
-your chart structure and classifies every field by origin and ownership.
+**WET** is what generators produce: rendered Kubernetes manifests with every
+field traced back to its DRY source. cub-gen classifies chart structure,
+values-file precedence, and invocation-time Helm overrides so you can see which
+layer actually won for a rendered field.
 
 **LIVE** is what's running in your cluster. Flux or ArgoCD reconciles WET to LIVE.
 cub-gen doesn't touch this layer — your existing reconciler stays in control.

--- a/internal/contracts/schemas/provenance.v1.schema.json
+++ b/internal/contracts/schemas/provenance.v1.schema.json
@@ -120,6 +120,38 @@
         "minLength": 1
       }
     },
+    "helm_cli_overrides": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "flag",
+          "key"
+        ],
+        "properties": {
+          "flag": {
+            "type": "string",
+            "enum": [
+              "set",
+              "set-string",
+              "set-file"
+            ]
+          },
+          "key": {
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "type": "string"
+          },
+          "file_path": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "rendered_object_lineage": {
       "type": "array",
       "items": {

--- a/internal/gitops/flow.go
+++ b/internal/gitops/flow.go
@@ -73,6 +73,7 @@ type ImportFlowResult struct {
 	RenderTargetPath   string                       `json:"render_target_path,omitempty"`
 	Ref                string                       `json:"ref"`
 	WhereResource      string                       `json:"where_resource,omitempty"`
+	HelmCLIOverrides   []model.HelmCLIOverride      `json:"helm_cli_overrides,omitempty"`
 	DiscoverUnitSlug   string                       `json:"discover_unit_slug"`
 	ImportedAt         string                       `json:"imported_at"`
 	Discovered         []DiscoveredResource         `json:"discovered"`
@@ -176,6 +177,12 @@ func Discover(targetPath, ref, space, whereResource string) (DiscoverResult, err
 
 // Import runs discover and then creates local import artifacts from discovered resources.
 func Import(targetPath, renderTargetSlug, ref, space, whereResource string) (ImportFlowResult, error) {
+	return ImportWithOptions(targetPath, renderTargetSlug, ref, space, whereResource, importer.ImportOptions{})
+}
+
+// ImportWithOptions mirrors Import but accepts invocation-specific provenance
+// hints such as Helm CLI overrides.
+func ImportWithOptions(targetPath, renderTargetSlug, ref, space, whereResource string, opts importer.ImportOptions) (ImportFlowResult, error) {
 	renderTarget, err := resolveTarget(renderTargetSlug, targetModeRender)
 	if err != nil {
 		return ImportFlowResult{}, fmt.Errorf("resolve render target: %w", err)
@@ -198,6 +205,7 @@ func Import(targetPath, renderTargetSlug, ref, space, whereResource string) (Imp
 			RenderTargetPath: renderTarget.Path,
 			Ref:              discovered.Ref,
 			WhereResource:    discovered.WhereResource,
+			HelmCLIOverrides: append([]model.HelmCLIOverride(nil), opts.HelmCLIOverrides...),
 			DiscoverUnitSlug: discovered.DiscoverUnitSlug,
 			ImportedAt:       time.Now().UTC().Format(time.RFC3339),
 			Discovered:       discovered.Resources,
@@ -208,12 +216,12 @@ func Import(targetPath, renderTargetSlug, ref, space, whereResource string) (Imp
 		return ImportFlowResult{}, err
 	}
 
-	importResult, err := importer.ImportDetection(model.DetectionResult{
+	importResult, err := importer.ImportDetectionWithOptions(model.DetectionResult{
 		Repo:       discovered.TargetPath,
 		Ref:        discovered.Ref,
 		DetectedAt: discovered.DiscoveredAt,
 		Generators: discovered.Detections,
-	}, discovered.Space)
+	}, discovered.Space, opts)
 	if err != nil {
 		return ImportFlowResult{}, err
 	}
@@ -228,6 +236,7 @@ func Import(targetPath, renderTargetSlug, ref, space, whereResource string) (Imp
 		RenderTargetPath:   renderTarget.Path,
 		Ref:                discovered.Ref,
 		WhereResource:      discovered.WhereResource,
+		HelmCLIOverrides:   append([]model.HelmCLIOverride(nil), opts.HelmCLIOverrides...),
 		DiscoverUnitSlug:   discovered.DiscoverUnitSlug,
 		ImportedAt:         time.Now().UTC().Format(time.RFC3339),
 		Discovered:         discovered.Resources,

--- a/internal/importer/helm_overrides.go
+++ b/internal/importer/helm_overrides.go
@@ -1,0 +1,176 @@
+package importer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/confighub/cub-gen/internal/model"
+)
+
+type ImportOptions struct {
+	HelmCLIOverrides []model.HelmCLIOverride
+}
+
+func ParseHelmCLIOverrides(setValues, setStringValues, setFileValues []string) ([]model.HelmCLIOverride, error) {
+	overrides := make([]model.HelmCLIOverride, 0, len(setValues)+len(setStringValues)+len(setFileValues))
+
+	parsedSet, err := parseHelmCLIOverrideAssignments("set", setValues)
+	if err != nil {
+		return nil, err
+	}
+	overrides = append(overrides, parsedSet...)
+
+	parsedSetString, err := parseHelmCLIOverrideAssignments("set-string", setStringValues)
+	if err != nil {
+		return nil, err
+	}
+	overrides = append(overrides, parsedSetString...)
+
+	parsedSetFile, err := parseHelmCLIOverrideAssignments("set-file", setFileValues)
+	if err != nil {
+		return nil, err
+	}
+	overrides = append(overrides, parsedSetFile...)
+
+	return overrides, nil
+}
+
+func HelmCLIOverrideDisplay(override model.HelmCLIOverride) string {
+	switch override.Flag {
+	case "set-file":
+		return fmt.Sprintf("--%s %s=%s", override.Flag, override.Key, override.FilePath)
+	default:
+		return fmt.Sprintf("--%s %s=%s", override.Flag, override.Key, override.Value)
+	}
+}
+
+func HelmCLIOverrideDigestParts(overrides []model.HelmCLIOverride) []string {
+	parts := make([]string, 0, len(overrides))
+	for _, override := range overrides {
+		part := override.Flag + ":" + override.Key + "="
+		if override.Flag == "set-file" {
+			part += override.FilePath
+		} else {
+			part += override.Value
+		}
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+func parseHelmCLIOverrideAssignments(flagName string, rawValues []string) ([]model.HelmCLIOverride, error) {
+	overrides := make([]model.HelmCLIOverride, 0, len(rawValues))
+	for _, rawValue := range rawValues {
+		assignments := splitHelmCLIOverrideAssignments(rawValue)
+		for _, assignment := range assignments {
+			key, value, err := splitHelmCLIOverrideAssignment(assignment)
+			if err != nil {
+				return nil, fmt.Errorf("--%s %q: %w", flagName, rawValue, err)
+			}
+			override := model.HelmCLIOverride{
+				Flag: flagName,
+				Key:  key,
+			}
+			if flagName == "set-file" {
+				override.FilePath = value
+				if strings.TrimSpace(override.FilePath) == "" {
+					return nil, fmt.Errorf("--%s %q: file path is required", flagName, rawValue)
+				}
+			} else {
+				override.Value = value
+			}
+			overrides = append(overrides, override)
+		}
+	}
+	return overrides, nil
+}
+
+func splitHelmCLIOverrideAssignments(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	var (
+		out     []string
+		current strings.Builder
+		escaped bool
+	)
+	for _, r := range raw {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		switch r {
+		case '\\':
+			escaped = true
+		case ',':
+			out = append(out, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if escaped {
+		current.WriteRune('\\')
+	}
+	out = append(out, current.String())
+	return out
+}
+
+func splitHelmCLIOverrideAssignment(raw string) (string, string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", "", fmt.Errorf("expected key=value")
+	}
+
+	var (
+		keyBuilder   strings.Builder
+		valueBuilder strings.Builder
+		escaped      bool
+		seenEquals   bool
+	)
+	for _, r := range trimmed {
+		if escaped {
+			if seenEquals {
+				valueBuilder.WriteRune(r)
+			} else {
+				keyBuilder.WriteRune(r)
+			}
+			escaped = false
+			continue
+		}
+		switch r {
+		case '\\':
+			escaped = true
+		case '=':
+			if !seenEquals {
+				seenEquals = true
+				continue
+			}
+			valueBuilder.WriteRune(r)
+		default:
+			if seenEquals {
+				valueBuilder.WriteRune(r)
+			} else {
+				keyBuilder.WriteRune(r)
+			}
+		}
+	}
+	if escaped {
+		if seenEquals {
+			valueBuilder.WriteRune('\\')
+		} else {
+			keyBuilder.WriteRune('\\')
+		}
+	}
+	if !seenEquals {
+		return "", "", fmt.Errorf("expected key=value")
+	}
+
+	key := strings.TrimSpace(keyBuilder.String())
+	if key == "" {
+		return "", "", fmt.Errorf("key is required")
+	}
+	return key, strings.TrimSpace(valueBuilder.String()), nil
+}

--- a/internal/importer/helm_overrides_test.go
+++ b/internal/importer/helm_overrides_test.go
@@ -1,0 +1,105 @@
+package importer
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-gen/internal/model"
+)
+
+func TestParseHelmCLIOverrides(t *testing.T) {
+	overrides, err := ParseHelmCLIOverrides(
+		[]string{"image.tag=v1.2.4,appConfig.logLevel=debug"},
+		[]string{"database.password=changeme"},
+		[]string{"tlsCert=./certs/prod.pem"},
+	)
+	if err != nil {
+		t.Fatalf("ParseHelmCLIOverrides returned error: %v", err)
+	}
+
+	if len(overrides) != 4 {
+		t.Fatalf("expected 4 overrides, got %d", len(overrides))
+	}
+	if overrides[0].Flag != "set" || overrides[0].Key != "image.tag" || overrides[0].Value != "v1.2.4" {
+		t.Fatalf("unexpected first override: %+v", overrides[0])
+	}
+	if overrides[1].Flag != "set" || overrides[1].Key != "appConfig.logLevel" || overrides[1].Value != "debug" {
+		t.Fatalf("unexpected second override: %+v", overrides[1])
+	}
+	if overrides[2].Flag != "set-string" || overrides[2].Key != "database.password" || overrides[2].Value != "changeme" {
+		t.Fatalf("unexpected set-string override: %+v", overrides[2])
+	}
+	if overrides[3].Flag != "set-file" || overrides[3].Key != "tlsCert" || overrides[3].FilePath != "./certs/prod.pem" {
+		t.Fatalf("unexpected set-file override: %+v", overrides[3])
+	}
+}
+
+func TestImportRepoWithHelmCLIOverridesAddsProvenance(t *testing.T) {
+	repo := filepath.Join("..", "..", "examples", "helm-paas")
+
+	plain, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+
+	overrideImport, err := ImportRepoWithOptions(repo, "main", "platform", ImportOptions{
+		HelmCLIOverrides: []model.HelmCLIOverride{{
+			Flag:  "set",
+			Key:   "image.tag",
+			Value: "v9.9.9",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ImportRepoWithOptions returned error: %v", err)
+	}
+
+	if plain.ChangeID == overrideImport.ChangeID {
+		t.Fatalf("expected override import to change change_id, got %q", overrideImport.ChangeID)
+	}
+
+	if len(overrideImport.Provenance) != 1 {
+		t.Fatalf("expected 1 provenance record, got %d", len(overrideImport.Provenance))
+	}
+	prov := overrideImport.Provenance[0]
+	if len(prov.HelmCLIOverrides) != 1 {
+		t.Fatalf("expected 1 helm_cli_override, got %+v", prov.HelmCLIOverrides)
+	}
+	if got := prov.HelmCLIOverrides[0]; got.Flag != "set" || got.Key != "image.tag" || got.Value != "v9.9.9" {
+		t.Fatalf("unexpected helm_cli_override: %+v", got)
+	}
+	if len(prov.FieldOriginMap) == 0 {
+		t.Fatalf("expected field origins, got none")
+	}
+	if prov.FieldOriginMap[0].Transform != "helm-cli-override" {
+		t.Fatalf("expected override field origin first, got %+v", prov.FieldOriginMap[0])
+	}
+	if prov.FieldOriginMap[0].Confidence != 1.0 {
+		t.Fatalf("expected override confidence 1.0, got %v", prov.FieldOriginMap[0].Confidence)
+	}
+	if !strings.Contains(prov.FieldOriginMap[0].SourcePath, "--set image.tag=v9.9.9") {
+		t.Fatalf("expected override source path, got %q", prov.FieldOriginMap[0].SourcePath)
+	}
+
+	foundOverrideSource := false
+	for _, source := range prov.Sources {
+		if source.Role == "cli-override" && strings.Contains(source.Path, "--set image.tag=v9.9.9") {
+			foundOverrideSource = true
+			break
+		}
+	}
+	if !foundOverrideSource {
+		t.Fatalf("expected cli-override source in %+v", prov.Sources)
+	}
+
+	foundDryInput := false
+	for _, dryInput := range overrideImport.DryInputs {
+		if dryInput.Role == "cli-override" && strings.Contains(dryInput.Path, "--set image.tag=v9.9.9") {
+			foundDryInput = true
+			break
+		}
+	}
+	if !foundDryInput {
+		t.Fatalf("expected cli-override dry input in %+v", overrideImport.DryInputs)
+	}
+}

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -21,25 +21,38 @@ import (
 )
 
 const (
-	generatorContractSchema = "cub.confighub.io/generator-contract/v1"
-	provenanceSchema        = "cub.confighub.io/provenance/v1"
-	inversePlanSchema       = "cub.confighub.io/inverse-transform-plan/v1"
+	generatorContractSchema  = "cub.confighub.io/generator-contract/v1"
+	provenanceSchema         = "cub.confighub.io/provenance/v1"
+	inversePlanSchema        = "cub.confighub.io/inverse-transform-plan/v1"
+	helmCLIOverrideTransform = "helm-cli-override"
 )
 
 // ImportRepo detects generators in a repository and produces the initial
 // ConfigHub-oriented import artifacts (units, links, contracts, provenance, inverse plans).
 func ImportRepo(repoPath, ref, space string) (model.ImportResult, error) {
+	return ImportRepoWithOptions(repoPath, ref, space, ImportOptions{})
+}
+
+// ImportRepoWithOptions mirrors ImportRepo but accepts invocation-specific
+// provenance hints such as Helm CLI overrides.
+func ImportRepoWithOptions(repoPath, ref, space string, opts ImportOptions) (model.ImportResult, error) {
 	detection, err := detect.ScanRepo(repoPath, ref)
 	if err != nil {
 		return model.ImportResult{}, err
 	}
 
-	return ImportDetection(detection, space)
+	return ImportDetectionWithOptions(detection, space, opts)
 }
 
 // ImportDetection builds import artifacts from a precomputed detection result.
 // This allows a discover -> import flow that matches cub gitops command stages.
 func ImportDetection(detection model.DetectionResult, space string) (model.ImportResult, error) {
+	return ImportDetectionWithOptions(detection, space, ImportOptions{})
+}
+
+// ImportDetectionWithOptions builds import artifacts from a precomputed
+// detection result and invocation-specific provenance hints.
+func ImportDetectionWithOptions(detection model.DetectionResult, space string, opts ImportOptions) (model.ImportResult, error) {
 	if detection.Repo == "" {
 		return model.ImportResult{}, errors.New("detection repo is required")
 	}
@@ -47,7 +60,7 @@ func ImportDetection(detection model.DetectionResult, space string) (model.Impor
 	if space == "" {
 		space = "default"
 	}
-	changeID := stableChangeID(detection, space)
+	changeID := stableChangeID(detection, space, opts)
 
 	units := make([]model.UnitRef, 0, len(detection.Generators)*3)
 	links := make([]model.UnitLink, 0, len(detection.Generators))
@@ -74,7 +87,7 @@ func ImportDetection(detection model.DetectionResult, space string) (model.Impor
 		})
 
 		contract := buildContract(detection, g)
-		provenanceRecord := buildProvenance(changeID, space, detection, g, importedAt)
+		provenanceRecord := buildProvenance(changeID, space, detection, g, importedAt, opts)
 		inversePlan := buildInversePlan(changeID, dryUnitID, detection, g, importedAt)
 		if err := contracts.ValidateTriple(contract, provenanceRecord, inversePlan); err != nil {
 			return model.ImportResult{}, fmt.Errorf("validate contract triple for generator %q (%s): %w", g.ID, g.Kind, err)
@@ -84,6 +97,7 @@ func ImportDetection(detection model.DetectionResult, space string) (model.Impor
 		provenance = append(provenance, provenanceRecord)
 		inversePlans = append(inversePlans, inversePlan)
 		dryInputs = append(dryInputs, dryInputsForGenerator(g)...)
+		dryInputs = append(dryInputs, dryInputsForHelmCLIOverrides(g, opts.HelmCLIOverrides)...)
 		wetTargets = append(wetTargets, wetManifestTargetsForGenerator(detection, g)...)
 	}
 
@@ -136,7 +150,7 @@ func buildContract(detection model.DetectionResult, g model.GeneratorDetection) 
 	}
 }
 
-func buildProvenance(changeID, space string, detection model.DetectionResult, g model.GeneratorDetection, renderedAt string) model.ProvenanceRecord {
+func buildProvenance(changeID, space string, detection model.DetectionResult, g model.GeneratorDetection, renderedAt string, opts ImportOptions) model.ProvenanceRecord {
 	sources := make([]model.SourceRef, 0, len(g.Inputs))
 	for _, in := range g.Inputs {
 		sources = append(sources, model.SourceRef{
@@ -146,10 +160,13 @@ func buildProvenance(changeID, space string, detection model.DetectionResult, g 
 			Path:     in,
 		})
 	}
+	sources = append(sources, helmCLIOverrideSourcesForGenerator(detection.Ref, g, opts.HelmCLIOverrides)...)
 
 	outputURI := fmt.Sprintf("oci://example.local/%s/%s:latest", space, sanitizeName(g.Name))
 	outputDigest := digestFor(strings.Join([]string{changeID, g.ID, outputURI}, "|"))
-	inputDigest := digestFor(strings.Join(g.Inputs, "|"))
+	inputDigestParts := append([]string{}, g.Inputs...)
+	inputDigestParts = append(inputDigestParts, HelmCLIOverrideDigestParts(helmCLIOverridesForGenerator(g, opts.HelmCLIOverrides))...)
+	inputDigest := digestFor(strings.Join(inputDigestParts, "|"))
 	helmPaths := helmProvenancePathsForGenerator(detection.Repo, g)
 
 	return model.ProvenanceRecord{
@@ -169,8 +186,9 @@ func buildProvenance(changeID, space string, detection model.DetectionResult, g 
 		}},
 		ChartPath:           helmPaths.ChartPath,
 		ValuesPaths:         helmPaths.ValuesPaths,
+		HelmCLIOverrides:    helmCLIOverridesForGenerator(g, opts.HelmCLIOverrides),
 		RenderedLineage:     renderedLineageForGenerator(detection, g),
-		FieldOriginMap:      fieldOriginsForGenerator(detection, g),
+		FieldOriginMap:      fieldOriginsForGenerator(detection, g, opts.HelmCLIOverrides),
 		InverseEditPointers: inversePointersForGenerator(detection, g),
 		HelmLayeredAnalysis: helmLayeredAnalysisForGenerator(detection, g),
 		ApplicationSet:      applicationSetAnalysisForGenerator(detection, g),
@@ -194,11 +212,12 @@ func buildInversePlan(changeID, targetUnitID string, detection model.DetectionRe
 	}
 }
 
-func stableChangeID(detection model.DetectionResult, space string) string {
+func stableChangeID(detection model.DetectionResult, space string, opts ImportOptions) string {
 	parts := make([]string, 0, len(detection.Generators)+3)
 	parts = append(parts, "v1")
 	parts = append(parts, strings.TrimSpace(strings.ToLower(space)))
 	parts = append(parts, strings.TrimSpace(detection.Ref))
+	parts = append(parts, HelmCLIOverrideDigestParts(opts.HelmCLIOverrides)...)
 
 	entries := make([]string, 0, len(detection.Generators))
 	for _, g := range detection.Generators {
@@ -554,12 +573,14 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 	}
 }
 
-func fieldOriginsForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.FieldOrigin {
+func fieldOriginsForGenerator(detection model.DetectionResult, g model.GeneratorDetection, helmCLIOverrides []model.HelmCLIOverride) []model.FieldOrigin {
 	switch g.Kind {
 	case model.GeneratorHelm:
 		hints := helmProvenancePathsForGenerator(detection.Repo, g)
 		imageTagPaths := helmImageTagSourcePaths(detection.Repo, hints)
-		origins := make([]model.FieldOrigin, 0, len(imageTagPaths))
+		overrideOrigins := helmCLIOverrideFieldOrigins(g, helmCLIOverrides)
+		origins := make([]model.FieldOrigin, 0, len(overrideOrigins)+len(imageTagPaths))
+		origins = append(origins, overrideOrigins...)
 		for idx, sourcePath := range imageTagPaths {
 			transform := registry.FieldOriginTransform(g.Kind)
 			confidenceKey := "image_tag_base"
@@ -1398,6 +1419,25 @@ func dryInputsForGenerator(g model.GeneratorDetection) []model.DryInputRef {
 	return out
 }
 
+func dryInputsForHelmCLIOverrides(g model.GeneratorDetection, overrides []model.HelmCLIOverride) []model.DryInputRef {
+	if g.Kind != model.GeneratorHelm || len(overrides) == 0 {
+		return nil
+	}
+
+	out := make([]model.DryInputRef, 0, len(overrides))
+	for _, override := range overrides {
+		out = append(out, model.DryInputRef{
+			GeneratorID: g.ID,
+			Profile:     g.Profile,
+			Role:        "cli-override",
+			Owner:       "release-automation",
+			Path:        HelmCLIOverrideDisplay(override),
+			Required:    false,
+		})
+	}
+	return out
+}
+
 func wetManifestTargetsForGenerator(detection model.DetectionResult, g model.GeneratorDetection) []model.WetManifestTarget {
 	if g.Kind == model.GeneratorApplicationSet {
 		analysis := applicationSetAnalysisForGenerator(detection, g)
@@ -1635,6 +1675,59 @@ func firstDistinctPath(paths []string, primary string) string {
 		}
 	}
 	return ""
+}
+
+func helmCLIOverridesForGenerator(g model.GeneratorDetection, overrides []model.HelmCLIOverride) []model.HelmCLIOverride {
+	if g.Kind != model.GeneratorHelm || len(overrides) == 0 {
+		return nil
+	}
+	out := make([]model.HelmCLIOverride, len(overrides))
+	copy(out, overrides)
+	return out
+}
+
+func helmCLIOverrideSourcesForGenerator(ref string, g model.GeneratorDetection, overrides []model.HelmCLIOverride) []model.SourceRef {
+	if g.Kind != model.GeneratorHelm || len(overrides) == 0 {
+		return nil
+	}
+	sources := make([]model.SourceRef, 0, len(overrides))
+	for _, override := range overrides {
+		sources = append(sources, model.SourceRef{
+			Role:     "cli-override",
+			URI:      fmt.Sprintf("helm-cli://%s/%s", override.Flag, override.Key),
+			Revision: ref,
+			Path:     HelmCLIOverrideDisplay(override),
+		})
+	}
+	return sources
+}
+
+func helmCLIOverrideFieldOrigins(g model.GeneratorDetection, overrides []model.HelmCLIOverride) []model.FieldOrigin {
+	if g.Kind != model.GeneratorHelm {
+		return nil
+	}
+
+	override, ok := lastHelmCLIOverrideForKey(overrides, "image.tag")
+	if !ok {
+		return nil
+	}
+
+	return []model.FieldOrigin{{
+		DryPath:    "values.image.tag",
+		WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+		SourcePath: HelmCLIOverrideDisplay(override),
+		Transform:  helmCLIOverrideTransform,
+		Confidence: 1.0,
+	}}
+}
+
+func lastHelmCLIOverrideForKey(overrides []model.HelmCLIOverride, key string) (model.HelmCLIOverride, bool) {
+	for idx := len(overrides) - 1; idx >= 0; idx-- {
+		if overrides[idx].Key == key {
+			return overrides[idx], true
+		}
+	}
+	return model.HelmCLIOverride{}, false
 }
 
 func applicationSetAnalysisForGenerator(detection model.DetectionResult, g model.GeneratorDetection) *model.ApplicationSetAnalysis {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -96,6 +96,13 @@ type FieldOrigin struct {
 	Confidence float64 `json:"confidence"`
 }
 
+type HelmCLIOverride struct {
+	Flag     string `json:"flag"`
+	Key      string `json:"key"`
+	Value    string `json:"value,omitempty"`
+	FilePath string `json:"file_path,omitempty"`
+}
+
 type HelmLayeredAnalysis struct {
 	ApplicationSetPath       string   `json:"application_set_path,omitempty"`
 	ClusterInventoryPaths    []string `json:"cluster_inventory_paths,omitempty"`
@@ -202,6 +209,7 @@ type ProvenanceRecord struct {
 	Outputs             []OutputRef             `json:"outputs"`
 	ChartPath           string                  `json:"chart_path,omitempty"`
 	ValuesPaths         []string                `json:"values_paths,omitempty"`
+	HelmCLIOverrides    []HelmCLIOverride       `json:"helm_cli_overrides,omitempty"`
 	RenderedLineage     []RenderedObjectLineage `json:"rendered_object_lineage,omitempty"`
 	FieldOriginMap      []FieldOrigin           `json:"field_origin_map"`
 	InverseEditPointers []InverseEditPointer    `json:"inverse_edit_pointers"`


### PR DESCRIPTION
## Summary
- accept Helm-style `--set`, `--set-string`, and `--set-file` flags on local import/publish/change flows and the repo-first change API
- record invocation overrides in provenance, dry inputs, and field origins so Helm CLI wins show up with confidence `1.0`
- make `change explain` and Helm docs warn when a CLI override won instead of pointing people at `values.yaml`

## Testing
- `go test ./...`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`
- `go run ./cmd/cub-gen gitops import --space platform --json --set image.tag=v1.2.4 ./examples/helm-paas`
- `go run ./cmd/cub-gen change explain --space platform --set image.tag=v1.2.4 ./examples/helm-paas`

Closes #242
Refs #239