### PR TITLE
Sync v0.4 roadmap after bridge linkage

### DIFF
--- a/docs/plans/2026-04-30-platform-generator-product-worklist.md
+++ b/docs/plans/2026-04-30-platform-generator-product-worklist.md
@@ -1,7 +1,7 @@
 # Platform Generator Product Worklist
 
-Status: issues created
-Date: 2026-04-30
+Status: issues sequenced; first product slices landed
+Date: 2026-05-01
 
 This worklist turns the platform-generator manifesto into product work. It
 combines the current open roadmap items with the gaps exposed by the
@@ -13,13 +13,15 @@ and GitHub parent issue [#287](https://github.com/confighub/cub-gen/issues/287).
 
 ## Current Open Roadmap Touchpoints
 
-Open issues checked on 2026-04-30:
+Open issues checked on 2026-05-01:
 
 | Issue | Title | Why it matters for the manifesto |
 |---|---|---|
-| [#275](https://github.com/confighub/cub-gen/issues/275) | bridge ingest 404 against hub.confighub.com | connected proof must work before PR/MR magic feels real |
+| [#287](https://github.com/confighub/cub-gen/issues/287) | make cub-gen role and value obvious | parent roadmap issue keeping the product story coherent |
+| [#283](https://github.com/confighub/cub-gen/issues/283) | enforce generator route metadata server-side | route ownership must become an authoritative backend decision |
+| [#281](https://github.com/confighub/cub-gen/issues/281) | propose governed config rewrites | import should lead to reviewable improvements, not magic rewrites |
+| [#277](https://github.com/confighub/cub-gen/issues/277) | OpenChoreo adapter | external platform-family proof needs upstream conformance |
 | [#236](https://github.com/confighub/cub-gen/issues/236) | ship cub-gen as `cub gen` plugin | product workflow should feel like one platform, not a sidecar binary |
-| [#219](https://github.com/confighub/cub-gen/issues/219) | bridge worker disconnected despite heartbeats | live/connected trust depends on correct runtime status |
 | [#213](https://github.com/confighub/cub-gen/issues/213) | GUI provenance trace | click-field-to-source is the core teaching moment |
 | [#212](https://github.com/confighub/cub-gen/issues/212) | GUI regeneration/refresh preview | users need to see generated impact before merge/apply |
 | [#211](https://github.com/confighub/cub-gen/issues/211) | GUI mutation history/activity log | overlay, lift, and block decisions need visible history |
@@ -276,6 +278,11 @@ Definition of done:
 Problem: PR/MR linkage exists as contracts, bridge promote commands, and demo
 scripts, but not as one easy product workflow.
 
+Status: landed in PR #297 via `cub-gen bridge link`. The command derives
+`change_id` from a verified publish bundle, emits canonical review-link JSON for
+local evidence, and can POST the linkage record to ConfigHub with a deterministic
+idempotency key.
+
 Deterministic success criteria:
 
 1. Given a GitHub PR and a `cub-gen publish` bundle, one command creates or
@@ -333,6 +340,11 @@ Definition of done:
 
 Problem: Jesper-style skepticism is evidence that the thesis needs teaching
 artifacts, not only commands.
+
+Status: landed in PR #296. The teaching pack now has conservative
+OpenChoreo-support language, stricter docs checks, and fixture-backed diagrams
+and examples. The `spring-platform` teaching repo was aligned in
+`confighub/examples` PR #138.
 
 Deterministic success criteria:
 

--- a/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
+++ b/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
@@ -1,7 +1,7 @@
 # v0.4 Working Roadmap: Component -> Deployable Variant -> Proof
 
-Status: post-PR #286 roadmap; OpenChoreo, app-of-apps, platform graph, fanout, and enrichment slices landed on main
-Date: 2026-04-30
+Status: post-PR #297 roadmap; connected trust, PR/MR linkage, teaching QA, OpenChoreo, app-of-apps, platform graph, fanout, and enrichment slices landed on main
+Date: 2026-05-01
 GitHub milestone: [v0.4: Component -> Deployable Variant -> Proof](https://github.com/confighub/cub-gen/milestone/4)
 GitHub parent issue: [#287](https://github.com/confighub/cub-gen/issues/287)
 
@@ -18,7 +18,11 @@ adapter, `gitops discover --adoption-report`, OpenChoreo field-route proof, a
 fixture-backed app-of-apps adapter, a read-only multi-repo platform-estate
 import graph, manifest-driven variant fanout for Helm/Score/Spring, enrichment
 sidecars, and golden parity coverage. It is not yet full upstream OpenChoreo
-conformance or implicit/glob-based variant discovery.
+conformance or implicit/glob-based variant discovery. PRs #294, #295, and #297
+then tightened the connected bridge path, Spring worker readiness proof, and
+one-command GitHub PR to ConfigHub MR linkage. PR #296 finished the platform
+teaching pack QA; `confighub/examples` PR #138 aligned the older
+`spring-platform` teaching repo with the productized `springboot-paas` path.
 
 ## Product Promise
 
@@ -67,8 +71,8 @@ This is first because the product cannot win if people cannot explain it.
 Subtasks:
 
 - [x] [#286](https://github.com/confighub/cub-gen/pull/286) Add platform generator doctrine
-- [ ] [#284](https://github.com/confighub/cub-gen/issues/284) Finish platform generator teaching-pack QA
-- [ ] [#285](https://github.com/confighub/cub-gen/issues/285) Align spring-platform teaching docs with springboot-paas product path
+- [x] [#284](https://github.com/confighub/cub-gen/issues/284) Finish platform generator teaching-pack QA
+- [x] [#285](https://github.com/confighub/cub-gen/issues/285) Align spring-platform teaching docs with springboot-paas product path
 - [x] [#288](https://github.com/confighub/cub-gen/issues/288) Make README OpenChoreo claims honest and explicit
 - [x] [#289](https://github.com/confighub/cub-gen/issues/289) Add an OpenChoreo-shaped field trace example
 
@@ -83,10 +87,13 @@ leans hard on connected PR/MR and backend-governance proof.
 
 Subtasks:
 
-- [ ] [#275](https://github.com/confighub/cub-gen/issues/275) Fix or preflight the connected bridge ingest default path
-- [ ] [#219](https://github.com/confighub/cub-gen/issues/219) Fix stale worker disconnected status despite heartbeats
+- [x] [#275](https://github.com/confighub/cub-gen/issues/275) Fix or preflight the connected bridge ingest default path
+- [x] [#219](https://github.com/confighub/cub-gen/issues/219) Fix stale worker disconnected status despite heartbeats
 
-Done means the connected story does not create a bad first impression.
+Done means the connected story does not create a bad first impression. The
+current implementation now fails fast before deep bundle work when bridge ingest
+is unavailable, and Spring worker installation reports stale ConfigHub
+`Disconnected` state even when local heartbeats are alive.
 
 ### Phase 2: Build The Component/Variant Spine
 
@@ -174,7 +181,7 @@ This work converts proof into decisions and product workflows.
 
 Subtasks:
 
-- [ ] [#282](https://github.com/confighub/cub-gen/issues/282) Productize GitHub PR to ConfigHub MR linkage
+- [x] [#282](https://github.com/confighub/cub-gen/issues/282) Productize GitHub PR to ConfigHub MR linkage
 - [ ] [#283](https://github.com/confighub/cub-gen/issues/283) Enforce generator route metadata server-side
 - [ ] [#281](https://github.com/confighub/cub-gen/issues/281) Propose governed config rewrites
 - [ ] [#212](https://github.com/confighub/cub-gen/issues/212) GUI regeneration/refresh preview
@@ -190,6 +197,12 @@ Likely sequence:
 
 Done means changes can be routed as apply-here, lift-upstream, or block/escalate
 without asking users to reason through implementation layers.
+
+Current state: `cub-gen bridge link` is now the single-command PR/MR
+correlation path. It derives `change_id` from a verified publish bundle, emits
+canonical local evidence, and can POST the link to ConfigHub with a deterministic
+idempotency key. Server-side route enforcement and rewrite proposals remain the
+core open governance work.
 
 ### Phase 6: Product Integration
 


### PR DESCRIPTION
## Summary

Updates the v0.4 roadmap and platform-generator worklist after the latest merged product slices.

## What changed

- Marks connected ingest preflight, Spring worker readiness, teaching-pack QA, spring-platform alignment, and PR/MR linkage as landed.
- Updates the open roadmap touchpoints so the remaining work is clear: #283, #281, #277, #236, and GUI proof/product surfaces.
- Records `cub-gen bridge link` as the landed PG-07 implementation.

## Validation

- `git diff --check`
- `./test/checks/check-docs-entrypoints.sh && ./test/checks/check-platform-teaching-pack.sh`
- `python3 -m venv .tmp/docs-venv && .tmp/docs-venv/bin/python -m pip install -q -r docs/requirements.txt && .tmp/docs-venv/bin/mkdocs build --strict`