### PR TITLE
Finish #239-#241

### DIFF
--- a/cmd/cub-gen/change_command_test.go
+++ b/cmd/cub-gen/change_command_test.go
@@ -609,6 +609,40 @@ func TestChangeDiffJSON(t *testing.T) {
 	}
 }
 
+func TestChangeRevisionDiffJSON(t *testing.T) {
+	repo := t.TempDir()
+	fromRef := seedGitHelmRepo(t, repo, "v1.0.0")
+	toRef := updateGitHelmRepoValue(t, repo, "v1.0.1")
+
+	result, err := buildChangeRevisionDiffResult(repo, repo, "platform", fromRef, toRef, "", nil, "", "", "")
+	if err != nil {
+		t.Fatalf("buildChangeRevisionDiffResult returned error: %v", err)
+	}
+	if result.Query.FromRef != fromRef {
+		t.Fatalf("expected from_ref=%s, got %v", fromRef, result.Query.FromRef)
+	}
+	if result.Query.ToRef != toRef {
+		t.Fatalf("expected to_ref=%s, got %v", toRef, result.Query.ToRef)
+	}
+	if len(result.Changes) == 0 {
+		t.Fatalf("expected non-empty revision diff changes")
+	}
+
+	first := result.Changes[0]
+	if first.Cause.AfterDryPath != "values.image.tag" {
+		t.Fatalf("expected after dry path values.image.tag, got %+v", first.Cause)
+	}
+	if first.Effect.WetPath != "Deployment/spec/template/spec/containers[0]/image" {
+		t.Fatalf("expected image wet path, got %+v", first.Effect)
+	}
+	if first.Effect.Before.Value != "ghcr.io/example/diff-demo:v1.0.0" {
+		t.Fatalf("unexpected before effect value: %v", first.Effect.Before.Value)
+	}
+	if first.Effect.After.Value != "ghcr.io/example/diff-demo:v1.0.1" {
+		t.Fatalf("unexpected after effect value: %v", first.Effect.After.Value)
+	}
+}
+
 func TestChangeCommandErrorModes(t *testing.T) {
 	tests := []struct {
 		name string
@@ -639,6 +673,11 @@ func TestChangeCommandErrorModes(t *testing.T) {
 			name: "diff-missing-targets",
 			args: []string{"change", "diff", "--before-ref", "main", "--after-ref", "HEAD"},
 			sub:  "usage: cub-gen change diff",
+		},
+		{
+			name: "revision-diff-missing-targets",
+			args: []string{"change", "revision-diff", "--from", "main", "--to", "HEAD"},
+			sub:  "usage: cub-gen change revision-diff",
 		},
 		{
 			name: "explain-missing-targets",

--- a/cmd/cub-gen/gitops_parity_test.go
+++ b/cmd/cub-gen/gitops_parity_test.go
@@ -217,6 +217,37 @@ func TestGitOpsParityGoldenDiscoverApplicationSet(t *testing.T) {
 	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gitops-discover-applicationset.golden.json"), got)
 }
 
+func TestDetectReportsGeneratorChainSummary(t *testing.T) {
+	repoPath, err := filepath.Abs(filepath.Join("..", "..", "examples", "incubator", "score-helm-chain"))
+	if err != nil {
+		t.Fatalf("resolve chain fixture: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{"detect", "--repo", repoPath})
+	if err != nil {
+		t.Fatalf("detect returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal detect output: %v\noutput=%s", err, out)
+	}
+	summaries, ok := got["chain_summaries"].([]any)
+	if !ok || len(summaries) != 1 {
+		t.Fatalf("expected one chain summary, got %T %+v", got["chain_summaries"], got["chain_summaries"])
+	}
+	summary, ok := summaries[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected chain summary object, got %T", summaries[0])
+	}
+	if summary["display"] != "score -> helm" {
+		t.Fatalf("expected display score -> helm, got %v", summary["display"])
+	}
+}
+
 func TestGitOpsParityGoldenImport(t *testing.T) {
 	setupAliases(t)
 
@@ -260,6 +291,42 @@ func TestGitOpsImportDefaultsRenderTargetToTarget(t *testing.T) {
 	}
 	if got["render_target_slug"] != "helm-paas" {
 		t.Fatalf("expected render_target_slug=helm-paas, got %v", got["render_target_slug"])
+	}
+}
+
+func TestGitOpsDiscoverPrintsGeneratorChains(t *testing.T) {
+	repoPath, err := filepath.Abs(filepath.Join("..", "..", "examples", "incubator", "score-helm-chain"))
+	if err != nil {
+		t.Fatalf("resolve chain fixture: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{"gitops", "discover", "--space", "platform", repoPath})
+	if err != nil {
+		t.Fatalf("gitops discover returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(out, "Generator chains") || !strings.Contains(out, "score -> helm") {
+		t.Fatalf("expected chain summary in discover output, got:\n%s", out)
+	}
+}
+
+func TestGitOpsImportPrintsGeneratorChains(t *testing.T) {
+	repoPath, err := filepath.Abs(filepath.Join("..", "..", "examples", "incubator", "score-helm-chain"))
+	if err != nil {
+		t.Fatalf("resolve chain fixture: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{"gitops", "import", "--space", "platform", repoPath})
+	if err != nil {
+		t.Fatalf("gitops import returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(out, "Generator chains") || !strings.Contains(out, "score -> helm") {
+		t.Fatalf("expected chain summary in import output, got:\n%s", out)
 	}
 }
 

--- a/cmd/cub-gen/helm_override_command_test.go
+++ b/cmd/cub-gen/helm_override_command_test.go
@@ -337,6 +337,61 @@ spec:
 	}
 }
 
+func TestChangeExplainHelmExternalOriginWarning(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: external-demo\nversion: 0.1.0\n")
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  repository: ghcr.io/example/external-demo\n  tag: ref+vault://kv/data/external-demo#image-tag\n")
+	mustWriteFile(t, filepath.Join(repo, "templates", "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-demo
+spec:
+  template:
+    spec:
+      containers:
+        - name: external-demo
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+`)
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"change", "explain",
+		"--space", "platform",
+		repo,
+	})
+	if err != nil {
+		t.Fatalf("change explain returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal change explain output: %v\noutput=%s", err, out)
+	}
+	explanation, ok := got["explanation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected explanation object, got %T", got["explanation"])
+	}
+	if explanation["origin_type"] != "external" {
+		t.Fatalf("expected origin_type=external, got %v", explanation["origin_type"])
+	}
+	if explanation["source_transform"] != "helm-external" {
+		t.Fatalf("expected source_transform=helm-external, got %v", explanation["source_transform"])
+	}
+	if explanation["source_path"] != "values.yaml" {
+		t.Fatalf("expected source_path values.yaml, got %v", explanation["source_path"])
+	}
+	warning, _ := explanation["warning"].(string)
+	if !strings.Contains(warning, "sourced externally") {
+		t.Fatalf("expected external warning, got %q", warning)
+	}
+	editHint, _ := explanation["edit_hint"].(string)
+	if !strings.Contains(editHint, "external reference") {
+		t.Fatalf("expected external edit hint, got %q", editHint)
+	}
+}
+
 func mustWriteFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -26,6 +26,7 @@ import (
 )
 
 const helmCLIOverrideTransform = "helm-cli-override"
+const helmExternalTransform = "helm-external"
 const helmBuiltinTransform = "helm-builtin"
 const helmHelperTransform = "helm-helper"
 const helmNonDeterministicTransform = "helm-nondeterministic"
@@ -1154,6 +1155,56 @@ type changeDiffResult struct {
 	Diffs  []changeDiffEntry  `json:"diffs"`
 }
 
+type changeRevisionDiffInput struct {
+	TargetSlug       string                  `json:"target_slug"`
+	TargetPath       string                  `json:"target_path,omitempty"`
+	RenderTargetSlug string                  `json:"render_target_slug"`
+	RenderTargetPath string                  `json:"render_target_path,omitempty"`
+	Space            string                  `json:"space"`
+	FromRef          string                  `json:"from_ref"`
+	ToRef            string                  `json:"to_ref"`
+	WhereResource    string                  `json:"where_resource,omitempty"`
+	HelmCLIOverrides []model.HelmCLIOverride `json:"helm_cli_overrides,omitempty"`
+}
+
+type changeRevisionDiffQuery struct {
+	FromRef       string `json:"from_ref"`
+	ToRef         string `json:"to_ref"`
+	DryPathFilter string `json:"dry_path_filter,omitempty"`
+	WetPathFilter string `json:"wet_path_filter,omitempty"`
+	OwnerFilter   string `json:"owner_filter,omitempty"`
+	MatchCount    int    `json:"match_count"`
+}
+
+type changeRevisionDiffCause struct {
+	Owner                 string                `json:"owner,omitempty"`
+	EditHint              string                `json:"edit_hint,omitempty"`
+	Confidence            float64               `json:"confidence,omitempty"`
+	BeforeDryPath         string                `json:"before_dry_path,omitempty"`
+	AfterDryPath          string                `json:"after_dry_path,omitempty"`
+	BeforeSourcePath      string                `json:"before_source_path,omitempty"`
+	AfterSourcePath       string                `json:"after_source_path,omitempty"`
+	BeforeSourceTransform string                `json:"before_source_transform,omitempty"`
+	AfterSourceTransform  string                `json:"after_source_transform,omitempty"`
+	BeforeOriginType      string                `json:"before_origin_type,omitempty"`
+	AfterOriginType       string                `json:"after_origin_type,omitempty"`
+	Hops                  []changeProvenanceHop `json:"hops,omitempty"`
+	Warning               string                `json:"warning,omitempty"`
+}
+
+type changeRevisionDiffEntry struct {
+	Cause  changeRevisionDiffCause `json:"cause"`
+	Effect changeDiffEntry         `json:"effect"`
+}
+
+type changeRevisionDiffResult struct {
+	Input   changeRevisionDiffInput   `json:"input"`
+	Query   changeRevisionDiffQuery   `json:"query"`
+	Before  changeDiffSnapshot        `json:"before"`
+	After   changeDiffSnapshot        `json:"after"`
+	Changes []changeRevisionDiffEntry `json:"changes"`
+}
+
 type changeExplainQuery struct {
 	WetPathFilter string `json:"wet_path_filter,omitempty"`
 	DryPathFilter string `json:"dry_path_filter,omitempty"`
@@ -1199,6 +1250,8 @@ func runChange(args []string) error {
 		return runChangeRun(args[1:])
 	case "diff":
 		return runChangeDiff(args[1:])
+	case "revision-diff":
+		return runChangeRevisionDiff(args[1:])
 	case "impact":
 		return runChangeImpact(args[1:])
 	case "explain":
@@ -1394,6 +1447,67 @@ func runChangeDiff(args []string) error {
 	return writeJSON(f, result, *pretty)
 }
 
+func runChangeRevisionDiff(args []string) error {
+	fs := flag.NewFlagSet("change revision-diff", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	space := fs.String("space", "default", "ConfigHub space label")
+	fromRef := fs.String("from", "", "Git ref to treat as the before/source revision")
+	toRef := fs.String("to", "", "Git ref to treat as the after/target revision")
+	whereResource := fs.String("where-resource", "", "Additional resource filter expression")
+	dryFilter := fs.String("dry-path", "", "Filter by DRY path")
+	wetFilter := fs.String("wet-path", "", "Filter by WET path")
+	ownerFilter := fs.String("owner", "", "Filter by owner")
+	out := fs.String("out", "-", "Output file path, or '-' for stdout")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	overrideFlags := addHelmCLIOverrideFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	helmCLIOverrides, err := overrideFlags.parse()
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*fromRef) == "" || strings.TrimSpace(*toRef) == "" {
+		return errors.New("change revision-diff requires --from and --to")
+	}
+
+	targetSlug, renderTargetSlug, err := resolveTargetPairArgs(fs, "usage: cub-gen change revision-diff --from REF --to REF [flags] <target-path> [<render-target-path>]")
+	if err != nil {
+		return err
+	}
+
+	result, err := buildChangeRevisionDiffResult(
+		targetSlug,
+		renderTargetSlug,
+		*space,
+		*fromRef,
+		*toRef,
+		*whereResource,
+		helmCLIOverrides,
+		*dryFilter,
+		*wetFilter,
+		*ownerFilter,
+	)
+	if err != nil {
+		return err
+	}
+
+	if *out == "-" {
+		return writeJSON(os.Stdout, result, *pretty)
+	}
+	f, err := os.Create(*out)
+	if err != nil {
+		return fmt.Errorf("create output file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	return writeJSON(f, result, *pretty)
+}
+
 type gitRefMaterialization struct {
 	TargetPath       string
 	RenderTargetPath string
@@ -1505,6 +1619,61 @@ func buildChangeDiffResult(
 			DiscoveredResource: len(afterImported.Discovered),
 		},
 		Diffs: diffs,
+	}, nil
+}
+
+func buildChangeRevisionDiffResult(
+	targetSlug, renderTargetSlug, space, fromRef, toRef, whereResource string,
+	helmCLIOverrides []model.HelmCLIOverride,
+	dryFilter, wetFilter, ownerFilter string,
+) (changeRevisionDiffResult, error) {
+	diff, err := buildChangeDiffResult(
+		targetSlug,
+		renderTargetSlug,
+		space,
+		fromRef,
+		toRef,
+		whereResource,
+		helmCLIOverrides,
+		dryFilter,
+		wetFilter,
+		ownerFilter,
+	)
+	if err != nil {
+		return changeRevisionDiffResult{}, err
+	}
+
+	changes := make([]changeRevisionDiffEntry, 0, len(diff.Diffs))
+	for _, entry := range diff.Diffs {
+		changes = append(changes, changeRevisionDiffEntry{
+			Cause:  revisionDiffCause(entry),
+			Effect: entry,
+		})
+	}
+
+	return changeRevisionDiffResult{
+		Input: changeRevisionDiffInput{
+			TargetSlug:       diff.Input.TargetSlug,
+			TargetPath:       diff.Input.TargetPath,
+			RenderTargetSlug: diff.Input.RenderTargetSlug,
+			RenderTargetPath: diff.Input.RenderTargetPath,
+			Space:            diff.Input.Space,
+			FromRef:          fromRef,
+			ToRef:            toRef,
+			WhereResource:    diff.Input.WhereResource,
+			HelmCLIOverrides: append([]model.HelmCLIOverride(nil), diff.Input.HelmCLIOverrides...),
+		},
+		Query: changeRevisionDiffQuery{
+			FromRef:       fromRef,
+			ToRef:         toRef,
+			DryPathFilter: diff.Query.DryPathFilter,
+			WetPathFilter: diff.Query.WetPathFilter,
+			OwnerFilter:   diff.Query.OwnerFilter,
+			MatchCount:    len(changes),
+		},
+		Before:  diff.Before,
+		After:   diff.After,
+		Changes: changes,
 	}, nil
 }
 
@@ -1856,6 +2025,45 @@ func collectChangeDiffEntries(
 	return out
 }
 
+func revisionDiffCause(entry changeDiffEntry) changeRevisionDiffCause {
+	owner := strings.TrimSpace(entry.After.Owner)
+	if owner == "" {
+		owner = strings.TrimSpace(entry.Before.Owner)
+	}
+	editHint := strings.TrimSpace(entry.After.EditHint)
+	if editHint == "" {
+		editHint = strings.TrimSpace(entry.Before.EditHint)
+	}
+	confidence := entry.After.Confidence
+	if confidence == 0 {
+		confidence = entry.Before.Confidence
+	}
+	hops := entry.After.Hops
+	if len(hops) == 0 {
+		hops = entry.Before.Hops
+	}
+	warning := strings.TrimSpace(entry.After.Warning)
+	if warning == "" {
+		warning = strings.TrimSpace(entry.Before.Warning)
+	}
+
+	return changeRevisionDiffCause{
+		Owner:                 owner,
+		EditHint:              editHint,
+		Confidence:            confidence,
+		BeforeDryPath:         entry.Before.DryPath,
+		AfterDryPath:          entry.After.DryPath,
+		BeforeSourcePath:      entry.Before.SourcePath,
+		AfterSourcePath:       entry.After.SourcePath,
+		BeforeSourceTransform: entry.Before.SourceTransform,
+		AfterSourceTransform:  entry.After.SourceTransform,
+		BeforeOriginType:      entry.Before.OriginType,
+		AfterOriginType:       entry.After.OriginType,
+		Hops:                  hops,
+		Warning:               warning,
+	}
+}
+
 func changeDiffStateFromProvenance(provenance []model.ProvenanceRecord, wetPath string, value any) changeDiffFieldState {
 	best := changeDiffFieldState{Exists: true, Value: value, WetPath: wetPath}
 	bestConfidence := -1.0
@@ -1890,8 +2098,14 @@ func changeDiffStateFromProvenance(provenance []model.ProvenanceRecord, wetPath 
 		switch origin.Transform {
 		case helmCLIOverrideTransform:
 			candidate.Warning = overrideAwareWarning()
+		case helmExternalTransform:
+			candidate.Warning = externalAwareWarning(origin.SourcePath)
 		case helmBuiltinTransform:
 			candidate.Warning = builtinAwareWarning(origin.SourcePath)
+		case helmHelperTransform:
+			candidate.Warning = helperAwareWarning()
+		case helmNonDeterministicTransform:
+			candidate.Warning = nonDeterministicAwareWarning(origin.SourcePath)
 		case helmDefaultTransform:
 			candidate.Warning = defaultAwareWarning()
 		}
@@ -2335,6 +2549,13 @@ func pickInverseSuggestion(
 					candidate.Confidence = sourceConfidence
 				}
 			}
+			if sourceTransform == helmExternalTransform {
+				candidate.EditHint = externalAwareEditHint(sourcePath, pointer.EditHint)
+				candidate.Warning = externalAwareWarning(sourcePath)
+				if sourceConfidence > candidate.Confidence {
+					candidate.Confidence = sourceConfidence
+				}
+			}
 			if sourceTransform == helmBuiltinTransform {
 				candidate.Warning = builtinAwareWarning(sourcePath)
 				if sourceConfidence > candidate.Confidence {
@@ -2410,6 +2631,9 @@ func collectImpactSuggestions(
 				entry.Owner = "release-automation"
 				entry.EditHint = overrideAwareEditHint(origin.SourcePath, entry.EditHint)
 				entry.Warning = overrideAwareWarning()
+			case helmExternalTransform:
+				entry.EditHint = externalAwareEditHint(origin.SourcePath, entry.EditHint)
+				entry.Warning = externalAwareWarning(origin.SourcePath)
 			case helmBuiltinTransform:
 				entry.Warning = builtinAwareWarning(origin.SourcePath)
 			case helmHelperTransform:
@@ -2567,6 +2791,8 @@ func applyFieldOriginToPointer(pointer model.InverseEditPointer, origin model.Fi
 	case helmCLIOverrideTransform:
 		pointer.Owner = "release-automation"
 		pointer.EditHint = overrideAwareEditHint(origin.SourcePath, pointer.EditHint)
+	case helmExternalTransform:
+		pointer.EditHint = externalAwareEditHint(origin.SourcePath, pointer.EditHint)
 	case helmBuiltinTransform, helmHelperTransform, helmNonDeterministicTransform, helmDefaultTransform:
 		// Keep the generator-produced edit hint, but let the higher-confidence
 		// provenance source win when the hint already points at the right layer.
@@ -2588,6 +2814,20 @@ func overrideAwareEditHint(sourcePath, fallback string) string {
 
 func overrideAwareWarning() string {
 	return "This field was overridden by the Helm CLI invocation for this run, so editing values files alone will not change the rendered output."
+}
+
+func externalAwareEditHint(sourcePath, fallback string) string {
+	if strings.TrimSpace(sourcePath) == "" {
+		return fallback
+	}
+	return fmt.Sprintf("This field is declared as an external reference in %s. Update that external source or change the reference in %s before editing local values.", sourcePath, sourcePath)
+}
+
+func externalAwareWarning(sourcePath string) string {
+	if strings.TrimSpace(sourcePath) == "" {
+		return "This field is sourced externally, so provenance ends at that external system instead of a repo-owned value."
+	}
+	return fmt.Sprintf("This field is sourced externally via %s, so provenance ends at that external system instead of a repo-owned value.", sourcePath)
 }
 
 func builtinAwareWarning(sourcePath string) string {
@@ -2619,6 +2859,8 @@ func defaultAwareWarning() string {
 func explainOriginType(sourcePath, sourceTransform string) string {
 	switch {
 	case sourceTransform == helmCLIOverrideTransform:
+		return "external"
+	case sourceTransform == helmExternalTransform:
 		return "external"
 	case sourceTransform == helmBuiltinTransform:
 		return "builtin"
@@ -2818,6 +3060,8 @@ func runGitOpsCleanup(args []string) error {
 }
 
 func printDiscoverTable(result gitopsflow.DiscoverResult) {
+	printGeneratorChainSummaries(result.ChainSummaries)
+
 	kindCapabilities := map[string]string{}
 	for _, kind := range registry.Kinds() {
 		spec, ok := registry.Spec(kind)
@@ -2865,6 +3109,8 @@ func printDiscoverTable(result gitopsflow.DiscoverResult) {
 }
 
 func printImportTable(result gitopsflow.ImportFlowResult) {
+	printGeneratorChainSummaries(result.ChainSummaries)
+
 	fmt.Printf("Discovered %d GitOps resources, creating renderer units...\n", len(result.Discovered))
 	printImportDiscoveredTable(result)
 	fmt.Printf("Created renderer units: %d\n", len(result.DryUnits))
@@ -2876,6 +3122,18 @@ func printImportTable(result gitopsflow.ImportFlowResult) {
 	fmt.Printf("Generated inverse transform plans: %d\n", len(result.InversePlans))
 	printImportTripleSummary(result)
 	fmt.Println("GitOps import complete")
+}
+
+func printGeneratorChainSummaries(summaries []model.GeneratorChainSummary) {
+	if len(summaries) == 0 {
+		return
+	}
+	fmt.Println("Generator chains")
+	fmt.Println("ID\tDisplay\tStages\tMappings")
+	for _, summary := range summaries {
+		fmt.Printf("%s\t%s\t%d\t%d\n", summary.ID, summary.Display, summary.StageCount, summary.MappingCount)
+	}
+	fmt.Println()
 }
 
 func printImportDiscoveredTable(result gitopsflow.ImportFlowResult) {
@@ -3205,6 +3463,7 @@ func printChangeUsage(out io.Writer) {
 			"Use these commands after you know the repo path and want to answer:",
 			"  - what will change?",
 			"  - what changed between two rendered refs?",
+			"  - what changed between two release revisions, and which DRY edits caused it?",
 			"  - which rendered fields does this DRY path affect?",
 			"  - where should I edit DRY source?",
 			"  - should I ask ConfigHub for a decision?",
@@ -3215,6 +3474,7 @@ func printChangeUsage(out io.Writer) {
 				"  cub-gen change preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-path> [<render-target-path>]",
 				"  cub-gen change run [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--mode local|connected] [--base-url URL] [--token TOKEN] [--ingest-endpoint PATH] [--decision-endpoint PATH] [--out FILE|-] [--verifier NAME] [--json] [--pretty] <target-path> [<render-target-path>]",
 				"  cub-gen change diff --before-ref REF --after-ref REF [--space SPACE] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--dry-path PATH] [--wet-path PATH] [--owner OWNER] [--out FILE|-] [--pretty] <target-path> [<render-target-path>]",
+				"  cub-gen change revision-diff --from REF --to REF [--space SPACE] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--dry-path PATH] [--wet-path PATH] [--owner OWNER] [--out FILE|-] [--pretty] <target-path> [<render-target-path>]",
 				"  cub-gen change impact [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--dry-path PATH] [--wet-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-path> [<render-target-path>]",
 				"  cub-gen change impact --change-id ID --bundle FILE [--dry-path PATH] [--wet-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty]",
 				"  cub-gen change explain [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--wet-path PATH] [--dry-path PATH] [--owner OWNER] [--out FILE|-] [--json] [--pretty] <target-path> [<render-target-path>]",
@@ -3227,6 +3487,7 @@ func printChangeUsage(out io.Writer) {
 			Lines: []string{
 				"  cub-gen change preview --space my-space ./examples/helm-paas",
 				"  cub-gen change diff --before-ref main --after-ref HEAD ./examples/helm-paas",
+				"  cub-gen change revision-diff --from v0.2-preview.1 --to v0.2-preview.2 ./examples/helm-paas",
 				"  cub-gen change impact --space my-space --dry-path values.image.tag ./examples/helm-paas",
 				"  cub-gen change explain --space my-space --set image.tag=v1.2.4 ./examples/helm-paas",
 				"  cub-gen change run --mode local --space my-space ./examples/scoredev-paas",
@@ -3240,6 +3501,7 @@ func printChangeUsage(out io.Writer) {
 			Lines: []string{
 				"  - Start with 'change explain' if you already know the rendered field you care about",
 				"  - Use 'change diff' when you want a field-level before/after render comparison between two git refs",
+				"  - Use 'change revision-diff' when you want release-note style DRY->WET pairs between two refs",
 				"  - Use 'change impact' when you know the DRY path and want the downstream blast radius",
 				"  - Start with 'change preview' before 'change run'",
 				"  - Helm CLI overrides win over values-prod.yaml, values.yaml, and chart defaults",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -12,6 +12,7 @@ not cluster/runtime ones.
 |---|---|
 | What does this repo render, and where did it come from? | `gitops import` |
 | What changed between two rendered git refs? | `change diff` |
+| What changed between two release refs, and which DRY edits caused it? | `change revision-diff` |
 | Which DRY file/path should I edit for a rendered field? | `change explain` |
 | Which rendered fields would this DRY path affect? | `change impact` |
 | What evidence bundle and safe next step should I prepare? | `change preview` |
@@ -48,6 +49,10 @@ cub-gen gitops discover --space <space> [--json] [--where-resource <expr>] <targ
 | `--space` | Space label for discover state partitioning |
 | `--json` | Emit JSON output (default: table) |
 | `--where-resource` | Filter resources (`kind`, `name`, `root`, `id`, `LIKE`, `IN`, `AND`) |
+
+If a repo declares a generator chain, `gitops discover` now reports that chain
+directly as a compact pipeline summary such as `score -> helm`, instead of
+making you infer it from separate stage detections.
 
 ### `gitops import`
 
@@ -126,6 +131,21 @@ Current scope:
 - it expects `<target-path>` to live in a git repo
 - it renders each side with the Helm value files `cub-gen` already selected for import/provenance
 - output includes `before.value`, `after.value`, and before/after provenance metadata for each changed field
+
+### `change revision-diff`
+
+Compare two git refs and pair each rendered field change with the DRY edit route
+that produced it.
+
+```
+cub-gen change revision-diff --from <ref> --to <ref> [--space <space>] [--where-resource <expr>] [--dry-path <path>] [--wet-path <path>] [--owner <owner>] <target-path> [<render-target-path>]
+```
+
+Current scope:
+
+- today this reuses the Helm-first field-level diff engine
+- output groups each changed rendered field under a `cause` block with before/after DRY paths, source paths, origin types, edit hint, and warning metadata
+- use this when you want release-note style "what DRY edit caused what deployed-field change?" output instead of just a raw before/after render diff
 
 ### `verify`
 
@@ -340,9 +360,10 @@ What works today:
 - One `gitops import` / `publish` invocation works on one repo path pair.
 - Supported generators can pick up overlay files that already live in that repo, such as Helm `values-prod.yaml`, Spring `application-dev.yaml`, and generator-specific overlay files.
 - Helm flows also capture invocation-time `--set`, `--set-string`, and `--set-file` overrides and rank them above values files in provenance and `change explain`.
-- Helm `change explain` also calls out when a field is currently coming from `.Chart.AppVersion`, `.Files.Get`, a helper chain, `lookup`/other render-time logic, or an unresolved chart-default path instead of an observed values file.
+- Helm `change explain` also calls out when a field is currently coming from `.Chart.AppVersion`, `.Files.Get`, a helper chain, `lookup`/other render-time logic, an external ref declared in values, or an unresolved chart-default path instead of an observed values file.
 - Provenance records include those generator inputs in `dry_inputs`, `values_paths`, and `field_origin_map` when the generator emits separate overlay transforms.
 - When a repo declares a generator chain, `change explain` includes `hops[]` so you can see the upstream DRY stage and the downstream generator stage together instead of stopping at the last transform boundary.
+- `gitops discover` and `gitops import` also surface declared generator chains directly in table output so the Score -> Helm style pipeline is obvious on first run.
 - `change explain` can point to overlay-specific edit locations. For Spring Boot, the current edit hint routes `server.port` changes to `application-dev.yaml` for environment overrides while keeping `application.yaml` as the base.
 
 What does not work today:

--- a/docs/contracts/change-cli-v1.md
+++ b/docs/contracts/change-cli-v1.md
@@ -9,7 +9,7 @@ Goal: one stable interface for terminal users, CI jobs, and agent tool-calls.
 
 ## Design principles
 
-1. One `change_id` lifecycle across preview, run, explain, and impact.
+1. One `change_id` lifecycle across preview, run, explain, impact, diff, and revision-diff.
 2. Same JSON shape across local and connected execution.
 3. No shell parsing of multiple intermediate files required.
 4. Additive over existing `discover/import/publish/verify/attest` pipeline.
@@ -148,6 +148,30 @@ Expected output fields (`ChangeImpactResult`):
 - `query.{dry_path_filter,wet_path_filter,owner_filter,match_count}`
 - `impacts[].{owner,wet_path,dry_path,edit_hint,confidence,source_path,source_transform,origin_type,generator_name,generator_profile}`
 
+### 6) `cub-gen change revision-diff`
+
+Purpose:
+- Show the DRY-to-WET change pairs between two source revisions of the same repo path.
+
+Supported invocation mode:
+
+- `cub-gen change revision-diff --from <ref> --to <ref> [filters] <target-path> [<render-target-path>]`
+
+Filters:
+
+- `--dry-path <path>` (optional)
+- `--wet-path <path>` (optional)
+- `--owner <owner>` (optional)
+
+Expected output fields (`ChangeRevisionDiffResult`):
+
+- `input.{target_path,render_target_path,target_slug,render_target_slug,space,from_ref,to_ref}`
+- `query.{from_ref,to_ref,dry_path_filter,wet_path_filter,owner_filter,match_count}`
+- `before.change.{change_id,bundle_digest,attestation_digest}`
+- `after.change.{change_id,bundle_digest,attestation_digest}`
+- `changes[].cause.{before_dry_path,after_dry_path,before_source_path,after_source_path,before_source_transform,after_source_transform,before_origin_type,after_origin_type,owner,edit_hint,confidence,warning,hops[]}`
+- `changes[].effect.{manifest,wet_path,before,after}`
+
 ## Exit code contract
 
 - `0`: success (`ALLOW` or successful local run)
@@ -166,6 +190,7 @@ Native subcommands are implemented for:
 - `change preview`
 - `change run (local|connected)`
 - `change diff`
+- `change revision-diff`
 - `change explain`
 - `change impact`
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -101,12 +101,43 @@ func ScanRepo(repoPath, ref string) (model.DetectionResult, error) {
 	}
 
 	return model.DetectionResult{
-		Repo:       absRepo,
-		Ref:        ref,
-		DetectedAt: time.Now().UTC().Format(time.RFC3339),
-		Generators: all,
-		Chains:     chains,
+		Repo:           absRepo,
+		Ref:            ref,
+		DetectedAt:     time.Now().UTC().Format(time.RFC3339),
+		Generators:     all,
+		Chains:         chains,
+		ChainSummaries: SummarizeGeneratorChains(chains),
 	}, nil
+}
+
+// SummarizeGeneratorChains converts low-level chain metadata into a compact
+// display shape that is easier to surface in CLI output.
+func SummarizeGeneratorChains(chains []model.GeneratorChain) []model.GeneratorChainSummary {
+	if len(chains) == 0 {
+		return nil
+	}
+
+	summaries := make([]model.GeneratorChainSummary, 0, len(chains))
+	for _, chain := range chains {
+		stages := make([]string, 0, len(chain.Stages))
+		for _, stage := range chain.Stages {
+			label := strings.TrimSpace(string(stage.Kind))
+			if label == "" {
+				continue
+			}
+			stages = append(stages, label)
+		}
+		display := strings.Join(stages, " -> ")
+		summaries = append(summaries, model.GeneratorChainSummary{
+			ID:           chain.ID,
+			Name:         chain.Name,
+			Display:      display,
+			StageCount:   len(chain.Stages),
+			Stages:       stages,
+			MappingCount: len(chain.Mappings),
+		})
+	}
+	return summaries
 }
 
 type rawGeneratorChainFile struct {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -281,6 +281,12 @@ func TestScanRepoGeneratorChains(t *testing.T) {
 	if chain.Mappings[0].UpstreamDryPath != "containers.api.image" {
 		t.Fatalf("expected image mapping upstream dry path, got %+v", chain.Mappings[0])
 	}
+	if len(result.ChainSummaries) != 1 {
+		t.Fatalf("expected 1 chain summary, got %d", len(result.ChainSummaries))
+	}
+	if result.ChainSummaries[0].Display != "score -> helm" {
+		t.Fatalf("expected chain display score -> helm, got %+v", result.ChainSummaries[0])
+	}
 }
 
 func TestScanRepoC3AgentStructuralDetection(t *testing.T) {

--- a/internal/gitops/flow.go
+++ b/internal/gitops/flow.go
@@ -51,42 +51,45 @@ type DiscoveredResource struct {
 
 // DiscoverResult is the local discover-unit state used by import and cleanup.
 type DiscoverResult struct {
-	Space            string                     `json:"space"`
-	TargetSlug       string                     `json:"target_slug"`
-	TargetPath       string                     `json:"target_path"`
-	Ref              string                     `json:"ref"`
-	WhereResource    string                     `json:"where_resource,omitempty"`
-	DiscoverUnitSlug string                     `json:"discover_unit_slug"`
-	DiscoverFile     string                     `json:"discover_file"`
-	DiscoveredAt     string                     `json:"discovered_at"`
-	Resources        []DiscoveredResource       `json:"resources"`
-	Detections       []model.GeneratorDetection `json:"detections"`
-	Chains           []model.GeneratorChain     `json:"chains,omitempty"`
+	Space            string                        `json:"space"`
+	TargetSlug       string                        `json:"target_slug"`
+	TargetPath       string                        `json:"target_path"`
+	Ref              string                        `json:"ref"`
+	WhereResource    string                        `json:"where_resource,omitempty"`
+	DiscoverUnitSlug string                        `json:"discover_unit_slug"`
+	DiscoverFile     string                        `json:"discover_file"`
+	DiscoveredAt     string                        `json:"discovered_at"`
+	Resources        []DiscoveredResource          `json:"resources"`
+	Detections       []model.GeneratorDetection    `json:"detections"`
+	Chains           []model.GeneratorChain        `json:"chains,omitempty"`
+	ChainSummaries   []model.GeneratorChainSummary `json:"chain_summaries,omitempty"`
 }
 
 // ImportFlowResult models the staged import output in the same conceptual shape
 // as cub gitops import: discover -> dry units -> rendered wet units + links.
 type ImportFlowResult struct {
-	Space              string                       `json:"space"`
-	TargetSlug         string                       `json:"target_slug"`
-	TargetPath         string                       `json:"target_path"`
-	RenderTargetSlug   string                       `json:"render_target_slug"`
-	RenderTargetPath   string                       `json:"render_target_path,omitempty"`
-	Ref                string                       `json:"ref"`
-	WhereResource      string                       `json:"where_resource,omitempty"`
-	HelmCLIOverrides   []model.HelmCLIOverride      `json:"helm_cli_overrides,omitempty"`
-	DiscoverUnitSlug   string                       `json:"discover_unit_slug"`
-	ImportedAt         string                       `json:"imported_at"`
-	Discovered         []DiscoveredResource         `json:"discovered"`
-	DryUnits           []model.UnitRef              `json:"dry_units"`
-	WetUnits           []model.UnitRef              `json:"wet_units"`
-	GeneratorUnits     []model.UnitRef              `json:"generator_units"`
-	Links              []model.UnitLink             `json:"links"`
-	Contracts          []model.GeneratorContract    `json:"contracts"`
-	Provenance         []model.ProvenanceRecord     `json:"provenance"`
-	InversePlans       []model.InverseTransformPlan `json:"inverse_transform_plans"`
-	DryInputs          []model.DryInputRef          `json:"dry_inputs"`
-	WetManifestTargets []model.WetManifestTarget    `json:"wet_manifest_targets"`
+	Space              string                        `json:"space"`
+	TargetSlug         string                        `json:"target_slug"`
+	TargetPath         string                        `json:"target_path"`
+	RenderTargetSlug   string                        `json:"render_target_slug"`
+	RenderTargetPath   string                        `json:"render_target_path,omitempty"`
+	Ref                string                        `json:"ref"`
+	WhereResource      string                        `json:"where_resource,omitempty"`
+	HelmCLIOverrides   []model.HelmCLIOverride       `json:"helm_cli_overrides,omitempty"`
+	DiscoverUnitSlug   string                        `json:"discover_unit_slug"`
+	ImportedAt         string                        `json:"imported_at"`
+	Discovered         []DiscoveredResource          `json:"discovered"`
+	Chains             []model.GeneratorChain        `json:"chains,omitempty"`
+	ChainSummaries     []model.GeneratorChainSummary `json:"chain_summaries,omitempty"`
+	DryUnits           []model.UnitRef               `json:"dry_units"`
+	WetUnits           []model.UnitRef               `json:"wet_units"`
+	GeneratorUnits     []model.UnitRef               `json:"generator_units"`
+	Links              []model.UnitLink              `json:"links"`
+	Contracts          []model.GeneratorContract     `json:"contracts"`
+	Provenance         []model.ProvenanceRecord      `json:"provenance"`
+	InversePlans       []model.InverseTransformPlan  `json:"inverse_transform_plans"`
+	DryInputs          []model.DryInputRef           `json:"dry_inputs"`
+	WetManifestTargets []model.WetManifestTarget     `json:"wet_manifest_targets"`
 }
 
 // CleanupResult reports the resolved target identity and discover state path
@@ -169,6 +172,7 @@ func Discover(targetPath, ref, space, whereResource string) (DiscoverResult, err
 		Resources:        resources,
 		Detections:       filtered,
 		Chains:           filteredChains,
+		ChainSummaries:   detect.SummarizeGeneratorChains(filteredChains),
 	}
 
 	if err := persistDiscoverResult(result); err != nil {
@@ -212,6 +216,8 @@ func ImportWithOptions(targetPath, renderTargetSlug, ref, space, whereResource s
 			DiscoverUnitSlug: discovered.DiscoverUnitSlug,
 			ImportedAt:       time.Now().UTC().Format(time.RFC3339),
 			Discovered:       discovered.Resources,
+			Chains:           discovered.Chains,
+			ChainSummaries:   discovered.ChainSummaries,
 		}, nil
 	}
 	requiredProviders := requiredProvidersForDiscovered(discovered.Resources)
@@ -244,6 +250,8 @@ func ImportWithOptions(targetPath, renderTargetSlug, ref, space, whereResource s
 		DiscoverUnitSlug:   discovered.DiscoverUnitSlug,
 		ImportedAt:         time.Now().UTC().Format(time.RFC3339),
 		Discovered:         discovered.Resources,
+		Chains:             discovered.Chains,
+		ChainSummaries:     discovered.ChainSummaries,
 		DryUnits:           dryUnits,
 		WetUnits:           wetUnits,
 		GeneratorUnits:     generatorUnits,

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -27,6 +27,7 @@ const (
 	provenanceSchema              = "cub.confighub.io/provenance/v1"
 	inversePlanSchema             = "cub.confighub.io/inverse-transform-plan/v1"
 	helmCLIOverrideTransform      = "helm-cli-override"
+	helmExternalTransform         = "helm-external"
 	helmBuiltinTransform          = "helm-builtin"
 	helmHelperTransform           = "helm-helper"
 	helmNonDeterministicTransform = "helm-nondeterministic"
@@ -762,6 +763,9 @@ func fieldOriginsForGenerator(detection model.DetectionResult, g model.Generator
 				transform = helmHelperTransform
 				confidenceKey = ""
 				confidenceFallback = 1.0
+			}
+			if source.External {
+				transform = helmExternalTransform
 			}
 			origins = append(origins, model.FieldOrigin{
 				DryPath:     "values.image.tag",
@@ -1732,8 +1736,9 @@ type helmProvenancePaths struct {
 }
 
 type helmValueSource struct {
-	Path  string
-	Layer string
+	Path     string
+	Layer    string
+	External bool
 }
 
 type helmDependencyDoc struct {
@@ -1845,8 +1850,9 @@ func helmImageTagSources(repoPath string, hints helmProvenancePaths) []helmValue
 	ordered := make([]helmValueSource, 0, len(imageTagPaths))
 	for _, path := range imageTagPaths {
 		ordered = append(ordered, helmValueSource{
-			Path:  path,
-			Layer: helmValuesSourceLayer(path, umbrella),
+			Path:     path,
+			Layer:    helmValuesSourceLayer(path, umbrella),
+			External: helmValuesPathImageTagIsExternal(repoPath, path),
 		})
 	}
 	return ordered
@@ -2176,42 +2182,87 @@ func stringSliceContains(items []string, want string) bool {
 }
 
 func helmValuesPathDefinesImageTag(repoPath, relPath string) bool {
-	if strings.TrimSpace(repoPath) == "" || strings.TrimSpace(relPath) == "" {
+	_, ok := helmValuesPathImageTagValue(repoPath, relPath)
+	return ok
+}
+
+func helmValuesPathImageTagIsExternal(repoPath, relPath string) bool {
+	value, ok := helmValuesPathImageTagValue(repoPath, relPath)
+	if !ok {
 		return false
+	}
+	return helmValueLooksExternal(value)
+}
+
+func helmValuesPathImageTagValue(repoPath, relPath string) (string, bool) {
+	if strings.TrimSpace(repoPath) == "" || strings.TrimSpace(relPath) == "" {
+		return "", false
 	}
 	content, err := os.ReadFile(filepath.Join(repoPath, relPath))
 	if err != nil {
-		return false
+		return "", false
 	}
 
 	var doc yaml.Node
 	if err := yaml.Unmarshal(content, &doc); err != nil {
-		return false
+		return "", false
 	}
-	return yamlPathExists(&doc, []string{"image", "tag"})
+	node := yamlPathNode(&doc, []string{"image", "tag"})
+	if node == nil {
+		return "", false
+	}
+	if node.Kind == yaml.AliasNode {
+		node = node.Alias
+	}
+	if node == nil {
+		return "", false
+	}
+	if node.Kind == yaml.ScalarNode {
+		return strings.TrimSpace(node.Value), true
+	}
+	return "", true
 }
 
-func yamlPathExists(node *yaml.Node, path []string) bool {
+func yamlPathNode(node *yaml.Node, path []string) *yaml.Node {
 	if node == nil {
-		return false
+		return nil
 	}
 	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
-		return yamlPathExists(node.Content[0], path)
+		return yamlPathNode(node.Content[0], path)
 	}
 	if len(path) == 0 {
-		return true
+		return node
 	}
 	if node.Kind != yaml.MappingNode {
 		if node.Kind == yaml.AliasNode {
-			return yamlPathExists(node.Alias, path)
+			return yamlPathNode(node.Alias, path)
 		}
-		return false
+		return nil
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		if node.Content[i].Value != path[0] {
 			continue
 		}
-		return yamlPathExists(node.Content[i+1], path[1:])
+		return yamlPathNode(node.Content[i+1], path[1:])
+	}
+	return nil
+}
+
+func helmValueLooksExternal(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(value, "vault://"),
+		strings.HasPrefix(value, "ref+vault://"),
+		strings.HasPrefix(value, "secretref+"),
+		strings.HasPrefix(value, "aws-secretsmanager://"),
+		strings.HasPrefix(value, "ssm://"),
+		strings.HasPrefix(value, "azurekeyvault://"),
+		strings.HasPrefix(value, "gcpsecret://"),
+		strings.HasPrefix(value, "external://"):
+		return true
 	}
 	return false
 }

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -718,6 +718,32 @@ spec:
 	}
 }
 
+func TestImportRepoHelmExternalOriginUsesExternalTransform(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "Chart.yaml"), "apiVersion: v2\nname: external-demo\nversion: 0.1.0\n")
+	mustWriteFile(t, filepath.Join(repo, "values.yaml"), "image:\n  repository: ghcr.io/example/external-demo\n  tag: ref+vault://kv/data/external-demo#image-tag\n")
+
+	result, err := ImportRepo(repo, "main", "platform")
+	if err != nil {
+		t.Fatalf("ImportRepo returned error: %v", err)
+	}
+	if len(result.Provenance) != 1 {
+		t.Fatalf("expected single provenance record, got %d", len(result.Provenance))
+	}
+
+	prov := result.Provenance[0]
+	imageOrigin, ok := fieldOriginByWetPath(prov.FieldOriginMap, "Deployment/spec/template/spec/containers[0]/image")
+	if !ok {
+		t.Fatalf("expected image origin, got %+v", prov.FieldOriginMap)
+	}
+	if imageOrigin.Transform != helmExternalTransform {
+		t.Fatalf("expected helm-external transform, got %+v", imageOrigin)
+	}
+	if imageOrigin.SourcePath != "values.yaml" {
+		t.Fatalf("expected external source path values.yaml, got %+v", imageOrigin)
+	}
+}
+
 func TestImportRepoSpringBootDryWetContract(t *testing.T) {
 	repo := filepath.Join("..", "..", "examples", "springboot-paas")
 	result, err := ImportRepo(repo, "main", "platform")

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -53,12 +53,22 @@ type GeneratorChain struct {
 	Mappings []GeneratorChainMapping `json:"mappings,omitempty"`
 }
 
+type GeneratorChainSummary struct {
+	ID           string   `json:"id"`
+	Name         string   `json:"name,omitempty"`
+	Display      string   `json:"display"`
+	StageCount   int      `json:"stage_count"`
+	Stages       []string `json:"stages,omitempty"`
+	MappingCount int      `json:"mapping_count"`
+}
+
 type DetectionResult struct {
-	Repo       string               `json:"repo"`
-	Ref        string               `json:"ref"`
-	DetectedAt string               `json:"detected_at"`
-	Generators []GeneratorDetection `json:"generators"`
-	Chains     []GeneratorChain     `json:"chains,omitempty"`
+	Repo           string                  `json:"repo"`
+	Ref            string                  `json:"ref"`
+	DetectedAt     string                  `json:"detected_at"`
+	Generators     []GeneratorDetection    `json:"generators"`
+	Chains         []GeneratorChain        `json:"chains,omitempty"`
+	ChainSummaries []GeneratorChainSummary `json:"chain_summaries,omitempty"`
 }
 
 type UnitRef struct {


### PR DESCRIPTION
## Summary
- finish Helm provenance honesty with external-ref warnings and edit routing
- add `change revision-diff` for DRY-to-WET release-note pairs across two refs
- surface declared generator chains directly in detect/discover/import outputs and JSON summaries

## Validation
- `go test ./...`
- `./test/checks/check-docs-entrypoints.sh`
- `./test/checks/check-story-status.sh`
- `go run ./cmd/cub-gen gitops discover --space platform ./examples/incubator/score-helm-chain`
- `go run ./cmd/cub-gen change revision-diff --from <temp-ref-1> --to <temp-ref-2> <temp-helm-repo>`

Closes #239
Closes #240
Closes #241