### PR TITLE
[codex] simplify examples index

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -96,7 +96,7 @@ uses it as a repo-level AI marker.
 | [`swamp-automation`](./swamp-automation/) | how do we govern agent-written workflow graph changes? |
 | [`swamp-project`](./swamp-project/) | how do we govern the Helm/runtime side of an AI platform? |
 
-### Other stacks and companion examples
+## Other stacks and companion examples
 
 - [`backstage-idp`](./backstage-idp/) — Backstage catalog governance
 - [`just-apps-no-platform-config`](./just-apps-no-platform-config/) — smallest

--- a/examples/README.md
+++ b/examples/README.md
@@ -118,6 +118,17 @@ Use cluster-first tools when the urgent question is "what is running right now?"
 
 Those are complementary flows, not competing ones.
 
+## Use your own repo quickly
+
+If you already have a repo and want the shortest local-first proof:
+
+```bash
+REPO=/path/to/your/repo
+./cub-gen change preview --space platform "$REPO"
+./cub-gen change explain --space platform --owner app-team "$REPO"
+./cub-gen publish --space platform "$REPO" | ./cub-gen verify --in -
+```
+
 ## When You Need More Than The Index
 
 - each example README carries its own honest "what this proves today" section
@@ -125,6 +136,10 @@ Those are complementary flows, not competing ones.
   repo-wide proof source
 - the [Domain POV Matrix](../docs/workflows/domain-pov-matrix.md) helps if you
   want to pick by team or operating model instead of by technology
+- the [Confidence score guide](../docs/workflows/confidence-scores.md) explains
+  how to read tracing certainty
+- the [Operation registry real-apps guide](../docs/workflows/operation-registry-real-apps.md)
+  shows where the stronger real-app proof paths live
 
 If the first operator is an AI assistant, the flagship examples also ship
 example-local `AI_START_HERE.md` files and prompt packs. Use those inside the

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,373 +1,119 @@
-# Examples — Governed Config for Every Stack
+# cub-gen Examples
 
-You already have a deployment pipeline: Git, Helm, Flux, Argo, Spring Boot, Score, or internal workflows.
+These examples are for source-first questions:
 
-`cub-gen` adds the missing answers:
+- which file or path produced this rendered field?
+- what should I edit safely?
+- what provenance bundle can I verify or publish?
 
-- who changed this field,
-- what source produced this deployed value,
-- who owns it,
-- what file to edit safely.
+If your question starts in a live cluster instead of a source repo, start with
+[`cub-scout`](https://github.com/confighub/cub-scout) or `cub gitops import`
+first.
 
-Each example in this directory is runnable and maps to a real platform/app pattern.
+## Start With One Flagship Path
 
-## Pick a path in 30 seconds
+Do not start by reading the whole catalog. Start with the example that matches
+the stack you already run.
 
-Do not start by scanning the whole catalog. Start with the path that matches
-what you already run:
-
-| If you already run... | Start here | Then do this | What you can inspect | Current truth |
-|---|---|---|---|---|
-| Helm plus Argo/Flux platform repos | `./examples/demo/start-platform-first.sh` | `./examples/helm-paas/demo-governed-change.sh`, then `cub auth login && RECONCILER=argo ./examples/helm-paas/demo-runtime.sh` | values ownership now, local ALLOW/BLOCK proof next, and live Argo/Flux proof from the Helm flagship itself after | Strongest platform-first source-side path today |
-| Spring Boot app repos | `./examples/demo/start-app-first.sh` | `./examples/springboot-paas/demo-embedded-config-mutation.sh`, then `cub auth login && ./examples/springboot-paas/demo-connected.sh` | config ownership now, direct embedded apply-here proof next, live `inventory-api` proof after | Strongest standalone end-to-end example in the repo today |
-| Score.dev workloads | `./examples/demo/start-score-first.sh` | `./examples/scoredev-paas/demo-governed-workload.sh`, then `./examples/scoredev-paas/demo-runtime.sh` | `score.yaml` field origin now, local ALLOW/ESCALATE proof next, live `checkout-api` proof after | Strongest Score end-to-end path for source, governance, and standalone runtime now |
-| A running cluster and GitOps controller | ConfigHub GitOps import + [`cub-scout`](https://github.com/confighub/cub-scout) + then `cub-gen` | trace one chosen field back to source | live cluster state first, source provenance second | Best when the cluster is already the urgent source of truth |
-
-## Flagship AI bundles
-
-The four flagship examples now carry the same AI-first operator bundle:
-
-| Example | AI start | Prompt pack | Inspection contract |
+| If you already run... | Start here | First command | What success looks like |
 |---|---|---|---|
-| [`helm-paas`](./helm-paas/) | [AI_START_HERE.md](./helm-paas/AI_START_HERE.md) | [prompts.md](./helm-paas/prompts.md) | [contracts.md](./helm-paas/contracts.md) |
-| [`scoredev-paas`](./scoredev-paas/) | [AI_START_HERE.md](./scoredev-paas/AI_START_HERE.md) | [prompts.md](./scoredev-paas/prompts.md) | [contracts.md](./scoredev-paas/contracts.md) |
-| [`springboot-paas`](./springboot-paas/) | [AI_START_HERE.md](./springboot-paas/AI_START_HERE.md) | [prompts.md](./springboot-paas/prompts.md) | [contracts.md](./springboot-paas/contracts.md) |
-| [`swamp-automation`](./swamp-automation/) | [AI_START_HERE.md](./swamp-automation/AI_START_HERE.md) | [prompts.md](./swamp-automation/prompts.md) | [contracts.md](./swamp-automation/contracts.md) |
+| Helm plus Argo/Flux platform repos | [`helm-paas`](./helm-paas/) | `./examples/demo/start-platform-first.sh` | you can trace one rendered field back to chart or values ownership |
+| Spring Boot app repos | [`springboot-paas`](./springboot-paas/) | `./examples/demo/start-app-first.sh` | you can tell which config changes are app-owned, lift-upstream, or blocked |
+| Score.dev workloads | [`scoredev-paas`](./scoredev-paas/) | `./examples/demo/start-score-first.sh` | you can trace `score.yaml` intent to rendered runtime fields |
+| Real GitOps runtime proof | [`live-reconcile`](./live-reconcile/) | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | you see WET output survive Flux or Argo reconciliation on kind |
 
-## What ends with something live today
+If you are unsure, start with `helm-paas` for the platform view or
+`springboot-paas` for the app-team view.
 
-| Path | Live thing you can inspect | Command | Truth today |
-|---|---|---|---|
-| [`springboot-paas`](./springboot-paas/) | real `inventory-api` app on a kind cluster | `./examples/springboot-paas/verify-e2e.sh` | Standalone live app proof is real |
-| [`helm-paas`](./helm-paas/) | Flux and Argo reconciliation of rendered Helm output plus connected governance evidence | `RECONCILER=both ./examples/helm-paas/demo-runtime.sh` | Example-owned wrapper, with the shared live-reconcile harness beneath it |
-| [`scoredev-paas`](./scoredev-paas/) | `checkout-api` on kind from merged `score.yaml` + `score-prod.yaml` | `./examples/scoredev-paas/verify-e2e.sh` | Standalone live Score proof is real |
+## What Is Strongest Today
 
-## Two audiences, one set of wrappers
+- [`helm-paas`](./helm-paas/) is the strongest platform-first path today. It
+  covers source-side provenance, governed change, layered Helm/ApplicationSet
+  proof, and a paired live runtime wrapper.
+- [`springboot-paas`](./springboot-paas/) is the strongest standalone
+  end-to-end app example today.
+- [`scoredev-paas`](./scoredev-paas/) is the strongest Score end-to-end path
+  today.
+- [`live-reconcile`](./live-reconcile/) is the runtime harness. Pair it with
+  `helm-paas` when you need WET-to-LIVE proof instead of source-side ownership.
 
-Every flagship example supports the same two entry points:
+For exact proof status, use the generated
+[Example Truth Matrix](../docs/testing/example-truth-matrix.md).
 
-- Local first: `./examples/<example>/demo-local.sh`
-- Connected next: `cub auth login && ./examples/<example>/demo-connected.sh`
+## Run Order That Repeats Well
 
-If you already use ConfigHub, start with the connected wrapper for one example.
-If you already use Helm, Argo, Flux, Score, or Spring, start with local mode so
-you see value before backend setup.
-
-## What `--space` means
-
-`--space` is the ConfigHub space where cub-gen records bundle metadata and
-decision-related context.
-
-- In local examples, `platform` is the default teaching value.
-- In connected runs, use the space from your current ConfigHub context.
-- If you only want source-side proof, you can treat `--space` as descriptive
-  context rather than a deployment target.
-
-## Source-first vs cluster-first
-
-Use the `cub-gen` examples when your starting point is a source repo and your
-question is "what rendered this field?" Use ConfigHub GitOps import plus
-[`cub-scout`](https://github.com/confighub/cub-scout) when your starting point
-is a live Argo or Flux workload and your question is "what is running right
-now?"
-
-That split is especially important for:
-
-- Helm plus Argo/Flux teams using chart values and overlays,
-- Score teams keeping `score.yaml` as the app-team contract,
-- platform teams tracing one cluster field back to the DRY source that produced it.
-
-## Flagship truth right now
-
-| Example | Best current answer for | Current trust level |
-|---|---|---|
-| [`helm-paas`](./helm-paas/) | Helm + Argo/Flux + values ownership | Strongest platform-first source-side path, with example-owned ALLOW/BLOCK and runtime wrappers |
-| [`springboot-paas`](./springboot-paas/) | Real app-team + platform-team config ownership | Strongest standalone end-to-end example in the repo today, now with direct embedded ConfigHub payload mutation proof |
-| [`scoredev-paas`](./scoredev-paas/) | Score intent to rendered runtime fields plus workload-contract escalation | Strongest Score end-to-end path today, now with example-owned ALLOW/ESCALATE proof and standalone runtime verification |
-
-## What happens after import? (Day-2 stories)
-
-Import is day 1. The real value shows on day 2:
-
-| Day | What you do | What you gain |
-|---|---|---|
-| **Day 1** | Import and explain | Field-origin tracing, ownership clarity, inverse-edit guidance |
-| **Day 2** | Governed change, promotion, or live-origin proposal | ALLOW/BLOCK decisions, cross-repo promotion, live→DRY proposals |
-| **Day 3** | Optional AI-assisted change lane | Prompt-as-DRY, mutation-ledger evidence, verification boundary |
-
-Every example should answer: "I imported my config. Now what?" The answer is
-governed change, promotion, or live-origin proposal, not "wait for the next
-feature."
-
-## Current truth matrix
-
-Use the generated [Example Truth Matrix](../docs/testing/example-truth-matrix.md) when you need an exact answer for:
-
-- which examples are first-class generator fixtures,
-- which ones are CI-proven through the full source-side `cub-gen` chain,
-- which ones are in the connected smoke lane,
-- which ones have real WET->LIVE proof today,
-- which ones are explicitly AI-first versus only adjacent.
-
-If you are about to spend real time on one example, check the matrix first.
-It is the repo's source of truth for what is source-side only, what is connected,
-and what has real live proof today.
-
-For workflow and AI examples specifically, use the
-[AI Example Hygiene Checklist](../docs/workflows/ai-example-hygiene-checklist.md)
-as the repo's current bar for "what good looks like."
-
-## Pick your domain POV first
-
-Start with the example that matches how your team already thinks:
-
-| If you are... | Start here | First value you should see |
-|---|---|---|
-| Spring Boot platform or app lead | [`springboot-paas`](./springboot-paas/) | "Which Spring property changed, who owns it, and what file do I edit?" |
-| Helm/Flux/Argo platform team (umbrella charts, overlays) | [`helm-paas`](./helm-paas/) | Ownership + field trace map, layered selector-to-overlay proof, and live runtime follow-through |
-| Score.dev platform team | [`scoredev-paas`](./scoredev-paas/) | Visibility from `score.yaml` intent to rendered runtime fields |
-| Ops/SRE workflow owner | [`ops-workflow`](./ops-workflow/) | Governed schedule/action changes with explicit ALLOW/BLOCK outcomes |
-| AI workflow / Swamp-style team | [`swamp-automation`](./swamp-automation/) | Structural workflow-change classification with explicit ALLOW/BLOCK workflow evidence |
-| AI fleet platform owner | [`c3agent`](./c3agent/) or [`ai-ops-paas`](./ai-ops-paas/) | Model/budget/credential governance over fleet config changes |
-| Backstage catalog owner | [`backstage-idp`](./backstage-idp/) | Catalog ownership/lifecycle changes become traceable and reviewable |
-| Reconciler reliability owner | [`live-reconcile`](./live-reconcile/) | Real Flux+Argo create/update/drift-correction proof harness |
-
-If you are unsure, start with `helm-paas` (platform POV) or `springboot-paas` (app-team POV).
-
-Deeper persona framing (from domain feedback): [Domain POV Matrix](../docs/workflows/domain-pov-matrix.md)
-
-## What `cub-gen` does
-
-`cub-gen` is a deterministic, Git-native generator importer. It reads existing config and emits:
-
-1. generator detection (what type of project this is),
-2. DRY/WET classification (authoring intent vs rendered targets),
-3. field-origin tracing (WET field -> DRY source path),
-4. inverse-edit guidance (where to edit),
-5. evidence bundles (`publish`, `verify`, `attest`).
-
-## How this differs from ConfigHub GitOps Import
-
-If you have also seen ConfigHub's GitOps Import wizard or `cub gitops import`, the split is:
-
-- ConfigHub GitOps import starts from ArgoCD/Flux resources already represented in a cluster.
-- `cub-gen` starts from source repos and generator inputs such as `Chart.yaml`, `score.yaml`, `application.yaml`, or workflow files.
-
-That means:
-
-- use ConfigHub import for brownfield cluster/app discovery,
-- use these `cub-gen` examples for source-side provenance, ownership routing, and governed edits.
-
-If confidence scores are new to your team, use:
-- [Confidence score guide](../docs/workflows/confidence-scores.md)
-
-## Run modes
-
-## Local mode (fastest, no login required)
+From the repo root:
 
 ```bash
 go build -o ./cub-gen ./cmd/cub-gen
-
-# Platform-first
-./examples/helm-paas/demo-local.sh
-
-# App-first
-./examples/springboot-paas/demo-local.sh
-
-# Score-first
-./examples/scoredev-paas/demo-local.sh
 ```
 
-## Connected mode (ConfigHub smoke first)
+Then use this order:
 
-```bash
-cub auth login
-cub info
+1. Run one local wrapper first: `./examples/<example>/demo-local.sh`
+2. If the local proof makes sense, log in: `cub auth login`
+3. Run the connected smoke check: `./examples/demo/run-connected-smoke.sh`
+4. Then run the connected wrapper: `./examples/<example>/demo-connected.sh`
 
-# Repo-wide smoke check for the current connected surface
-./examples/demo/run-connected-smoke.sh
+The wrappers are the safest first-run path because they encode the current happy
+path for each flagship example.
 
-# Platform-first
-./examples/helm-paas/demo-connected.sh
+## Example Families
 
-# App-first
-./examples/springboot-paas/demo-connected.sh
+### Flagship platform and app paths
 
-# Score-first
-./examples/scoredev-paas/demo-connected.sh
-```
+- [`helm-paas`](./helm-paas/) — Helm, overlays, ApplicationSet layering, live
+  reconciler pairing
+- [`springboot-paas`](./springboot-paas/) — Spring Boot app/team vs platform
+  ownership
+- [`scoredev-paas`](./scoredev-paas/) — Score intent to rendered manifests
+- [`live-reconcile`](./live-reconcile/) — Flux and Argo runtime proof harness
 
-Use local mode for first value. Use connected smoke to confirm your ConfigHub
-environment and the flagship wrappers. Use the deeper bridge/promotion scripts
-only when you specifically need backend decision-query or promotion flows.
+### Workflow and automation
 
-After that, use [`live-reconcile`](./live-reconcile/) for WET to LIVE proof and
-[`cub-scout`](https://github.com/confighub/cub-scout) for cluster-side inspection.
+- [`ops-workflow`](./ops-workflow/) — governed SRE workflow config
+- [`swamp-automation`](./swamp-automation/) — governed AI-written workflow
+  structure
+- [`confighub-actions`](./confighub-actions/) — ConfigHub lifecycle as governed
+  config
 
-## Use your own repo quickly
+### AI, fleet, and platform governance
 
-```bash
-REPO=/path/to/your/repo
-./cub-gen change preview --space platform "$REPO"
-./cub-gen change run --mode local --space platform "$REPO"
-./cub-gen change explain --space platform --owner app-team "$REPO"
-```
+- [`c3agent`](./c3agent/) — governed AI fleet config
+- [`ai-ops-paas`](./ai-ops-paas/) — fuller platform version of the AI fleet
+  story
+- [`swamp-project`](./swamp-project/) — governed Helm/runtime side of Swamp
 
-Advanced connected decision path for the same repo:
+### Other stacks and companion examples
 
-```bash
-cub auth login
-BASE_URL="${CONFIGHUB_BASE_URL:-$(cub context get --json | jq -r '.coordinate.serverURL')}"
-TOKEN="$(cub auth get-token)"
-./cub-gen change run --mode connected --base-url "$BASE_URL" --token "$TOKEN" --space platform "$REPO"
-```
+- [`backstage-idp`](./backstage-idp/) — Backstage catalog governance
+- [`just-apps-no-platform-config`](./just-apps-no-platform-config/) — smallest
+  app-only governance path
+- [`demo`](./demo/) — shared wrappers and connected smoke runners
+- [`incubator`](./incubator/) — experimental or companion material
 
-Use that path when your backend exposes the bridge endpoints used by
-`change run --mode connected`. For a simpler connected first run, prefer the
-example wrappers and `./examples/demo/run-connected-smoke.sh`.
+## Source-First vs Cluster-First
 
-Deep connected full-entrypoint runner:
+Use these `cub-gen` examples when you start in a source repo and want source to
+rendered provenance.
 
-```bash
-cub auth login
-./examples/demo/run-all-connected-entrypoints.sh
-```
+Use cluster-first tools when the urgent question is "what is running right now?":
 
-Per-example wrappers:
+- [`cub-scout`](https://github.com/confighub/cub-scout) for read-only cluster
+  observation, ownership, and troubleshooting
+- `cub gitops import` for ConfigHub import starting from a live Argo or Flux
+  target
 
-- Local: `./examples/<example>/demo-local.sh`
-- Connected: `./examples/<example>/demo-connected.sh` (starts with `cub auth login`)
+Those are complementary flows, not competing ones.
 
-## Verifier identity
+## When You Need More Than The Index
 
-When you run `cub-gen attest --verifier <name>`, the verifier name records who/what attested the bundle.
+- each example README carries its own honest "what this proves today" section
+- the [Example Truth Matrix](../docs/testing/example-truth-matrix.md) is the
+  repo-wide proof source
+- the [Domain POV Matrix](../docs/workflows/domain-pov-matrix.md) helps if you
+  want to pick by team or operating model instead of by technology
 
-| Verifier | When to use |
-|----------|-------------|
-| `ci-bot` | CI pipeline attestation |
-| `platform-lead` | Human platform sign-off |
-| `security-review` | Security approval |
-| `deploy-agent` | Automated deployment agent |
-
-## Choose your starting view
-
-| If you are... | Start here | Direct viewpoint section | First command |
-|---------|-----------|--------------------------|---------------|
-| Helm / umbrella-chart platform team | [helm-paas](helm-paas/) | [If you already run Helm heavily](helm-paas/README.md#if-you-already-run-helm-heavily) | `./examples/helm-paas/demo-local.sh` |
-| Spring Boot platform/app lead | [springboot-paas](springboot-paas/) | [If you already ship Spring Boot services](springboot-paas/README.md#if-you-already-ship-spring-boot-services) | `./examples/springboot-paas/demo-local.sh` |
-| Score.dev platform team | [scoredev-paas](scoredev-paas/) | [If you already use Score.dev in production](scoredev-paas/README.md#if-you-already-use-scoredev-in-production) | `./examples/scoredev-paas/demo-local.sh` |
-| Backstage/IDP owner | [backstage-idp](backstage-idp/) | [If you already run Backstage catalogs at scale](backstage-idp/README.md#if-you-already-run-backstage-catalogs-at-scale) | `./examples/backstage-idp/demo-local.sh` |
-| Ops workflow/SRE automation team | [ops-workflow](ops-workflow/) | [If you already run operational workflows at scale](ops-workflow/README.md#if-you-already-run-operational-workflows-at-scale) | `./examples/ops-workflow/demo-local.sh` |
-| AI agent fleet platform team | [c3agent](c3agent/) | [If you already run agent fleets operationally](c3agent/README.md#if-you-already-run-agent-fleets-operationally) | `./examples/c3agent/demo-local.sh` |
-| Full AI PaaS builder | [ai-ops-paas](ai-ops-paas/) | [If you already run AI/ops platforms on Kubernetes](ai-ops-paas/README.md#if-you-already-run-aiops-platforms-on-kubernetes) | `./examples/ai-ops-paas/demo-local.sh` |
-| Workflow automation platform team | [swamp-automation](swamp-automation/) | [If you already build workflow automation systems](swamp-automation/README.md#if-you-already-build-workflow-automation-systems) | `./examples/swamp-automation/demo-governed-structure.sh` |
-| Helm-based AI runtime team | [swamp-project](swamp-project/) | [If you already operate Helm-based AI runtimes](swamp-project/README.md#if-you-already-operate-helm-based-ai-runtimes) | `./examples/swamp-project/demo-local.sh` |
-| Reconciler/platform reliability engineer | [live-reconcile](live-reconcile/) | [If you already operate Flux/Argo at scale](live-reconcile/README.md#if-you-already-operate-fluxargo-at-scale) | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` |
-
-If you want copy/paste 5-minute paths per persona, use:
-
-- [Persona 5-minute runbooks](../docs/workflows/persona-5-minute-runbooks.md)
-
-## Workflow-first quick path (Ops + Swamp)
-
-If your users mostly run workflows (not app manifests), start with these two:
-
-```bash
-# Ops workflows: actions/schedules/approval-gates as governed config
-./examples/ops-workflow/demo-local.sh
-./examples/ops-workflow/demo-governed-policy.sh
-./cub-gen gitops import --space platform --json ./examples/ops-workflow \
-  | jq '.provenance[0].ops_workflow_analysis'
-
-# Swamp workflows: model/method/required-step structural governance
-./examples/swamp-automation/demo-local.sh
-./examples/swamp-automation/demo-governed-structure.sh
-```
-
-Operation-registry walkthrough (AI Ops + Ops Workflow + Swamp):
-- [docs/workflows/operation-registry-real-apps.md](../docs/workflows/operation-registry-real-apps.md)
-Now includes Helm + Spring Boot registry-backed platform examples too.
-
-## Platform + app patterns (Kubernetes workloads)
-
-| Example | You use... | cub-gen shows you... |
-|---------|-----------|---------------------|
-| [**helm-paas**](helm-paas/) | Helm charts + values overlays | Chart contract tracing, layered selector-to-overlay provenance, and ALLOW/BLOCK governance |
-| [**scoredev-paas**](scoredev-paas/) | Score.dev workload specs | DRY intent with field-origin mapping |
-| [**springboot-paas**](springboot-paas/) | Spring Boot + `application.yaml` | App/platform ownership boundaries |
-
-## Integration patterns (external services + developer portals)
-
-| Example | You use... | cub-gen shows you... |
-|---------|-----------|---------------------|
-| [**backstage-idp**](backstage-idp/) | Backstage software catalog | Catalog governance with ownership standards |
-| [**just-apps-no-platform-config**](just-apps-no-platform-config/) | SaaS provider config | App-only config governance without platform layer |
-
-## AI + automation patterns
-
-| Example | You use... | cub-gen shows you... |
-|---------|-----------|---------------------|
-| [**c3agent**](c3agent/) | AI agent fleets | Fleet config governance, model policy, budget controls |
-| [**ai-ops-paas**](ai-ops-paas/) | Full AI platform + constraints | Registry + constraints + governed lifecycle |
-| [**swamp-automation**](swamp-automation/) | Swamp agent-authored workflows | Workflow-graph change governance (models/methods/required steps) |
-| [**swamp-project**](swamp-project/) | Helm chart for AI runtime | Helm-based runtime policy mapping |
-
-### AI prompt-as-DRY (first-class product lane)
-
-For AI and workflow examples, the DRY/WET model extends to prompts and context:
-
-| Concept | How it maps |
-|---------|-------------|
-| **Prompt + context** | DRY input (what the team authors) |
-| **LLM/agent layer** | Non-deterministic generator (produces WET output) |
-| **Verification + attestation** | Safety boundary (makes non-determinism governable) |
-| **Mutation ledger** | Compliance and forensics proof |
-
-This means human-authored changes and AI-assisted changes can run through the same
-governed ConfigHub MR path. The mutation ledger is what makes this auditable.
-
-See the [AI lane workflow](../docs/workflows/prompt-as-dry.md) for details.
-
-## Operations patterns
-
-| Example | You use... | cub-gen shows you... |
-|---------|-----------|---------------------|
-| [**ops-workflow**](ops-workflow/) | Scheduled maintenance workflows | Structural workflow governance (actions/schedules/approval gates) |
-| [**confighub-actions**](confighub-actions/) | ConfigHub lifecycle automation | Recursive governance (ConfigHub governing itself) |
-
-## Infrastructure
-
-| Example | Purpose |
-|---------|---------|
-| [**live-reconcile**](live-reconcile/) | Flux + Argo e2e fixtures proving WET->LIVE reconciliation |
-| [**demo**](demo/) | Runnable demo script index |
-
-## Add your own generator
-
-If your platform has its own config format (not Helm, Score, Spring Boot, etc.),
-you can add `cub-gen` support for it.
-
-See [Custom Generator Onboarding](../docs/workflows/custom-generator-onboarding.md) for:
-
-- When you need a custom generator
-- Fork-and-extend path for internal platforms
-- Request-inclusion path for community-relevant generators
-- Kubara-like layered platform requirements
-
-## How to read each example
-
-Every example README satisfies the [Universal Example Contract](../docs/workflows/example-checklist.md):
-
-| Section | What it tells you |
-|---------|-------------------|
-| 1. Who this is for | Two-audience paths (ConfigHub-first + tool-first) |
-| 2. What runs | Real app/runtime, real cluster objects, real inspection target |
-| 3. Why ConfigHub + cub-gen helps | One pain, one answer, one governed change win |
-| 4. Run from ConfigHub | Connected mode instructions |
-| 5. Run from platform tool | Local mode instructions |
-| 6. Inspect the result | URL/pods/evidence artifacts |
-| 7. Governed change | ALLOW + ESCALATE/BLOCK examples |
-| 8. Generation chain | (Layered only) Multi-hop tracing |
-| 9. Ownership boundary | (Layered only) Platform vs downstream guidance |
-
-For full contract details, see the [Universal Example Contract](../docs/workflows/example-checklist.md).
+If the first operator is an AI assistant, the flagship examples also ship
+example-local `AI_START_HERE.md` files and prompt packs. Use those inside the
+selected example, not as a replacement for choosing the right example first.

--- a/examples/README.md
+++ b/examples/README.md
@@ -84,6 +84,18 @@ path for each flagship example.
   story
 - [`swamp-project`](./swamp-project/) — governed Helm/runtime side of Swamp
 
+## AI + automation patterns
+
+This section stays intentionally small because the truth-matrix tooling still
+uses it as a repo-level AI marker.
+
+| Example | Best starting question |
+|---|---|
+| [`c3agent`](./c3agent/) | how do we govern model, budget, and credential changes for an AI fleet? |
+| [`ai-ops-paas`](./ai-ops-paas/) | what does the fuller platform version of that AI fleet story look like? |
+| [`swamp-automation`](./swamp-automation/) | how do we govern agent-written workflow graph changes? |
+| [`swamp-project`](./swamp-project/) | how do we govern the Helm/runtime side of an AI platform? |
+
 ### Other stacks and companion examples
 
 - [`backstage-idp`](./backstage-idp/) — Backstage catalog governance


### PR DESCRIPTION
## Summary
- replace the top-level examples index with a shorter source-first guide
- center the README on the three flagship first paths and the runtime harness
- make proof expectations and run order clearer for repeatable first runs

## Why
The previous index tried to teach every taxonomy at once. This pass turns it into a decision guide: pick one stack, run one wrapper, then move from local proof to connected proof.

## Validation
- `git diff --check`
- local markdown link check for the edited README