### PR TITLE
feat: add Helm builtin/default provenance honesty

### DIFF
--- a/cmd/cub-gen/helm_override_command_test.go
+++ b/cmd/cub-gen/helm_override_command_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -129,5 +131,109 @@ func TestChangeAPIHTTPPreviewWithHelmCLIOverride(t *testing.T) {
 	overrides, ok := input["helm_cli_overrides"].([]any)
 	if !ok || len(overrides) != 1 {
 		t.Fatalf("expected echoed helm_cli_overrides, got %T %+v", input["helm_cli_overrides"], input["helm_cli_overrides"])
+	}
+}
+
+func TestChangeExplainHelmDefaultOriginWarning(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: no-values\nversion: 0.1.0\n")
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		repo,
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, out)
+	}
+	explanation, ok := got["explanation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected explanation object, got %T", got["explanation"])
+	}
+	if explanation["origin_type"] != "default" {
+		t.Fatalf("expected origin_type=default, got %v", explanation["origin_type"])
+	}
+	if explanation["source_transform"] != "helm-default" {
+		t.Fatalf("expected source_transform=helm-default, got %v", explanation["source_transform"])
+	}
+	if explanation["source_path"] != "<helm-default>:values.image.tag" {
+		t.Fatalf("expected default synthetic source, got %v", explanation["source_path"])
+	}
+	warning, _ := explanation["warning"].(string)
+	if !strings.Contains(warning, "not set in the observed values files") {
+		t.Fatalf("expected default warning, got %q", warning)
+	}
+}
+
+func TestChangeExplainHelmBuiltinOriginWarning(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: builtin-demo\nversion: 0.1.0\nappVersion: 2.3.4\n")
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  repository: ghcr.io/example/builtin-demo\n")
+	mustWriteFile(t, filepath.Join(repo, "templates", "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: builtin-demo
+spec:
+  template:
+    spec:
+      containers:
+        - name: builtin-demo
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+`)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		repo,
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, out)
+	}
+	explanation, ok := got["explanation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected explanation object, got %T", got["explanation"])
+	}
+	if explanation["origin_type"] != "builtin" {
+		t.Fatalf("expected origin_type=builtin, got %v", explanation["origin_type"])
+	}
+	if explanation["source_transform"] != "helm-builtin" {
+		t.Fatalf("expected source_transform=helm-builtin, got %v", explanation["source_transform"])
+	}
+	if explanation["source_path"] != "<helm-builtin>:.Chart.AppVersion" {
+		t.Fatalf("expected builtin synthetic source, got %v", explanation["source_path"])
+	}
+	warning, _ := explanation["warning"].(string)
+	if !strings.Contains(warning, "Helm built-in .Chart.AppVersion") {
+		t.Fatalf("expected builtin warning, got %q", warning)
+	}
+	editHint, _ := explanation["edit_hint"].(string)
+	if !strings.Contains(editHint, "Edit appVersion in Chart.yaml") {
+		t.Fatalf("expected builtin edit hint, got %q", editHint)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -20,6 +20,8 @@ import (
 )
 
 const helmCLIOverrideTransform = "helm-cli-override"
+const helmBuiltinTransform = "helm-builtin"
+const helmDefaultTransform = "helm-default"
 
 func main() {
 	if err := run(os.Args[1:]); err != nil {
@@ -1056,6 +1058,7 @@ type changeExplainSuggestion struct {
 	Confidence       float64 `json:"confidence"`
 	SourcePath       string  `json:"source_path,omitempty"`
 	SourceTransform  string  `json:"source_transform,omitempty"`
+	OriginType       string  `json:"origin_type,omitempty"`
 	GeneratorName    string  `json:"generator_name,omitempty"`
 	GeneratorProfile string  `json:"generator_profile,omitempty"`
 	Warning          string  `json:"warning,omitempty"`
@@ -1474,6 +1477,7 @@ func pickInverseSuggestion(
 				Confidence:       pointer.Confidence,
 				SourcePath:       sourcePath,
 				SourceTransform:  sourceTransform,
+				OriginType:       explainOriginType(sourcePath, sourceTransform),
 				GeneratorName:    record.GeneratorName,
 				GeneratorProfile: record.GeneratorProfile,
 			}
@@ -1481,6 +1485,18 @@ func pickInverseSuggestion(
 				candidate.Owner = "release-automation"
 				candidate.EditHint = overrideAwareEditHint(sourcePath, pointer.EditHint)
 				candidate.Warning = overrideAwareWarning()
+				if sourceConfidence > candidate.Confidence {
+					candidate.Confidence = sourceConfidence
+				}
+			}
+			if sourceTransform == helmBuiltinTransform {
+				candidate.Warning = builtinAwareWarning(sourcePath)
+				if sourceConfidence > candidate.Confidence {
+					candidate.Confidence = sourceConfidence
+				}
+			}
+			if sourceTransform == helmDefaultTransform {
+				candidate.Warning = defaultAwareWarning()
 				if sourceConfidence > candidate.Confidence {
 					candidate.Confidence = sourceConfidence
 				}
@@ -1547,11 +1563,16 @@ func bestFieldOrigin(origins []model.FieldOrigin, wetPath, dryPath string) (mode
 }
 
 func applyFieldOriginToPointer(pointer model.InverseEditPointer, origin model.FieldOrigin) model.InverseEditPointer {
-	if origin.Transform != helmCLIOverrideTransform {
+	switch origin.Transform {
+	case helmCLIOverrideTransform:
+		pointer.Owner = "release-automation"
+		pointer.EditHint = overrideAwareEditHint(origin.SourcePath, pointer.EditHint)
+	case helmBuiltinTransform, helmDefaultTransform:
+		// Keep the generator-produced edit hint, but let the higher-confidence
+		// provenance source win when the hint already points at the right layer.
+	default:
 		return pointer
 	}
-	pointer.Owner = "release-automation"
-	pointer.EditHint = overrideAwareEditHint(origin.SourcePath, pointer.EditHint)
 	if origin.Confidence > pointer.Confidence {
 		pointer.Confidence = origin.Confidence
 	}
@@ -1567,6 +1588,32 @@ func overrideAwareEditHint(sourcePath, fallback string) string {
 
 func overrideAwareWarning() string {
 	return "This field was overridden by the Helm CLI invocation for this run, so editing values files alone will not change the rendered output."
+}
+
+func builtinAwareWarning(sourcePath string) string {
+	if sourcePath == "<helm-builtin>:.Chart.AppVersion" {
+		return "This field currently comes from the Helm built-in .Chart.AppVersion path, not from an observed values file."
+	}
+	return "This field currently comes from a Helm built-in source, not from an observed values file."
+}
+
+func defaultAwareWarning() string {
+	return "This field is not set in the observed values files, so chart defaults or helper logic are likely supplying it."
+}
+
+func explainOriginType(sourcePath, sourceTransform string) string {
+	switch {
+	case sourceTransform == helmCLIOverrideTransform:
+		return "external"
+	case sourceTransform == helmBuiltinTransform:
+		return "builtin"
+	case sourceTransform == helmDefaultTransform:
+		return "default"
+	case strings.TrimSpace(sourcePath) != "":
+		return "dry-file"
+	default:
+		return ""
+	}
 }
 
 func discoveredProfiles(discovered []gitopsflow.DiscoveredResource) []string {

--- a/cmd/cub-gen/testdata/parity/change-api-http-run.golden.json
+++ b/cmd/cub-gen/testdata/parity/change-api-http-run.golden.json
@@ -11,6 +11,7 @@
       "edit_hint": "Edit the Score container image in score.yaml.",
       "generator_name": "scoredev-paas",
       "generator_profile": "scoredev-paas",
+      "origin_type": "dry-file",
       "owner": "app-team",
       "source_path": "score.yaml",
       "source_transform": "score-to-k8s",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -308,6 +308,7 @@ What works today:
 - One `gitops import` / `publish` invocation works on one repo path pair.
 - Supported generators can pick up overlay files that already live in that repo, such as Helm `values-prod.yaml`, Spring `application-dev.yaml`, and generator-specific overlay files.
 - Helm flows also capture invocation-time `--set`, `--set-string`, and `--set-file` overrides and rank them above values files in provenance and `change explain`.
+- Helm `change explain` also calls out when a field is currently coming from `.Chart.AppVersion` or an unresolved chart-default path instead of an observed values file.
 - Provenance records include those generator inputs in `dry_inputs`, `values_paths`, and `field_origin_map` when the generator emits separate overlay transforms.
 - `change explain` can point to overlay-specific edit locations. For Spring Boot, the current edit hint routes `server.port` changes to `application-dev.yaml` for environment overrides while keeping `application.yaml` as the base.
 

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -33,7 +33,7 @@ Known gaps still open:
 
 - umbrella/subchart/alias/conditional chart support is still open work ([#238](https://github.com/confighub/cub-gen/issues/238))
 - one-command multi-variant fan-out is not exposed yet ([#237](https://github.com/confighub/cub-gen/issues/237))
-- helper/template/builtin provenance honesty is still partial ([#239](https://github.com/confighub/cub-gen/issues/239))
+- helper chains, `lookup`, and external value-source provenance honesty are still partial ([#239](https://github.com/confighub/cub-gen/issues/239))
 
 ## AI-first bundle
 
@@ -120,8 +120,8 @@ source won, and what to edit next.
 ## What you get
 
 - **Field-origin tracing**: every deployed field maps back to `values.yaml`,
-  `values-prod.yaml`, a Helm CLI override, or a chart template — with owner and
-  confidence score
+  `values-prod.yaml`, a Helm CLI override, a Helm built-in/default, or a chart
+  template — with owner and confidence score
 - **Inverse-edit guidance**: "to change the image tag in production, edit
   `values-prod.yaml`, not the chart template"
 - **Governance decisions**: ALLOW, ESCALATE, or BLOCK changes based on who

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -25,6 +25,8 @@ const (
 	provenanceSchema         = "cub.confighub.io/provenance/v1"
 	inversePlanSchema        = "cub.confighub.io/inverse-transform-plan/v1"
 	helmCLIOverrideTransform = "helm-cli-override"
+	helmBuiltinTransform     = "helm-builtin"
+	helmDefaultTransform     = "helm-default"
 )
 
 // ImportRepo detects generators in a repository and produces the initial
@@ -581,6 +583,14 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 		overrideOrigins := helmCLIOverrideFieldOrigins(g, helmCLIOverrides)
 		origins := make([]model.FieldOrigin, 0, len(overrideOrigins)+len(imageTagPaths))
 		origins = append(origins, overrideOrigins...)
+		if len(imageTagPaths) == 0 {
+			if builtinOrigin, ok := helmImageTagBuiltinOrigin(detection.Repo, hints); ok {
+				origins = append(origins, builtinOrigin)
+				return origins
+			}
+			origins = append(origins, helmImageTagDefaultOrigin())
+			return origins
+		}
 		for idx, sourcePath := range imageTagPaths {
 			transform := registry.FieldOriginTransform(g.Kind)
 			confidenceKey := "image_tag_base"
@@ -909,6 +919,28 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 		policy := registry.InversePointerTemplateFor(g.Kind, "image_tag", registry.InversePointerTemplate{
 			Owner: "app-team", Confidence: 0.86,
 		})
+		if len(imageTagPaths) == 0 {
+			if _, ok := helmImageTagBuiltinOrigin(detection.Repo, hints); ok {
+				return []model.InverseEditPointer{
+					{
+						WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+						DryPath:    "values.image.tag",
+						Owner:      "platform-engineer",
+						EditHint:   "This field currently comes from Helm built-in .Chart.AppVersion. Edit appVersion in Chart.yaml or pass --set image.tag=... for an invocation-specific override.",
+						Confidence: 1.0,
+					},
+				}
+			}
+			return []model.InverseEditPointer{
+				{
+					WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+					DryPath:    "values.image.tag",
+					Owner:      "platform-engineer",
+					EditHint:   "This field is not set in the observed Helm values files. Inspect Chart.yaml, templates/, and helper defaults before editing values.yaml.",
+					Confidence: 0.40,
+				},
+			}
+		}
 		preferredImageTagPath := hints.PrimaryValuesPath
 		if hints.OverlayValuesPath != "" {
 			preferredImageTagPath = hints.OverlayValuesPath
@@ -1579,10 +1611,7 @@ func helmImageTagSourcePaths(repoPath string, hints helmProvenancePaths) []strin
 		}
 	}
 	if len(imageTagPaths) == 0 {
-		if strings.TrimSpace(hints.PrimaryValuesPath) == "" {
-			return nil
-		}
-		return []string{hints.PrimaryValuesPath}
+		return nil
 	}
 
 	ordered := make([]string, 0, len(imageTagPaths))
@@ -1596,6 +1625,85 @@ func helmImageTagSourcePaths(repoPath string, hints helmProvenancePaths) []strin
 		ordered = append(ordered, path)
 	}
 	return ordered
+}
+
+func helmImageTagBuiltinOrigin(repoPath string, hints helmProvenancePaths) (model.FieldOrigin, bool) {
+	if strings.TrimSpace(repoPath) == "" {
+		return model.FieldOrigin{}, false
+	}
+	if !helmTemplatesUseChartAppVersionFallback(repoPath) {
+		return model.FieldOrigin{}, false
+	}
+	if appVersion := helmChartAppVersion(repoPath, hints.ChartPath); strings.TrimSpace(appVersion) != "" {
+		return model.FieldOrigin{
+			DryPath:    "values.image.tag",
+			WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+			SourcePath: "<helm-builtin>:.Chart.AppVersion",
+			Transform:  helmBuiltinTransform,
+			Confidence: 1.0,
+		}, true
+	}
+	return model.FieldOrigin{}, false
+}
+
+func helmImageTagDefaultOrigin() model.FieldOrigin {
+	return model.FieldOrigin{
+		DryPath:    "values.image.tag",
+		WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+		SourcePath: "<helm-default>:values.image.tag",
+		Transform:  helmDefaultTransform,
+		Confidence: 0.40,
+	}
+}
+
+func helmTemplatesUseChartAppVersionFallback(repoPath string) bool {
+	templatesDir := filepath.Join(repoPath, "templates")
+	info, err := os.Stat(templatesDir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+
+	patterns := []string{
+		".Values.image.tag | default .Chart.AppVersion",
+		"default .Chart.AppVersion .Values.image.tag",
+	}
+	found := false
+	_ = filepath.Walk(templatesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		text := string(content)
+		for _, pattern := range patterns {
+			if strings.Contains(text, pattern) {
+				found = true
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+	return found
+}
+
+func helmChartAppVersion(repoPath, chartPath string) string {
+	if strings.TrimSpace(repoPath) == "" || strings.TrimSpace(chartPath) == "" {
+		return ""
+	}
+	content, err := os.ReadFile(filepath.Join(repoPath, chartPath))
+	if err != nil {
+		return ""
+	}
+
+	var chartDoc struct {
+		AppVersion string `yaml:"appVersion"`
+	}
+	if err := yaml.Unmarshal(content, &chartDoc); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(chartDoc.AppVersion)
 }
 
 func stringSliceContains(items []string, want string) bool {

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -583,8 +583,44 @@ func TestImportRepoHelmWithoutValuesDoesNotPointToChartYaml(t *testing.T) {
 	if fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "Chart.yaml") {
 		t.Fatalf("expected Chart.yaml not to be treated as a values source, got %+v", prov.FieldOriginMap)
 	}
-	if inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "Chart.yaml") {
-		t.Fatalf("expected Chart.yaml not to appear in Helm inverse edit guidance, got %+v", prov.InverseEditPointers)
+	if !fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "<helm-default>:values.image.tag") {
+		t.Fatalf("expected default synthetic origin for unset Helm image tag, got %+v", prov.FieldOriginMap)
+	}
+	if !inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "Inspect Chart.yaml, templates/, and helper defaults") {
+		t.Fatalf("expected Helm inverse pointer to explain unresolved chart defaults, got %+v", prov.InverseEditPointers)
+	}
+}
+
+func TestImportRepoHelmBuiltinOriginUsesChartAppVersion(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: builtin-demo\nversion: 0.1.0\nappVersion: 2.3.4\n")
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  repository: ghcr.io/example/builtin-demo\n")
+	mustWriteFile(t, filepath.Join(repo, "templates", "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: builtin-demo
+spec:
+  template:
+    spec:
+      containers:
+        - name: builtin-demo
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+`)
+
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+	if len(result.Provenance) != 1 {
+		t.Fatalf("expected single provenance record, got %d", len(result.Provenance))
+	}
+
+	prov := result.Provenance[0]
+	if !fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "<helm-builtin>:.Chart.AppVersion") {
+		t.Fatalf("expected builtin Chart.AppVersion origin, got %+v", prov.FieldOriginMap)
+	}
+	if !inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "Edit appVersion in Chart.yaml") {
+		t.Fatalf("expected builtin inverse pointer to mention Chart.yaml appVersion, got %+v", prov.InverseEditPointers)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop pretending Helm image-tag provenance always came from a values file when the chart is really using a built-in or default fallback
- surface `.Chart.AppVersion` fallbacks as Helm built-in origins and unresolved no-values cases as default origins in `change explain`
- document the narrower remaining #239 scope around helpers, `lookup`, and external value sources

## Testing
- `go test ./...`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`

Refs #239
Stacked on #264