### PR TITLE
provenance: add generator chain slice

### DIFF
--- a/cmd/cub-gen/change_command_test.go
+++ b/cmd/cub-gen/change_command_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/confighub/cub-gen/internal/model"
 )
 
 func TestChangePreviewJSON(t *testing.T) {
@@ -190,6 +192,59 @@ func TestChangeExplainJSON(t *testing.T) {
 	}
 	if dryPath, ok := explanation["dry_path"].(string); !ok || strings.TrimSpace(dryPath) == "" {
 		t.Fatalf("expected non-empty dry_path, got %v", explanation["dry_path"])
+	}
+}
+
+func TestPickInverseSuggestionIncludesGeneratorChainHops(t *testing.T) {
+	provenance := []model.ProvenanceRecord{{
+		GeneratorName:    "checkout-api",
+		GeneratorProfile: "helm-paas",
+		FieldOriginMap: []model.FieldOrigin{{
+			DryPath:    "containers.api.image",
+			WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+			SourcePath: "score.yaml",
+			Transform:  "score-to-helm",
+			Confidence: 0.80,
+			Hops: []model.FieldOriginHop{
+				{
+					GeneratorKind:    "score",
+					GeneratorProfile: "scoredev-paas",
+					DryPath:          "containers.api.image",
+					SourcePath:       "score.yaml",
+					Transform:        "score-to-helm",
+					Confidence:       0.94,
+				},
+				{
+					GeneratorKind:    "helm",
+					GeneratorProfile: "helm-paas",
+					DryPath:          "values.image.tag",
+					SourcePath:       "chart/values.yaml",
+					Transform:        "helm-values",
+					Confidence:       0.86,
+				},
+			},
+		}},
+		InverseEditPointers: []model.InverseEditPointer{{
+			WetPath:    "Deployment/spec/template/spec/containers[0]/image",
+			DryPath:    "containers.api.image",
+			Owner:      "app-team",
+			EditHint:   "Edit containers.api.image in score.yaml.",
+			Confidence: 0.80,
+		}},
+	}}
+
+	suggestion, matchCount, ok := pickInverseSuggestion(provenance, "Deployment/spec/template/spec/containers[0]/image", "", "")
+	if !ok {
+		t.Fatal("expected inverse suggestion")
+	}
+	if matchCount != 1 {
+		t.Fatalf("expected 1 match, got %d", matchCount)
+	}
+	if len(suggestion.Hops) != 2 {
+		t.Fatalf("expected 2 provenance hops, got %+v", suggestion.Hops)
+	}
+	if suggestion.Hops[0].GeneratorKind != "score" || suggestion.Hops[1].GeneratorKind != "helm" {
+		t.Fatalf("unexpected hop order: %+v", suggestion.Hops)
 	}
 }
 

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -1056,18 +1056,28 @@ type changeImpactQuery struct {
 	MatchCount    int    `json:"match_count"`
 }
 
-type changeImpactEntry struct {
-	Owner            string  `json:"owner,omitempty"`
-	WetPath          string  `json:"wet_path"`
-	DryPath          string  `json:"dry_path"`
-	EditHint         string  `json:"edit_hint,omitempty"`
-	Confidence       float64 `json:"confidence"`
+type changeProvenanceHop struct {
+	GeneratorKind    string  `json:"generator_kind,omitempty"`
+	GeneratorProfile string  `json:"generator_profile,omitempty"`
+	DryPath          string  `json:"dry_path,omitempty"`
 	SourcePath       string  `json:"source_path,omitempty"`
 	SourceTransform  string  `json:"source_transform,omitempty"`
-	OriginType       string  `json:"origin_type,omitempty"`
-	GeneratorName    string  `json:"generator_name,omitempty"`
-	GeneratorProfile string  `json:"generator_profile,omitempty"`
-	Warning          string  `json:"warning,omitempty"`
+	Confidence       float64 `json:"confidence,omitempty"`
+}
+
+type changeImpactEntry struct {
+	Owner            string                `json:"owner,omitempty"`
+	WetPath          string                `json:"wet_path"`
+	DryPath          string                `json:"dry_path"`
+	EditHint         string                `json:"edit_hint,omitempty"`
+	Confidence       float64               `json:"confidence"`
+	SourcePath       string                `json:"source_path,omitempty"`
+	SourceTransform  string                `json:"source_transform,omitempty"`
+	OriginType       string                `json:"origin_type,omitempty"`
+	GeneratorName    string                `json:"generator_name,omitempty"`
+	GeneratorProfile string                `json:"generator_profile,omitempty"`
+	Hops             []changeProvenanceHop `json:"hops,omitempty"`
+	Warning          string                `json:"warning,omitempty"`
 }
 
 type changeImpactResult struct {
@@ -1105,19 +1115,20 @@ type changeDiffManifestRef struct {
 }
 
 type changeDiffFieldState struct {
-	Exists           bool    `json:"exists"`
-	Value            any     `json:"value,omitempty"`
-	Owner            string  `json:"owner,omitempty"`
-	WetPath          string  `json:"wet_path,omitempty"`
-	DryPath          string  `json:"dry_path,omitempty"`
-	EditHint         string  `json:"edit_hint,omitempty"`
-	Confidence       float64 `json:"confidence,omitempty"`
-	SourcePath       string  `json:"source_path,omitempty"`
-	SourceTransform  string  `json:"source_transform,omitempty"`
-	OriginType       string  `json:"origin_type,omitempty"`
-	GeneratorName    string  `json:"generator_name,omitempty"`
-	GeneratorProfile string  `json:"generator_profile,omitempty"`
-	Warning          string  `json:"warning,omitempty"`
+	Exists           bool                  `json:"exists"`
+	Value            any                   `json:"value,omitempty"`
+	Owner            string                `json:"owner,omitempty"`
+	WetPath          string                `json:"wet_path,omitempty"`
+	DryPath          string                `json:"dry_path,omitempty"`
+	EditHint         string                `json:"edit_hint,omitempty"`
+	Confidence       float64               `json:"confidence,omitempty"`
+	SourcePath       string                `json:"source_path,omitempty"`
+	SourceTransform  string                `json:"source_transform,omitempty"`
+	OriginType       string                `json:"origin_type,omitempty"`
+	GeneratorName    string                `json:"generator_name,omitempty"`
+	GeneratorProfile string                `json:"generator_profile,omitempty"`
+	Hops             []changeProvenanceHop `json:"hops,omitempty"`
+	Warning          string                `json:"warning,omitempty"`
 }
 
 type changeDiffEntry struct {
@@ -1149,17 +1160,18 @@ type changeExplainQuery struct {
 }
 
 type changeExplainSuggestion struct {
-	Owner            string  `json:"owner"`
-	WetPath          string  `json:"wet_path"`
-	DryPath          string  `json:"dry_path"`
-	EditHint         string  `json:"edit_hint"`
-	Confidence       float64 `json:"confidence"`
-	SourcePath       string  `json:"source_path,omitempty"`
-	SourceTransform  string  `json:"source_transform,omitempty"`
-	OriginType       string  `json:"origin_type,omitempty"`
-	GeneratorName    string  `json:"generator_name,omitempty"`
-	GeneratorProfile string  `json:"generator_profile,omitempty"`
-	Warning          string  `json:"warning,omitempty"`
+	Owner            string                `json:"owner"`
+	WetPath          string                `json:"wet_path"`
+	DryPath          string                `json:"dry_path"`
+	EditHint         string                `json:"edit_hint"`
+	Confidence       float64               `json:"confidence"`
+	SourcePath       string                `json:"source_path,omitempty"`
+	SourceTransform  string                `json:"source_transform,omitempty"`
+	OriginType       string                `json:"origin_type,omitempty"`
+	GeneratorName    string                `json:"generator_name,omitempty"`
+	GeneratorProfile string                `json:"generator_profile,omitempty"`
+	Hops             []changeProvenanceHop `json:"hops,omitempty"`
+	Warning          string                `json:"warning,omitempty"`
 }
 
 type changeExplainResult struct {
@@ -1863,6 +1875,7 @@ func changeDiffStateFromProvenance(provenance []model.ProvenanceRecord, wetPath 
 			OriginType:       explainOriginType(origin.SourcePath, origin.Transform),
 			GeneratorName:    record.GeneratorName,
 			GeneratorProfile: record.GeneratorProfile,
+			Hops:             changeProvenanceHops(origin),
 		}
 		if pointer, ok := bestInversePointer(record.InverseEditPointers, wetPath, origin.DryPath); ok {
 			pointer = applyFieldOriginToPointer(pointer, origin)
@@ -2288,10 +2301,12 @@ func pickInverseSuggestion(
 			}
 			matchCount++
 
+			var origin model.FieldOrigin
 			sourcePath := ""
 			sourceTransform := ""
 			sourceConfidence := 0.0
 			if source, ok := bestFieldOrigin(record.FieldOriginMap, pointer.WetPath, pointer.DryPath); ok {
+				origin = source
 				sourcePath = source.SourcePath
 				sourceTransform = source.Transform
 				sourceConfidence = source.Confidence
@@ -2308,6 +2323,7 @@ func pickInverseSuggestion(
 				OriginType:       explainOriginType(sourcePath, sourceTransform),
 				GeneratorName:    record.GeneratorName,
 				GeneratorProfile: record.GeneratorProfile,
+				Hops:             changeProvenanceHops(origin),
 			}
 			if sourceTransform == helmCLIOverrideTransform {
 				candidate.Owner = "release-automation"
@@ -2369,6 +2385,7 @@ func collectImpactSuggestions(
 				OriginType:       explainOriginType(origin.SourcePath, origin.Transform),
 				GeneratorName:    record.GeneratorName,
 				GeneratorProfile: record.GeneratorProfile,
+				Hops:             changeProvenanceHops(origin),
 			}
 			if ok {
 				entry.Owner = pointer.Owner
@@ -2459,6 +2476,24 @@ func bestFieldOrigin(origins []model.FieldOrigin, wetPath, dryPath string) (mode
 		return model.FieldOrigin{}, false
 	}
 	return best, true
+}
+
+func changeProvenanceHops(origin model.FieldOrigin) []changeProvenanceHop {
+	if len(origin.Hops) == 0 {
+		return nil
+	}
+	hops := make([]changeProvenanceHop, 0, len(origin.Hops))
+	for _, hop := range origin.Hops {
+		hops = append(hops, changeProvenanceHop{
+			GeneratorKind:    hop.GeneratorKind,
+			GeneratorProfile: hop.GeneratorProfile,
+			DryPath:          hop.DryPath,
+			SourcePath:       hop.SourcePath,
+			SourceTransform:  hop.Transform,
+			Confidence:       hop.Confidence,
+		})
+	}
+	return hops
 }
 
 func bestInversePointer(pointers []model.InverseEditPointer, wetPath, dryPath string) (model.InverseEditPointer, bool) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -342,6 +342,7 @@ What works today:
 - Helm flows also capture invocation-time `--set`, `--set-string`, and `--set-file` overrides and rank them above values files in provenance and `change explain`.
 - Helm `change explain` also calls out when a field is currently coming from `.Chart.AppVersion` or an unresolved chart-default path instead of an observed values file.
 - Provenance records include those generator inputs in `dry_inputs`, `values_paths`, and `field_origin_map` when the generator emits separate overlay transforms.
+- When a repo declares a generator chain, `change explain` includes `hops[]` so you can see the upstream DRY stage and the downstream generator stage together instead of stopping at the last transform boundary.
 - `change explain` can point to overlay-specific edit locations. For Spring Boot, the current edit hint routes `server.port` changes to `application-dev.yaml` for environment overrides while keeping `application.yaml` as the base.
 
 What does not work today:

--- a/docs/contracts/change-cli-v1.md
+++ b/docs/contracts/change-cli-v1.md
@@ -91,7 +91,7 @@ Expected output fields (`ChangeExplainResult`):
 - `input.{target_path,render_target_path,target_slug,render_target_slug}`
 - `change.{change_id,bundle_digest,attestation_digest}`
 - `query.{wet_path_filter,dry_path_filter,owner_filter,match_count}`
-- `explanation.{owner,wet_path,dry_path,edit_hint,confidence,source_path,source_transform,generator_name,generator_profile}`
+- `explanation.{owner,wet_path,dry_path,edit_hint,confidence,source_path,source_transform,generator_name,generator_profile,hops[]}`
 
 ### 4) `cub-gen change diff`
 
@@ -119,6 +119,7 @@ Expected output fields (`ChangeDiffResult`):
 Current implementation note:
 
 - the first shipped slice is Helm-first and compares rendered field values plus before/after provenance
+- when a repo declares a generator chain, provenance can also carry `hops[]` to show the upstream and downstream stages involved in the explanation
 
 ### 5) `cub-gen change impact`
 

--- a/examples/incubator/score-helm-chain/.cub-gen-chain.yaml
+++ b/examples/incubator/score-helm-chain/.cub-gen-chain.yaml
@@ -1,0 +1,27 @@
+chains:
+  - id: score-to-helm
+    name: Score to Helm
+    stages:
+      - kind: score
+        root: .
+      - kind: helm
+        root: chart
+    mappings:
+      - downstream_wet_path: Deployment/spec/template/spec/containers[0]/image
+        downstream_dry_path: values.image.tag
+        upstream_kind: score
+        upstream_root: .
+        upstream_dry_path: containers.api.image
+        upstream_source_path: score.yaml
+        upstream_owner: app-team
+        upstream_transform: score-to-helm
+        upstream_confidence: 0.94
+      - downstream_wet_path: Service/spec/ports[name=http]/port
+        downstream_dry_path: values.service.port
+        upstream_kind: score
+        upstream_root: .
+        upstream_dry_path: service.ports.http.port
+        upstream_source_path: score.yaml
+        upstream_owner: app-team
+        upstream_transform: score-to-helm
+        upstream_confidence: 0.91

--- a/examples/incubator/score-helm-chain/chart/Chart.yaml
+++ b/examples/incubator/score-helm-chain/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: checkout-api
+version: 0.1.0
+appVersion: v1.2.3

--- a/examples/incubator/score-helm-chain/chart/templates/deployment.yaml
+++ b/examples/incubator/score-helm-chain/chart/templates/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-api
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: checkout-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: checkout-api
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.service.port }}

--- a/examples/incubator/score-helm-chain/chart/templates/service.yaml
+++ b/examples/incubator/score-helm-chain/chart/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout-api
+spec:
+  selector:
+    app.kubernetes.io/name: checkout-api
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}

--- a/examples/incubator/score-helm-chain/chart/values.yaml
+++ b/examples/incubator/score-helm-chain/chart/values.yaml
@@ -1,0 +1,5 @@
+image:
+  repository: ghcr.io/example/checkout-api
+  tag: v1.2.3
+service:
+  port: 8080

--- a/examples/incubator/score-helm-chain/score.yaml
+++ b/examples/incubator/score-helm-chain/score.yaml
@@ -1,0 +1,10 @@
+apiVersion: score.dev/v1b1
+metadata:
+  name: checkout-api
+containers:
+  api:
+    image: ghcr.io/example/checkout-api:v1.2.3
+service:
+  ports:
+    http:
+      port: 8080

--- a/internal/contracts/schemas/provenance.v1.schema.json
+++ b/internal/contracts/schemas/provenance.v1.schema.json
@@ -220,6 +220,40 @@
             "type": "number",
             "minimum": 0,
             "maximum": 1
+          },
+          "hops": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "generator_kind": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "generator_profile": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "dry_path": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source_path": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "transform": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "confidence": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                }
+              }
+            }
           }
         }
       }

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -16,6 +16,7 @@ import (
 	"github.com/confighub/cub-gen/internal/applicationset"
 	"github.com/confighub/cub-gen/internal/model"
 	"github.com/confighub/cub-gen/internal/registry"
+	"gopkg.in/yaml.v3"
 )
 
 // ScanRepo scans a local repository path and returns deterministic generator detections.
@@ -94,12 +95,195 @@ func ScanRepo(repoPath, ref string) (model.DetectionResult, error) {
 		return all[i].Name < all[j].Name
 	})
 
+	chains, err := loadGeneratorChains(absRepo, all)
+	if err != nil {
+		return model.DetectionResult{}, err
+	}
+
 	return model.DetectionResult{
 		Repo:       absRepo,
 		Ref:        ref,
 		DetectedAt: time.Now().UTC().Format(time.RFC3339),
 		Generators: all,
+		Chains:     chains,
 	}, nil
+}
+
+type rawGeneratorChainFile struct {
+	Chains []rawGeneratorChain `yaml:"chains"`
+}
+
+type rawGeneratorChain struct {
+	ID       string                     `yaml:"id"`
+	Name     string                     `yaml:"name"`
+	Stages   []rawGeneratorChainStage   `yaml:"stages"`
+	Mappings []rawGeneratorChainMapping `yaml:"mappings"`
+}
+
+type rawGeneratorChainStage struct {
+	Kind string `yaml:"kind"`
+	Root string `yaml:"root"`
+}
+
+type rawGeneratorChainMapping struct {
+	DownstreamWetPath  string  `yaml:"downstream_wet_path"`
+	DownstreamDryPath  string  `yaml:"downstream_dry_path"`
+	UpstreamKind       string  `yaml:"upstream_kind"`
+	UpstreamRoot       string  `yaml:"upstream_root"`
+	UpstreamDryPath    string  `yaml:"upstream_dry_path"`
+	UpstreamSourcePath string  `yaml:"upstream_source_path"`
+	UpstreamOwner      string  `yaml:"upstream_owner"`
+	UpstreamTransform  string  `yaml:"upstream_transform"`
+	UpstreamConfidence float64 `yaml:"upstream_confidence"`
+}
+
+func loadGeneratorChains(repo string, detections []model.GeneratorDetection) ([]model.GeneratorChain, error) {
+	path := filepath.Join(repo, ".cub-gen-chain.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read generator chains: %w", err)
+	}
+
+	var raw rawGeneratorChainFile
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse generator chains: %w", err)
+	}
+	if len(raw.Chains) == 0 {
+		return nil, nil
+	}
+
+	out := make([]model.GeneratorChain, 0, len(raw.Chains))
+	for idx, chain := range raw.Chains {
+		if len(chain.Stages) < 2 {
+			return nil, fmt.Errorf("generator chain %q must declare at least two stages", rawChainID(chain, idx))
+		}
+
+		stages := make([]model.GeneratorChainStage, 0, len(chain.Stages))
+		for stageIdx, stage := range chain.Stages {
+			kind, err := parseGeneratorKind(stage.Kind)
+			if err != nil {
+				return nil, fmt.Errorf("generator chain %q stage %d: %w", rawChainID(chain, idx), stageIdx+1, err)
+			}
+			root := normalizeChainRoot(stage.Root)
+			detection, ok := matchGeneratorDetection(detections, kind, root)
+			if !ok {
+				return nil, fmt.Errorf("generator chain %q stage %d: no detected generator matched kind=%q root=%q", rawChainID(chain, idx), stageIdx+1, kind, root)
+			}
+			stages = append(stages, model.GeneratorChainStage{
+				Kind:        detection.Kind,
+				Profile:     detection.Profile,
+				Name:        detection.Name,
+				Root:        detection.Root,
+				DetectionID: detection.ID,
+				Confidence:  detection.Confidence,
+			})
+		}
+
+		mappings := make([]model.GeneratorChainMapping, 0, len(chain.Mappings))
+		for mappingIdx, mapping := range chain.Mappings {
+			if strings.TrimSpace(mapping.DownstreamWetPath) == "" {
+				return nil, fmt.Errorf("generator chain %q mapping %d must declare downstream_wet_path", rawChainID(chain, idx), mappingIdx+1)
+			}
+			if strings.TrimSpace(mapping.UpstreamDryPath) == "" {
+				return nil, fmt.Errorf("generator chain %q mapping %d must declare upstream_dry_path", rawChainID(chain, idx), mappingIdx+1)
+			}
+			if strings.TrimSpace(mapping.UpstreamSourcePath) == "" {
+				return nil, fmt.Errorf("generator chain %q mapping %d must declare upstream_source_path", rawChainID(chain, idx), mappingIdx+1)
+			}
+			if mapping.UpstreamConfidence < 0 || mapping.UpstreamConfidence > 1 {
+				return nil, fmt.Errorf("generator chain %q mapping %d upstream_confidence must be between 0 and 1", rawChainID(chain, idx), mappingIdx+1)
+			}
+
+			upstreamStage := stages[0]
+			if strings.TrimSpace(mapping.UpstreamKind) != "" || strings.TrimSpace(mapping.UpstreamRoot) != "" {
+				kind, err := parseGeneratorKind(mapping.UpstreamKind)
+				if err != nil {
+					return nil, fmt.Errorf("generator chain %q mapping %d: %w", rawChainID(chain, idx), mappingIdx+1, err)
+				}
+				root := normalizeChainRoot(mapping.UpstreamRoot)
+				stage, ok := matchChainStage(stages, kind, root)
+				if !ok {
+					return nil, fmt.Errorf("generator chain %q mapping %d: no upstream stage matched kind=%q root=%q", rawChainID(chain, idx), mappingIdx+1, kind, root)
+				}
+				upstreamStage = stage
+			}
+
+			confidence := mapping.UpstreamConfidence
+			if confidence == 0 {
+				confidence = upstreamStage.Confidence
+			}
+			mappings = append(mappings, model.GeneratorChainMapping{
+				DownstreamWetPath:  strings.TrimSpace(mapping.DownstreamWetPath),
+				DownstreamDryPath:  strings.TrimSpace(mapping.DownstreamDryPath),
+				UpstreamKind:       upstreamStage.Kind,
+				UpstreamProfile:    upstreamStage.Profile,
+				UpstreamRoot:       upstreamStage.Root,
+				UpstreamDryPath:    strings.TrimSpace(mapping.UpstreamDryPath),
+				UpstreamSourcePath: filepath.ToSlash(strings.TrimSpace(mapping.UpstreamSourcePath)),
+				UpstreamOwner:      strings.TrimSpace(mapping.UpstreamOwner),
+				UpstreamTransform:  strings.TrimSpace(mapping.UpstreamTransform),
+				UpstreamConfidence: confidence,
+			})
+		}
+
+		out = append(out, model.GeneratorChain{
+			ID:       rawChainID(chain, idx),
+			Name:     strings.TrimSpace(chain.Name),
+			Stages:   stages,
+			Mappings: mappings,
+		})
+	}
+
+	return out, nil
+}
+
+func rawChainID(chain rawGeneratorChain, idx int) string {
+	if strings.TrimSpace(chain.ID) != "" {
+		return strings.TrimSpace(chain.ID)
+	}
+	if strings.TrimSpace(chain.Name) != "" {
+		return strings.TrimSpace(chain.Name)
+	}
+	return fmt.Sprintf("chain-%d", idx+1)
+}
+
+func parseGeneratorKind(raw string) (model.GeneratorKind, error) {
+	kind := model.GeneratorKind(strings.TrimSpace(raw))
+	for _, supported := range registry.Kinds() {
+		if supported == kind {
+			return kind, nil
+		}
+	}
+	return "", fmt.Errorf("unknown generator kind %q", raw)
+}
+
+func normalizeChainRoot(root string) string {
+	root = filepath.ToSlash(strings.TrimSpace(root))
+	if root == "." {
+		return ""
+	}
+	return root
+}
+
+func matchGeneratorDetection(detections []model.GeneratorDetection, kind model.GeneratorKind, root string) (model.GeneratorDetection, bool) {
+	for _, detection := range detections {
+		if detection.Kind == kind && normalizeChainRoot(detection.Root) == root {
+			return detection, true
+		}
+	}
+	return model.GeneratorDetection{}, false
+}
+
+func matchChainStage(stages []model.GeneratorChainStage, kind model.GeneratorKind, root string) (model.GeneratorChainStage, bool) {
+	for _, stage := range stages {
+		if stage.Kind == kind && normalizeChainRoot(stage.Root) == root {
+			return stage, true
+		}
+	}
+	return model.GeneratorChainStage{}, false
 }
 
 func detectHelm(repo string) ([]model.GeneratorDetection, error) {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -247,6 +247,42 @@ func TestScanRepoApplicationSetStandalone(t *testing.T) {
 	}
 }
 
+func TestScanRepoGeneratorChains(t *testing.T) {
+	t.Parallel()
+
+	repo := filepath.Join("..", "..", "examples", "incubator", "score-helm-chain")
+	result, err := ScanRepo(repo, "main")
+	if err != nil {
+		t.Fatalf("ScanRepo returned error: %v", err)
+	}
+	if len(result.Generators) != 2 {
+		t.Fatalf("expected 2 generators, got %d", len(result.Generators))
+	}
+	if len(result.Chains) != 1 {
+		t.Fatalf("expected 1 generator chain, got %d", len(result.Chains))
+	}
+
+	chain := result.Chains[0]
+	if chain.ID != "score-to-helm" {
+		t.Fatalf("expected chain ID score-to-helm, got %q", chain.ID)
+	}
+	if len(chain.Stages) != 2 {
+		t.Fatalf("expected 2 chain stages, got %d", len(chain.Stages))
+	}
+	if chain.Stages[0].Kind != model.GeneratorScore || chain.Stages[0].Root != "" {
+		t.Fatalf("unexpected upstream stage: %+v", chain.Stages[0])
+	}
+	if chain.Stages[1].Kind != model.GeneratorHelm || chain.Stages[1].Root != "chart" {
+		t.Fatalf("unexpected downstream stage: %+v", chain.Stages[1])
+	}
+	if len(chain.Mappings) != 2 {
+		t.Fatalf("expected 2 chain mappings, got %d", len(chain.Mappings))
+	}
+	if chain.Mappings[0].UpstreamDryPath != "containers.api.image" {
+		t.Fatalf("expected image mapping upstream dry path, got %+v", chain.Mappings[0])
+	}
+}
+
 func TestScanRepoC3AgentStructuralDetection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gitops/flow.go
+++ b/internal/gitops/flow.go
@@ -61,6 +61,7 @@ type DiscoverResult struct {
 	DiscoveredAt     string                     `json:"discovered_at"`
 	Resources        []DiscoveredResource       `json:"resources"`
 	Detections       []model.GeneratorDetection `json:"detections"`
+	Chains           []model.GeneratorChain     `json:"chains,omitempty"`
 }
 
 // ImportFlowResult models the staged import output in the same conceptual shape
@@ -150,6 +151,7 @@ func Discover(targetPath, ref, space, whereResource string) (DiscoverResult, err
 	if err != nil {
 		return DiscoverResult{}, err
 	}
+	filteredChains := filterChains(detection.Chains, filtered)
 	resources := toDiscoveredResources(filtered)
 
 	discoverSlug := discoverUnitSlug(resolved.Slug, space, resolved.Path)
@@ -166,6 +168,7 @@ func Discover(targetPath, ref, space, whereResource string) (DiscoverResult, err
 		DiscoveredAt:     time.Now().UTC().Format(time.RFC3339),
 		Resources:        resources,
 		Detections:       filtered,
+		Chains:           filteredChains,
 	}
 
 	if err := persistDiscoverResult(result); err != nil {
@@ -221,6 +224,7 @@ func ImportWithOptions(targetPath, renderTargetSlug, ref, space, whereResource s
 		Ref:        discovered.Ref,
 		DetectedAt: discovered.DiscoveredAt,
 		Generators: discovered.Detections,
+		Chains:     discovered.Chains,
 	}, discovered.Space, opts)
 	if err != nil {
 		return ImportFlowResult{}, err
@@ -700,6 +704,39 @@ func filterDetections(in []model.GeneratorDetection, where string) ([]model.Gene
 		}
 	}
 	return out, nil
+}
+
+func filterChains(in []model.GeneratorChain, detections []model.GeneratorDetection) []model.GeneratorChain {
+	if len(in) == 0 {
+		return nil
+	}
+	allowed := make(map[string]struct{}, len(detections))
+	for _, detection := range detections {
+		if strings.TrimSpace(detection.ID) == "" {
+			continue
+		}
+		allowed[detection.ID] = struct{}{}
+	}
+	out := make([]model.GeneratorChain, 0, len(in))
+	for _, chain := range in {
+		include := true
+		for _, stage := range chain.Stages {
+			if strings.TrimSpace(stage.DetectionID) == "" {
+				continue
+			}
+			if _, ok := allowed[stage.DetectionID]; !ok {
+				include = false
+				break
+			}
+		}
+		if include {
+			out = append(out, chain)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func matchesAllClauses(g model.GeneratorDetection, clauses []string) (bool, error) {

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -28,6 +28,7 @@ const (
 	helmCLIOverrideTransform = "helm-cli-override"
 	helmBuiltinTransform     = "helm-builtin"
 	helmDefaultTransform     = "helm-default"
+	generatorChainTransform  = "generator-chain"
 )
 
 // ImportRepo detects generators in a repository and produces the initial
@@ -576,6 +577,145 @@ func defaultPatchesForGenerator(detection model.DetectionResult, g model.Generat
 	}
 }
 
+func chainForGenerator(detection model.DetectionResult, g model.GeneratorDetection) (model.GeneratorChain, bool) {
+	for _, chain := range detection.Chains {
+		if len(chain.Stages) == 0 {
+			continue
+		}
+		downstream := chain.Stages[len(chain.Stages)-1]
+		if downstream.Kind == g.Kind && strings.TrimSpace(downstream.Root) == strings.TrimSpace(g.Root) {
+			return chain, true
+		}
+	}
+	return model.GeneratorChain{}, false
+}
+
+func chainStageForMapping(chain model.GeneratorChain, mapping model.GeneratorChainMapping) model.GeneratorChainStage {
+	for _, stage := range chain.Stages {
+		if mapping.UpstreamKind != "" && stage.Kind != mapping.UpstreamKind {
+			continue
+		}
+		if strings.TrimSpace(mapping.UpstreamRoot) != "" && strings.TrimSpace(stage.Root) != strings.TrimSpace(mapping.UpstreamRoot) {
+			continue
+		}
+		return stage
+	}
+	if len(chain.Stages) > 0 {
+		return chain.Stages[0]
+	}
+	return model.GeneratorChainStage{}
+}
+
+func chainMappingForOrigin(chain model.GeneratorChain, wetPath, dryPath string) (model.GeneratorChainMapping, bool) {
+	for _, mapping := range chain.Mappings {
+		if mapping.DownstreamWetPath != wetPath {
+			continue
+		}
+		if strings.TrimSpace(mapping.DownstreamDryPath) != "" && mapping.DownstreamDryPath != dryPath {
+			continue
+		}
+		return mapping, true
+	}
+	return model.GeneratorChainMapping{}, false
+}
+
+func chainHops(upstream model.GeneratorChainStage, mapping model.GeneratorChainMapping, downstream model.GeneratorDetection, downstreamOrigin model.FieldOrigin) []model.FieldOriginHop {
+	upstreamTransform := mapping.UpstreamTransform
+	if strings.TrimSpace(upstreamTransform) == "" {
+		upstreamTransform = generatorChainTransform
+	}
+	upstreamConfidence := mapping.UpstreamConfidence
+	if upstreamConfidence == 0 {
+		upstreamConfidence = upstream.Confidence
+	}
+	return []model.FieldOriginHop{
+		{
+			GeneratorKind:    string(upstream.Kind),
+			GeneratorProfile: upstream.Profile,
+			DryPath:          mapping.UpstreamDryPath,
+			SourcePath:       mapping.UpstreamSourcePath,
+			Transform:        upstreamTransform,
+			Confidence:       upstreamConfidence,
+		},
+		{
+			GeneratorKind:    string(downstream.Kind),
+			GeneratorProfile: downstream.Profile,
+			DryPath:          downstreamOrigin.DryPath,
+			SourcePath:       downstreamOrigin.SourcePath,
+			Transform:        downstreamOrigin.Transform,
+			Confidence:       downstreamOrigin.Confidence,
+		},
+	}
+}
+
+func applyGeneratorChainOrigins(detection model.DetectionResult, g model.GeneratorDetection, origins []model.FieldOrigin) []model.FieldOrigin {
+	chain, ok := chainForGenerator(detection, g)
+	if !ok || len(chain.Mappings) == 0 {
+		return origins
+	}
+
+	updated := make([]model.FieldOrigin, 0, len(origins))
+	for _, origin := range origins {
+		mapping, matched := chainMappingForOrigin(chain, origin.WetPath, origin.DryPath)
+		if !matched {
+			updated = append(updated, origin)
+			continue
+		}
+		downstreamOrigin := origin
+		upstream := chainStageForMapping(chain, mapping)
+		upstreamTransform := mapping.UpstreamTransform
+		if strings.TrimSpace(upstreamTransform) == "" {
+			upstreamTransform = generatorChainTransform
+		}
+		upstreamConfidence := mapping.UpstreamConfidence
+		if upstreamConfidence == 0 {
+			upstreamConfidence = upstream.Confidence
+		}
+		origin.DryPath = mapping.UpstreamDryPath
+		origin.SourcePath = mapping.UpstreamSourcePath
+		origin.Transform = upstreamTransform
+		origin.Confidence = origin.Confidence * upstreamConfidence
+		origin.Hops = chainHops(upstream, mapping, g, downstreamOrigin)
+		updated = append(updated, origin)
+	}
+	return updated
+}
+
+func applyGeneratorChainPointers(detection model.DetectionResult, g model.GeneratorDetection, pointers []model.InverseEditPointer) []model.InverseEditPointer {
+	chain, ok := chainForGenerator(detection, g)
+	if !ok || len(chain.Mappings) == 0 {
+		return pointers
+	}
+
+	updated := make([]model.InverseEditPointer, 0, len(pointers))
+	for _, pointer := range pointers {
+		mapping, matched := chainMappingForOrigin(chain, pointer.WetPath, pointer.DryPath)
+		if !matched {
+			updated = append(updated, pointer)
+			continue
+		}
+		upstream := chainStageForMapping(chain, mapping)
+		upstreamConfidence := mapping.UpstreamConfidence
+		if upstreamConfidence == 0 {
+			upstreamConfidence = upstream.Confidence
+		}
+		pointer.DryPath = mapping.UpstreamDryPath
+		if strings.TrimSpace(mapping.UpstreamOwner) != "" {
+			pointer.Owner = mapping.UpstreamOwner
+		}
+		pointer.EditHint = fmt.Sprintf(
+			"Edit %s in %s. This value flows through %s -> %s before reaching the rendered manifest.",
+			mapping.UpstreamDryPath,
+			mapping.UpstreamSourcePath,
+			string(upstream.Kind),
+			string(g.Kind),
+		)
+		pointer.Confidence = pointer.Confidence * upstreamConfidence
+		updated = append(updated, pointer)
+	}
+	return updated
+}
+
 func fieldOriginsForGenerator(detection model.DetectionResult, g model.GeneratorDetection, helmCLIOverrides []model.HelmCLIOverride) []model.FieldOrigin {
 	switch g.Kind {
 	case model.GeneratorHelm:
@@ -614,7 +754,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				Confidence:  registry.FieldOriginConfidenceFor(g.Kind, confidenceKey, confidenceFallback),
 			})
 		}
-		return origins
+		return applyGeneratorChainOrigins(detection, g, origins)
 	case model.GeneratorApplicationSet:
 		hints := applicationSetHintsFromInputs(detection.Repo, g.Inputs)
 		origins := []model.FieldOrigin{
@@ -638,7 +778,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 		return origins
 	case model.GeneratorScore:
 		hints := scorePathHintsFromInputs(detection.Repo, g.Inputs)
-		return []model.FieldOrigin{
+		return applyGeneratorChainOrigins(detection, g, []model.FieldOrigin{
 			{
 				DryPath:    fmt.Sprintf("containers.%s.image", hints.ContainerName),
 				WetPath:    fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/image", hints.ContainerName),
@@ -660,7 +800,7 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				Transform:  registry.FieldOriginTransform(g.Kind),
 				Confidence: registry.FieldOriginConfidenceFor(g.Kind, "port", 0.91),
 			},
-		}
+		})
 	case model.GeneratorSpringBoot:
 		hints := springPathHintsFromInputs(g.Inputs)
 		origins := []model.FieldOrigin{
@@ -963,7 +1103,7 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 			hintKey = "image_tag_overlay"
 			hintFallback = "Edit values.image.tag in {{overlay_values_path}} for environment-specific overrides; use {{base_values_path}} for defaults."
 		}
-		return []model.InverseEditPointer{
+		return applyGeneratorChainPointers(detection, g, []model.InverseEditPointer{
 			{
 				WetPath:    "Deployment/spec/template/spec/containers[0]/image",
 				DryPath:    "values.image.tag",
@@ -971,7 +1111,7 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, hintKey, hintFallback), vars),
 				Confidence: policy.Confidence,
 			},
-		}
+		})
 	case model.GeneratorApplicationSet:
 		hints := applicationSetHintsFromInputs(detection.Repo, g.Inputs)
 		namePolicy := registry.InversePointerTemplateFor(g.Kind, "child_name", registry.InversePointerTemplate{
@@ -1017,7 +1157,7 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 			"variable_name":     hints.VariableName,
 			"service_port_name": hints.ServicePortName,
 		}
-		return []model.InverseEditPointer{
+		return applyGeneratorChainPointers(detection, g, []model.InverseEditPointer{
 			{
 				WetPath:    fmt.Sprintf("Deployment/spec/template/spec/containers[name=%s]/image", hints.ContainerName),
 				DryPath:    fmt.Sprintf("containers.%s.image", hints.ContainerName),
@@ -1039,7 +1179,7 @@ func inversePointersForGenerator(detection model.DetectionResult, g model.Genera
 				EditHint:   renderTargetTemplate(registry.InverseEditHint(g.Kind, "port", "Edit {{service_port_name}} service port in {{source_path}}."), vars),
 				Confidence: portPolicy.Confidence,
 			},
-		}
+		})
 	case model.GeneratorSpringBoot:
 		hints := springPathHintsFromInputs(g.Inputs)
 		appNamePolicy := registry.InversePointerTemplateFor(g.Kind, "app_name", registry.InversePointerTemplate{

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/confighub/cub-gen/internal/applicationset"
+	"github.com/confighub/cub-gen/internal/detect"
 	"github.com/confighub/cub-gen/internal/model"
 )
 
@@ -1153,6 +1154,58 @@ service:
 	}
 }
 
+func TestImportDetectionAppliesGeneratorChainMappings(t *testing.T) {
+	repo := filepath.Join("..", "..", "examples", "incubator", "score-helm-chain")
+	detection, err := detect.ScanRepo(repo, "main")
+	if err != nil {
+		t.Fatalf("ScanRepo returned error: %v", err)
+	}
+
+	result, err := ImportDetection(detection, "platform")
+	if err != nil {
+		t.Fatalf("ImportDetection returned error: %v", err)
+	}
+
+	var helmProv *model.ProvenanceRecord
+	for i := range result.Provenance {
+		if result.Provenance[i].GeneratorProfile == "helm-paas" {
+			helmProv = &result.Provenance[i]
+			break
+		}
+	}
+	if helmProv == nil {
+		t.Fatalf("expected helm provenance record, got %+v", result.Provenance)
+	}
+
+	imageOrigin, ok := fieldOriginByWetPath(helmProv.FieldOriginMap, "Deployment/spec/template/spec/containers[0]/image")
+	if !ok {
+		t.Fatalf("expected image origin, got %+v", helmProv.FieldOriginMap)
+	}
+	if imageOrigin.DryPath != "containers.api.image" {
+		t.Fatalf("expected chained dry path containers.api.image, got %+v", imageOrigin)
+	}
+	if imageOrigin.SourcePath != "score.yaml" {
+		t.Fatalf("expected chained source path score.yaml, got %+v", imageOrigin)
+	}
+	if len(imageOrigin.Hops) != 2 {
+		t.Fatalf("expected 2 provenance hops, got %+v", imageOrigin.Hops)
+	}
+	if imageOrigin.Hops[0].GeneratorKind != string(model.GeneratorScore) || imageOrigin.Hops[1].GeneratorKind != string(model.GeneratorHelm) {
+		t.Fatalf("unexpected hop order: %+v", imageOrigin.Hops)
+	}
+
+	imagePointer, ok := inversePointerByWetPath(helmProv.InverseEditPointers, "Deployment/spec/template/spec/containers[0]/image")
+	if !ok {
+		t.Fatalf("expected inverse pointer, got %+v", helmProv.InverseEditPointers)
+	}
+	if imagePointer.DryPath != "containers.api.image" {
+		t.Fatalf("expected chained pointer dry path, got %+v", imagePointer)
+	}
+	if !strings.Contains(imagePointer.EditHint, "score.yaml") {
+		t.Fatalf("expected chained edit hint to mention score.yaml, got %q", imagePointer.EditHint)
+	}
+}
+
 func TestImportDetectionFailsOnInvalidContractTriple(t *testing.T) {
 	repo := t.TempDir()
 	detection := model.DetectionResult{
@@ -1215,6 +1268,24 @@ func inversePointerHasDryPath(v []model.InverseEditPointer, dryPath string) bool
 		}
 	}
 	return false
+}
+
+func fieldOriginByWetPath(v []model.FieldOrigin, wetPath string) (model.FieldOrigin, bool) {
+	for _, item := range v {
+		if item.WetPath == wetPath {
+			return item, true
+		}
+	}
+	return model.FieldOrigin{}, false
+}
+
+func inversePointerByWetPath(v []model.InverseEditPointer, wetPath string) (model.InverseEditPointer, bool) {
+	for _, item := range v {
+		if item.WetPath == wetPath {
+			return item, true
+		}
+	}
+	return model.InverseEditPointer{}, false
 }
 
 func inversePointerHintContains(v []model.InverseEditPointer, dryPath, needle string) bool {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -24,11 +24,41 @@ type GeneratorDetection struct {
 	Confidence float64       `json:"confidence"`
 }
 
+type GeneratorChainStage struct {
+	Kind        GeneratorKind `json:"kind"`
+	Profile     string        `json:"profile,omitempty"`
+	Name        string        `json:"name,omitempty"`
+	Root        string        `json:"root,omitempty"`
+	DetectionID string        `json:"detection_id,omitempty"`
+	Confidence  float64       `json:"confidence,omitempty"`
+}
+
+type GeneratorChainMapping struct {
+	DownstreamWetPath  string        `json:"downstream_wet_path"`
+	DownstreamDryPath  string        `json:"downstream_dry_path,omitempty"`
+	UpstreamKind       GeneratorKind `json:"upstream_kind,omitempty"`
+	UpstreamProfile    string        `json:"upstream_profile,omitempty"`
+	UpstreamRoot       string        `json:"upstream_root,omitempty"`
+	UpstreamDryPath    string        `json:"upstream_dry_path,omitempty"`
+	UpstreamSourcePath string        `json:"upstream_source_path,omitempty"`
+	UpstreamOwner      string        `json:"upstream_owner,omitempty"`
+	UpstreamTransform  string        `json:"upstream_transform,omitempty"`
+	UpstreamConfidence float64       `json:"upstream_confidence,omitempty"`
+}
+
+type GeneratorChain struct {
+	ID       string                  `json:"id"`
+	Name     string                  `json:"name,omitempty"`
+	Stages   []GeneratorChainStage   `json:"stages"`
+	Mappings []GeneratorChainMapping `json:"mappings,omitempty"`
+}
+
 type DetectionResult struct {
 	Repo       string               `json:"repo"`
 	Ref        string               `json:"ref"`
 	DetectedAt string               `json:"detected_at"`
 	Generators []GeneratorDetection `json:"generators"`
+	Chains     []GeneratorChain     `json:"chains,omitempty"`
 }
 
 type UnitRef struct {
@@ -89,12 +119,22 @@ type RenderedObjectLineage struct {
 }
 
 type FieldOrigin struct {
-	DryPath     string  `json:"dry_path"`
-	WetPath     string  `json:"wet_path"`
-	SourcePath  string  `json:"source_path"`
-	SourceLayer string  `json:"source_layer,omitempty"`
-	Transform   string  `json:"transform"`
-	Confidence  float64 `json:"confidence"`
+	DryPath     string           `json:"dry_path"`
+	WetPath     string           `json:"wet_path"`
+	SourcePath  string           `json:"source_path"`
+	SourceLayer string           `json:"source_layer,omitempty"`
+	Transform   string           `json:"transform"`
+	Confidence  float64          `json:"confidence"`
+	Hops        []FieldOriginHop `json:"hops,omitempty"`
+}
+
+type FieldOriginHop struct {
+	GeneratorKind    string  `json:"generator_kind,omitempty"`
+	GeneratorProfile string  `json:"generator_profile,omitempty"`
+	DryPath          string  `json:"dry_path,omitempty"`
+	SourcePath       string  `json:"source_path,omitempty"`
+	Transform        string  `json:"transform,omitempty"`
+	Confidence       float64 `json:"confidence,omitempty"`
 }
 
 type HelmCLIOverride struct {


### PR DESCRIPTION
## Summary
- add repo-declared generator chain metadata and carry it through detect -> discover -> import
- rewrite downstream provenance/inverse hints through a declared Score -> Helm chain and expose hops in change explain
- add an incubator score-helm-chain fixture plus focused detect/import/change tests

## Validation
- go test ./...
- ./test/checks/check-docs-entrypoints.sh
- ./test/checks/check-story-status.sh
- go run ./cmd/cub-gen change explain --space platform --wet-path 'Deployment/spec/template/spec/containers[0]/image' ./examples/incubator/score-helm-chain ./examples/incubator/score-helm-chain

## Notes
- stacked on #269 to keep the diff focused
- narrows #241; it does not close the full multi-stage chaining issue yet