### PR TITLE
Sync roadmap after PR 286 merge

### DIFF
--- a/docs/plans/2026-04-30-platform-generator-product-worklist.md
+++ b/docs/plans/2026-04-30-platform-generator-product-worklist.md
@@ -65,7 +65,7 @@ Problem: `cub-gen` import is still repo/generator oriented. Platform estates
 often spread app intent, platform contracts, environment bindings, and rendered
 output across multiple repos.
 
-Status: implemented in branch via `cub-gen platform import --json <manifest>`.
+Status: landed in PR #286 via `cub-gen platform import --json <manifest>`.
 The command reads a local manifest, imports each existing repo read-only, emits
 Components, Deployable Variants, Targets, generator inputs, WET targets, and
 connections, and reports missing repo, missing owner, and unsupported generator
@@ -145,7 +145,7 @@ Definition of done:
 
 ### PG-03: App-of-Apps Generator Boundary
 
-Status: implemented on this branch as a fixture-backed initial adapter.
+Status: landed in PR #286 as a fixture-backed initial adapter.
 
 Problem: ApplicationSet has bounded support, and app-of-apps needed the same
 root/child generator boundary rather than remaining only a documented pattern.
@@ -178,7 +178,7 @@ Definition of done:
 Problem: the docs explicitly say there is no one-command multi-env/tenant
 fanout.
 
-Status: implemented in branch via `cub-gen platform fanout`. The command reads
+Status: landed in PR #286 via `cub-gen platform fanout`. The command reads
 explicit `variants:` entries from a platform manifest, emits one standard
 `change-bundle/v1` per variant, supports `--variant` scoping, and lets
 `change explain` select a variant bundle from fanout JSON. It remains
@@ -212,7 +212,7 @@ Definition of done:
 Problem: users may want provenance annotations on platform and app artifacts,
 but automatic in-place edits would be risky.
 
-Status: implemented in branch via `cub-gen enrich preview` and
+Status: landed in PR #286 via `cub-gen enrich preview` and
 `cub-gen enrich write`. The command proposes sidecar provenance under
 `.cub-gen/enrichment/`, emits JSON or patch preview, and treats existing
 sidecars as `review-required` instead of overwriting them.

--- a/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
+++ b/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
@@ -1,6 +1,6 @@
 # v0.4 Working Roadmap: Component -> Deployable Variant -> Proof
 
-Status: connected roadmap draft; OpenChoreo and app-of-apps vertical slices implemented on this branch
+Status: post-PR #286 roadmap; OpenChoreo, app-of-apps, platform graph, fanout, and enrichment slices landed on main
 Date: 2026-04-30
 GitHub milestone: [v0.4: Component -> Deployable Variant -> Proof](https://github.com/confighub/cub-gen/milestone/4)
 GitHub parent issue: [#287](https://github.com/confighub/cub-gen/issues/287)
@@ -13,7 +13,7 @@ OpenChoreo credibility until the README is honest about support status, the
 adoption path starts read-only, an OpenChoreo-shaped fixture proves the hard
 case, and generated-resource ownership/edit routing is modeled.
 
-Current implementation note: this branch adds a fixture-backed OpenChoreo
+Current implementation note: PR #286 added a fixture-backed OpenChoreo
 adapter, `gitops discover --adoption-report`, OpenChoreo field-route proof, a
 fixture-backed app-of-apps adapter, a read-only multi-repo platform-estate
 import graph, manifest-driven variant fanout for Helm/Score/Spring, enrichment
@@ -66,7 +66,7 @@ This is first because the product cannot win if people cannot explain it.
 
 Subtasks:
 
-- [ ] [#286](https://github.com/confighub/cub-gen/pull/286) Add platform generator doctrine
+- [x] [#286](https://github.com/confighub/cub-gen/pull/286) Add platform generator doctrine
 - [ ] [#284](https://github.com/confighub/cub-gen/issues/284) Finish platform generator teaching-pack QA
 - [ ] [#285](https://github.com/confighub/cub-gen/issues/285) Align spring-platform teaching docs with springboot-paas product path
 - [x] [#288](https://github.com/confighub/cub-gen/issues/288) Make README OpenChoreo claims honest and explicit
@@ -95,9 +95,9 @@ depth because those adapters need somewhere coherent to land.
 
 Subtasks:
 
-- [x] [#276](https://github.com/confighub/cub-gen/issues/276) Add generic platform import graph (implemented in branch; closes when PR merges)
+- [x] [#276](https://github.com/confighub/cub-gen/issues/276) Add generic platform import graph
 - [x] [#290](https://github.com/confighub/cub-gen/issues/290) Produce an existing-platform adoption report before rewrites
-- [x] [#279](https://github.com/confighub/cub-gen/issues/279) Add one-command multi-env and tenant fanout (manifest-driven fanout implemented in branch; closes when PR merges)
+- [x] [#279](https://github.com/confighub/cub-gen/issues/279) Add one-command multi-env and tenant fanout
 
 Dependency:
 
@@ -107,8 +107,8 @@ Dependency:
 
 Done means `cub-gen` can show Components and Deployable Variants as product
 objects, not only as generator internals, and can start with a read-only report
-for an existing platform before proposing annotations or rewrites. The branch
-now emits one standard change bundle per declared variant and lets
+for an existing platform before proposing annotations or rewrites. The merged
+implementation emits one standard change bundle per declared variant and lets
 `change explain` scope a fanout file with `--variant`.
 
 ### Phase 3: Add Concrete Platform Families
@@ -152,7 +152,7 @@ to know how to inspect.
 
 Subtasks:
 
-- [x] [#280](https://github.com/confighub/cub-gen/issues/280) Preview and write provenance enrichment artifacts (implemented in branch; closes when PR merges)
+- [x] [#280](https://github.com/confighub/cub-gen/issues/280) Preview and write provenance enrichment artifacts
 - [ ] [#213](https://github.com/confighub/cub-gen/issues/213) GUI provenance trace
 - [ ] [#209](https://github.com/confighub/cub-gen/issues/209) GUI field-level route badges
 - [ ] [#211](https://github.com/confighub/cub-gen/issues/211) GUI mutation history and activity log


### PR DESCRIPTION
## Summary\n\n- Update v0.4 roadmap docs from branch/pre-merge language to post-merge language.\n- Mark PR #286 and its landed slices as merged rather than pending closure.\n- Replace stale "implemented in branch" wording in the platform generator worklist.\n\n## Validation\n\n- \n