### PR TITLE
Preflight connected bridge ingest endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -77,6 +77,9 @@ check-example-truth-matrix:
 check-connected-release-gate:
 	./test/checks/check-connected-release-gate.sh
 
+check-connected-ingest-preflight:
+	bash ./test/checks/check-connected-ingest-preflight.sh
+
 check-no-legacy-provider-terms:
 	./test/checks/check-no-legacy-provider-terms.sh
 
@@ -92,9 +95,9 @@ update-goldens:
 sync-triple-styles:
 	go run ./cmd/cub-gen-style-sync
 
-ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
+ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 
-ci-connected: build test-connected-smoke check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
+ci-connected: build test-connected-smoke check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 
 ci-connected-deep: ci-connected test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo check-story-evidence check-flow-evidence
 

--- a/docs/workflows/connected-ci-bootstrap.md
+++ b/docs/workflows/connected-ci-bootstrap.md
@@ -83,6 +83,12 @@ This explicitly enables:
 - `ALLOW_FALLBACK_INGEST=1`
 - `ALLOW_STORY_10_SKIP=1`
 
+The deep lifecycle wrapper preflights the bridge ingest endpoint before it
+builds bundles. With the default `CONNECTED_FALLBACK_MODE=off`, a missing
+bridge endpoint fails immediately with remediation. With
+`CONNECTED_FALLBACK_MODE=auto`, a 404 switches to changeset fallback before the
+create/update phases run.
+
 ## 6) PR DRY ownership gate (WET edit blocker)
 
 Use the dedicated workflow:

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -208,9 +208,14 @@ not the release-facing default connected path.
 
 | Mode | Behavior |
 |------|----------|
-| Default (`CONNECTED_FALLBACK_MODE=off`) | Fail fast unless bridge endpoints are reachable |
-| Auto fallback (`CONNECTED_FALLBACK_MODE=auto`) | Fall back to backend `changeset` on 404 |
-| Forced fallback (`CONNECTED_FALLBACK_MODE=changeset`) | Always use backend fallback (troubleshooting) |
+| Default (`CONNECTED_FALLBACK_MODE=off`) | Preflight the bridge ingest endpoint and fail before bundle work if it is unavailable |
+| Auto fallback (`CONNECTED_FALLBACK_MODE=auto`) | Preflight bridge ingest; use backend `changeset` fallback on 404 |
+| Forced fallback (`CONNECTED_FALLBACK_MODE=changeset`) | Skip bridge ingest and always use backend fallback (troubleshooting) |
+
+`run-confighub-lifecycle-connected.sh` probes the configured ingest endpoint
+before it runs discover/import/publish. This keeps SaaS users from doing a long
+successful-looking setup only to hit a final bridge-only 404. Use
+`run-connected-smoke.sh` for the standard SaaS-safe connected proof lane.
 
 CI behavior:
 - `make ci-connected` runs the smaller ConfigHub smoke lane and does not touch bridge endpoints

--- a/examples/demo/run-confighub-lifecycle-connected.sh
+++ b/examples/demo/run-confighub-lifecycle-connected.sh
@@ -15,6 +15,7 @@ SPACE="${SPACE:-}"
 VERIFIER="${VERIFIER:-ci-bot}"
 BRIDGE_INGEST_ENDPOINT="${BRIDGE_INGEST_ENDPOINT:-}"
 BRIDGE_DECISION_ENDPOINT="${BRIDGE_DECISION_ENDPOINT:-}"
+BRIDGE_INGEST_PREFLIGHT_TIMEOUT_SECS="${BRIDGE_INGEST_PREFLIGHT_TIMEOUT_SECS:-5}"
 DECISION_POLL_TIMEOUT_SECS="${DECISION_POLL_TIMEOUT_SECS:-120}"
 DECISION_POLL_INTERVAL_SECS="${DECISION_POLL_INTERVAL_SECS:-3}"
 REQUIRE_TERMINAL_DECISION="${REQUIRE_TERMINAL_DECISION:-1}"
@@ -92,6 +93,97 @@ should_use_fallback() {
       ;;
     *)
       echo "error: unsupported CONNECTED_FALLBACK_MODE=$CONNECTED_FALLBACK_MODE (expected off|auto|changeset)" >&2
+      return 1
+      ;;
+  esac
+}
+
+bridge_ingest_endpoint_path() {
+  if [ -n "$BRIDGE_INGEST_ENDPOINT" ]; then
+    case "$BRIDGE_INGEST_ENDPOINT" in
+      /*) printf '%s' "$BRIDGE_INGEST_ENDPOINT" ;;
+      *) printf '/%s' "$BRIDGE_INGEST_ENDPOINT" ;;
+    esac
+    return 0
+  fi
+  printf '%s' "/api/v1/governed-wet-artifacts:ingest"
+}
+
+bridge_ingest_url() {
+  local base path
+  base="${CONFIGHUB_BASE_URL%/}"
+  path="$(bridge_ingest_endpoint_path)"
+  printf '%s%s' "$base" "$path"
+}
+
+preflight_bridge_ingest_endpoint() {
+  case "$CONNECTED_FALLBACK_MODE" in
+    changeset)
+      echo "[connected] bridge ingest preflight: skipped (CONNECTED_FALLBACK_MODE=changeset)"
+      return 0
+      ;;
+    off|auto) ;;
+    *)
+      echo "error: unsupported CONNECTED_FALLBACK_MODE=$CONNECTED_FALLBACK_MODE (expected off|auto|changeset)" >&2
+      return 1
+      ;;
+  esac
+
+  require_cmd curl
+
+  local url status tmp_body tmp_err body err
+  url="$(bridge_ingest_url)"
+  tmp_body="$(mktemp)"
+  tmp_err="$(mktemp)"
+  status="$(
+    curl -sS \
+      --max-time "$BRIDGE_INGEST_PREFLIGHT_TIMEOUT_SECS" \
+      -o "$tmp_body" \
+      -w "%{http_code}" \
+      -X POST "$url" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $CONFIGHUB_TOKEN" \
+      -H "Idempotency-Key: cub-gen-ingest-preflight" \
+      --data '{"schema_version":"cub.confighub.io/bridge-ingest-preflight/v1","source":"cub-gen-preflight"}' \
+      2>"$tmp_err" || true
+  )"
+  body="$(tr '\n' ' ' < "$tmp_body" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  err="$(tr '\n' ' ' < "$tmp_err" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  rm -f "$tmp_body" "$tmp_err"
+
+  case "$status" in
+    200|201|202|400|405|409|415|422)
+      echo "[connected] bridge ingest preflight: endpoint reachable ($status) at $url"
+      return 0
+      ;;
+    404)
+      if [ "$CONNECTED_FALLBACK_MODE" = "auto" ]; then
+        echo "[connected] bridge ingest preflight: endpoint not found at $url; using changeset fallback"
+        CONNECTED_FALLBACK_MODE=changeset
+        export CONNECTED_FALLBACK_MODE
+        return 0
+      fi
+      echo "error: bridge ingest endpoint is not available at $url (status=404)." >&2
+      echo "details: ${body:-Not Found}" >&2
+      echo "remediation: set BRIDGE_INGEST_ENDPOINT to a backend path that exposes ingest, use CONNECTED_FALLBACK_MODE=auto|changeset, or start with ./examples/demo/run-connected-smoke.sh for SaaS-safe connected proof." >&2
+      return 1
+      ;;
+    401|403)
+      echo "error: bridge ingest preflight was rejected at $url (status=$status)." >&2
+      echo "details: ${body:-$err}" >&2
+      echo "remediation: refresh ConfigHub auth with 'cub auth login' or export a CONFIGHUB_TOKEN with bridge ingest permissions." >&2
+      return 1
+      ;;
+    000|"")
+      echo "error: bridge ingest preflight could not reach $url." >&2
+      echo "details: ${err:-curl returned no HTTP status}" >&2
+      echo "remediation: verify CONFIGHUB_BASE_URL, network access, and BRIDGE_INGEST_ENDPOINT; use CONNECTED_FALLBACK_MODE=changeset only when you intentionally want the backend changeset fallback." >&2
+      return 1
+      ;;
+    *)
+      echo "error: bridge ingest preflight failed at $url (status=$status)." >&2
+      echo "details: ${body:-$err}" >&2
+      echo "remediation: ensure the configured backend exposes the bridge ingest endpoint or set CONNECTED_FALLBACK_MODE=auto|changeset for fallback evidence." >&2
       return 1
       ;;
   esac
@@ -220,7 +312,12 @@ run_governed_cycle_connected() {
   fi
   local used_fallback=0
   local bridge_ingest_error=""
-  if ! "${ingest_cmd[@]}" > "$outdir/ingest.json" 2>"$outdir/ingest.error"; then
+  if [ "$CONNECTED_FALLBACK_MODE" = "changeset" ]; then
+    bridge_ingest_error="bridge ingest skipped by CONNECTED_FALLBACK_MODE=changeset"
+    echo "[connected][$phase] using changeset-backed fallback; bridge ingest skipped"
+    run_changeset_fallback "$phase" "$outdir" "$bridge_ingest_error"
+    used_fallback=1
+  elif ! "${ingest_cmd[@]}" > "$outdir/ingest.json" 2>"$outdir/ingest.error"; then
     bridge_ingest_error="$(tr '\n' ' ' < "$outdir/ingest.error" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
     if should_use_fallback "$bridge_ingest_error"; then
       echo "[connected][$phase] bridge ingest unavailable; using changeset-backed fallback"
@@ -330,6 +427,8 @@ summary_line() {
     --argjson attested_valid "$(jq '.valid' "$outdir/attestation-verify.json")" \
     '{phase: $phase, change_id: $change_id, bundle_digest: $bundle_digest, ingest_status: $ingest_status, decision_state: $decision_state, decision_authority: $decision_authority, wet_targets: $wet_targets, inverse_patches: $inverse_patches, attestation_valid: $attested_valid}'
 }
+
+preflight_bridge_ingest_endpoint
 
 echo "[lifecycle][connected] example: $EXAMPLE_SLUG"
 echo "[lifecycle][connected] source: $REPO_PATH"

--- a/test/checks/check-connected-ingest-preflight.sh
+++ b/test/checks/check-connected-ingest-preflight.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+mkdir -p "$tmpdir/bin"
+
+cat > "$tmpdir/bin/cub" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$*" in
+  "auth get-token")
+    printf '%s\n' "test-token"
+    ;;
+  "context get --json")
+    cat <<'JSON'
+{
+  "coordinate": {
+    "serverURL": "https://hub.confighub.com",
+    "user": "preflight-test@example.com"
+  },
+  "settings": {
+    "defaultSpace": "platform"
+  }
+}
+JSON
+    ;;
+  "space list")
+    printf '%s\n' "[]"
+    ;;
+  *)
+    echo "unexpected cub invocation: $*" >&2
+    exit 1
+    ;;
+esac
+SCRIPT
+
+cat > "$tmpdir/bin/curl" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+out="/dev/null"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+printf '%s' '{"message":"Not Found"}' > "$out"
+printf '%s' "404"
+SCRIPT
+
+chmod +x "$tmpdir/bin/cub" "$tmpdir/bin/curl"
+
+stdout="$tmpdir/stdout.txt"
+stderr="$tmpdir/stderr.txt"
+outdir="$tmpdir/out"
+
+if PATH="$tmpdir/bin:$PATH" \
+  SKIP_BUILD=1 \
+  CONNECTED_FALLBACK_MODE=off \
+  ./examples/demo/run-confighub-lifecycle-connected.sh \
+    ./examples/helm-paas \
+    ./examples/helm-paas \
+    helm-paas \
+    "$outdir" >"$stdout" 2>"$stderr"; then
+  fail "expected bridge ingest preflight to fail on default 404"
+fi
+
+if ! grep -q "bridge ingest endpoint is not available" "$stderr"; then
+  fail "missing actionable preflight failure; stderr was: $(cat "$stderr")"
+fi
+
+if [ -d "$outdir/create" ] || [ -d "$outdir/update" ]; then
+  fail "preflight should fail before create/update lifecycle directories are written"
+fi
+
+echo "ok: connected lifecycle fails fast before bridge ingest bundle work when endpoint is missing"


### PR DESCRIPTION
## Summary

- Add a bridge ingest endpoint preflight to `run-confighub-lifecycle-connected.sh` before create/update bundle work starts.
- Keep default `CONNECTED_FALLBACK_MODE=off` honest: missing ingest endpoint now fails immediately with remediation instead of after discover/import/publish/verify.
- Make `CONNECTED_FALLBACK_MODE=auto` switch to changeset fallback on preflight 404, and make `changeset` skip bridge ingest entirely.
- Add a CI check with fake `cub`/`curl` that proves a 404 fails before create/update evidence dirs are written.
- Update connected demo and CI docs to describe the new behavior.

## Validation

- `bash -n examples/demo/run-confighub-lifecycle-connected.sh test/checks/check-connected-ingest-preflight.sh`
- `bash ./test/checks/check-connected-ingest-preflight.sh`
- `make ci`

Closes #275.
