### PR TITLE
Guard platform generator teaching pack claims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -71,6 +71,9 @@ check-ai-only-scope:
 check-docs-entrypoints:
 	./test/checks/check-docs-entrypoints.sh
 
+check-platform-teaching-pack:
+	./test/checks/check-platform-teaching-pack.sh
+
 check-example-truth-matrix:
 	./test/checks/check-example-truth-matrix.sh
 
@@ -98,7 +101,7 @@ update-goldens:
 sync-triple-styles:
 	go run ./cmd/cub-gen-style-sync
 
-ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
+ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 
 ci-connected: build test-connected-smoke check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 

--- a/docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md
+++ b/docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md
@@ -1,6 +1,8 @@
 # OpenChoreo as a Clean Generator
 
-Status: worked example, not yet an implemented `cub-gen` adapter.
+Status: worked example plus fixture-backed hardgate support. `cub-gen` can
+detect and import the OpenChoreo-shaped fixture in `testdata/openchoreo-hardgate`;
+that is not the same as full upstream OpenChoreo conformance.
 
 This example uses OpenChoreo to teach the distinction between a brittle platform
 abstraction and a clean platform generator.
@@ -145,8 +147,9 @@ The platform `ComponentType` decides how those inputs become `Deployment`,
 
 ## Field-Origin Map
 
-For this component, an OpenChoreo-aware `cub-gen` adapter would emit a field map
-like this.
+For this component shape, the fixture-backed OpenChoreo path emits field routes
+like this. Real OpenChoreo estate support still needs broader upstream
+conformance and repo-shape testing.
 
 | Rendered field | Value | Source object | Source path | Owner | Route |
 |---|---:|---|---|---|---|
@@ -246,7 +249,7 @@ sequenceDiagram
 
 | Capability | Status in cub-gen today | OpenChoreo-specific status |
 |---|---|---|
-| Generator contract triple | implemented for current generator families | fixture-backed initial adapter |
+| Generator contract triple | implemented for current generator families | fixture-backed hardgate support; not full upstream conformance |
 | Field-origin and inverse edit pointers | implemented for current generator families | field routes proved by `testdata/openchoreo-hardgate` |
 | Apply-here / lift-upstream / block-escalate teaching model | strongest in Spring examples | model maps cleanly |
 | PR/MR linkage contract | commands and demos exist | OC wiring needed |

--- a/docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md
+++ b/docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md
@@ -307,4 +307,4 @@ Argo has at least three roles:
 - Argo CD docs: [Cluster Bootstrapping / App of Apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/)
 - cub-gen: [ApplicationSet Generator Boundary](../../contracts/applicationset-generator-boundary.md)
 - cub-gen: [App-of-Apps Generator Boundary](../../contracts/app-of-apps-generator-boundary.md)
-- cub-gen: [Helm PaaS layered proof](../../../examples/helm-paas/README.md)
+- cub-gen: [Helm PaaS layered proof](https://github.com/confighub/cub-gen/tree/main/examples/helm-paas)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.6,<2
+mkdocs-material>=9.6,<10
+pymdown-extensions>=10.16,<11

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,7 +47,7 @@ become full runnable adapters.
 
 | Pattern | Worked example | What it teaches | Product status |
 |---|---|---|---|
-| OpenChoreo-style component platform | [OpenChoreo as a Clean Generator](../docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md) | Workload + ReleaseBinding + SecretReference + ComponentType -> rendered release | fixture-backed initial adapter |
+| OpenChoreo-style component platform | [OpenChoreo as a Clean Generator](../docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md) | Workload + ReleaseBinding + SecretReference + ComponentType -> rendered release | fixture-backed hardgate; not full upstream conformance |
 | Argo ApplicationSet | [Argo Generators](../docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md) | selectors, inventory, and templates generate child Applications | bounded support exists |
 | Argo app-of-apps | [Argo Generators](../docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md) | root app plus child app catalog behaves like a generator | fixture-backed initial adapter |
 | Multi-repo platform estate | [`platform-estate`](../testdata/platform-estate/) | read-only manifest import before rewrites or fanout | fixture-backed graph proof |

--- a/test/checks/check-platform-teaching-pack.sh
+++ b/test/checks/check-platform-teaching-pack.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+declare -a failures=()
+
+require_file() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    failures+=("missing required file: $file")
+  fi
+}
+
+require_pattern() {
+  local file="$1"
+  local pattern="$2"
+  local message="$3"
+  if ! grep -Eq -- "$pattern" "$file"; then
+    failures+=("$message")
+  fi
+}
+
+require_min_count() {
+  local file="$1"
+  local pattern="$2"
+  local min_count="$3"
+  local message="$4"
+  local count
+  count="$(grep -Ec -- "$pattern" "$file" || true)"
+  if [ "$count" -lt "$min_count" ]; then
+    failures+=("$message")
+  fi
+}
+
+openchoreo_doc="docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md"
+argo_doc="docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md"
+manifesto_doc="docs/agentic-gitops/02-design/90-platform-generators-manifesto.md"
+appset_contract="docs/contracts/applicationset-generator-boundary.md"
+appofapps_contract="docs/contracts/app-of-apps-generator-boundary.md"
+
+for file in "$openchoreo_doc" "$argo_doc" "$manifesto_doc" "$appset_contract" "$appofapps_contract" "README.md" "docs/index.md" "examples/README.md" "mkdocs.yml"; do
+  require_file "$file"
+done
+
+require_min_count "$openchoreo_doc" '^```mermaid$' 2 "OpenChoreo worked example must stay diagram-heavy"
+require_min_count "$argo_doc" '^```mermaid$' 2 "Argo worked example must include ApplicationSet and app-of-apps diagrams"
+
+require_pattern "$openchoreo_doc" 'fixture-backed hardgate support' "OpenChoreo doc must state fixture-backed support status"
+require_pattern "$openchoreo_doc" 'not (the same as )?full upstream OpenChoreo conformance' "OpenChoreo doc must not overclaim upstream conformance"
+require_pattern "$openchoreo_doc" 'testdata/openchoreo-hardgate' "OpenChoreo doc must point at the real hardgate fixture"
+require_pattern "$openchoreo_doc" 'apply-here|lift-upstream|block/escalate|temporary overlay' "OpenChoreo doc must explain edit routing"
+
+require_pattern "$argo_doc" 'Status: worked example plus fixture-backed adapters' "Argo doc must state current support status"
+require_pattern "$argo_doc" './cub-gen gitops import --space platform --json ./testdata/applicationset-standalone' "Argo doc must prove ApplicationSet against a real fixture"
+require_pattern "$argo_doc" './cub-gen gitops import --space platform --json ./testdata/app-of-apps-standalone' "Argo doc must prove app-of-apps against a real fixture"
+require_pattern "$argo_doc" 'unsupported generator types.*observed-only|observed-only or degraded' "Argo doc must describe graceful degradation"
+
+require_pattern "README.md" 'That is the pitch: \*\*repo in, explanation out\*\*' "README must keep the first-minute pitch"
+require_pattern "README.md" 'It does not deploy\. Flux and Argo still reconcile|Not a Flux or Argo replacement' "README must explain generator, not replacement"
+require_pattern "docs/index.md" 'not by replacing the platform' "Docs index must explain generator, not replacement"
+require_pattern "examples/README.md" 'fixture-backed hardgate; not full upstream conformance' "Examples index must keep OpenChoreo claims conservative"
+
+require_pattern "mkdocs.yml" '05-openchoreo-generator-worked-example.md' "MkDocs nav must include OpenChoreo worked example"
+require_pattern "mkdocs.yml" '06-argo-generators-worked-example.md' "MkDocs nav must include Argo worked example"
+require_pattern "mkdocs.yml" 'applicationset-generator-boundary.md' "MkDocs nav must include ApplicationSet contract"
+require_pattern "mkdocs.yml" 'app-of-apps-generator-boundary.md' "MkDocs nav must include app-of-apps contract"
+
+if [ "${#failures[@]}" -gt 0 ]; then
+  echo "error: platform teaching pack check failed:" >&2
+  for failure in "${failures[@]}"; do
+    echo "  - $failure" >&2
+  done
+  exit 1
+fi
+
+echo "ok: platform generator teaching pack has conservative claims, diagrams, fixture proof, and nav coverage"


### PR DESCRIPTION
## Summary
- make OpenChoreo teaching docs honest about fixture-backed hardgate support versus full upstream conformance
- fix the MkDocs warning from the Argo worked-example cross-link and add reproducible docs requirements
- add a CI-local teaching-pack guard for diagrams, fixture proof commands, nav coverage, and conservative product claims

Closes #284.

## Validation
- make ci
- python3 -m venv .tmp/docs-venv && .tmp/docs-venv/bin/python -m pip install -q -r docs/requirements.txt && .tmp/docs-venv/bin/mkdocs build --strict