### PR TITLE
fix: replace cub info with reliable cub space list / context get

### DIFF
--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -152,7 +152,7 @@ Start with authentication:
 
 ```bash
 cub auth login
-cub info
+cub space list                                     # auth + API reachability check
 cub context get --json | jq -r '.coordinate.user'
 ```
 

--- a/examples/demo/lib/connected-preflight.sh
+++ b/examples/demo/lib/connected-preflight.sh
@@ -82,7 +82,7 @@ require_connected_preflight() {
     return 1
   fi
 
-  if ! cub info >/dev/null 2>&1; then
+  if ! cub space list >/dev/null 2>&1; then
     require_cmd curl
     if ! curl -fsS --max-time 5 "$base_url" >/dev/null 2>&1; then
       echo "error: unable to reach ConfigHub server at $base_url." >&2

--- a/examples/demo/run-connected-smoke.sh
+++ b/examples/demo/run-connected-smoke.sh
@@ -68,7 +68,7 @@ mkdir -p "$OUT_DIR"
 if cub context get --json > "$OUT_DIR/context.json" 2>/dev/null; then
   :
 fi
-cub info > "$OUT_DIR/cub-info.txt"
+cub context get --json > "$OUT_DIR/cub-context.json" 2>/dev/null || true
 
 if [ "${SKIP_BUILD:-0}" != "1" ]; then
   echo "[connected-smoke] build cub-gen once"


### PR DESCRIPTION
## Summary
- Replace unreliable `cub info` calls with `cub space list` (auth gate) and `cub context get --json` (diagnostic dump)
- `cub info` always succeeds regardless of auth state — it prints local config and is useless as an auth gate

## Test plan
- [ ] `cub space list` fails with clear auth error when token is expired
- [ ] `cub context get --json` produces server URL without a network call
- [ ] Connected smoke script still produces diagnostic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)