### PR TITLE
feat: add change impact forward reasoning

### DIFF
--- a/cmd/cub-gen/change_command_test.go
+++ b/cmd/cub-gen/change_command_test.go
@@ -192,6 +192,91 @@ func TestChangeExplainJSON(t *testing.T) {
 	}
 }
 
+func TestChangeImpactJSON(t *testing.T) {
+	setupAliases(t)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "impact",
+		"--space", "platform",
+		"--dry-path", "service.ports.web.port",
+		"score",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("change impact returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change impact output: %v\noutput=%s", err, out)
+	}
+
+	query, ok := got["query"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected query object, got %T", got["query"])
+	}
+	if gotDryPath, ok := query["dry_path_filter"].(string); !ok || gotDryPath != "service.ports.web.port" {
+		t.Fatalf("expected dry_path_filter=service.ports.web.port, got %v", query["dry_path_filter"])
+	}
+
+	impacts, ok := got["impacts"].([]any)
+	if !ok || len(impacts) == 0 {
+		t.Fatalf("expected non-empty impacts, got %T %#v", got["impacts"], got["impacts"])
+	}
+	first, ok := impacts[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected impact entry object, got %T", impacts[0])
+	}
+	if wetPath, ok := first["wet_path"].(string); !ok || wetPath != "Service/spec/ports[name=web]/port" {
+		t.Fatalf("expected wet_path=Service/spec/ports[name=web]/port, got %v", first["wet_path"])
+	}
+	if owner, ok := first["owner"].(string); !ok || owner != "app-team" {
+		t.Fatalf("expected owner=app-team, got %v", first["owner"])
+	}
+}
+
+func TestChangeImpactHelmShowsOverlayAndBaseSources(t *testing.T) {
+	setupAliases(t)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "impact",
+		"--space", "platform",
+		"--dry-path", "values.image.tag",
+		"helm",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("change impact returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change impact output: %v\noutput=%s", err, out)
+	}
+
+	impacts, ok := got["impacts"].([]any)
+	if !ok || len(impacts) != 2 {
+		t.Fatalf("expected 2 impacts for Helm image tag, got %T %#v", got["impacts"], got["impacts"])
+	}
+	first, ok := impacts[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected first impact entry object, got %T", impacts[0])
+	}
+	second, ok := impacts[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected second impact entry object, got %T", impacts[1])
+	}
+	if first["source_path"] != "values-prod.yaml" || second["source_path"] != "values.yaml" {
+		t.Fatalf("expected overlay-first sources, got %v then %v", first["source_path"], second["source_path"])
+	}
+}
+
 func TestChangeHelmOverlayRecommendation(t *testing.T) {
 	setupAliases(t)
 
@@ -292,6 +377,56 @@ func TestChangeExplainWetPathFilter(t *testing.T) {
 	}
 	if got, ok := query["wet_path_filter"].(string); !ok || got != wetPath {
 		t.Fatalf("expected wet_path_filter=%q, got %v", wetPath, query["wet_path_filter"])
+	}
+}
+
+func TestChangeImpactByChangeIDFromBundle(t *testing.T) {
+	setupAliases(t)
+
+	publishOut, stderr, err := runWithCapturedIO([]string{
+		"publish",
+		"--space", "platform",
+		"score",
+		"render-target",
+	})
+	if err != nil {
+		t.Fatalf("publish returned error: %v\nstderr=%s", err, stderr)
+	}
+
+	var bundle map[string]any
+	if err := json.Unmarshal([]byte(publishOut), &bundle); err != nil {
+		t.Fatalf("unmarshal publish output: %v", err)
+	}
+	changeID, ok := bundle["change_id"].(string)
+	if !ok || strings.TrimSpace(changeID) == "" {
+		t.Fatalf("missing change_id in bundle: %v", bundle["change_id"])
+	}
+
+	bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(bundlePath, []byte(publishOut), 0o600); err != nil {
+		t.Fatalf("write bundle file: %v", err)
+	}
+
+	out, impactErr, err := runWithCapturedIO([]string{
+		"change", "impact",
+		"--change-id", changeID,
+		"--bundle", bundlePath,
+		"--dry-path", "containers.main.image",
+	})
+	if err != nil {
+		t.Fatalf("change impact by change-id returned error: %v\nstderr=%s", err, impactErr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change impact output: %v\noutput=%s", err, out)
+	}
+	change, ok := got["change"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected change object, got %T", got["change"])
+	}
+	if gotID, ok := change["change_id"].(string); !ok || gotID != changeID {
+		t.Fatalf("expected change_id=%q, got %v", changeID, change["change_id"])
 	}
 }
 
@@ -407,8 +542,18 @@ func TestChangeCommandErrorModes(t *testing.T) {
 			sub:  "usage: cub-gen change explain",
 		},
 		{
+			name: "impact-missing-targets",
+			args: []string{"change", "impact"},
+			sub:  "usage: cub-gen change impact",
+		},
+		{
 			name: "explain-change-id-missing-bundle",
 			args: []string{"change", "explain", "--change-id", "chg_123"},
+			sub:  "requires --bundle FILE",
+		},
+		{
+			name: "impact-change-id-missing-bundle",
+			args: []string{"change", "impact", "--change-id", "chg_123"},
 			sub:  "requires --bundle FILE",
 		},
 		{

--- a/cmd/cub-gen/helm_override_command_test.go
+++ b/cmd/cub-gen/helm_override_command_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -129,5 +131,109 @@ func TestChangeAPIHTTPPreviewWithHelmCLIOverride(t *testing.T) {
 	overrides, ok := input["helm_cli_overrides"].([]any)
 	if !ok || len(overrides) != 1 {
 		t.Fatalf("expected echoed helm_cli_overrides, got %T %+v", input["helm_cli_overrides"], input["helm_cli_overrides"])
+	}
+}
+
+func TestChangeExplainHelmDefaultOriginWarning(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: no-values\nversion: 0.1.0\n")
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		repo,
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, out)
+	}
+	explanation, ok := got["explanation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected explanation object, got %T", got["explanation"])
+	}
+	if explanation["origin_type"] != "default" {
+		t.Fatalf("expected origin_type=default, got %v", explanation["origin_type"])
+	}
+	if explanation["source_transform"] != "helm-default" {
+		t.Fatalf("expected source_transform=helm-default, got %v", explanation["source_transform"])
+	}
+	if explanation["source_path"] != "<helm-default>:values.image.tag" {
+		t.Fatalf("expected default synthetic source, got %v", explanation["source_path"])
+	}
+	warning, _ := explanation["warning"].(string)
+	if !strings.Contains(warning, "not set in the observed values files") {
+		t.Fatalf("expected default warning, got %q", warning)
+	}
+}
+
+func TestChangeExplainHelmBuiltinOriginWarning(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: builtin-demo\nversion: 0.1.0\nappVersion: 2.3.4\n")
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  repository: ghcr.io/example/builtin-demo\n")
+	mustWriteFile(t, filepath.Join(repo, "templates", "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: builtin-demo
+spec:
+  template:
+    spec:
+      containers:
+        - name: builtin-demo
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+`)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		repo,
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, out)
+	}
+	explanation, ok := got["explanation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected explanation object, got %T", got["explanation"])
+	}
+	if explanation["origin_type"] != "builtin" {
+		t.Fatalf("expected origin_type=builtin, got %v", explanation["origin_type"])
+	}
+	if explanation["source_transform"] != "helm-builtin" {
+		t.Fatalf("expected source_transform=helm-builtin, got %v", explanation["source_transform"])
+	}
+	if explanation["source_path"] != "<helm-builtin>:.Chart.AppVersion" {
+		t.Fatalf("expected builtin synthetic source, got %v", explanation["source_path"])
+	}
+	warning, _ := explanation["warning"].(string)
+	if !strings.Contains(warning, "Helm built-in .Chart.AppVersion") {
+		t.Fatalf("expected builtin warning, got %q", warning)
+	}
+	editHint, _ := explanation["edit_hint"].(string)
+	if !strings.Contains(editHint, "Edit appVersion in Chart.yaml") {
+		t.Fatalf("expected builtin edit hint, got %q", editHint)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -1043,6 +1043,34 @@ type changeRunResult struct {
 	PromotionReady bool                `json:"promotion_ready"`
 }
 
+type changeImpactQuery struct {
+	DryPathFilter string `json:"dry_path_filter,omitempty"`
+	WetPathFilter string `json:"wet_path_filter,omitempty"`
+	OwnerFilter   string `json:"owner_filter,omitempty"`
+	MatchCount    int    `json:"match_count"`
+}
+
+type changeImpactEntry struct {
+	Owner            string  `json:"owner,omitempty"`
+	WetPath          string  `json:"wet_path"`
+	DryPath          string  `json:"dry_path"`
+	EditHint         string  `json:"edit_hint,omitempty"`
+	Confidence       float64 `json:"confidence"`
+	SourcePath       string  `json:"source_path,omitempty"`
+	SourceTransform  string  `json:"source_transform,omitempty"`
+	OriginType       string  `json:"origin_type,omitempty"`
+	GeneratorName    string  `json:"generator_name,omitempty"`
+	GeneratorProfile string  `json:"generator_profile,omitempty"`
+	Warning          string  `json:"warning,omitempty"`
+}
+
+type changeImpactResult struct {
+	Input   changePreviewInput   `json:"input"`
+	Change  changePreviewSummary `json:"change"`
+	Query   changeImpactQuery    `json:"query"`
+	Impacts []changeImpactEntry  `json:"impacts"`
+}
+
 type changeExplainQuery struct {
 	WetPathFilter string `json:"wet_path_filter,omitempty"`
 	DryPathFilter string `json:"dry_path_filter,omitempty"`
@@ -1085,6 +1113,8 @@ func runChange(args []string) error {
 		return runChangePreview(args[1:])
 	case "run":
 		return runChangeRun(args[1:])
+	case "impact":
+		return runChangeImpact(args[1:])
 	case "explain":
 		return runChangeExplain(args[1:])
 	case "api":
@@ -1352,6 +1382,139 @@ func runChangeExplain(args []string) error {
 	return writeJSON(f, result, *pretty)
 }
 
+func runChangeImpact(args []string) error {
+	fs := flag.NewFlagSet("change impact", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	space := fs.String("space", "default", "ConfigHub space label")
+	ref := fs.String("ref", "HEAD", "Git ref label to include in output")
+	whereResource := fs.String("where-resource", "", "Additional resource filter expression")
+	changeID := fs.String("change-id", "", "Existing change ID to explain without creating a new lifecycle")
+	bundlePath := fs.String("bundle", "", "Existing change bundle JSON file to use with --change-id")
+	dryPath := fs.String("dry-path", "", "Filter impacts to a specific DRY path")
+	wetPath := fs.String("wet-path", "", "Filter impacts to a specific WET path")
+	owner := fs.String("owner", "", "Filter impacts to a specific owner")
+	out := fs.String("out", "-", "Output file path, or '-' for stdout")
+	jsonOut := fs.Bool("json", true, "Output JSON")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	overrideFlags := addHelmCLIOverrideFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	_ = jsonOut
+	helmCLIOverrides, err := overrideFlags.parse()
+	if err != nil {
+		return err
+	}
+
+	dryFilter := strings.TrimSpace(*dryPath)
+	wetFilter := strings.TrimSpace(*wetPath)
+	ownerFilter := strings.TrimSpace(*owner)
+	changeIDFilter := strings.TrimSpace(*changeID)
+
+	var (
+		input      changePreviewInput
+		change     changePreviewSummary
+		provenance []model.ProvenanceRecord
+	)
+
+	if changeIDFilter != "" {
+		if len(helmCLIOverrides) > 0 {
+			return errors.New("change impact --change-id/--bundle cannot be combined with Helm CLI override flags")
+		}
+		if fs.NArg() != 0 {
+			return errors.New("usage: cub-gen change impact --change-id ID --bundle FILE [flags]")
+		}
+		bundleRaw := strings.TrimSpace(*bundlePath)
+		if bundleRaw == "" {
+			return errors.New("change impact --change-id requires --bundle FILE")
+		}
+		var bundle publish.ChangeBundle
+		if err := readJSONInput(bundleRaw, &bundle); err != nil {
+			return fmt.Errorf("read bundle json: %w", err)
+		}
+		if err := publish.VerifyBundle(bundle); err != nil {
+			return fmt.Errorf("verify bundle before impact: %w", err)
+		}
+		if bundle.ChangeID == "" {
+			return errors.New("bundle does not contain change_id")
+		}
+		if bundle.ChangeID != changeIDFilter {
+			return fmt.Errorf("bundle change_id mismatch: expected %s, got %s", changeIDFilter, bundle.ChangeID)
+		}
+		input = changePreviewInput{
+			TargetSlug:       bundle.TargetSlug,
+			TargetPath:       bundle.TargetPath,
+			RenderTargetSlug: bundle.RenderTargetSlug,
+			RenderTargetPath: bundle.RenderTargetPath,
+			Space:            bundle.Space,
+			Ref:              bundle.Ref,
+		}
+		change = changePreviewSummary{
+			ChangeID:          bundle.ChangeID,
+			BundleDigest:      bundle.BundleDigest,
+			AttestationDigest: "",
+		}
+		provenance = bundle.Provenance
+	} else {
+		if strings.TrimSpace(*bundlePath) != "" {
+			return errors.New("change impact --bundle requires --change-id")
+		}
+		targetSlug, renderTargetSlug, resolveErr := resolveTargetPairArgs(fs, "usage: cub-gen change impact [flags] <target-path> [<render-target-path>]")
+		if resolveErr != nil {
+			return resolveErr
+		}
+
+		preview, _, imported, err := buildChangePreviewResult(
+			targetSlug,
+			renderTargetSlug,
+			*space,
+			*ref,
+			*whereResource,
+			"cub-gen",
+			helmCLIOverrides,
+		)
+		if err != nil {
+			return err
+		}
+		input = preview.Input
+		change = preview.Change
+		provenance = imported.Provenance
+	}
+
+	impacts, matchCount, ok := collectImpactSuggestions(provenance, dryFilter, wetFilter, ownerFilter)
+	if !ok {
+		return fmt.Errorf("no change impact matched filters (dry_path=%q wet_path=%q owner=%q)", dryFilter, wetFilter, ownerFilter)
+	}
+
+	result := changeImpactResult{
+		Input:  input,
+		Change: change,
+		Query: changeImpactQuery{
+			DryPathFilter: dryFilter,
+			WetPathFilter: wetFilter,
+			OwnerFilter:   ownerFilter,
+			MatchCount:    matchCount,
+		},
+		Impacts: impacts,
+	}
+
+	if *out == "-" {
+		return writeJSON(os.Stdout, result, *pretty)
+	}
+
+	f, err := os.Create(*out)
+	if err != nil {
+		return fmt.Errorf("create output file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	return writeJSON(f, result, *pretty)
+}
+
 func buildChangePreviewResult(
 	targetSlug, renderTargetSlug, space, ref, whereResource, verifier string,
 	helmCLIOverrides []model.HelmCLIOverride,
@@ -1514,6 +1677,77 @@ func pickInverseSuggestion(
 	return best, matchCount, true
 }
 
+func collectImpactSuggestions(
+	provenance []model.ProvenanceRecord,
+	dryFilter, wetFilter, ownerFilter string,
+) ([]changeImpactEntry, int, bool) {
+	impacts := make([]changeImpactEntry, 0)
+
+	for _, record := range provenance {
+		for _, origin := range record.FieldOriginMap {
+			if dryFilter != "" && origin.DryPath != dryFilter {
+				continue
+			}
+			if wetFilter != "" && origin.WetPath != wetFilter {
+				continue
+			}
+
+			pointer, ok := bestInversePointer(record.InverseEditPointers, origin.WetPath, origin.DryPath)
+			entry := changeImpactEntry{
+				Owner:            "",
+				WetPath:          origin.WetPath,
+				DryPath:          origin.DryPath,
+				EditHint:         "",
+				Confidence:       origin.Confidence,
+				SourcePath:       origin.SourcePath,
+				SourceTransform:  origin.Transform,
+				OriginType:       explainOriginType(origin.SourcePath, origin.Transform),
+				GeneratorName:    record.GeneratorName,
+				GeneratorProfile: record.GeneratorProfile,
+			}
+			if ok {
+				entry.Owner = pointer.Owner
+				entry.EditHint = pointer.EditHint
+			}
+			switch origin.Transform {
+			case helmCLIOverrideTransform:
+				entry.Owner = "release-automation"
+				entry.EditHint = overrideAwareEditHint(origin.SourcePath, entry.EditHint)
+				entry.Warning = overrideAwareWarning()
+			case helmBuiltinTransform:
+				entry.Warning = builtinAwareWarning(origin.SourcePath)
+			case helmDefaultTransform:
+				entry.Warning = defaultAwareWarning()
+			}
+			if ownerFilter != "" && entry.Owner != ownerFilter {
+				continue
+			}
+			impacts = append(impacts, entry)
+		}
+	}
+
+	sort.Slice(impacts, func(i, j int) bool {
+		if impacts[i].DryPath != impacts[j].DryPath {
+			return impacts[i].DryPath < impacts[j].DryPath
+		}
+		if impacts[i].WetPath != impacts[j].WetPath {
+			return impacts[i].WetPath < impacts[j].WetPath
+		}
+		if impacts[i].Confidence != impacts[j].Confidence {
+			return impacts[i].Confidence > impacts[j].Confidence
+		}
+		if impacts[i].SourcePath != impacts[j].SourcePath {
+			return impacts[i].SourcePath < impacts[j].SourcePath
+		}
+		return impacts[i].GeneratorName < impacts[j].GeneratorName
+	})
+
+	if len(impacts) == 0 {
+		return nil, 0, false
+	}
+	return impacts, len(impacts), true
+}
+
 func bestFieldOrigin(origins []model.FieldOrigin, wetPath, dryPath string) (model.FieldOrigin, bool) {
 	best := model.FieldOrigin{}
 	bestConfidence := -1.0
@@ -1558,6 +1792,54 @@ func bestFieldOrigin(origins []model.FieldOrigin, wetPath, dryPath string) (mode
 	}
 	if bestConfidence < 0 {
 		return model.FieldOrigin{}, false
+	}
+	return best, true
+}
+
+func bestInversePointer(pointers []model.InverseEditPointer, wetPath, dryPath string) (model.InverseEditPointer, bool) {
+	best := model.InverseEditPointer{}
+	bestConfidence := -1.0
+
+	for _, pointer := range pointers {
+		if wetPath != "" && pointer.WetPath != wetPath {
+			continue
+		}
+		if dryPath != "" && pointer.DryPath != dryPath {
+			continue
+		}
+		if pointer.Confidence > bestConfidence {
+			best = pointer
+			bestConfidence = pointer.Confidence
+		}
+	}
+	if bestConfidence >= 0 {
+		return best, true
+	}
+
+	for _, pointer := range pointers {
+		if dryPath != "" && pointer.DryPath != dryPath {
+			continue
+		}
+		if pointer.Confidence > bestConfidence {
+			best = pointer
+			bestConfidence = pointer.Confidence
+		}
+	}
+	if bestConfidence >= 0 {
+		return best, true
+	}
+
+	for _, pointer := range pointers {
+		if wetPath != "" && pointer.WetPath != wetPath {
+			continue
+		}
+		if pointer.Confidence > bestConfidence {
+			best = pointer
+			bestConfidence = pointer.Confidence
+		}
+	}
+	if bestConfidence < 0 {
+		return model.InverseEditPointer{}, false
 	}
 	return best, true
 }
@@ -2136,6 +2418,7 @@ func printUsage(out io.Writer) {
 			Lines: []string{
 				"  gitops import     See what a repo renders and where each field came from",
 				"  change explain    Find the DRY file/path to edit for a rendered field",
+				"  change impact     See which rendered fields a DRY path can affect",
 				"  change preview    Preview a safe repo change",
 				"  detect            Detect generators in a repo",
 				"  generators        List supported generators (Helm, Score, Spring Boot, ...)",
@@ -2180,10 +2463,11 @@ func printUsage(out io.Writer) {
 func printChangeUsage(out io.Writer) {
 	printCommandHelp(
 		out,
-		"cub-gen change: preview and explain safe source edits",
+		"cub-gen change: preview, impact, and explain safe source edits",
 		[]string{
 			"Use these commands after you know the repo path and want to answer:",
 			"  - what will change?",
+			"  - which rendered fields does this DRY path affect?",
 			"  - where should I edit DRY source?",
 			"  - should I ask ConfigHub for a decision?",
 		},
@@ -2192,6 +2476,8 @@ func printChangeUsage(out io.Writer) {
 			Lines: []string{
 				"  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-path> [<render-target-path>]",
 				"  cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-path> [<render-target-path>]",
+				"  cub-gen change impact [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--dry-path PATH] [--wet-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-path> [<render-target-path>]",
+				"  cub-gen change impact --change-id ID --bundle FILE [--dry-path PATH] [--wet-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty]",
 				"  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-path> [<render-target-path>]",
 				"  cub-gen change explain --change-id ID --bundle FILE [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty]",
 				"  cub-gen change api serve [--listen ADDR] [--space SPACE] [--ref REF] [--verifier NAME]",
@@ -2201,6 +2487,7 @@ func printChangeUsage(out io.Writer) {
 			Title: "Examples",
 			Lines: []string{
 				"  cub-gen change preview --space my-space ./examples/helm-paas",
+				"  cub-gen change impact --space my-space --dry-path values.image.tag ./examples/helm-paas",
 				"  cub-gen change explain --space my-space --set image.tag=v1.2.4 ./examples/helm-paas",
 				"  cub-gen change run --mode local --space my-space ./examples/scoredev-paas",
 				"  cub-gen change explain --space my-space --wet-path \"Deployment/spec/template/spec/containers[0]/ports[0]/containerPort\" ./examples/springboot-paas",
@@ -2212,6 +2499,7 @@ func printChangeUsage(out io.Writer) {
 			Title: "Tips",
 			Lines: []string{
 				"  - Start with 'change explain' if you already know the rendered field you care about",
+				"  - Use 'change impact' when you know the DRY path and want the downstream blast radius",
 				"  - Start with 'change preview' before 'change run'",
 				"  - Helm CLI overrides win over values-prod.yaml, values.yaml, and chart defaults",
 				"  - 'change run --mode connected' asks ConfigHub for a decision; it does not deploy",

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -20,6 +20,8 @@ import (
 )
 
 const helmCLIOverrideTransform = "helm-cli-override"
+const helmBuiltinTransform = "helm-builtin"
+const helmDefaultTransform = "helm-default"
 
 func main() {
 	if err := run(os.Args[1:]); err != nil {
@@ -1056,6 +1058,7 @@ type changeExplainSuggestion struct {
 	Confidence       float64 `json:"confidence"`
 	SourcePath       string  `json:"source_path,omitempty"`
 	SourceTransform  string  `json:"source_transform,omitempty"`
+	OriginType       string  `json:"origin_type,omitempty"`
 	GeneratorName    string  `json:"generator_name,omitempty"`
 	GeneratorProfile string  `json:"generator_profile,omitempty"`
 	Warning          string  `json:"warning,omitempty"`
@@ -1474,6 +1477,7 @@ func pickInverseSuggestion(
 				Confidence:       pointer.Confidence,
 				SourcePath:       sourcePath,
 				SourceTransform:  sourceTransform,
+				OriginType:       explainOriginType(sourcePath, sourceTransform),
 				GeneratorName:    record.GeneratorName,
 				GeneratorProfile: record.GeneratorProfile,
 			}
@@ -1481,6 +1485,18 @@ func pickInverseSuggestion(
 				candidate.Owner = "release-automation"
 				candidate.EditHint = overrideAwareEditHint(sourcePath, pointer.EditHint)
 				candidate.Warning = overrideAwareWarning()
+				if sourceConfidence > candidate.Confidence {
+					candidate.Confidence = sourceConfidence
+				}
+			}
+			if sourceTransform == helmBuiltinTransform {
+				candidate.Warning = builtinAwareWarning(sourcePath)
+				if sourceConfidence > candidate.Confidence {
+					candidate.Confidence = sourceConfidence
+				}
+			}
+			if sourceTransform == helmDefaultTransform {
+				candidate.Warning = defaultAwareWarning()
 				if sourceConfidence > candidate.Confidence {
 					candidate.Confidence = sourceConfidence
 				}
@@ -1547,11 +1563,16 @@ func bestFieldOrigin(origins []model.FieldOrigin, wetPath, dryPath string) (mode
 }
 
 func applyFieldOriginToPointer(pointer model.InverseEditPointer, origin model.FieldOrigin) model.InverseEditPointer {
-	if origin.Transform != helmCLIOverrideTransform {
+	switch origin.Transform {
+	case helmCLIOverrideTransform:
+		pointer.Owner = "release-automation"
+		pointer.EditHint = overrideAwareEditHint(origin.SourcePath, pointer.EditHint)
+	case helmBuiltinTransform, helmDefaultTransform:
+		// Keep the generator-produced edit hint, but let the higher-confidence
+		// provenance source win when the hint already points at the right layer.
+	default:
 		return pointer
 	}
-	pointer.Owner = "release-automation"
-	pointer.EditHint = overrideAwareEditHint(origin.SourcePath, pointer.EditHint)
 	if origin.Confidence > pointer.Confidence {
 		pointer.Confidence = origin.Confidence
 	}
@@ -1567,6 +1588,32 @@ func overrideAwareEditHint(sourcePath, fallback string) string {
 
 func overrideAwareWarning() string {
 	return "This field was overridden by the Helm CLI invocation for this run, so editing values files alone will not change the rendered output."
+}
+
+func builtinAwareWarning(sourcePath string) string {
+	if sourcePath == "<helm-builtin>:.Chart.AppVersion" {
+		return "This field currently comes from the Helm built-in .Chart.AppVersion path, not from an observed values file."
+	}
+	return "This field currently comes from a Helm built-in source, not from an observed values file."
+}
+
+func defaultAwareWarning() string {
+	return "This field is not set in the observed values files, so chart defaults or helper logic are likely supplying it."
+}
+
+func explainOriginType(sourcePath, sourceTransform string) string {
+	switch {
+	case sourceTransform == helmCLIOverrideTransform:
+		return "external"
+	case sourceTransform == helmBuiltinTransform:
+		return "builtin"
+	case sourceTransform == helmDefaultTransform:
+		return "default"
+	case strings.TrimSpace(sourcePath) != "":
+		return "dry-file"
+	default:
+		return ""
+	}
 }
 
 func discoveredProfiles(discovered []gitopsflow.DiscoveredResource) []string {

--- a/cmd/cub-gen/testdata/parity/change-api-http-run.golden.json
+++ b/cmd/cub-gen/testdata/parity/change-api-http-run.golden.json
@@ -11,6 +11,7 @@
       "edit_hint": "Edit the Score container image in score.yaml.",
       "generator_name": "scoredev-paas",
       "generator_profile": "scoredev-paas",
+      "origin_type": "dry-file",
       "owner": "app-team",
       "source_path": "score.yaml",
       "source_transform": "score-to-k8s",

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -8,6 +8,7 @@ Use cub-gen when your question starts in the repo, not the cluster:
 START HERE:
   gitops import     See what a repo renders and where each field came from
   change explain    Find the DRY file/path to edit for a rendered field
+  change impact     See which rendered fields a DRY path can affect
   change preview    Preview a safe repo change
   detect            Detect generators in a repo
   generators        List supported generators (Helm, Score, Spring Boot, ...)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -12,7 +12,8 @@ not cluster/runtime ones.
 |---|---|
 | What does this repo render, and where did it come from? | `gitops import` |
 | Which DRY file/path should I edit for a rendered field? | `change explain` |
-| What would change if I made this edit? | `change preview` |
+| Which rendered fields would this DRY path affect? | `change impact` |
+| What evidence bundle and safe next step should I prepare? | `change preview` |
 | What evidence bundle should I verify or ship? | `publish -> verify -> attest` |
 | How do I use the deeper ConfigHub API flow? | `bridge` |
 
@@ -325,6 +326,10 @@ Reality-check example:
 ./cub-gen gitops import --space platform --json ./examples/springboot-paas \
   | jq '.provenance[0].field_origin_map[] | select(.dry_path=="server.port")'
 
+./cub-gen change impact --space platform \
+  --dry-path "values.image.tag" \
+  ./examples/helm-paas
+
 ./cub-gen change explain --space platform \
   --wet-path "Deployment/spec/template/spec/containers[0]/ports[0]/containerPort" \
   ./examples/springboot-paas
@@ -356,6 +361,8 @@ go build -o ./cub-gen ./cmd/cub-gen
 ./cub-gen gitops discover --space platform ./examples/helm-paas
 ./cub-gen gitops import --space platform --json ./examples/helm-paas \
   | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets}'
+./cub-gen change impact --space platform --dry-path values.image.tag \
+  ./examples/helm-paas
 ./cub-gen change explain --space platform --set image.tag=v1.2.4 \
   ./examples/helm-paas
 ./cub-gen gitops cleanup --space platform ./examples/helm-paas

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -308,6 +308,7 @@ What works today:
 - One `gitops import` / `publish` invocation works on one repo path pair.
 - Supported generators can pick up overlay files that already live in that repo, such as Helm `values-prod.yaml`, Spring `application-dev.yaml`, and generator-specific overlay files.
 - Helm flows also capture invocation-time `--set`, `--set-string`, and `--set-file` overrides and rank them above values files in provenance and `change explain`.
+- Helm `change explain` also calls out when a field is currently coming from `.Chart.AppVersion` or an unresolved chart-default path instead of an observed values file.
 - Provenance records include those generator inputs in `dry_inputs`, `values_paths`, and `field_origin_map` when the generator emits separate overlay transforms.
 - `change explain` can point to overlay-specific edit locations. For Spring Boot, the current edit hint routes `server.port` changes to `application-dev.yaml` for environment overrides while keeping `application.yaml` as the base.
 

--- a/docs/contracts/change-cli-v1.md
+++ b/docs/contracts/change-cli-v1.md
@@ -9,7 +9,7 @@ Goal: one stable interface for terminal users, CI jobs, and agent tool-calls.
 
 ## Design principles
 
-1. One `change_id` lifecycle across preview, run, and explain.
+1. One `change_id` lifecycle across preview, run, explain, and impact.
 2. Same JSON shape across local and connected execution.
 3. No shell parsing of multiple intermediate files required.
 4. Additive over existing `discover/import/publish/verify/attest` pipeline.
@@ -93,6 +93,33 @@ Expected output fields (`ChangeExplainResult`):
 - `query.{wet_path_filter,dry_path_filter,owner_filter,match_count}`
 - `explanation.{owner,wet_path,dry_path,edit_hint,confidence,source_path,source_transform,generator_name,generator_profile}`
 
+### 4) `cub-gen change impact`
+
+Purpose:
+- Show the downstream rendered fields affected by a DRY path.
+
+Supported invocation modes:
+
+1. Fresh analysis mode (mints a new lifecycle):
+- `cub-gen change impact [filters] <target-path> [<render-target-path>]`
+
+2. Existing lifecycle mode (no new lifecycle minted):
+- `cub-gen change impact --change-id <id> --bundle <bundle.json> [filters]`
+
+Filters:
+
+- `--dry-path <path>` (optional, primary forward-reasoning filter)
+- `--wet-path <path>` (optional)
+- `--owner <owner>` (optional)
+- `--json` (default output format)
+
+Expected output fields (`ChangeImpactResult`):
+
+- `input.{target_path,render_target_path,target_slug,render_target_slug}`
+- `change.{change_id,bundle_digest,attestation_digest}`
+- `query.{dry_path_filter,wet_path_filter,owner_filter,match_count}`
+- `impacts[].{owner,wet_path,dry_path,edit_hint,confidence,source_path,source_transform,origin_type,generator_name,generator_profile}`
+
 ## Exit code contract
 
 - `0`: success (`ALLOW` or successful local run)
@@ -111,6 +138,7 @@ Native subcommands are implemented for:
 - `change preview`
 - `change run (local|connected)`
 - `change explain`
+- `change impact`
 
 Compatibility wrappers remain useful for demo packaging and story scripts:
 

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -33,7 +33,7 @@ Known gaps still open:
 
 - umbrella/subchart/alias/conditional chart support is still open work ([#238](https://github.com/confighub/cub-gen/issues/238))
 - one-command multi-variant fan-out is not exposed yet ([#237](https://github.com/confighub/cub-gen/issues/237))
-- helper/template/builtin provenance honesty is still partial ([#239](https://github.com/confighub/cub-gen/issues/239))
+- helper chains, `lookup`, and external value-source provenance honesty are still partial ([#239](https://github.com/confighub/cub-gen/issues/239))
 
 ## AI-first bundle
 
@@ -120,8 +120,8 @@ source won, and what to edit next.
 ## What you get
 
 - **Field-origin tracing**: every deployed field maps back to `values.yaml`,
-  `values-prod.yaml`, a Helm CLI override, or a chart template — with owner and
-  confidence score
+  `values-prod.yaml`, a Helm CLI override, a Helm built-in/default, or a chart
+  template — with owner and confidence score
 - **Inverse-edit guidance**: "to change the image tag in production, edit
   `values-prod.yaml`, not the chart template"
 - **Governance decisions**: ALLOW, ESCALATE, or BLOCK changes based on who

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -25,6 +25,8 @@ const (
 	provenanceSchema         = "cub.confighub.io/provenance/v1"
 	inversePlanSchema        = "cub.confighub.io/inverse-transform-plan/v1"
 	helmCLIOverrideTransform = "helm-cli-override"
+	helmBuiltinTransform     = "helm-builtin"
+	helmDefaultTransform     = "helm-default"
 )
 
 // ImportRepo detects generators in a repository and produces the initial
@@ -581,6 +583,14 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 		overrideOrigins := helmCLIOverrideFieldOrigins(g, helmCLIOverrides)
 		origins := make([]model.FieldOrigin, 0, len(overrideOrigins)+len(imageTagPaths))
 		origins = append(origins, overrideOrigins...)
+		if len(imageTagPaths) == 0 {
+			if builtinOrigin, ok := helmImageTagBuiltinOrigin(detection.Repo, hints); ok {
+				origins = append(origins, builtinOrigin)
+				return origins
+			}
+			origins = append(origins, helmImageTagDefaultOrigin())
+			return origins
+		}
 		for idx, sourcePath := range imageTagPaths {
 			transform := registry.FieldOriginTransform(g.Kind)
 			confidenceKey := "image_tag_base"
@@ -909,6 +919,28 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 		policy := registry.InversePointerTemplateFor(g.Kind, "image_tag", registry.InversePointerTemplate{
 			Owner: "app-team", Confidence: 0.86,
 		})
+		if len(imageTagPaths) == 0 {
+			if _, ok := helmImageTagBuiltinOrigin(detection.Repo, hints); ok {
+				return []model.InverseEditPointer{
+					{
+						WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+						DryPath:    "values.image.tag",
+						Owner:      "platform-engineer",
+						EditHint:   "This field currently comes from Helm built-in .Chart.AppVersion. Edit appVersion in Chart.yaml or pass --set image.tag=... for an invocation-specific override.",
+						Confidence: 1.0,
+					},
+				}
+			}
+			return []model.InverseEditPointer{
+				{
+					WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+					DryPath:    "values.image.tag",
+					Owner:      "platform-engineer",
+					EditHint:   "This field is not set in the observed Helm values files. Inspect Chart.yaml, templates/, and helper defaults before editing values.yaml.",
+					Confidence: 0.40,
+				},
+			}
+		}
 		preferredImageTagPath := hints.PrimaryValuesPath
 		if hints.OverlayValuesPath != "" {
 			preferredImageTagPath = hints.OverlayValuesPath
@@ -1579,10 +1611,7 @@ func helmImageTagSourcePaths(repoPath string, hints helmProvenancePaths) []strin
 		}
 	}
 	if len(imageTagPaths) == 0 {
-		if strings.TrimSpace(hints.PrimaryValuesPath) == "" {
-			return nil
-		}
-		return []string{hints.PrimaryValuesPath}
+		return nil
 	}
 
 	ordered := make([]string, 0, len(imageTagPaths))
@@ -1596,6 +1625,85 @@ func helmImageTagSourcePaths(repoPath string, hints helmProvenancePaths) []strin
 		ordered = append(ordered, path)
 	}
 	return ordered
+}
+
+func helmImageTagBuiltinOrigin(repoPath string, hints helmProvenancePaths) (model.FieldOrigin, bool) {
+	if strings.TrimSpace(repoPath) == "" {
+		return model.FieldOrigin{}, false
+	}
+	if !helmTemplatesUseChartAppVersionFallback(repoPath) {
+		return model.FieldOrigin{}, false
+	}
+	if appVersion := helmChartAppVersion(repoPath, hints.ChartPath); strings.TrimSpace(appVersion) != "" {
+		return model.FieldOrigin{
+			DryPath:    "values.image.tag",
+			WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+			SourcePath: "<helm-builtin>:.Chart.AppVersion",
+			Transform:  helmBuiltinTransform,
+			Confidence: 1.0,
+		}, true
+	}
+	return model.FieldOrigin{}, false
+}
+
+func helmImageTagDefaultOrigin() model.FieldOrigin {
+	return model.FieldOrigin{
+		DryPath:    "values.image.tag",
+		WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+		SourcePath: "<helm-default>:values.image.tag",
+		Transform:  helmDefaultTransform,
+		Confidence: 0.40,
+	}
+}
+
+func helmTemplatesUseChartAppVersionFallback(repoPath string) bool {
+	templatesDir := filepath.Join(repoPath, "templates")
+	info, err := os.Stat(templatesDir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+
+	patterns := []string{
+		".Values.image.tag | default .Chart.AppVersion",
+		"default .Chart.AppVersion .Values.image.tag",
+	}
+	found := false
+	_ = filepath.Walk(templatesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		text := string(content)
+		for _, pattern := range patterns {
+			if strings.Contains(text, pattern) {
+				found = true
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+	return found
+}
+
+func helmChartAppVersion(repoPath, chartPath string) string {
+	if strings.TrimSpace(repoPath) == "" || strings.TrimSpace(chartPath) == "" {
+		return ""
+	}
+	content, err := os.ReadFile(filepath.Join(repoPath, chartPath))
+	if err != nil {
+		return ""
+	}
+
+	var chartDoc struct {
+		AppVersion string `yaml:"appVersion"`
+	}
+	if err := yaml.Unmarshal(content, &chartDoc); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(chartDoc.AppVersion)
 }
 
 func stringSliceContains(items []string, want string) bool {

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -583,8 +583,44 @@ func TestImportRepoHelmWithoutValuesDoesNotPointToChartYaml(t *testing.T) {
 	if fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "Chart.yaml") {
 		t.Fatalf("expected Chart.yaml not to be treated as a values source, got %+v", prov.FieldOriginMap)
 	}
-	if inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "Chart.yaml") {
-		t.Fatalf("expected Chart.yaml not to appear in Helm inverse edit guidance, got %+v", prov.InverseEditPointers)
+	if !fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "<helm-default>:values.image.tag") {
+		t.Fatalf("expected default synthetic origin for unset Helm image tag, got %+v", prov.FieldOriginMap)
+	}
+	if !inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "Inspect Chart.yaml, templates/, and helper defaults") {
+		t.Fatalf("expected Helm inverse pointer to explain unresolved chart defaults, got %+v", prov.InverseEditPointers)
+	}
+}
+
+func TestImportRepoHelmBuiltinOriginUsesChartAppVersion(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: builtin-demo\nversion: 0.1.0\nappVersion: 2.3.4\n")
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  repository: ghcr.io/example/builtin-demo\n")
+	mustWriteFile(t, filepath.Join(repo, "templates", "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: builtin-demo
+spec:
+  template:
+    spec:
+      containers:
+        - name: builtin-demo
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+`)
+
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+	if len(result.Provenance) != 1 {
+		t.Fatalf("expected single provenance record, got %d", len(result.Provenance))
+	}
+
+	prov := result.Provenance[0]
+	if !fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "<helm-builtin>:.Chart.AppVersion") {
+		t.Fatalf("expected builtin Chart.AppVersion origin, got %+v", prov.FieldOriginMap)
+	}
+	if !inversePointerHintContains(prov.InverseEditPointers, "values.image.tag", "Edit appVersion in Chart.yaml") {
+		t.Fatalf("expected builtin inverse pointer to mention Chart.yaml appVersion, got %+v", prov.InverseEditPointers)
 	}
 }
 


### PR DESCRIPTION
## Summary
- recover the stranded Helm builtin/default provenance honesty work from the old stacked #265 branch so it lands on main
- add `cub-gen change impact` for forward reasoning from DRY paths to affected WET fields, with bundle-mode reuse and owner/source/origin metadata
- update help and CLI docs so the new forward-reasoning path is discoverable

## Testing
- `go test ./...`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`
- `go run ./cmd/cub-gen change impact --space platform --dry-path values.image.tag ./examples/helm-paas`

Refs #239
Refs #240