### PR TITLE
helm: improve provenance honesty warnings

### DIFF
--- a/cmd/cub-gen/helm_override_command_test.go
+++ b/cmd/cub-gen/helm_override_command_test.go
@@ -228,6 +228,115 @@ spec:
 	}
 }
 
+func TestChangeExplainHelmHelperOriginWarning(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: helper-demo\nversion: 0.1.0\n")
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  repository: ghcr.io/example/helper-demo\n  tag: v1.2.3\n")
+	mustWriteFile(t, filepath.Join(repo, "templates", "_helpers.tpl"), `{{- define "helper-demo.imageTag" -}}
+{{ .Values.image.tag }}
+{{- end -}}
+`)
+	mustWriteFile(t, filepath.Join(repo, "templates", "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helper-demo
+spec:
+  template:
+    spec:
+      containers:
+        - name: helper-demo
+          image: "{{ .Values.image.repository }}:{{ include "helper-demo.imageTag" . }}"
+`)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		repo,
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, out)
+	}
+	explanation, ok := got["explanation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected explanation object, got %T", got["explanation"])
+	}
+	if explanation["origin_type"] != "helper" {
+		t.Fatalf("expected origin_type=helper, got %v", explanation["origin_type"])
+	}
+	if explanation["source_transform"] != "helm-helper" {
+		t.Fatalf("expected source_transform=helm-helper, got %v", explanation["source_transform"])
+	}
+	if explanation["source_path"] != "values.yaml" {
+		t.Fatalf("expected helper chain to resolve back to values.yaml, got %v", explanation["source_path"])
+	}
+	warning, _ := explanation["warning"].(string)
+	if !strings.Contains(warning, "helper chain") {
+		t.Fatalf("expected helper warning, got %q", warning)
+	}
+}
+
+func TestChangeExplainHelmNonDeterministicOriginWarning(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: nondeterministic-demo\nversion: 0.1.0\n")
+	mustWriteFile(t, filepath.Join(repo, "templates", "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nondeterministic-demo
+spec:
+  template:
+    spec:
+      containers:
+        - name: nondeterministic-demo
+          image: "{{ lookup "v1" "ConfigMap" "default" "release-info" }}"
+`)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		repo,
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, out)
+	}
+	explanation, ok := got["explanation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected explanation object, got %T", got["explanation"])
+	}
+	if explanation["origin_type"] != "non-deterministic" {
+		t.Fatalf("expected origin_type=non-deterministic, got %v", explanation["origin_type"])
+	}
+	if explanation["source_transform"] != "helm-nondeterministic" {
+		t.Fatalf("expected source_transform=helm-nondeterministic, got %v", explanation["source_transform"])
+	}
+	if explanation["source_path"] != "<helm-nondeterministic>:lookup" {
+		t.Fatalf("expected non-deterministic synthetic source, got %v", explanation["source_path"])
+	}
+	warning, _ := explanation["warning"].(string)
+	if !strings.Contains(warning, "render-time lookup logic") {
+		t.Fatalf("expected non-deterministic warning, got %q", warning)
+	}
+	editHint, _ := explanation["edit_hint"].(string)
+	if !strings.Contains(editHint, "render-time logic") {
+		t.Fatalf("expected non-deterministic edit hint, got %q", editHint)
+	}
+}
+
 func mustWriteFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -27,6 +27,8 @@ import (
 
 const helmCLIOverrideTransform = "helm-cli-override"
 const helmBuiltinTransform = "helm-builtin"
+const helmHelperTransform = "helm-helper"
+const helmNonDeterministicTransform = "helm-nondeterministic"
 const helmDefaultTransform = "helm-default"
 
 func main() {
@@ -2339,6 +2341,18 @@ func pickInverseSuggestion(
 					candidate.Confidence = sourceConfidence
 				}
 			}
+			if sourceTransform == helmHelperTransform {
+				candidate.Warning = helperAwareWarning()
+				if sourceConfidence > candidate.Confidence {
+					candidate.Confidence = sourceConfidence
+				}
+			}
+			if sourceTransform == helmNonDeterministicTransform {
+				candidate.Warning = nonDeterministicAwareWarning(sourcePath)
+				if sourceConfidence > candidate.Confidence {
+					candidate.Confidence = sourceConfidence
+				}
+			}
 			if sourceTransform == helmDefaultTransform {
 				candidate.Warning = defaultAwareWarning()
 				if sourceConfidence > candidate.Confidence {
@@ -2398,6 +2412,10 @@ func collectImpactSuggestions(
 				entry.Warning = overrideAwareWarning()
 			case helmBuiltinTransform:
 				entry.Warning = builtinAwareWarning(origin.SourcePath)
+			case helmHelperTransform:
+				entry.Warning = helperAwareWarning()
+			case helmNonDeterministicTransform:
+				entry.Warning = nonDeterministicAwareWarning(origin.SourcePath)
 			case helmDefaultTransform:
 				entry.Warning = defaultAwareWarning()
 			}
@@ -2549,7 +2567,7 @@ func applyFieldOriginToPointer(pointer model.InverseEditPointer, origin model.Fi
 	case helmCLIOverrideTransform:
 		pointer.Owner = "release-automation"
 		pointer.EditHint = overrideAwareEditHint(origin.SourcePath, pointer.EditHint)
-	case helmBuiltinTransform, helmDefaultTransform:
+	case helmBuiltinTransform, helmHelperTransform, helmNonDeterministicTransform, helmDefaultTransform:
 		// Keep the generator-produced edit hint, but let the higher-confidence
 		// provenance source win when the hint already points at the right layer.
 	default:
@@ -2576,7 +2594,22 @@ func builtinAwareWarning(sourcePath string) string {
 	if sourcePath == "<helm-builtin>:.Chart.AppVersion" {
 		return "This field currently comes from the Helm built-in .Chart.AppVersion path, not from an observed values file."
 	}
+	if strings.HasPrefix(sourcePath, "<helm-builtin>:.Files.Get(") {
+		return "This field currently comes from Helm built-in .Files.Get chart-file input, not from an observed values file."
+	}
 	return "This field currently comes from a Helm built-in source, not from an observed values file."
+}
+
+func helperAwareWarning() string {
+	return "This field is routed through a Helm helper chain before it reaches the rendered manifest, so cub-gen traced the helper back to the underlying values source."
+}
+
+func nonDeterministicAwareWarning(sourcePath string) string {
+	fn := strings.TrimPrefix(sourcePath, "<helm-nondeterministic>:")
+	if strings.TrimSpace(fn) == "" || fn == sourcePath {
+		return "This field currently comes from Helm render-time logic, so provenance ends at render time instead of a stable DRY file."
+	}
+	return fmt.Sprintf("This field currently comes from Helm render-time %s logic, so provenance ends at render time instead of a stable DRY file.", fn)
 }
 
 func defaultAwareWarning() string {
@@ -2589,6 +2622,10 @@ func explainOriginType(sourcePath, sourceTransform string) string {
 		return "external"
 	case sourceTransform == helmBuiltinTransform:
 		return "builtin"
+	case sourceTransform == helmHelperTransform:
+		return "helper"
+	case sourceTransform == helmNonDeterministicTransform:
+		return "non-deterministic"
 	case sourceTransform == helmDefaultTransform:
 		return "default"
 	case strings.TrimSpace(sourcePath) != "":

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -340,7 +340,7 @@ What works today:
 - One `gitops import` / `publish` invocation works on one repo path pair.
 - Supported generators can pick up overlay files that already live in that repo, such as Helm `values-prod.yaml`, Spring `application-dev.yaml`, and generator-specific overlay files.
 - Helm flows also capture invocation-time `--set`, `--set-string`, and `--set-file` overrides and rank them above values files in provenance and `change explain`.
-- Helm `change explain` also calls out when a field is currently coming from `.Chart.AppVersion` or an unresolved chart-default path instead of an observed values file.
+- Helm `change explain` also calls out when a field is currently coming from `.Chart.AppVersion`, `.Files.Get`, a helper chain, `lookup`/other render-time logic, or an unresolved chart-default path instead of an observed values file.
 - Provenance records include those generator inputs in `dry_inputs`, `values_paths`, and `field_origin_map` when the generator emits separate overlay transforms.
 - When a repo declares a generator chain, `change explain` includes `hops[]` so you can see the upstream DRY stage and the downstream generator stage together instead of stopping at the last transform boundary.
 - `change explain` can point to overlay-specific edit locations. For Spring Boot, the current edit hint routes `server.port` changes to `application-dev.yaml` for environment overrides while keeping `application.yaml` as the base.

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -33,7 +33,7 @@ Known gaps still open:
 
 - umbrella/subchart/alias/conditional chart support is still open work ([#238](https://github.com/confighub/cub-gen/issues/238))
 - one-command multi-variant fan-out is not exposed yet ([#237](https://github.com/confighub/cub-gen/issues/237))
-- helper chains, `lookup`, and external value-source provenance honesty are still partial ([#239](https://github.com/confighub/cub-gen/issues/239))
+- external value-source provenance honesty is still partial ([#239](https://github.com/confighub/cub-gen/issues/239)); helper-chain and `lookup` origins now surface as explicit warnings instead of pretending they came from a normal values file
 
 ## AI-first bundle
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -22,13 +23,20 @@ import (
 )
 
 const (
-	generatorContractSchema  = "cub.confighub.io/generator-contract/v1"
-	provenanceSchema         = "cub.confighub.io/provenance/v1"
-	inversePlanSchema        = "cub.confighub.io/inverse-transform-plan/v1"
-	helmCLIOverrideTransform = "helm-cli-override"
-	helmBuiltinTransform     = "helm-builtin"
-	helmDefaultTransform     = "helm-default"
-	generatorChainTransform  = "generator-chain"
+	generatorContractSchema       = "cub.confighub.io/generator-contract/v1"
+	provenanceSchema              = "cub.confighub.io/provenance/v1"
+	inversePlanSchema             = "cub.confighub.io/inverse-transform-plan/v1"
+	helmCLIOverrideTransform      = "helm-cli-override"
+	helmBuiltinTransform          = "helm-builtin"
+	helmHelperTransform           = "helm-helper"
+	helmNonDeterministicTransform = "helm-nondeterministic"
+	helmDefaultTransform          = "helm-default"
+	generatorChainTransform       = "generator-chain"
+)
+
+var (
+	helmHelperDefineRe = regexp.MustCompile(`(?s)\{\{[- ]*define\s+"([^"]+)"[- ]*\}\}(.*?)\{\{[- ]*end[- ]*\}\}`)
+	helmHelperRefRe    = regexp.MustCompile(`(?:include|template)\s+"([^"]+)"`)
 )
 
 // ImportRepo detects generators in a repository and produces the initial
@@ -721,10 +729,15 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 	case model.GeneratorHelm:
 		hints := helmProvenancePathsForGenerator(detection.Repo, g)
 		imageTagSources := helmImageTagSources(detection.Repo, hints)
+		helperChain := helmImageTagUsesHelperChain(detection.Repo)
 		overrideOrigins := helmCLIOverrideFieldOrigins(g, helmCLIOverrides)
 		origins := make([]model.FieldOrigin, 0, len(overrideOrigins)+len(imageTagSources)+1)
 		origins = append(origins, overrideOrigins...)
 		if len(imageTagSources) == 0 {
+			if nondeterministicOrigin, ok := helmImageTagNonDeterministicOrigin(detection.Repo); ok {
+				origins = append(origins, nondeterministicOrigin)
+				return origins
+			}
 			if builtinOrigin, ok := helmImageTagBuiltinOrigin(detection.Repo, hints); ok {
 				origins = append(origins, builtinOrigin)
 				return origins
@@ -744,6 +757,11 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 			if strings.HasPrefix(source.Path, "charts/") {
 				confidenceKey = "image_tag_subchart"
 				confidenceFallback = 0.74
+			}
+			if helperChain {
+				transform = helmHelperTransform
+				confidenceKey = ""
+				confidenceFallback = 1.0
 			}
 			origins = append(origins, model.FieldOrigin{
 				DryPath:     "values.image.tag",
@@ -1066,6 +1084,17 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 			Owner: "app-team", Confidence: 0.86,
 		})
 		if len(imageTagSources) == 0 {
+			if nondeterministicOrigin, ok := helmImageTagNonDeterministicOrigin(detection.Repo); ok {
+				return []model.InverseEditPointer{
+					{
+						WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+						DryPath:    "values.image.tag",
+						Owner:      "platform-engineer",
+						EditHint:   "This field currently comes from Helm render-time logic like lookup/now/randAlphaNum/uuidv4. Edit the chart template or helper chain instead of values.yaml.",
+						Confidence: nondeterministicOrigin.Confidence,
+					},
+				}
+			}
 			if _, ok := helmImageTagBuiltinOrigin(detection.Repo, hints); ok {
 				return []model.InverseEditPointer{
 					{
@@ -1874,6 +1903,15 @@ func helmImageTagBuiltinOrigin(repoPath string, hints helmProvenancePaths) (mode
 	if strings.TrimSpace(repoPath) == "" {
 		return model.FieldOrigin{}, false
 	}
+	if fileRef := helmTemplatesUseFilesGetForImageTag(repoPath); fileRef != "" {
+		return model.FieldOrigin{
+			DryPath:    "values.image.tag",
+			WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+			SourcePath: fmt.Sprintf("<helm-builtin>:.Files.Get(%s)", fileRef),
+			Transform:  helmBuiltinTransform,
+			Confidence: 1.0,
+		}, true
+	}
 	if !helmTemplatesUseChartAppVersionFallback(repoPath) {
 		return model.FieldOrigin{}, false
 	}
@@ -1887,6 +1925,20 @@ func helmImageTagBuiltinOrigin(repoPath string, hints helmProvenancePaths) (mode
 		}, true
 	}
 	return model.FieldOrigin{}, false
+}
+
+func helmImageTagNonDeterministicOrigin(repoPath string) (model.FieldOrigin, bool) {
+	fn := helmTemplatesUseNonDeterministicImageTagSource(repoPath)
+	if fn == "" {
+		return model.FieldOrigin{}, false
+	}
+	return model.FieldOrigin{
+		DryPath:    "values.image.tag",
+		WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+		SourcePath: "<helm-nondeterministic>:" + fn,
+		Transform:  helmNonDeterministicTransform,
+		Confidence: 1.0,
+	}, true
 }
 
 func helmImageTagDefaultOrigin() model.FieldOrigin {
@@ -1925,6 +1977,171 @@ func helmTemplatesUseChartAppVersionFallback(repoPath string) bool {
 				found = true
 				return filepath.SkipAll
 			}
+		}
+		return nil
+	})
+	return found
+}
+
+func helmImageTagUsesHelperChain(repoPath string) bool {
+	helpers := helmHelperDefinitions(repoPath)
+	if len(helpers) == 0 {
+		return false
+	}
+	for _, ref := range helmReferencedHelpers(repoPath) {
+		if helmHelperUsesImageTag(helpers, ref, map[string]struct{}{}) {
+			return true
+		}
+	}
+	return false
+}
+
+func helmHelperDefinitions(repoPath string) map[string]string {
+	templatesDir := filepath.Join(repoPath, "templates")
+	info, err := os.Stat(templatesDir)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+	out := map[string]string{}
+	_ = filepath.Walk(templatesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".tpl" {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		for _, match := range helmHelperDefineRe.FindAllStringSubmatch(string(content), -1) {
+			if len(match) < 3 {
+				continue
+			}
+			out[match[1]] = match[2]
+		}
+		return nil
+	})
+	return out
+}
+
+func helmReferencedHelpers(repoPath string) []string {
+	templatesDir := filepath.Join(repoPath, "templates")
+	info, err := os.Stat(templatesDir)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+	refs := map[string]struct{}{}
+	_ = filepath.Walk(templatesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		for _, match := range helmHelperRefRe.FindAllStringSubmatch(string(content), -1) {
+			if len(match) < 2 {
+				continue
+			}
+			refs[match[1]] = struct{}{}
+		}
+		return nil
+	})
+	out := make([]string, 0, len(refs))
+	for ref := range refs {
+		out = append(out, ref)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func helmHelperUsesImageTag(helpers map[string]string, helper string, seen map[string]struct{}) bool {
+	if _, ok := seen[helper]; ok {
+		return false
+	}
+	body, ok := helpers[helper]
+	if !ok {
+		return false
+	}
+	seen[helper] = struct{}{}
+	if strings.Contains(body, ".Values.image.tag") {
+		return true
+	}
+	for _, match := range helmHelperRefRe.FindAllStringSubmatch(body, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		if helmHelperUsesImageTag(helpers, match[1], seen) {
+			return true
+		}
+	}
+	return false
+}
+
+func helmTemplatesUseFilesGetForImageTag(repoPath string) string {
+	return helmImageTagTemplateFunctionArg(repoPath, ".Files.Get")
+}
+
+func helmTemplatesUseNonDeterministicImageTagSource(repoPath string) string {
+	for _, fn := range []string{"lookup", "now", "randAlphaNum", "uuidv4"} {
+		if helmImageTagTemplateMentions(repoPath, fn) {
+			return fn
+		}
+	}
+	return ""
+}
+
+func helmImageTagTemplateFunctionArg(repoPath, fn string) string {
+	templatesDir := filepath.Join(repoPath, "templates")
+	info, err := os.Stat(templatesDir)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+
+	pattern := regexp.MustCompile(regexp.QuoteMeta(fn) + `\s+"([^"]+)"`)
+	ref := ""
+	_ = filepath.Walk(templatesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		text := string(content)
+		if !strings.Contains(text, "image") || !strings.Contains(text, fn) {
+			return nil
+		}
+		match := pattern.FindStringSubmatch(text)
+		if len(match) < 2 {
+			return nil
+		}
+		ref = match[1]
+		return filepath.SkipAll
+	})
+	return ref
+}
+
+func helmImageTagTemplateMentions(repoPath, token string) bool {
+	templatesDir := filepath.Join(repoPath, "templates")
+	info, err := os.Stat(templatesDir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	found := false
+	_ = filepath.Walk(templatesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		text := string(content)
+		if strings.Contains(text, "image") && strings.Contains(text, token) {
+			found = true
+			return filepath.SkipAll
 		}
 		return nil
 	})


### PR DESCRIPTION
Refs #239

## Summary
- mark Helm image-tag provenance as `helper` when cub-gen walks a helper chain back to a real values source
- surface `non-deterministic` warnings for render-time image sources like `lookup`, and extend builtin honesty to `.Files.Get`
- update Helm docs so helper-chain and lookup cases are described honestly without claiming external refs are solved

## Validation
- go test ./...
- ./test/checks/check-docs-entrypoints.sh
- ./test/checks/check-story-status.sh