### PR TITLE
helm: add umbrella chart provenance

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -70,6 +70,18 @@ Arguments:
 
 Output includes: `generator_profile`, `dry_inputs`, `wet_manifest_targets`, `provenance` (field-origin map, inverse-edit pointers).
 
+For layered Helm repos, `provenance[].helm_layered_analysis` also explains how
+the chart is composed:
+
+- `dependency_charts`: subcharts, aliases, vendored chart paths, and any
+  `condition:` expression that controls whether the subchart is active
+- `field_origin_map[].source_layer`: which Helm layer won for a field
+  (`umbrella` vs a subchart alias/name)
+- `crd_paths`: CRDs under `crds/`, kept separate from templated resources
+- `hook_templates`: hook template paths plus their `helm.sh/hook` annotations
+- `values_schema_path`, `schema_validation_state`,
+  `schema_validation_violations`: pre-render values-schema findings
+
 ### `gitops cleanup`
 
 Remove local discover state.

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -359,6 +359,13 @@ DRY:  values.yaml      → image.tag = "v1.0.0"
 WET:  Deployment/spec/template/spec/containers[0]/image = "ghcr.io/example/payments-api:v1.0.3"
 ```
 
+For umbrella-style Helm repos, the same import output also tells you which
+layer won. `field_origin_map[].source_layer` distinguishes umbrella values from
+subchart defaults, while `helm_layered_analysis.dependency_charts` records
+aliased/conditional subcharts, `crd_paths` isolates `crds/`, `hook_templates`
+shows `helm.sh/hook` annotations, and the `values_schema_*` fields surface
+schema violations before you trust the render.
+
 ## Key files
 
 | File | Owner | Purpose |

--- a/internal/contracts/schemas/provenance.v1.schema.json
+++ b/internal/contracts/schemas/provenance.v1.schema.json
@@ -208,6 +208,10 @@
             "type": "string",
             "minLength": 1
           },
+          "source_layer": {
+            "type": "string",
+            "minLength": 1
+          },
           "transform": {
             "type": "string",
             "minLength": 1
@@ -281,6 +285,102 @@
           }
         },
         "customer_catalog_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "dependency_charts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "alias": {
+                "type": "string",
+                "minLength": 1
+              },
+              "layer": {
+                "type": "string",
+                "minLength": 1
+              },
+              "condition": {
+                "type": "string",
+                "minLength": 1
+              },
+              "repository": {
+                "type": "string",
+                "minLength": 1
+              },
+              "version": {
+                "type": "string",
+                "minLength": 1
+              },
+              "chart_path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "values_path": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "crd_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "hook_templates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "path"
+            ],
+            "properties": {
+              "path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "hooks": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "hook_template_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "values_schema_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "schema_validation_state": {
+          "type": "string",
+          "minLength": 1
+        },
+        "schema_validation_violations": {
           "type": "array",
           "items": {
             "type": "string",

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -123,6 +123,9 @@ func detectHelm(repo string) ([]model.GeneratorDetection, error) {
 		if relRoot == "." {
 			relRoot = ""
 		}
+		if isNestedHelmDependencyChart(relRoot) {
+			return nil
+		}
 		inputs := []string{filepath.ToSlash(relJoin(relRoot, "Chart.yaml"))}
 		matches, _ := filepath.Glob(filepath.Join(root, "values*.yaml"))
 		for _, match := range matches {
@@ -156,8 +159,9 @@ func detectHelm(repo string) ([]model.GeneratorDetection, error) {
 }
 
 func existingHelmAuxiliaryInputs(repo, root string) []string {
-	candidates := make([]string, 0, 12)
+	candidates := make([]string, 0, 24)
 	globs := []string{
+		filepath.Join(root, "values.schema.json"),
 		filepath.Join(root, "gitops", "argo", "applicationset.yaml"),
 		filepath.Join(root, "gitops", "argo", "applicationset.yml"),
 		filepath.Join(root, "platform", "clusters", "*.yaml"),
@@ -180,7 +184,52 @@ func existingHelmAuxiliaryInputs(repo, root string) []string {
 			candidates = append(candidates, filepath.ToSlash(rel))
 		}
 	}
+	_ = filepath.WalkDir(filepath.Join(root, "crds"), func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		rel, err := filepath.Rel(repo, path)
+		if err != nil {
+			return nil
+		}
+		candidates = append(candidates, filepath.ToSlash(rel))
+		return nil
+	})
+	_ = filepath.WalkDir(filepath.Join(root, "charts"), func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := strings.ToLower(d.Name())
+		if name != "chart.yaml" && !strings.HasPrefix(name, "values") {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(name))
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		rel, err := filepath.Rel(repo, path)
+		if err != nil {
+			return nil
+		}
+		candidates = append(candidates, filepath.ToSlash(rel))
+		return nil
+	})
 	return uniqueSortedStrings(candidates)
+}
+
+func isNestedHelmDependencyChart(relRoot string) bool {
+	normalized := filepath.ToSlash(strings.TrimSpace(relRoot))
+	return normalized == "charts" || strings.HasPrefix(normalized, "charts/")
 }
 
 func detectApplicationSet(repo string) ([]model.GeneratorDetection, error) {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -169,6 +169,54 @@ func TestScanRepoHelmIncludesLayeredAuxiliaryInputs(t *testing.T) {
 	}
 }
 
+func TestScanRepoHelmUmbrellaKeepsSingleGeneratorAndTracksAuxiliaryInputs(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	mustWriteDetectFile(t, filepath.Join(repo, "Chart.yaml"), `apiVersion: v2
+name: umbrella-demo
+version: 0.1.0
+dependencies:
+  - name: cache
+    alias: cache-primary
+    condition: cache.enabled
+    version: 1.2.3
+    repository: file://charts/cache-primary
+`)
+	mustWriteDetectFile(t, filepath.Join(repo, "values.yaml"), "image:\n  tag: umbrella-v1\n")
+	mustWriteDetectFile(t, filepath.Join(repo, "values-prod.yaml"), "image:\n  tag: umbrella-v2\n")
+	mustWriteDetectFile(t, filepath.Join(repo, "values.schema.json"), `{"type":"object","properties":{"image":{"type":"object","properties":{"tag":{"type":"string"}}}}}`)
+	mustWriteDetectFile(t, filepath.Join(repo, "crds", "widgets.example.io.yaml"), "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n")
+	mustWriteDetectFile(t, filepath.Join(repo, "charts", "cache-primary", "Chart.yaml"), "apiVersion: v2\nname: cache\nversion: 1.2.3\n")
+	mustWriteDetectFile(t, filepath.Join(repo, "charts", "cache-primary", "values.yaml"), "image:\n  tag: cache-v1\n")
+
+	result, err := ScanRepo(repo, "main")
+	if err != nil {
+		t.Fatalf("ScanRepo returned error: %v", err)
+	}
+	if len(result.Generators) != 1 {
+		t.Fatalf("expected 1 umbrella generator, got %+v", result.Generators)
+	}
+
+	g := result.Generators[0]
+	if g.Kind != model.GeneratorHelm {
+		t.Fatalf("expected helm kind, got %q", g.Kind)
+	}
+	for _, expected := range []string{
+		"Chart.yaml",
+		"values.yaml",
+		"values-prod.yaml",
+		"values.schema.json",
+		"crds/widgets.example.io.yaml",
+		"charts/cache-primary/Chart.yaml",
+		"charts/cache-primary/values.yaml",
+	} {
+		if !contains(g.Inputs, expected) && !containsSuffix(g.Inputs, expected) {
+			t.Fatalf("expected umbrella inputs to contain %q, got %v", expected, g.Inputs)
+		}
+	}
+}
+
 func TestScanRepoApplicationSetStandalone(t *testing.T) {
 	t.Parallel()
 
@@ -361,4 +409,14 @@ func containsSuffix(v []string, suffix string) bool {
 		}
 	}
 	return false
+}
+
+func mustWriteDetectFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
 }

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/confighub/cub-gen/internal/detect"
 	"github.com/confighub/cub-gen/internal/model"
 	"github.com/confighub/cub-gen/internal/registry"
+	"github.com/santhosh-tekuri/jsonschema/v5"
 	"gopkg.in/yaml.v3"
 )
 
@@ -579,11 +580,11 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 	switch g.Kind {
 	case model.GeneratorHelm:
 		hints := helmProvenancePathsForGenerator(detection.Repo, g)
-		imageTagPaths := helmImageTagSourcePaths(detection.Repo, hints)
+		imageTagSources := helmImageTagSources(detection.Repo, hints)
 		overrideOrigins := helmCLIOverrideFieldOrigins(g, helmCLIOverrides)
-		origins := make([]model.FieldOrigin, 0, len(overrideOrigins)+len(imageTagPaths))
+		origins := make([]model.FieldOrigin, 0, len(overrideOrigins)+len(imageTagSources)+1)
 		origins = append(origins, overrideOrigins...)
-		if len(imageTagPaths) == 0 {
+		if len(imageTagSources) == 0 {
 			if builtinOrigin, ok := helmImageTagBuiltinOrigin(detection.Repo, hints); ok {
 				origins = append(origins, builtinOrigin)
 				return origins
@@ -591,21 +592,26 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 			origins = append(origins, helmImageTagDefaultOrigin())
 			return origins
 		}
-		for idx, sourcePath := range imageTagPaths {
+		for _, source := range imageTagSources {
 			transform := registry.FieldOriginTransform(g.Kind)
 			confidenceKey := "image_tag_base"
 			confidenceFallback := 0.86
-			if idx > 0 || sourcePath != hints.PrimaryValuesPath {
+			if source.Path != hints.PrimaryValuesPath {
 				transform = registry.FieldOriginOverlayTransform(g.Kind)
 				confidenceKey = "image_tag_overlay"
 				confidenceFallback = 0.90
 			}
+			if strings.HasPrefix(source.Path, "charts/") {
+				confidenceKey = "image_tag_subchart"
+				confidenceFallback = 0.74
+			}
 			origins = append(origins, model.FieldOrigin{
-				DryPath:    "values.image.tag",
-				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
-				SourcePath: sourcePath,
-				Transform:  transform,
-				Confidence: registry.FieldOriginConfidenceFor(g.Kind, confidenceKey, confidenceFallback),
+				DryPath:     "values.image.tag",
+				WetPath:     "Deployment/spec/template/spec/containers[0]/image",
+				SourcePath:  source.Path,
+				SourceLayer: source.Layer,
+				Transform:   transform,
+				Confidence:  registry.FieldOriginConfidenceFor(g.Kind, confidenceKey, confidenceFallback),
 			})
 		}
 		return origins
@@ -915,11 +921,11 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 	switch g.Kind {
 	case model.GeneratorHelm:
 		hints := helmProvenancePathsForGenerator(detection.Repo, g)
-		imageTagPaths := helmImageTagSourcePaths(detection.Repo, hints)
+		imageTagSources := helmImageTagSources(detection.Repo, hints)
 		policy := registry.InversePointerTemplateFor(g.Kind, "image_tag", registry.InversePointerTemplate{
 			Owner: "app-team", Confidence: 0.86,
 		})
-		if len(imageTagPaths) == 0 {
+		if len(imageTagSources) == 0 {
 			if _, ok := helmImageTagBuiltinOrigin(detection.Repo, hints); ok {
 				return []model.InverseEditPointer{
 					{
@@ -944,8 +950,8 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 		preferredImageTagPath := hints.PrimaryValuesPath
 		if hints.OverlayValuesPath != "" {
 			preferredImageTagPath = hints.OverlayValuesPath
-		} else if len(imageTagPaths) > 0 {
-			preferredImageTagPath = imageTagPaths[0]
+		} else if len(imageTagSources) > 0 {
+			preferredImageTagPath = imageTagSources[0].Path
 		}
 		vars := map[string]string{
 			"base_values_path":    hints.PrimaryValuesPath,
@@ -961,7 +967,7 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 			{
 				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
 				DryPath:    "values.image.tag",
-				Owner:      policy.Owner,
+				Owner:      helmInversePointerOwner(preferredImageTagPath, policy.Owner),
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, hintKey, hintFallback), vars),
 				Confidence: policy.Confidence,
 			},
@@ -1308,6 +1314,16 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 	}
 }
 
+func helmInversePointerOwner(preferredImageTagPath, fallbackOwner string) string {
+	if helmIsSubchartPath(preferredImageTagPath) {
+		return "platform-engineer"
+	}
+	if strings.TrimSpace(fallbackOwner) == "" {
+		return "platform-engineer"
+	}
+	return fallbackOwner
+}
+
 type applicationSetHints struct {
 	ApplicationSetPath string
 	TemplateSourcePath string
@@ -1546,6 +1562,21 @@ type helmProvenancePaths struct {
 	OverlayValuesPath string
 }
 
+type helmValueSource struct {
+	Path  string
+	Layer string
+}
+
+type helmDependencyDoc struct {
+	Name       string `yaml:"name"`
+	Alias      string `yaml:"alias"`
+	Condition  string `yaml:"condition"`
+	Repository string `yaml:"repository"`
+	Version    string `yaml:"version"`
+	ChartPath  string
+	ValuesPath string
+}
+
 func helmProvenancePathsForGenerator(repoPath string, g model.GeneratorDetection) helmProvenancePaths {
 	if g.Kind != model.GeneratorHelm {
 		return helmProvenancePaths{}
@@ -1565,15 +1596,21 @@ func helmProvenancePathsForGenerator(repoPath string, g model.GeneratorDetection
 	}
 
 	chartPath := firstInputPathForRole(g.Kind, g.Inputs, chartRole)
-	valuesPaths := inputPathsForRole(g.Kind, g.Inputs, valuesRole)
+	valuesPaths := helmValuesPathsForInputs(g.Kind, g.Inputs, valuesRole)
 
 	primaryValuesPath := selectPrimaryHelmValuesPath(valuesPaths, primaryValuesBase)
-	imageTagPaths := helmImageTagSourcePaths(repoPath, helmProvenancePaths{
+	imageTagSources := helmImageTagSources(repoPath, helmProvenancePaths{
 		ChartPath:         chartPath,
 		ValuesPaths:       valuesPaths,
 		PrimaryValuesPath: primaryValuesPath,
 	})
-	overlayValuesPath := firstDistinctPath(imageTagPaths, primaryValuesPath)
+	overlayValuesPath := ""
+	for _, source := range imageTagSources {
+		if source.Path != primaryValuesPath {
+			overlayValuesPath = source.Path
+			break
+		}
+	}
 
 	return helmProvenancePaths{
 		ChartPath:         chartPath,
@@ -1594,6 +1631,18 @@ func selectPrimaryHelmValuesPath(valuesPaths []string, primaryValuesBase string)
 	return primaryValuesPath
 }
 
+func helmValuesPathsForInputs(kind model.GeneratorKind, inputs []string, valuesRole string) []string {
+	out := make([]string, 0, len(inputs))
+	for _, in := range inputs {
+		role := registry.InputRole(kind, in)
+		if role == valuesRole || role == "subchart-values" {
+			out = append(out, in)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 func firstInputPathForRole(kind model.GeneratorKind, inputs []string, role string) string {
 	for _, in := range inputs {
 		if registry.InputRole(kind, in) == role {
@@ -1603,7 +1652,7 @@ func firstInputPathForRole(kind model.GeneratorKind, inputs []string, role strin
 	return ""
 }
 
-func helmImageTagSourcePaths(repoPath string, hints helmProvenancePaths) []string {
+func helmImageTagSources(repoPath string, hints helmProvenancePaths) []helmValueSource {
 	imageTagPaths := make([]string, 0, len(hints.ValuesPaths))
 	for _, path := range hints.ValuesPaths {
 		if helmValuesPathDefinesImageTag(repoPath, path) {
@@ -1614,17 +1663,71 @@ func helmImageTagSourcePaths(repoPath string, hints helmProvenancePaths) []strin
 		return nil
 	}
 
-	ordered := make([]string, 0, len(imageTagPaths))
-	if stringSliceContains(imageTagPaths, hints.PrimaryValuesPath) {
-		ordered = append(ordered, hints.PrimaryValuesPath)
-	}
-	for _, path := range imageTagPaths {
-		if path == hints.PrimaryValuesPath {
-			continue
+	sort.SliceStable(imageTagPaths, func(i, j int) bool {
+		leftRank := helmValuesPathPrecedence(imageTagPaths[i], hints.PrimaryValuesPath, hints.ChartPath)
+		rightRank := helmValuesPathPrecedence(imageTagPaths[j], hints.PrimaryValuesPath, hints.ChartPath)
+		if leftRank != rightRank {
+			return leftRank < rightRank
 		}
-		ordered = append(ordered, path)
+		return imageTagPaths[i] < imageTagPaths[j]
+	})
+
+	umbrella := helmHasDependencyCharts(repoPath, hints.ChartPath)
+	ordered := make([]helmValueSource, 0, len(imageTagPaths))
+	for _, path := range imageTagPaths {
+		ordered = append(ordered, helmValueSource{
+			Path:  path,
+			Layer: helmValuesSourceLayer(path, umbrella),
+		})
 	}
 	return ordered
+}
+
+func helmValuesPathPrecedence(path, primaryValuesPath, chartPath string) int {
+	pathDir := filepath.ToSlash(filepath.Dir(strings.TrimSpace(path)))
+	if pathDir == "." {
+		pathDir = ""
+	}
+	switch {
+	case path == primaryValuesPath:
+		return 0
+	case helmIsSubchartPath(path):
+		return 2
+	case helmChartDir(chartPath) == pathDir:
+		return 1
+	default:
+		return 3
+	}
+}
+
+func helmValuesSourceLayer(path string, umbrella bool) string {
+	if helmIsSubchartPath(path) {
+		parts := strings.Split(filepath.ToSlash(path), "/")
+		if len(parts) >= 2 {
+			return parts[1]
+		}
+	}
+	if umbrella {
+		return "umbrella"
+	}
+	return ""
+}
+
+func helmIsSubchartPath(path string) bool {
+	normalized := filepath.ToSlash(strings.TrimSpace(path))
+	return normalized == "charts" || strings.HasPrefix(normalized, "charts/")
+}
+
+func helmChartDir(chartPath string) string {
+	dir := filepath.ToSlash(filepath.Dir(strings.TrimSpace(chartPath)))
+	if dir == "." {
+		return ""
+	}
+	return dir
+}
+
+func helmHasDependencyCharts(repoPath, chartPath string) bool {
+	return len(parseHelmDependencyDocs(repoPath, chartPath)) > 0
 }
 
 func helmImageTagBuiltinOrigin(repoPath string, hints helmProvenancePaths) (model.FieldOrigin, bool) {
@@ -1916,18 +2019,35 @@ func helmLayeredAnalysisForGenerator(detection model.DetectionResult, g model.Ge
 	clusterPaths := inputPathsForRole(g.Kind, g.Inputs, "cluster-inventory")
 	managedCatalogPaths := inputPathsForRole(g.Kind, g.Inputs, "managed-service-catalog")
 	customerCatalogPaths := inputPathsForRole(g.Kind, g.Inputs, "customer-service-catalog")
+	helmPaths := helmProvenancePathsForGenerator(detection.Repo, g)
+	dependencyCharts := helmDependencyChartsForGenerator(detection.Repo, helmPaths)
+	crdPaths := helmCRDPathsForChart(detection.Repo, helmPaths.ChartPath)
+	hookTemplates := helmHookTemplates(detection.Repo, helmPaths.ChartPath)
+	hookTemplatePaths := make([]string, 0, len(hookTemplates))
+	for _, hookTemplate := range hookTemplates {
+		hookTemplatePaths = append(hookTemplatePaths, hookTemplate.Path)
+	}
+	valuesSchemaPath := helmValuesSchemaPath(detection.Repo, helmPaths.ChartPath)
+	schemaState, schemaViolations := helmValuesSchemaValidation(detection.Repo, helmPaths, valuesSchemaPath)
 
-	if appsetPath == "" && len(clusterPaths) == 0 && len(managedCatalogPaths) == 0 && len(customerCatalogPaths) == 0 {
+	if appsetPath == "" && len(clusterPaths) == 0 && len(managedCatalogPaths) == 0 && len(customerCatalogPaths) == 0 &&
+		len(dependencyCharts) == 0 && len(crdPaths) == 0 && len(hookTemplatePaths) == 0 && valuesSchemaPath == "" {
 		return nil
 	}
 
-	helmPaths := helmProvenancePathsForGenerator(detection.Repo, g)
 	analysis := &model.HelmLayeredAnalysis{
-		ApplicationSetPath:    appsetPath,
-		ClusterInventoryPaths: append([]string(nil), clusterPaths...),
-		ManagedCatalogPaths:   append([]string(nil), managedCatalogPaths...),
-		CustomerCatalogPaths:  append([]string(nil), customerCatalogPaths...),
-		SelectedValueFiles:    append([]string(nil), helmPaths.ValuesPaths...),
+		ApplicationSetPath:         appsetPath,
+		ClusterInventoryPaths:      append([]string(nil), clusterPaths...),
+		ManagedCatalogPaths:        append([]string(nil), managedCatalogPaths...),
+		CustomerCatalogPaths:       append([]string(nil), customerCatalogPaths...),
+		DependencyCharts:           append([]model.HelmDependencyChart(nil), dependencyCharts...),
+		CRDPaths:                   append([]string(nil), crdPaths...),
+		HookTemplates:              append([]model.HelmHookTemplate(nil), hookTemplates...),
+		HookTemplatePaths:          append([]string(nil), hookTemplatePaths...),
+		ValuesSchemaPath:           valuesSchemaPath,
+		SchemaValidationState:      schemaState,
+		SchemaValidationViolations: append([]string(nil), schemaViolations...),
+		SelectedValueFiles:         append([]string(nil), helmPaths.ValuesPaths...),
 	}
 
 	if appsetPath != "" {
@@ -1989,6 +2109,346 @@ func helmLayeredAnalysisForGenerator(detection model.DetectionResult, g model.Ge
 	}
 
 	return analysis
+}
+
+func helmDependencyChartsForGenerator(repoPath string, hints helmProvenancePaths) []model.HelmDependencyChart {
+	deps := parseHelmDependencyDocs(repoPath, hints.ChartPath)
+	out := make([]model.HelmDependencyChart, 0, len(deps))
+	for _, dep := range deps {
+		layer := strings.TrimSpace(dep.Alias)
+		if layer == "" {
+			layer = strings.TrimSpace(dep.Name)
+		}
+		out = append(out, model.HelmDependencyChart{
+			Name:       dep.Name,
+			Alias:      dep.Alias,
+			Layer:      layer,
+			Condition:  dep.Condition,
+			Repository: dep.Repository,
+			Version:    dep.Version,
+			ChartPath:  dep.ChartPath,
+			ValuesPath: dep.ValuesPath,
+		})
+	}
+	return out
+}
+
+func parseHelmDependencyDocs(repoPath, chartPath string) []helmDependencyDoc {
+	if strings.TrimSpace(repoPath) == "" || strings.TrimSpace(chartPath) == "" {
+		return nil
+	}
+	content, err := os.ReadFile(filepath.Join(repoPath, filepath.FromSlash(chartPath)))
+	if err != nil {
+		return nil
+	}
+
+	var chartDoc struct {
+		Dependencies []helmDependencyDoc `yaml:"dependencies"`
+	}
+	if err := yaml.Unmarshal(content, &chartDoc); err != nil {
+		return nil
+	}
+
+	chartDir := helmChartDir(chartPath)
+	out := make([]helmDependencyDoc, 0, len(chartDoc.Dependencies))
+	for _, dep := range chartDoc.Dependencies {
+		layer := strings.TrimSpace(dep.Alias)
+		if layer == "" {
+			layer = strings.TrimSpace(dep.Name)
+		}
+		chartCandidate := filepath.ToSlash(filepath.Join(chartDir, "charts", layer, "Chart.yaml"))
+		valuesCandidate := filepath.ToSlash(filepath.Join(chartDir, "charts", layer, "values.yaml"))
+		if !fileExists(filepath.Join(repoPath, filepath.FromSlash(chartCandidate))) && strings.TrimSpace(dep.Name) != "" && dep.Name != layer {
+			fallbackChartCandidate := filepath.ToSlash(filepath.Join(chartDir, "charts", dep.Name, "Chart.yaml"))
+			fallbackValuesCandidate := filepath.ToSlash(filepath.Join(chartDir, "charts", dep.Name, "values.yaml"))
+			if fileExists(filepath.Join(repoPath, filepath.FromSlash(fallbackChartCandidate))) {
+				chartCandidate = fallbackChartCandidate
+				valuesCandidate = fallbackValuesCandidate
+			}
+		}
+		if !fileExists(filepath.Join(repoPath, filepath.FromSlash(chartCandidate))) {
+			chartCandidate = ""
+		}
+		if !fileExists(filepath.Join(repoPath, filepath.FromSlash(valuesCandidate))) {
+			valuesCandidate = ""
+		}
+		dep.ChartPath = chartCandidate
+		dep.ValuesPath = valuesCandidate
+		out = append(out, dep)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		left := out[i].Alias
+		if strings.TrimSpace(left) == "" {
+			left = out[i].Name
+		}
+		right := out[j].Alias
+		if strings.TrimSpace(right) == "" {
+			right = out[j].Name
+		}
+		return left < right
+	})
+	return out
+}
+
+func helmCRDPathsForChart(repoPath, chartPath string) []string {
+	chartDir := helmChartDir(chartPath)
+	crdDir := filepath.Join(repoPath, filepath.FromSlash(chartDir), "crds")
+	info, err := os.Stat(crdDir)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+
+	out := make([]string, 0)
+	_ = filepath.WalkDir(crdDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		rel, err := filepath.Rel(repoPath, path)
+		if err != nil {
+			return nil
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	sort.Strings(out)
+	return out
+}
+
+func helmHookTemplates(repoPath, chartPath string) []model.HelmHookTemplate {
+	chartDir := helmChartDir(chartPath)
+	templatesDir := filepath.Join(repoPath, filepath.FromSlash(chartDir), "templates")
+	info, err := os.Stat(templatesDir)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+
+	out := make([]model.HelmHookTemplate, 0)
+	_ = filepath.WalkDir(templatesDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		hooks := helmHookAnnotations(string(content))
+		if len(hooks) == 0 {
+			return nil
+		}
+		rel, err := filepath.Rel(repoPath, path)
+		if err != nil {
+			return nil
+		}
+		out = append(out, model.HelmHookTemplate{
+			Path:  filepath.ToSlash(rel),
+			Hooks: hooks,
+		})
+		return nil
+	})
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Path < out[j].Path
+	})
+	return out
+}
+
+func helmHookAnnotations(content string) []string {
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0)
+	seen := map[string]struct{}{}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "helm.sh/hook:") {
+			continue
+		}
+		raw := strings.TrimSpace(strings.TrimPrefix(trimmed, "helm.sh/hook:"))
+		raw = strings.Trim(raw, "\"'")
+		for _, hook := range strings.Split(raw, ",") {
+			hook = strings.TrimSpace(hook)
+			if hook == "" {
+				continue
+			}
+			if _, ok := seen[hook]; ok {
+				continue
+			}
+			seen[hook] = struct{}{}
+			out = append(out, hook)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func helmValuesSchemaPath(repoPath, chartPath string) string {
+	chartDir := helmChartDir(chartPath)
+	candidate := filepath.Join(repoPath, filepath.FromSlash(chartDir), "values.schema.json")
+	if !fileExists(candidate) {
+		return ""
+	}
+	rel, err := filepath.Rel(repoPath, candidate)
+	if err != nil {
+		return ""
+	}
+	return filepath.ToSlash(rel)
+}
+
+func helmValuesSchemaValidation(repoPath string, hints helmProvenancePaths, valuesSchemaPath string) (string, []string) {
+	if strings.TrimSpace(valuesSchemaPath) == "" {
+		return "", nil
+	}
+
+	schemaContent, err := os.ReadFile(filepath.Join(repoPath, filepath.FromSlash(valuesSchemaPath)))
+	if err != nil {
+		return "unresolved", []string{fmt.Sprintf("%s: %v", valuesSchemaPath, err)}
+	}
+
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(valuesSchemaPath, strings.NewReader(string(schemaContent))); err != nil {
+		return "unresolved", []string{fmt.Sprintf("%s: %v", valuesSchemaPath, err)}
+	}
+	schema, err := compiler.Compile(valuesSchemaPath)
+	if err != nil {
+		return "unresolved", []string{fmt.Sprintf("%s: %v", valuesSchemaPath, err)}
+	}
+
+	rootValuesPaths := make([]string, 0, len(hints.ValuesPaths))
+	for _, path := range hints.ValuesPaths {
+		if helmIsSubchartPath(path) {
+			continue
+		}
+		rootValuesPaths = append(rootValuesPaths, path)
+	}
+	sort.SliceStable(rootValuesPaths, func(i, j int) bool {
+		leftRank := helmValuesPathPrecedence(rootValuesPaths[i], hints.PrimaryValuesPath, hints.ChartPath)
+		rightRank := helmValuesPathPrecedence(rootValuesPaths[j], hints.PrimaryValuesPath, hints.ChartPath)
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		return rootValuesPaths[i] < rootValuesPaths[j]
+	})
+
+	merged := map[string]any{}
+	// Merge from lowest to highest precedence so overlays win over chart defaults.
+	for i := len(rootValuesPaths) - 1; i >= 0; i-- {
+		path := rootValuesPaths[i]
+		payload, err := yamlFileToJSONCompatible(filepath.Join(repoPath, filepath.FromSlash(path)))
+		if err != nil {
+			return "unresolved", []string{fmt.Sprintf("%s: %v", path, err)}
+		}
+		merged = mergeJSONObjects(merged, payload)
+	}
+
+	if err := schema.Validate(merged); err != nil {
+		return "invalid", jsonschemaValidationMessages(err)
+	}
+	return "valid", nil
+}
+
+func yamlFileToJSONCompatible(path string) (map[string]any, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw any
+	if err := yaml.Unmarshal(content, &raw); err != nil {
+		return nil, err
+	}
+	converted := yamlToJSONCompatible(raw)
+	if converted == nil {
+		return map[string]any{}, nil
+	}
+	if asMap, ok := converted.(map[string]any); ok {
+		return asMap, nil
+	}
+	return nil, fmt.Errorf("top-level values document must be a mapping")
+}
+
+func yamlToJSONCompatible(v any) any {
+	switch typed := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, value := range typed {
+			out[key] = yamlToJSONCompatible(value)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for key, value := range typed {
+			out[fmt.Sprint(key)] = yamlToJSONCompatible(value)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, value := range typed {
+			out = append(out, yamlToJSONCompatible(value))
+		}
+		return out
+	default:
+		return typed
+	}
+}
+
+func mergeJSONObjects(base, overlay map[string]any) map[string]any {
+	out := make(map[string]any, len(base))
+	for key, value := range base {
+		out[key] = value
+	}
+	for key, value := range overlay {
+		if baseMap, ok := out[key].(map[string]any); ok {
+			if overlayMap, ok := value.(map[string]any); ok {
+				out[key] = mergeJSONObjects(baseMap, overlayMap)
+				continue
+			}
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func jsonschemaValidationMessages(err error) []string {
+	var validationErr *jsonschema.ValidationError
+	if !errors.As(err, &validationErr) {
+		msg := strings.TrimSpace(err.Error())
+		if msg == "" {
+			return nil
+		}
+		return []string{msg}
+	}
+	leaves := flattenJSONSchemaValidationErrors(validationErr)
+	out := make([]string, 0, len(leaves))
+	for _, leaf := range leaves {
+		location := strings.TrimSpace(leaf.InstanceLocation)
+		if location == "" {
+			location = "/"
+		}
+		out = append(out, fmt.Sprintf("%s: %s", location, strings.TrimSpace(leaf.Message)))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func flattenJSONSchemaValidationErrors(err *jsonschema.ValidationError) []*jsonschema.ValidationError {
+	if err == nil {
+		return nil
+	}
+	if len(err.Causes) == 0 {
+		return []*jsonschema.ValidationError{err}
+	}
+	out := make([]*jsonschema.ValidationError, 0, len(err.Causes))
+	for _, cause := range err.Causes {
+		out = append(out, flattenJSONSchemaValidationErrors(cause)...)
+	}
+	return out
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 func parseHelmApplicationSetFile(repo, path string) (helmApplicationSetDoc, error) {

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -354,6 +354,99 @@ func TestImportRepoHelmDryWetContract(t *testing.T) {
 	}
 }
 
+func TestImportRepoHelmUmbrellaAnalysis(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), `apiVersion: v2
+name: umbrella-demo
+version: 0.1.0
+dependencies:
+  - name: cache
+    alias: cache-primary
+    condition: cache.enabled
+    version: 1.2.3
+    repository: file://charts/cache-primary
+`)
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  tag: umbrella-v1\n")
+	mustWriteFile(t, filepath.Join(repo, "values-prod.yaml"), "image:\n  tag: 7\n")
+	mustWriteFile(t, filepath.Join(repo, "values.schema.json"), `{
+  "type": "object",
+  "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "tag": {"type": "string"}
+      }
+    }
+  }
+}`)
+	mustWriteFile(t, filepath.Join(repo, "charts", "cache-primary", "Chart.yaml"), "apiVersion: v2\nname: cache\nversion: 1.2.3\n")
+	mustWriteFile(t, filepath.Join(repo, "charts", "cache-primary", "values.yaml"), "image:\n  tag: cache-v1\n")
+	mustWriteFile(t, filepath.Join(repo, "crds", "widgets.example.io.yaml"), "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n")
+	mustWriteFile(t, filepath.Join(repo, "templates", "migrate-job.yaml"), `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate
+  annotations:
+    helm.sh/hook: pre-install
+`)
+
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+	if len(result.Detection.Generators) != 1 {
+		t.Fatalf("expected single umbrella generator, got %+v", result.Detection.Generators)
+	}
+	if len(result.Provenance) != 1 {
+		t.Fatalf("expected single provenance record, got %d", len(result.Provenance))
+	}
+
+	prov := result.Provenance[0]
+	if prov.HelmLayeredAnalysis == nil {
+		t.Fatalf("expected helm layered analysis, got nil")
+	}
+	if len(prov.HelmLayeredAnalysis.DependencyCharts) != 1 {
+		t.Fatalf("expected one dependency chart, got %+v", prov.HelmLayeredAnalysis.DependencyCharts)
+	}
+	dep := prov.HelmLayeredAnalysis.DependencyCharts[0]
+	if dep.Name != "cache" || dep.Alias != "cache-primary" || dep.Layer != "cache-primary" {
+		t.Fatalf("expected cache dependency metadata, got %+v", dep)
+	}
+	if dep.Condition != "cache.enabled" {
+		t.Fatalf("expected dependency condition cache.enabled, got %+v", dep)
+	}
+	if dep.ChartPath != "charts/cache-primary/Chart.yaml" || dep.ValuesPath != "charts/cache-primary/values.yaml" {
+		t.Fatalf("expected vendored dependency paths, got %+v", dep)
+	}
+	if !containsString(prov.HelmLayeredAnalysis.CRDPaths, "crds/widgets.example.io.yaml") {
+		t.Fatalf("expected CRD path in analysis, got %+v", prov.HelmLayeredAnalysis)
+	}
+	if !containsString(prov.HelmLayeredAnalysis.HookTemplatePaths, "templates/migrate-job.yaml") {
+		t.Fatalf("expected hook template path in analysis, got %+v", prov.HelmLayeredAnalysis)
+	}
+	if !hookTemplateHasPathHook(prov.HelmLayeredAnalysis.HookTemplates, "templates/migrate-job.yaml", "pre-install") {
+		t.Fatalf("expected hook template metadata for pre-install, got %+v", prov.HelmLayeredAnalysis.HookTemplates)
+	}
+	if prov.HelmLayeredAnalysis.ValuesSchemaPath != "values.schema.json" {
+		t.Fatalf("expected values schema path, got %+v", prov.HelmLayeredAnalysis)
+	}
+	if prov.HelmLayeredAnalysis.SchemaValidationState != "invalid" {
+		t.Fatalf("expected invalid schema validation state, got %+v", prov.HelmLayeredAnalysis)
+	}
+	if !anyContainsString(prov.HelmLayeredAnalysis.SchemaValidationViolations, "/image/tag") {
+		t.Fatalf("expected schema validation violation for /image/tag, got %+v", prov.HelmLayeredAnalysis.SchemaValidationViolations)
+	}
+	if !fieldOriginHasDryPathSourcePath(prov.FieldOriginMap, "values.image.tag", "charts/cache-primary/values.yaml") {
+		t.Fatalf("expected subchart values source path in field origins, got %+v", prov.FieldOriginMap)
+	}
+	if !fieldOriginHasDryPathSourceLayer(prov.FieldOriginMap, "values.image.tag", "cache-primary") {
+		t.Fatalf("expected subchart source layer cache-primary in field origins, got %+v", prov.FieldOriginMap)
+	}
+	if !fieldOriginHasDryPathSourceLayer(prov.FieldOriginMap, "values.image.tag", "umbrella") {
+		t.Fatalf("expected umbrella source layer in field origins, got %+v", prov.FieldOriginMap)
+	}
+}
+
 func TestImportRepoApplicationSetDryWetContract(t *testing.T) {
 	repo := filepath.Join("..", "..", "testdata", "applicationset-standalone")
 	result, err := ImportRepo(repo, "main", "platform")
@@ -1106,6 +1199,15 @@ func fieldOriginHasDryPathSourcePath(v []model.FieldOrigin, dryPath, sourcePath 
 	return false
 }
 
+func fieldOriginHasDryPathSourceLayer(v []model.FieldOrigin, dryPath, sourceLayer string) bool {
+	for _, item := range v {
+		if item.DryPath == dryPath && item.SourceLayer == sourceLayer {
+			return true
+		}
+	}
+	return false
+}
+
 func inversePointerHasDryPath(v []model.InverseEditPointer, dryPath string) bool {
 	for _, item := range v {
 		if item.DryPath == dryPath {
@@ -1128,6 +1230,29 @@ func containsString(v []string, needle string) bool {
 	for _, item := range v {
 		if item == needle {
 			return true
+		}
+	}
+	return false
+}
+
+func anyContainsString(v []string, needle string) bool {
+	for _, item := range v {
+		if strings.Contains(item, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func hookTemplateHasPathHook(v []model.HelmHookTemplate, path, hook string) bool {
+	for _, item := range v {
+		if item.Path != path {
+			continue
+		}
+		for _, candidate := range item.Hooks {
+			if candidate == hook {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -89,11 +89,12 @@ type RenderedObjectLineage struct {
 }
 
 type FieldOrigin struct {
-	DryPath    string  `json:"dry_path"`
-	WetPath    string  `json:"wet_path"`
-	SourcePath string  `json:"source_path"`
-	Transform  string  `json:"transform"`
-	Confidence float64 `json:"confidence"`
+	DryPath     string  `json:"dry_path"`
+	WetPath     string  `json:"wet_path"`
+	SourcePath  string  `json:"source_path"`
+	SourceLayer string  `json:"source_layer,omitempty"`
+	Transform   string  `json:"transform"`
+	Confidence  float64 `json:"confidence"`
 }
 
 type HelmCLIOverride struct {
@@ -104,20 +105,43 @@ type HelmCLIOverride struct {
 }
 
 type HelmLayeredAnalysis struct {
-	ApplicationSetPath       string   `json:"application_set_path,omitempty"`
-	ClusterInventoryPaths    []string `json:"cluster_inventory_paths,omitempty"`
-	ManagedCatalogPaths      []string `json:"managed_catalog_paths,omitempty"`
-	CustomerCatalogPaths     []string `json:"customer_catalog_paths,omitempty"`
-	ClusterSelector          string   `json:"cluster_selector,omitempty"`
-	MatchedClusters          []string `json:"matched_clusters,omitempty"`
-	SelectedValueFiles       []string `json:"selected_value_files,omitempty"`
-	GenerationDecisionState  string   `json:"generation_decision_state,omitempty"`
-	GenerationDecisionReason string   `json:"generation_decision_reason,omitempty"`
-	SecurityControl          string   `json:"security_control,omitempty"`
-	SecurityControlPath      string   `json:"security_control_path,omitempty"`
-	SecurityOverridePath     string   `json:"security_override_path,omitempty"`
-	SecurityDecisionState    string   `json:"security_decision_state,omitempty"`
-	SecurityDecisionReason   string   `json:"security_decision_reason,omitempty"`
+	ApplicationSetPath         string                `json:"application_set_path,omitempty"`
+	ClusterInventoryPaths      []string              `json:"cluster_inventory_paths,omitempty"`
+	ManagedCatalogPaths        []string              `json:"managed_catalog_paths,omitempty"`
+	CustomerCatalogPaths       []string              `json:"customer_catalog_paths,omitempty"`
+	DependencyCharts           []HelmDependencyChart `json:"dependency_charts,omitempty"`
+	CRDPaths                   []string              `json:"crd_paths,omitempty"`
+	HookTemplates              []HelmHookTemplate    `json:"hook_templates,omitempty"`
+	HookTemplatePaths          []string              `json:"hook_template_paths,omitempty"`
+	ValuesSchemaPath           string                `json:"values_schema_path,omitempty"`
+	SchemaValidationState      string                `json:"schema_validation_state,omitempty"`
+	SchemaValidationViolations []string              `json:"schema_validation_violations,omitempty"`
+	ClusterSelector            string                `json:"cluster_selector,omitempty"`
+	MatchedClusters            []string              `json:"matched_clusters,omitempty"`
+	SelectedValueFiles         []string              `json:"selected_value_files,omitempty"`
+	GenerationDecisionState    string                `json:"generation_decision_state,omitempty"`
+	GenerationDecisionReason   string                `json:"generation_decision_reason,omitempty"`
+	SecurityControl            string                `json:"security_control,omitempty"`
+	SecurityControlPath        string                `json:"security_control_path,omitempty"`
+	SecurityOverridePath       string                `json:"security_override_path,omitempty"`
+	SecurityDecisionState      string                `json:"security_decision_state,omitempty"`
+	SecurityDecisionReason     string                `json:"security_decision_reason,omitempty"`
+}
+
+type HelmDependencyChart struct {
+	Name       string `json:"name"`
+	Alias      string `json:"alias,omitempty"`
+	Layer      string `json:"layer,omitempty"`
+	Condition  string `json:"condition,omitempty"`
+	Repository string `json:"repository,omitempty"`
+	Version    string `json:"version,omitempty"`
+	ChartPath  string `json:"chart_path,omitempty"`
+	ValuesPath string `json:"values_path,omitempty"`
+}
+
+type HelmHookTemplate struct {
+	Path  string   `json:"path"`
+	Hooks []string `json:"hooks,omitempty"`
 }
 
 type ApplicationSetGeneratedApplication struct {


### PR DESCRIPTION
Closes #238

## Summary
- add umbrella-aware Helm detect/import provenance for dependencies, aliased subcharts, conditions, CRDs, hooks, and values schema validation
- record `source_layer` in field origins so import output shows whether umbrella values or a subchart layer won
- document how to read layered Helm provenance in the CLI reference and Helm example docs

## Validation
- go test ./...
- ./test/checks/check-docs-entrypoints.sh
- ./test/checks/check-story-status.sh