### PR TITLE
Add one-command PR/MR bridge link

### DIFF
--- a/cmd/cub-gen/bridge.go
+++ b/cmd/cub-gen/bridge.go
@@ -28,6 +28,8 @@ func runBridge(args []string) error {
 		return nil
 	case "ingest":
 		return runBridgeIngest(args[1:])
+	case "link":
+		return runBridgeLink(args[1:])
 	case "decision":
 		return runBridgeDecision(args[1:])
 	case "promote":
@@ -80,6 +82,102 @@ func runBridgeIngest(args []string) error {
 	}
 	fmt.Printf("Bridge ingest OK: change_id=%s status=%s artifact_id=%s idempotent=%t\n", res.ChangeID, res.Status, res.ArtifactID, res.Idempotent)
 	return nil
+}
+
+func runBridgeLink(args []string) error {
+	fs := flag.NewFlagSet("bridge link", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	bundlePath := fs.String("bundle", "", "Publish bundle JSON path, or '-' for stdin, used to derive change_id")
+	changeID := fs.String("change-id", "", "Change ID override when --bundle is not supplied")
+	baseURL := fs.String("base-url", "", "Optional ConfigHub base URL; when omitted, writes the local review-link record")
+	token := fs.String("token", "", "Bearer token; defaults to CONFIGHUB_TOKEN when --base-url is set")
+	endpoint := fs.String("endpoint", "", "Optional review-link endpoint path override")
+	githubPRRepo := fs.String("github-pr-repo", "", "GitHub PR repository")
+	githubPRNumber := fs.Int("github-pr-number", 0, "GitHub PR number")
+	githubPRURL := fs.String("github-pr-url", "", "GitHub PR URL")
+	githubPRSHA := fs.String("github-pr-sha", "", "GitHub PR commit SHA")
+	appPRRepo := fs.String("app-pr-repo", "", "Alias for --github-pr-repo")
+	appPRNumber := fs.Int("app-pr-number", 0, "Alias for --github-pr-number")
+	appPRURL := fs.String("app-pr-url", "", "Alias for --github-pr-url")
+	appPRSHA := fs.String("app-pr-sha", "", "Alias for --github-pr-sha")
+	confighubMRID := fs.String("confighub-mr-id", "", "ConfigHub merge request ID")
+	confighubMRURL := fs.String("confighub-mr-url", "", "ConfigHub merge request URL")
+	confighubMRStatus := fs.String("confighub-mr-status", "", "Optional ConfigHub merge request status")
+	mrID := fs.String("mr-id", "", "Alias for --confighub-mr-id")
+	mrURL := fs.String("mr-url", "", "Alias for --confighub-mr-url")
+	mrStatus := fs.String("mr-status", "", "Alias for --confighub-mr-status")
+	out := fs.String("out", "-", "Review-link JSON output path, or '-' for stdout")
+	atRaw := fs.String("at", "", "Optional RFC3339 timestamp override")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: cub-gen bridge link [flags]")
+	}
+
+	resolvedChangeID, err := resolveBridgeLinkChangeID(strings.TrimSpace(*changeID), strings.TrimSpace(*bundlePath))
+	if err != nil {
+		return err
+	}
+	repo := firstNonEmpty(*githubPRRepo, *appPRRepo)
+	number := firstPositive(*githubPRNumber, *appPRNumber)
+	prURL := firstNonEmpty(*githubPRURL, *appPRURL)
+	prSHA := firstNonEmpty(*githubPRSHA, *appPRSHA)
+	if strings.TrimSpace(repo) == "" || number <= 0 || strings.TrimSpace(prURL) == "" {
+		return errors.New("bridge link requires --github-pr-repo, --github-pr-number, and --github-pr-url (or --app-pr-* aliases)")
+	}
+
+	linkMRID := firstNonEmpty(*confighubMRID, *mrID)
+	linkMRURL := firstNonEmpty(*confighubMRURL, *mrURL)
+	linkMRStatus := firstNonEmpty(*confighubMRStatus, *mrStatus)
+	if strings.TrimSpace(linkMRID) == "" || strings.TrimSpace(linkMRURL) == "" {
+		return errors.New("bridge link requires --confighub-mr-id and --confighub-mr-url (or --mr-* aliases)")
+	}
+
+	at, err := parseAt(*atRaw)
+	if err != nil {
+		return err
+	}
+	link, err := bridgeflow.NewReviewLink(resolvedChangeID, bridgeflow.PullRequestRef{
+		Repo:      strings.TrimSpace(repo),
+		Number:    number,
+		URL:       strings.TrimSpace(prURL),
+		CommitSHA: strings.TrimSpace(prSHA),
+	}, bridgeflow.MergeRequestRef{
+		ID:     strings.TrimSpace(linkMRID),
+		URL:    strings.TrimSpace(linkMRURL),
+		Status: strings.TrimSpace(linkMRStatus),
+	}, at)
+	if err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(*baseURL) == "" {
+		return writeJSONOutput(*out, link, *pretty)
+	}
+
+	resolvedToken := strings.TrimSpace(*token)
+	if resolvedToken == "" {
+		resolvedToken = strings.TrimSpace(os.Getenv("CONFIGHUB_TOKEN"))
+	}
+	if resolvedToken == "" {
+		return errors.New("bridge link requires --token or CONFIGHUB_TOKEN when --base-url is set")
+	}
+
+	result, err := bridgeflow.SubmitReviewLink(context.Background(), bridgeflow.LinkClient{
+		BaseURL:      strings.TrimSpace(*baseURL),
+		BearerToken:  resolvedToken,
+		EndpointPath: strings.TrimSpace(*endpoint),
+	}, link)
+	if err != nil {
+		return err
+	}
+	return writeJSONOutput(*out, result, *pretty)
 }
 
 func runBridgeDecision(args []string) error {
@@ -532,6 +630,40 @@ func runBridgePromoteMerge(args []string) error {
 	return writeJSONOutput(*out, updated, *pretty)
 }
 
+func resolveBridgeLinkChangeID(changeID, bundlePath string) (string, error) {
+	if strings.TrimSpace(bundlePath) == "" {
+		if strings.TrimSpace(changeID) == "" {
+			return "", errors.New("bridge link requires --bundle or --change-id")
+		}
+		return strings.TrimSpace(changeID), nil
+	}
+
+	var bundle publish.ChangeBundle
+	if err := readJSONInput(bundlePath, &bundle); err != nil {
+		return "", fmt.Errorf("read bundle json: %w", err)
+	}
+	if err := publish.VerifyBundle(bundle); err != nil {
+		return "", fmt.Errorf("verify bundle before link: %w", err)
+	}
+	bundleChangeID := strings.TrimSpace(bundle.ChangeID)
+	if bundleChangeID == "" {
+		return "", errors.New("bridge link bundle is missing change_id")
+	}
+	if strings.TrimSpace(changeID) != "" && strings.TrimSpace(changeID) != bundleChangeID {
+		return "", fmt.Errorf("bridge link change_id mismatch: --change-id=%s bundle=%s", strings.TrimSpace(changeID), bundleChangeID)
+	}
+	return bundleChangeID, nil
+}
+
+func firstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}
+
 func parseDecisionState(raw string) (bridgeflow.DecisionState, error) {
 	state := strings.ToUpper(strings.TrimSpace(raw))
 	switch state {
@@ -614,6 +746,7 @@ func printBridgeUsage(out io.Writer) {
 			Title: "Usage",
 			Lines: []string{
 				"  cub-gen bridge ingest [--in FILE|-] --base-url URL [--token TOKEN] [--endpoint PATH] [--json] [--pretty]",
+				"  cub-gen bridge link --bundle FILE|- --github-pr-repo REPO --github-pr-number N --github-pr-url URL --confighub-mr-id ID --confighub-mr-url URL [--base-url URL --token TOKEN]",
 				"  cub-gen bridge decision <create|attach|apply|query> [flags]",
 				"  cub-gen bridge promote <init|govern|verify|open|approve|merge> [flags]",
 			},
@@ -622,6 +755,7 @@ func printBridgeUsage(out io.Writer) {
 			Title: "What it's for",
 			Lines: []string{
 				"  ingest      Submit a verified bundle to ConfigHub",
+				"  link        Create/update GitHub PR <-> ConfigHub MR review links",
 				"  decision    Query backend decision state or simulate it offline",
 				"  promote     Track PR<->MR and upstream DRY promotion flows",
 			},
@@ -634,12 +768,14 @@ func printBridgeUsage(out io.Writer) {
 				"  cub-gen bridge decision attach --decision decision.json --attestation attestation.json",
 				"  cub-gen bridge decision apply --decision decision.json --state ALLOW --approved-by platform-admin --reason \"policy checks passed\"",
 				"  cub-gen bridge decision query --base-url https://confighub.example --change-id chg_123",
+				"  cub-gen bridge link --bundle bundle.json --github-pr-repo github.com/confighub/apps --github-pr-number 42 --github-pr-url https://github.com/confighub/apps/pull/42 --confighub-mr-id mr_123 --confighub-mr-url https://confighub.example/mr/123",
 				"  cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123",
 			},
 		},
 		helpSection{
 			Title: "Tips",
 			Lines: []string{
+				"  - bridge link is the single-command PR/MR correlation path",
 				"  - bridge decision query is the authoritative backend lookup path",
 				"  - local decision create|attach|apply commands are for offline contract simulation",
 			},

--- a/cmd/cub-gen/bridge_command_test.go
+++ b/cmd/cub-gen/bridge_command_test.go
@@ -242,6 +242,130 @@ func TestBridgePromoteLifecycleCommands(t *testing.T) {
 	}
 }
 
+func TestBridgeLinkCommandPostsReviewLinkFromBundle(t *testing.T) {
+	setupAliases(t)
+
+	publishOut, publishErr, err := runWithCapturedIO([]string{"publish", "--space", "platform", "helm", "render-target"})
+	if err != nil {
+		t.Fatalf("publish returned error: %v\nstderr=%s", err, publishErr)
+	}
+	if strings.TrimSpace(publishErr) != "" {
+		t.Fatalf("expected empty publish stderr, got %q", publishErr)
+	}
+
+	var bundle publish.ChangeBundle
+	if err := json.Unmarshal([]byte(publishOut), &bundle); err != nil {
+		t.Fatalf("unmarshal bundle: %v\noutput=%s", err, publishOut)
+	}
+
+	var gotPayload bridgeflow.ReviewLink
+	var gotKey string
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/pr-mr-links" {
+			t.Fatalf("unexpected link path: %s", r.URL.Path)
+		}
+		gotKey = r.Header.Get("Idempotency-Key")
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"link_id":"link_123","status":"linked"}`))
+	}))
+	defer srv.Close()
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{
+		"bridge", "link",
+		"--bundle", "-",
+		"--base-url", srv.URL,
+		"--token", "token-123",
+		"--github-pr-repo", "github.com/confighub/app",
+		"--github-pr-number", "42",
+		"--github-pr-url", "https://github.com/confighub/app/pull/42",
+		"--github-pr-sha", "abc123",
+		"--confighub-mr-id", "mr_123",
+		"--confighub-mr-url", "https://hub.confighub.com/mr/123",
+		"--confighub-mr-status", "OPEN",
+	}, publishOut)
+	if err != nil {
+		t.Fatalf("bridge link returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got bridgeflow.LinkResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal bridge link output: %v\noutput=%s", err, out)
+	}
+	if got.ChangeID != bundle.ChangeID {
+		t.Fatalf("expected change_id %q, got %q", bundle.ChangeID, got.ChangeID)
+	}
+	expectedKey := bundle.ChangeID + ":github.com/confighub/app:42:mr_123"
+	if gotKey != expectedKey || got.IdempotencyKey != expectedKey {
+		t.Fatalf("expected idempotency key %q, header=%q output=%q", expectedKey, gotKey, got.IdempotencyKey)
+	}
+	if gotAuth != "Bearer token-123" {
+		t.Fatalf("expected bearer auth, got %q", gotAuth)
+	}
+	if gotPayload.ChangeID != bundle.ChangeID {
+		t.Fatalf("expected payload change_id %q, got %q", bundle.ChangeID, gotPayload.ChangeID)
+	}
+	if got.LinkID != "link_123" || got.Status != "linked" || got.ReviewLink.GitPR.Number != 42 {
+		t.Fatalf("unexpected link result: %+v", got)
+	}
+}
+
+func TestBridgeLinkCommandLocalReviewLink(t *testing.T) {
+	out, stderr, err := runWithCapturedIO([]string{
+		"bridge", "link",
+		"--change-id", "chg_123",
+		"--app-pr-repo", "github.com/confighub/app",
+		"--app-pr-number", "42",
+		"--app-pr-url", "https://github.com/confighub/app/pull/42",
+		"--mr-id", "mr_123",
+		"--mr-url", "https://hub.confighub.com/mr/123",
+	})
+	if err != nil {
+		t.Fatalf("bridge link local returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var got bridgeflow.ReviewLink
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal local review link: %v\noutput=%s", err, out)
+	}
+	if got.ChangeID != "chg_123" || got.GitPR.Repo != "github.com/confighub/app" || got.ConfigHubMR.ID != "mr_123" {
+		t.Fatalf("unexpected local review link: %+v", got)
+	}
+}
+
+func TestBridgeLinkCommandRequiresTokenForRemote(t *testing.T) {
+	t.Setenv("CONFIGHUB_TOKEN", "")
+	_, stderr, err := runWithCapturedIO([]string{
+		"bridge", "link",
+		"--change-id", "chg_123",
+		"--base-url", "https://hub.confighub.test",
+		"--github-pr-repo", "github.com/confighub/app",
+		"--github-pr-number", "42",
+		"--github-pr-url", "https://github.com/confighub/app/pull/42",
+		"--confighub-mr-id", "mr_123",
+		"--confighub-mr-url", "https://hub.confighub.com/mr/123",
+	})
+	if err == nil {
+		t.Fatal("expected missing token error")
+	}
+	if !strings.Contains(err.Error(), "requires --token or CONFIGHUB_TOKEN") {
+		t.Fatalf("expected missing token error, got %v stderr=%s", err, stderr)
+	}
+}
+
 func TestBridgeDecisionQueryCommand(t *testing.T) {
 	record := bridgeflow.DecisionRecord{
 		SchemaVersion:     "cub.confighub.io/governed-decision-state/v1",

--- a/cmd/cub-gen/testdata/parity/bridge-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/bridge-help.stdout.golden.txt
@@ -5,11 +5,13 @@ Most users should start with demo-connected.sh or run-connected-smoke.sh first.
 
 Usage:
   cub-gen bridge ingest [--in FILE|-] --base-url URL [--token TOKEN] [--endpoint PATH] [--json] [--pretty]
+  cub-gen bridge link --bundle FILE|- --github-pr-repo REPO --github-pr-number N --github-pr-url URL --confighub-mr-id ID --confighub-mr-url URL [--base-url URL --token TOKEN]
   cub-gen bridge decision <create|attach|apply|query> [flags]
   cub-gen bridge promote <init|govern|verify|open|approve|merge> [flags]
 
 What it's for:
   ingest      Submit a verified bundle to ConfigHub
+  link        Create/update GitHub PR <-> ConfigHub MR review links
   decision    Query backend decision state or simulate it offline
   promote     Track PR<->MR and upstream DRY promotion flows
 
@@ -19,8 +21,10 @@ Examples:
   cub-gen bridge decision attach --decision decision.json --attestation attestation.json
   cub-gen bridge decision apply --decision decision.json --state ALLOW --approved-by platform-admin --reason "policy checks passed"
   cub-gen bridge decision query --base-url https://confighub.example --change-id chg_123
+  cub-gen bridge link --bundle bundle.json --github-pr-repo github.com/confighub/apps --github-pr-number 42 --github-pr-url https://github.com/confighub/apps/pull/42 --confighub-mr-id mr_123 --confighub-mr-url https://confighub.example/mr/123
   cub-gen bridge promote init --change-id chg_123 --app-pr-repo github.com/confighub/apps --app-pr-number 42 --app-pr-url https://github.com/confighub/apps/pull/42 --mr-id mr_123 --mr-url https://confighub.example/mr/123
 
 Tips:
+  - bridge link is the single-command PR/MR correlation path
   - bridge decision query is the authoritative backend lookup path
   - local decision create|attach|apply commands are for offline contract simulation

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -313,6 +313,27 @@ cub-gen bridge decision attach --decision <decision.json> --attestation <attesta
 cub-gen bridge decision apply --decision <decision.json> --state ALLOW --approved-by <who> --reason <why>
 ```
 
+### `bridge link`
+
+One-command GitHub PR to ConfigHub MR correlation. It derives `change_id` from a
+`cub-gen publish` bundle, builds the canonical review-link record, and can POST
+it to ConfigHub with an idempotency key.
+
+```bash
+cub-gen bridge link \
+  --bundle bundle.json \
+  --github-pr-repo github.com/confighub/apps \
+  --github-pr-number 42 \
+  --github-pr-url https://github.com/confighub/apps/pull/42 \
+  --confighub-mr-id mr_123 \
+  --confighub-mr-url https://confighub.example/mr/123 \
+  --base-url https://confighub.example \
+  --token "$CONFIGHUB_TOKEN"
+```
+
+Omit `--base-url` when you only want the local review-link JSON for a PR body,
+status payload, or changeset label set.
+
 ### `bridge promote`
 
 Promotion guardrail flow (app PR -> CH MR -> platform DRY PR).
@@ -667,6 +688,17 @@ connected path.
 # 4) Query decision state by change_id
 ./cub-gen bridge decision query --base-url https://confighub.example \
   --change-id "$(jq -r .change_id decision-allow.json)"
+
+# 5) Link the GitHub PR and ConfigHub MR with the same change_id
+./cub-gen bridge link \
+  --bundle bundle.json \
+  --github-pr-repo github.com/confighub/apps \
+  --github-pr-number 42 \
+  --github-pr-url https://github.com/confighub/apps/pull/42 \
+  --confighub-mr-id "$(jq -r .artifact_id ingest-result.json)" \
+  --confighub-mr-url https://confighub.example/mr/123 \
+  --base-url https://confighub.example \
+  --token "$CONFIGHUB_TOKEN"
 ```
 
 ### Promotion guardrail flow

--- a/docs/contracts/pr-mr-linkage-and-dry-promotion.md
+++ b/docs/contracts/pr-mr-linkage-and-dry-promotion.md
@@ -43,4 +43,5 @@ Blocked by contract:
 ## Implementation anchors
 
 1. Correlation + promotion state machine: `internal/bridge/workflow.go`
-2. Gate tests and happy-path proof: `internal/bridge/workflow_test.go`
+2. One-command PR/MR linkage CLI: `cub-gen bridge link`
+3. Gate tests and happy-path proof: `internal/bridge/workflow_test.go`

--- a/examples/demo/flow-a-git-pr-to-mr-connected.sh
+++ b/examples/demo/flow-a-git-pr-to-mr-connected.sh
@@ -181,41 +181,54 @@ if [ -n "$PR_NUMBER" ]; then
   fi
 fi
 
-jq -n \
-  --arg schema "cub.confighub.io/pr-mr-promotion-flow/v1" \
-  --arg change_id "$change_id" \
-  --arg git_repo "$GIT_REPO" \
-  --arg git_pr_number "${PR_NUMBER:-}" \
-  --arg git_pr_url "$pr_url" \
-  --arg git_pr_state "$pr_state" \
-  --arg confighub_mr_id "$artifact_id" \
-  --arg confighub_mr_status "$ingest_status" \
-  --arg decision_state "$decision_state" \
-  --arg policy_ref "$policy_ref" \
-  --arg flow "A" \
-  --arg flow_direction "git-pr-to-confighub-mr" \
-  --arg updated_at "$now" \
-  '{
-    schema: $schema,
-    change_id: $change_id,
-    flow: $flow,
-    flow_direction: $flow_direction,
-    git_pr: {
-      repo: $git_repo,
-      number: (if $git_pr_number == "" then null else ($git_pr_number | tonumber) end),
-      url: (if $git_pr_url == "" then null else $git_pr_url end),
-      state: (if $git_pr_state == "" then null else $git_pr_state end)
-    },
-    confighub_mr: {
-      id: $confighub_mr_id,
-      status: $confighub_mr_status
-    },
-    decision: {
-      state: $decision_state,
-      policy_ref: (if $policy_ref == "" then null else $policy_ref end)
-    },
-    updated_at: $updated_at
-  }' > "$OUT_DIR/pr-mr-linkage.json"
+if [ -n "$PR_NUMBER" ] && [ -n "$pr_url" ]; then
+  ./cub-gen bridge link \
+    --bundle "$OUT_DIR/bundle.json" \
+    --app-pr-repo "$GIT_REPO" \
+    --app-pr-number "$PR_NUMBER" \
+    --app-pr-url "$pr_url" \
+    --mr-id "$artifact_id" \
+    --mr-url "${CONFIGHUB_BASE_URL%/}/changes/${change_id}" \
+    --mr-status "$ingest_status" \
+    --at "$now" \
+    > "$OUT_DIR/pr-mr-linkage.json"
+else
+  jq -n \
+    --arg schema "cub.confighub.io/pr-mr-promotion-flow/v1" \
+    --arg change_id "$change_id" \
+    --arg git_repo "$GIT_REPO" \
+    --arg git_pr_number "${PR_NUMBER:-}" \
+    --arg git_pr_url "$pr_url" \
+    --arg git_pr_state "$pr_state" \
+    --arg confighub_mr_id "$artifact_id" \
+    --arg confighub_mr_status "$ingest_status" \
+    --arg decision_state "$decision_state" \
+    --arg policy_ref "$policy_ref" \
+    --arg flow "A" \
+    --arg flow_direction "git-pr-to-confighub-mr" \
+    --arg updated_at "$now" \
+    '{
+      schema: $schema,
+      change_id: $change_id,
+      flow: $flow,
+      flow_direction: $flow_direction,
+      git_pr: {
+        repo: $git_repo,
+        number: (if $git_pr_number == "" then null else ($git_pr_number | tonumber) end),
+        url: (if $git_pr_url == "" then null else $git_pr_url end),
+        state: (if $git_pr_state == "" then null else $git_pr_state end)
+      },
+      confighub_mr: {
+        id: $confighub_mr_id,
+        status: $confighub_mr_status
+      },
+      decision: {
+        state: $decision_state,
+        policy_ref: (if $policy_ref == "" then null else $policy_ref end)
+      },
+      updated_at: $updated_at
+    }' > "$OUT_DIR/pr-mr-linkage.json"
+fi
 
 # Step 6: Create ConfigHub changeset for audit trail
 echo "[flow-a][step-6] record linkage in ConfigHub changeset"

--- a/internal/bridge/link.go
+++ b/internal/bridge/link.go
@@ -1,0 +1,157 @@
+package bridge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const defaultReviewLinkPath = "/api/v1/pr-mr-links"
+
+// LinkClient holds bridge API connection settings for PR/MR review links.
+type LinkClient struct {
+	BaseURL      string
+	BearerToken  string
+	EndpointPath string
+	HTTPClient   *http.Client
+}
+
+// LinkResult captures ConfigHub review-link create/update response metadata.
+type LinkResult struct {
+	StatusCode     int        `json:"status_code"`
+	LinkID         string     `json:"link_id,omitempty"`
+	Status         string     `json:"status,omitempty"`
+	Idempotent     bool       `json:"idempotent"`
+	ChangeID       string     `json:"change_id"`
+	IdempotencyKey string     `json:"idempotency_key"`
+	ReviewLink     ReviewLink `json:"review_link"`
+}
+
+type linkAPIResponse struct {
+	LinkID  string `json:"link_id,omitempty"`
+	Status  string `json:"status,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func ReviewLinkIdempotencyKey(link ReviewLink) string {
+	return strings.Join([]string{
+		strings.TrimSpace(link.ChangeID),
+		strings.TrimSpace(link.GitPR.Repo),
+		strconv.Itoa(link.GitPR.Number),
+		strings.TrimSpace(link.ConfigHubMR.ID),
+	}, ":")
+}
+
+// SubmitReviewLink creates or updates the ConfigHub-side PR/MR linkage record.
+// HTTP 409 is treated as idempotent success.
+func SubmitReviewLink(ctx context.Context, client LinkClient, link ReviewLink) (LinkResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ValidateReviewLink(link); err != nil {
+		return LinkResult{}, err
+	}
+
+	endpoint, err := resolveReviewLinkEndpoint(client)
+	if err != nil {
+		return LinkResult{}, err
+	}
+
+	body, err := json.Marshal(link)
+	if err != nil {
+		return LinkResult{}, fmt.Errorf("marshal review link: %w", err)
+	}
+
+	idempotencyKey := ReviewLinkIdempotencyKey(link)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return LinkResult{}, fmt.Errorf("build review-link request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", idempotencyKey)
+	if token := strings.TrimSpace(client.BearerToken); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	httpClient := client.HTTPClient
+	if httpClient == nil {
+		httpClient = defaultHTTPClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return LinkResult{}, fmt.Errorf("send review-link request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return LinkResult{}, fmt.Errorf("read review-link response: %w", err)
+	}
+
+	var decoded linkAPIResponse
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusConflict {
+		if len(bytes.TrimSpace(respBody)) > 0 {
+			if err := json.Unmarshal(respBody, &decoded); err != nil {
+				return LinkResult{}, fmt.Errorf("decode review-link response: %w", err)
+			}
+		}
+	}
+
+	result := LinkResult{
+		StatusCode:     resp.StatusCode,
+		LinkID:         strings.TrimSpace(decoded.LinkID),
+		Status:         strings.TrimSpace(decoded.Status),
+		Idempotent:     resp.StatusCode == http.StatusConflict,
+		ChangeID:       link.ChangeID,
+		IdempotencyKey: idempotencyKey,
+		ReviewLink:     link,
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusAccepted:
+		if result.Status == "" {
+			result.Status = "linked"
+		}
+		return result, nil
+	case http.StatusConflict:
+		if result.Status == "" {
+			result.Status = "exists"
+		}
+		return result, nil
+	case http.StatusNotFound:
+		return LinkResult{}, fmt.Errorf("bridge link endpoint is not available: status=404; set --endpoint if your ConfigHub backend uses a different path")
+	default:
+		msg := strings.TrimSpace(string(respBody))
+		if msg == "" {
+			msg = "<empty>"
+		}
+		return LinkResult{}, fmt.Errorf("bridge link failed: status=%d body=%s", resp.StatusCode, msg)
+	}
+}
+
+func resolveReviewLinkEndpoint(client LinkClient) (string, error) {
+	base := strings.TrimSpace(client.BaseURL)
+	if base == "" {
+		return "", fmt.Errorf("bridge link base URL is required")
+	}
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse bridge link base URL: %w", err)
+	}
+	path := strings.TrimSpace(client.EndpointPath)
+	if path == "" {
+		path = defaultReviewLinkPath
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	parsed.Path = strings.TrimSuffix(parsed.Path, "/") + path
+	return parsed.String(), nil
+}

--- a/internal/bridge/link_test.go
+++ b/internal/bridge/link_test.go
@@ -1,0 +1,125 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSubmitReviewLinkCreated(t *testing.T) {
+	link := sampleReviewLink(t)
+	var gotPayload ReviewLink
+	var gotKey string
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != defaultReviewLinkPath {
+			t.Fatalf("expected path %s, got %s", defaultReviewLinkPath, r.URL.Path)
+		}
+		gotKey = r.Header.Get("Idempotency-Key")
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"link_id":"link_123","status":"linked"}`))
+	}))
+	defer srv.Close()
+
+	res, err := SubmitReviewLink(context.Background(), LinkClient{
+		BaseURL:     srv.URL,
+		BearerToken: "token-123",
+	}, link)
+	if err != nil {
+		t.Fatalf("SubmitReviewLink returned error: %v", err)
+	}
+
+	expectedKey := ReviewLinkIdempotencyKey(link)
+	if gotKey != expectedKey {
+		t.Fatalf("expected idempotency key %q, got %q", expectedKey, gotKey)
+	}
+	if gotAuth != "Bearer token-123" {
+		t.Fatalf("expected bearer auth header, got %q", gotAuth)
+	}
+	if gotPayload.ChangeID != link.ChangeID {
+		t.Fatalf("expected payload change_id %q, got %q", link.ChangeID, gotPayload.ChangeID)
+	}
+	if gotPayload.GitPR.Number != link.GitPR.Number {
+		t.Fatalf("expected PR number %d, got %d", link.GitPR.Number, gotPayload.GitPR.Number)
+	}
+	if res.StatusCode != http.StatusCreated || res.LinkID != "link_123" || res.Status != "linked" || res.Idempotent {
+		t.Fatalf("unexpected link result: %+v", res)
+	}
+	if res.ChangeID != link.ChangeID || res.IdempotencyKey != expectedKey {
+		t.Fatalf("unexpected link identity: %+v", res)
+	}
+}
+
+func TestSubmitReviewLinkConflictIsIdempotent(t *testing.T) {
+	link := sampleReviewLink(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"link_id":"link_123","status":"exists"}`))
+	}))
+	defer srv.Close()
+
+	res, err := SubmitReviewLink(context.Background(), LinkClient{BaseURL: srv.URL}, link)
+	if err != nil {
+		t.Fatalf("SubmitReviewLink returned error: %v", err)
+	}
+	if !res.Idempotent {
+		t.Fatalf("expected idempotent conflict result, got %+v", res)
+	}
+	if res.Status != "exists" {
+		t.Fatalf("expected exists status, got %+v", res)
+	}
+}
+
+func TestSubmitReviewLinkNotFoundIsActionable(t *testing.T) {
+	link := sampleReviewLink(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	}))
+	defer srv.Close()
+
+	_, err := SubmitReviewLink(context.Background(), LinkClient{BaseURL: srv.URL}, link)
+	if err == nil {
+		t.Fatal("expected 404 to fail")
+	}
+	if !strings.Contains(err.Error(), "bridge link endpoint is not available") {
+		t.Fatalf("expected actionable 404 error, got %q", err.Error())
+	}
+}
+
+func sampleReviewLink(t *testing.T) ReviewLink {
+	t.Helper()
+	link, err := NewReviewLink(
+		"chg_123",
+		PullRequestRef{
+			Repo:      "github.com/confighub/app",
+			Number:    42,
+			URL:       "https://github.com/confighub/app/pull/42",
+			CommitSHA: "abc123",
+		},
+		MergeRequestRef{
+			ID:     "mr_123",
+			URL:    "https://hub.confighub.com/mr/123",
+			Status: "OPEN",
+		},
+		time.Date(2026, 5, 1, 7, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("NewReviewLink returned error: %v", err)
+	}
+	return link
+}


### PR DESCRIPTION
## Summary

Adds `cub-gen bridge link` as the productized PR/MR correlation path for issue #282. The command derives `change_id` from a verified publish bundle, builds the canonical `ReviewLink`, and either emits local evidence or POSTs to ConfigHub with a deterministic idempotency key.

## What changed

- Added `internal/bridge` review-link client support with idempotent POST handling and actionable endpoint errors.
- Added CLI flags for GitHub PR refs, ConfigHub MR refs, local JSON output, and remote submission.
- Updated bridge help goldens, CLI docs, and the Flow A connected demo to use `bridge link` when PR context is available.

## Validation

- `go test ./cmd/cub-gen -run '^(TestBridge.*|TestTopLevelCommandGoldenHelp|TestTopLevelCommandErrorModes)$' -count=1 -v`
- `make ci`
- `python3 -m venv .tmp/docs-venv && .tmp/docs-venv/bin/python -m pip install -q -r docs/requirements.txt && .tmp/docs-venv/bin/mkdocs build --strict`

Closes #282