### PR TITLE
Fail fast on stale Spring worker readiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -80,6 +80,9 @@ check-connected-release-gate:
 check-connected-ingest-preflight:
 	bash ./test/checks/check-connected-ingest-preflight.sh
 
+check-springboot-worker-ready-guard:
+	bash ./test/checks/check-springboot-worker-ready-guard.sh
+
 check-no-legacy-provider-terms:
 	./test/checks/check-no-legacy-provider-terms.sh
 
@@ -95,7 +98,7 @@ update-goldens:
 sync-triple-styles:
 	go run ./cmd/cub-gen-style-sync
 
-ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
+ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 
 ci-connected: build test-connected-smoke check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -146,6 +146,11 @@ cub auth login
 ./verify-e2e.sh
 ```
 
+`./bin/install-worker` now treats ConfigHub's server-side worker condition as
+the source of truth. If the local worker process is still alive but ConfigHub
+continues to report `Disconnected`, the script exits with the PID, `LastSeenAt`,
+and recent worker log lines instead of letting the next proof step hang.
+
 Start with `./examples/demo/run-connected-smoke.sh` first to confirm the
 standard ConfigHub-connected environment. Use
 `./examples/springboot-paas/demo-connected.sh` when you specifically want the

--- a/examples/springboot-paas/bin/install-worker
+++ b/examples/springboot-paas/bin/install-worker
@@ -9,8 +9,42 @@ SPACE="${2:-springboot-infra}"
 KUBECONFIG_PATH="${PROJECT_DIR}/var/${CLUSTER_NAME}.kubeconfig"
 PID_FILE="${PROJECT_DIR}/var/worker.pid"
 LOG_FILE="${PROJECT_DIR}/var/worker.log"
+WORKER_READY_ATTEMPTS="${WORKER_READY_ATTEMPTS:-30}"
+WORKER_READY_SLEEP_SECONDS="${WORKER_READY_SLEEP_SECONDS:-2}"
 
 export KUBECONFIG="${KUBECONFIG_PATH}"
+
+worker_pid() {
+  if [[ -f "${PID_FILE}" ]]; then
+    cat "${PID_FILE}"
+  fi
+}
+
+worker_running() {
+  local pid="$1"
+  [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null
+}
+
+worker_condition() {
+  ${CUB} worker list --space "${SPACE}" --json 2>/dev/null | \
+    jq -r '.[0].BridgeWorker.Condition // "unknown"' 2>/dev/null || echo "unknown"
+}
+
+worker_last_seen() {
+  ${CUB} worker list --space "${SPACE}" --json 2>/dev/null | \
+    jq -r '.[0].BridgeWorker.LastSeenAt // .[0].LastSeenAt // "unknown"' 2>/dev/null || echo "unknown"
+}
+
+worker_log_has_heartbeat_ack() {
+  [[ -f "${LOG_FILE}" ]] && grep -Eiq 'heartbeat.*ack|ack.*heartbeat|Sending Heartbeat acknowledged' "${LOG_FILE}"
+}
+
+print_worker_log_tail() {
+  if [[ -f "${LOG_FILE}" ]]; then
+    echo "Recent worker log:" >&2
+    tail -n 20 "${LOG_FILE}" >&2
+  fi
+}
 
 echo "Installing ConfigHub worker for space '${SPACE}'..."
 
@@ -47,14 +81,54 @@ echo "  Worker started (PID $(cat "${PID_FILE}"))"
 
 # Wait for ready
 echo "Waiting for worker to become Ready..."
-for i in $(seq 1 30); do
-  CONDITION=$(${CUB} worker list --space "${SPACE}" --json 2>/dev/null | jq -r '.[0].BridgeWorker.Condition' 2>/dev/null || echo "unknown")
+READY=0
+CONDITION="unknown"
+for i in $(seq 1 "${WORKER_READY_ATTEMPTS}"); do
+  CONDITION="$(worker_condition)"
   if [[ "$CONDITION" == "Ready" ]]; then
     echo "  Worker is Ready."
+    READY=1
     break
   fi
-  sleep 2
+
+  if ! worker_running "$(worker_pid)"; then
+    break
+  fi
+
+  sleep "${WORKER_READY_SLEEP_SECONDS}"
 done
+
+if [[ "${READY}" != "1" ]]; then
+  CURRENT_PID="$(worker_pid)"
+  LAST_SEEN="$(worker_last_seen)"
+
+  echo "error: worker did not become Ready for space '${SPACE}'." >&2
+  echo "  Condition: ${CONDITION}" >&2
+  echo "  LastSeenAt: ${LAST_SEEN}" >&2
+  echo "  PID: ${CURRENT_PID:-unknown}" >&2
+  echo "  Log: ${LOG_FILE}" >&2
+
+  if worker_running "${CURRENT_PID:-}"; then
+    if worker_log_has_heartbeat_ack; then
+      echo "" >&2
+      echo "The worker process is alive and the log contains heartbeat acknowledgements, but ConfigHub still reports Condition=${CONDITION}." >&2
+      echo "This matches the stale worker-condition failure tracked in cub-gen issue #219." >&2
+      echo "Restart the worker with './bin/teardown && ./bin/install-worker', then re-run the proof." >&2
+    else
+      echo "" >&2
+      echo "The worker process is alive, but it has not reported Ready yet." >&2
+      echo "Inspect the worker log and ConfigHub worker state before continuing." >&2
+    fi
+  else
+    echo "" >&2
+    echo "The worker process exited before ConfigHub reported Ready." >&2
+    echo "Inspect the worker log before continuing." >&2
+  fi
+
+  echo "" >&2
+  print_worker_log_tail
+  exit 1
+fi
 
 echo ""
 echo "====================================="

--- a/test/checks/check-springboot-worker-ready-guard.sh
+++ b/test/checks/check-springboot-worker-ready-guard.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+  local pid_file="$tmpdir/project/var/worker.pid"
+  if [ -f "$pid_file" ]; then
+    kill "$(cat "$pid_file")" 2>/dev/null || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmpdir/bin" "$tmpdir/project/bin" "$tmpdir/project/var"
+cp examples/springboot-paas/bin/install-worker "$tmpdir/project/bin/install-worker"
+
+cat > "$tmpdir/bin/cub" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  space)
+    [ "${2:-}" = "create" ] || exit 1
+    ;;
+  target)
+    [ "${2:-}" = "create" ] || exit 1
+    ;;
+  worker)
+    case "${2:-}" in
+      run)
+        printf '%s\n' "Sending Heartbeat acknowledged for test worker"
+        while true; do sleep 1; done
+        ;;
+      list)
+        cat <<'JSON'
+[
+  {
+    "BridgeWorker": {
+      "Condition": "Disconnected",
+      "LastSeenAt": "2026-05-01T00:00:00Z"
+    }
+  }
+]
+JSON
+        ;;
+      *)
+        echo "unexpected cub worker invocation: $*" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected cub invocation: $*" >&2
+    exit 1
+    ;;
+esac
+SCRIPT
+
+chmod +x "$tmpdir/bin/cub" "$tmpdir/project/bin/install-worker"
+
+stdout="$tmpdir/stdout.txt"
+stderr="$tmpdir/stderr.txt"
+
+if CUB="$tmpdir/bin/cub" \
+  WORKER_READY_ATTEMPTS=2 \
+  WORKER_READY_SLEEP_SECONDS=0 \
+  "$tmpdir/project/bin/install-worker" test-cluster test-space >"$stdout" 2>"$stderr"; then
+  fail "expected install-worker to fail while ConfigHub reports Disconnected"
+fi
+
+if ! grep -q "worker did not become Ready" "$stderr"; then
+  fail "missing not-ready failure; stderr was: $(cat "$stderr")"
+fi
+
+if ! grep -q "heartbeat acknowledgements" "$stderr"; then
+  fail "missing heartbeat acknowledgement diagnosis; stderr was: $(cat "$stderr")"
+fi
+
+if ! grep -q "cub-gen issue #219" "$stderr"; then
+  fail "missing issue #219 stale-condition hint; stderr was: $(cat "$stderr")"
+fi
+
+if ! grep -q "2026-05-01T00:00:00Z" "$stderr"; then
+  fail "missing LastSeenAt evidence; stderr was: $(cat "$stderr")"
+fi
+
+echo "ok: springboot install-worker fails loudly when active heartbeats still report Disconnected"


### PR DESCRIPTION
## Summary
- make the Spring Boot live proof require ConfigHub's server-side worker condition to become Ready
- detect the stale Disconnected + heartbeat-ack symptom and print PID, LastSeenAt, log path, and restart guidance
- add a regression check to ci-local that simulates active heartbeat acknowledgements while worker list stays Disconnected

Closes #219.

## Validation
- make ci