### PR TITLE
[codex] Add normalize preview proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,17 @@ To make proof visible in a pull request without editing app manifests:
 under `.cub-gen/enrichment/` and refuses to overwrite existing artifacts; a
 conflict becomes `review-required`.
 
+To propose governed cleanups without touching source or rendered YAML:
+
+```bash
+./cub-gen normalize preview --space platform --patch ./examples/springboot-paas
+```
+
+`normalize preview` emits review-only sidecar proposals under
+`.cub-gen/normalize/`. In the Spring example it proposes route policy
+annotations, lift-upstream source routing, dev/stage/prod Deployable Variants,
+owner annotations, and an explicit datasource SecretReference candidate.
+
 ## Core capabilities
 
 | Capability | Plain English |
@@ -190,6 +201,7 @@ conflict becomes `review-required`.
 | Trace | Map rendered fields back to source files |
 | Explain | Say who owns the field and where to edit it |
 | Enrich | Create PR-friendly sidecar proof with source links, owners, route badges, and PR/MR link metadata |
+| Normalize | Propose reviewable cleanups when platform rules, owners, variants, or secret wiring are implicit |
 | Prove | Produce a reviewable bundle for local review, GitHub PRs, or ConfigHub |
 
 ## First runs

--- a/cmd/cub-gen/command_surface_parity_test.go
+++ b/cmd/cub-gen/command_surface_parity_test.go
@@ -49,6 +49,11 @@ func TestTopLevelCommandGoldenHelp(t *testing.T) {
 			stdoutGolden: filepath.Join("testdata", "parity", "enrich-help.stdout.golden.txt"),
 		},
 		{
+			name:         "normalize-help",
+			args:         []string{"normalize", "--help"},
+			stdoutGolden: filepath.Join("testdata", "parity", "normalize-help.stdout.golden.txt"),
+		},
+		{
 			name:         "platform-help",
 			args:         []string{"platform", "--help"},
 			stdoutGolden: filepath.Join("testdata", "parity", "platform-help.stdout.golden.txt"),
@@ -121,6 +126,11 @@ func TestTopLevelCommandErrorModes(t *testing.T) {
 			name: "enrich-missing-subcommand",
 			args: []string{"enrich"},
 			sub:  "enrich subcommand required",
+		},
+		{
+			name: "normalize-missing-subcommand",
+			args: []string{"normalize"},
+			sub:  "normalize subcommand required",
 		},
 		{
 			name: "platform-missing-subcommand",

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -51,6 +51,8 @@ func run(args []string) error {
 		return runChange(args[1:])
 	case "enrich":
 		return runEnrich(args[1:])
+	case "normalize":
+		return runNormalize(args[1:])
 	case "generators":
 		return runGenerators(args[1:])
 	case "gitops":
@@ -1043,6 +1045,7 @@ func printUsage(out io.Writer) {
 				"  change impact     See which rendered fields a DRY path can affect",
 				"  change preview    Preview a safe repo change",
 				"  enrich preview    Propose sidecar proof metadata for PR review",
+				"  normalize preview  Propose governed rewrite patches for review",
 				"  platform import   Read a multi-repo platform estate as a graph",
 				"  platform fanout   Emit one proof bundle per deployable variant",
 				"  detect            Detect generators in a repo",
@@ -1072,6 +1075,7 @@ func printUsage(out io.Writer) {
 				"  cub-gen platform fanout --variant dev --json ./testdata/variant-fanout/platform.yaml",
 				"  cub-gen change explain --space my-space --owner app-team ./examples/scoredev-paas",
 				"  cub-gen enrich preview --space my-space ./examples/helm-paas",
+				"  cub-gen normalize preview --space my-space ./examples/springboot-paas",
 				"  cub-gen publish --space my-space ./examples/helm-paas | cub-gen verify --in -",
 				"  cub-gen publish --space my-space ./examples/helm-paas | cub-gen attest --in - --verifier ci-bot",
 			},

--- a/cmd/cub-gen/normalize.go
+++ b/cmd/cub-gen/normalize.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
+	"github.com/confighub/cub-gen/internal/importer"
+	"github.com/confighub/cub-gen/internal/model"
+	normalizeflow "github.com/confighub/cub-gen/internal/normalize"
+)
+
+func runNormalize(args []string) error {
+	if len(args) == 0 {
+		printNormalizeUsage(os.Stderr)
+		return errors.New("normalize subcommand required")
+	}
+
+	switch args[0] {
+	case "help", "-h", "--help":
+		printNormalizeUsage(os.Stdout)
+		return nil
+	case "preview":
+		return runNormalizePreview(args[1:])
+	default:
+		printNormalizeUsage(os.Stderr)
+		return fmt.Errorf("unknown normalize subcommand: %s", args[0])
+	}
+}
+
+func runNormalizePreview(args []string) error {
+	fs := flag.NewFlagSet("normalize preview", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	space := fs.String("space", "default", "ConfigHub space label")
+	ref := fs.String("ref", "HEAD", "Git ref label to include in output")
+	whereResource := fs.String("where-resource", "", "Additional resource filter expression")
+	out := fs.String("out", "-", "Output file path, or '-' for stdout")
+	jsonOut := fs.Bool("json", true, "Output JSON")
+	patchOut := fs.Bool("patch", false, "Output a unified diff for proposed normalize sidecar files")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	overrideFlags := addHelmCLIOverrideFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if *patchOut {
+		*jsonOut = false
+	}
+	if !*jsonOut && !*patchOut {
+		return errors.New("cub-gen normalize preview requires --json or --patch")
+	}
+	helmCLIOverrides, err := overrideFlags.parse()
+	if err != nil {
+		return err
+	}
+	targetSlug, renderTargetSlug, err := resolveTargetPairArgs(fs, "usage: cub-gen normalize preview [flags] <target-path> [<render-target-path>]")
+	if err != nil {
+		return err
+	}
+
+	plan, err := buildNormalizePlan(targetSlug, renderTargetSlug, normalizeOptions{
+		Space:            *space,
+		Ref:              *ref,
+		WhereResource:    *whereResource,
+		HelmCLIOverrides: helmCLIOverrides,
+	})
+	if err != nil {
+		return err
+	}
+	if *patchOut {
+		patch, err := normalizeflow.RenderPatch(plan)
+		if err != nil {
+			return err
+		}
+		return writeTextOutput(*out, patch)
+	}
+	return writeJSONOutput(*out, plan, *pretty)
+}
+
+type normalizeOptions struct {
+	Space            string
+	Ref              string
+	WhereResource    string
+	HelmCLIOverrides []model.HelmCLIOverride
+}
+
+func buildNormalizePlan(targetSlug, renderTargetSlug string, opts normalizeOptions) (normalizeflow.Plan, error) {
+	imported, err := gitopsflow.ImportWithOptions(targetSlug, renderTargetSlug, opts.Ref, opts.Space, opts.WhereResource, importer.ImportOptions{
+		HelmCLIOverrides: opts.HelmCLIOverrides,
+	})
+	if err != nil {
+		return normalizeflow.Plan{}, err
+	}
+	return normalizeflow.BuildPlan(imported)
+}
+
+func printNormalizeUsage(out io.Writer) {
+	printCommandHelp(
+		out,
+		"cub-gen normalize: propose governed config rewrites without applying them",
+		[]string{
+			"Use normalize when a repo renders correctly but the review/governance shape is still too implicit.",
+			"Preview is read-only. It creates a reviewable patch set for sidecar proposals, not direct app or platform mutations.",
+		},
+		helpSection{
+			Title: "Usage",
+			Lines: []string{
+				"  cub-gen normalize preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--json|--patch] [--out FILE|-] [--pretty] <target-path> [<render-target-path>]",
+			},
+		},
+		helpSection{
+			Title: "Examples",
+			Lines: []string{
+				"  cub-gen normalize preview --space platform ./examples/springboot-paas",
+				"  cub-gen normalize preview --patch --space platform ./examples/springboot-paas",
+			},
+		},
+		helpSection{
+			Title: "Transforms",
+			Lines: []string{
+				"  - add-route-policy-annotation: turn field-route metadata into ConfigHub Unit route policy annotations",
+				"  - lift-generated-patch-to-source: show where rendered edits should become source PRs",
+				"  - split-env-values-into-variants: expose environment/profile files as Deployable Variants",
+				"  - add-missing-owners: propose owner labels from generator provenance",
+				"  - replace-implicit-secret-wiring: propose explicit SecretReference records for literal secret-shaped env values",
+			},
+		},
+	)
+}

--- a/cmd/cub-gen/normalize_command_test.go
+++ b/cmd/cub-gen/normalize_command_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	normalizeflow "github.com/confighub/cub-gen/internal/normalize"
+)
+
+func TestNormalizePreviewSpringJSON(t *testing.T) {
+	setupAliases(t)
+
+	stdout, stderr, err := runWithCapturedIO([]string{"normalize", "preview", "--space", "platform", "--json", "spring"})
+	if err != nil {
+		t.Fatalf("normalize preview failed: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got: %s", stderr)
+	}
+	var plan normalizeflow.Plan
+	if err := json.Unmarshal([]byte(stdout), &plan); err != nil {
+		t.Fatalf("parse normalize json: %v\n%s", err, stdout)
+	}
+	if plan.Summary.ProposalCount != 5 || plan.Summary.TransformCount != 5 {
+		t.Fatalf("unexpected normalize summary: %+v", plan.Summary)
+	}
+	if got := plan.PatchSet.Proposals[0].Transform; got != normalizeflow.TransformRoutePolicy {
+		t.Fatalf("expected route policy first, got %q", got)
+	}
+}
+
+func TestNormalizePreviewSpringPatchGolden(t *testing.T) {
+	setupAliases(t)
+
+	stdout, stderr, err := runWithCapturedIO([]string{"normalize", "preview", "--space", "platform", "--patch", "spring"})
+	if err != nil {
+		t.Fatalf("normalize preview --patch failed: %v\nstderr=%s", err, stderr)
+	}
+	assertGoldenText(t, filepath.Join("testdata", "parity", "normalize-preview-spring.patch.golden.diff"), stdout)
+}
+
+func TestNormalizePreviewUnknownRepoNoop(t *testing.T) {
+	target := t.TempDir()
+	stdout, stderr, err := runWithCapturedIO([]string{"normalize", "preview", "--space", "platform", "--json", target})
+	if err != nil {
+		t.Fatalf("normalize preview unknown failed: %v\nstderr=%s", err, stderr)
+	}
+	var plan normalizeflow.Plan
+	if err := json.Unmarshal([]byte(stdout), &plan); err != nil {
+		t.Fatalf("parse normalize noop json: %v\n%s", err, stdout)
+	}
+	if plan.Summary.ProposalCount != 0 {
+		t.Fatalf("expected no proposals, got %+v", plan.Summary)
+	}
+	if len(plan.Diagnostics) != 1 || plan.Diagnostics[0].Code != "NO_KNOWN_PATTERNS" {
+		t.Fatalf("expected no-op diagnostic, got %+v", plan.Diagnostics)
+	}
+}

--- a/cmd/cub-gen/testdata/parity/normalize-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/normalize-help.stdout.golden.txt
@@ -1,0 +1,18 @@
+cub-gen normalize: propose governed config rewrites without applying them
+
+Use normalize when a repo renders correctly but the review/governance shape is still too implicit.
+Preview is read-only. It creates a reviewable patch set for sidecar proposals, not direct app or platform mutations.
+
+Usage:
+  cub-gen normalize preview [--space SPACE] [--ref REF] [--where-resource EXPR] [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] [--json|--patch] [--out FILE|-] [--pretty] <target-path> [<render-target-path>]
+
+Examples:
+  cub-gen normalize preview --space platform ./examples/springboot-paas
+  cub-gen normalize preview --patch --space platform ./examples/springboot-paas
+
+Transforms:
+  - add-route-policy-annotation: turn field-route metadata into ConfigHub Unit route policy annotations
+  - lift-generated-patch-to-source: show where rendered edits should become source PRs
+  - split-env-values-into-variants: expose environment/profile files as Deployable Variants
+  - add-missing-owners: propose owner labels from generator provenance
+  - replace-implicit-secret-wiring: propose explicit SecretReference records for literal secret-shaped env values

--- a/cmd/cub-gen/testdata/parity/normalize-preview-spring.patch.golden.diff
+++ b/cmd/cub-gen/testdata/parity/normalize-preview-spring.patch.golden.diff
@@ -1,0 +1,215 @@
+diff --git a/.cub-gen/normalize/confighub-route-policy.annotation.json b/.cub-gen/normalize/confighub-route-policy.annotation.json
+new file mode 100644
+index 0000000..0000000
+--- /dev/null
++++ b/.cub-gen/normalize/confighub-route-policy.annotation.json
+@@ -0,0 +1,86 @@
++{
++  "schema_version": "cub.confighub.io/unit-annotation-proposal/v1",
++  "applies_to": {
++    "space": "platform",
++    "target_slug": "spring"
++  },
++  "annotations": {
++    "confighub.io/generator-route-policy": "{\"schema_version\":\"cub.confighub.io/generator-route-policy/v1\",\"routes\":[{\"resource_type\":\"ConfigMap\",\"resource_name\":\"inventory-api-config\",\"path\":\"data.application*.yaml:feature.inventory.*\",\"wet_path\":\"ConfigMap/data/application*.yaml:feature.inventory.*\",\"route\":\"apply-here\",\"owner\":\"app-team\",\"source_path\":\"operational/field-routes.yaml\",\"proposal_hint\":\"allow local ConfigHub mutation and preserve it across generator refresh\"},{\"resource_type\":\"Deployment\",\"resource_name\":\"inventory-api\",\"path\":\"spec.template.spec.containers[*].env[FEATURE_INVENTORY_*].value\",\"wet_path\":\"Deployment/spec/template/spec/containers[*]/env[FEATURE_INVENTORY_*]/value\",\"route\":\"apply-here\",\"owner\":\"app-team\",\"source_path\":\"operational/field-routes.yaml\",\"proposal_hint\":\"allow local ConfigHub mutation and preserve it across generator refresh\"},{\"resource_type\":\"ConfigMap\",\"resource_name\":\"inventory-api-config\",\"path\":\"data.application*.yaml:spring.datasource.*\",\"wet_path\":\"ConfigMap/data/application*.yaml:spring.datasource.*\",\"route\":\"generator-owned\",\"owner\":\"platform-engineering\",\"source_path\":\"operational/field-routes.yaml\",\"proposal_hint\":\"block direct mutation and escalate to the platform owner\"},{\"resource_type\":\"Deployment\",\"resource_name\":\"inventory-api\",\"path\":\"spec.template.spec.containers[*].env[SPRING_DATASOURCE_*].value\",\"wet_path\":\"Deployment/spec/template/spec/containers[*]/env[SPRING_DATASOURCE_*]/value\",\"route\":\"generator-owned\",\"owner\":\"platform-engineering\",\"source_path\":\"operational/field-routes.yaml\",\"proposal_hint\":\"block direct mutation and escalate to the platform owner\"},{\"resource_type\":\"Deployment\",\"resource_name\":\"inventory-api\",\"path\":\"spec.template.spec.securityContext.*\",\"wet_path\":\"Deployment/spec/template/spec/securityContext/*\",\"route\":\"generator-owned\",\"owner\":\"platform-engineering\",\"source_path\":\"operational/field-routes.yaml\",\"proposal_hint\":\"block direct mutation and escalate to the platform owner\"},{\"resource_type\":\"ConfigMap\",\"resource_name\":\"inventory-api-config\",\"path\":\"data.application*.yaml:spring.cache.*\",\"wet_path\":\"ConfigMap/data/application*.yaml:spring.cache.*\",\"route\":\"lift-upstream\",\"owner\":\"app-team\",\"source_path\":\"operational/field-routes.yaml\",\"proposal_hint\":\"create a source PR before accepting this as a durable change\"},{\"resource_type\":\"Deployment\",\"resource_name\":\"inventory-api\",\"path\":\"spec.template.spec.containers[*].env[SPRING_CACHE_*].value\",\"wet_path\":\"Deployment/spec/template/spec/containers[*]/env[SPRING_CACHE_*]/value\",\"route\":\"lift-upstream\",\"owner\":\"app-team\",\"source_path\":\"operational/field-routes.yaml\",\"proposal_hint\":\"create a source PR before accepting this as a durable change\"}]}",
++    "confighub.io/generator-route-policy-required": "true"
++  },
++  "policy": {
++    "schema_version": "cub.confighub.io/generator-route-policy/v1",
++    "routes": [
++      {
++        "resource_type": "ConfigMap",
++        "resource_name": "inventory-api-config",
++        "path": "data.application*.yaml:feature.inventory.*",
++        "wet_path": "ConfigMap/data/application*.yaml:feature.inventory.*",
++        "route": "apply-here",
++        "owner": "app-team",
++        "source_path": "operational/field-routes.yaml",
++        "proposal_hint": "allow local ConfigHub mutation and preserve it across generator refresh"
++      },
++      {
++        "resource_type": "Deployment",
++        "resource_name": "inventory-api",
++        "path": "spec.template.spec.containers[*].env[FEATURE_INVENTORY_*].value",
++        "wet_path": "Deployment/spec/template/spec/containers[*]/env[FEATURE_INVENTORY_*]/value",
++        "route": "apply-here",
++        "owner": "app-team",
++        "source_path": "operational/field-routes.yaml",
++        "proposal_hint": "allow local ConfigHub mutation and preserve it across generator refresh"
++      },
++      {
++        "resource_type": "ConfigMap",
++        "resource_name": "inventory-api-config",
++        "path": "data.application*.yaml:spring.datasource.*",
++        "wet_path": "ConfigMap/data/application*.yaml:spring.datasource.*",
++        "route": "generator-owned",
++        "owner": "platform-engineering",
++        "source_path": "operational/field-routes.yaml",
++        "proposal_hint": "block direct mutation and escalate to the platform owner"
++      },
++      {
++        "resource_type": "Deployment",
++        "resource_name": "inventory-api",
++        "path": "spec.template.spec.containers[*].env[SPRING_DATASOURCE_*].value",
++        "wet_path": "Deployment/spec/template/spec/containers[*]/env[SPRING_DATASOURCE_*]/value",
++        "route": "generator-owned",
++        "owner": "platform-engineering",
++        "source_path": "operational/field-routes.yaml",
++        "proposal_hint": "block direct mutation and escalate to the platform owner"
++      },
++      {
++        "resource_type": "Deployment",
++        "resource_name": "inventory-api",
++        "path": "spec.template.spec.securityContext.*",
++        "wet_path": "Deployment/spec/template/spec/securityContext/*",
++        "route": "generator-owned",
++        "owner": "platform-engineering",
++        "source_path": "operational/field-routes.yaml",
++        "proposal_hint": "block direct mutation and escalate to the platform owner"
++      },
++      {
++        "resource_type": "ConfigMap",
++        "resource_name": "inventory-api-config",
++        "path": "data.application*.yaml:spring.cache.*",
++        "wet_path": "ConfigMap/data/application*.yaml:spring.cache.*",
++        "route": "lift-upstream",
++        "owner": "app-team",
++        "source_path": "operational/field-routes.yaml",
++        "proposal_hint": "create a source PR before accepting this as a durable change"
++      },
++      {
++        "resource_type": "Deployment",
++        "resource_name": "inventory-api",
++        "path": "spec.template.spec.containers[*].env[SPRING_CACHE_*].value",
++        "wet_path": "Deployment/spec/template/spec/containers[*]/env[SPRING_CACHE_*]/value",
++        "route": "lift-upstream",
++        "owner": "app-team",
++        "source_path": "operational/field-routes.yaml",
++        "proposal_hint": "create a source PR before accepting this as a durable change"
++      }
++    ]
++  }
++}
+diff --git a/.cub-gen/normalize/lift-upstream.proposals.json b/.cub-gen/normalize/lift-upstream.proposals.json
+new file mode 100644
+index 0000000..0000000
+--- /dev/null
++++ b/.cub-gen/normalize/lift-upstream.proposals.json
+@@ -0,0 +1,20 @@
++{
++  "schema_version": "cub.confighub.io/lift-upstream-proposal/v1",
++  "routes": [
++    {
++      "field_pattern": "spring.cache.*",
++      "owner": "app-team",
++      "reason": "Cache adoption changes the app contract and should update upstream app inputs.",
++      "source_candidates": [
++        "src/main/resources/application-dev.yaml",
++        "src/main/resources/application-prod.yaml",
++        "src/main/resources/application-stage.yaml",
++        "src/main/resources/application.yaml"
++      ],
++      "rendered_paths": [
++        "ConfigMap/data/application*.yaml:spring.cache.*",
++        "Deployment/spec/template/spec/containers[*]/env[SPRING_CACHE_*]/value"
++      ]
++    }
++  ]
++}
+diff --git a/.cub-gen/normalize/deployable-variants.yaml b/.cub-gen/normalize/deployable-variants.yaml
+new file mode 100644
+index 0000000..0000000
+--- /dev/null
++++ b/.cub-gen/normalize/deployable-variants.yaml
+@@ -0,0 +1,15 @@
++schema_version: cub.confighub.io/deployable-variant-plan/v1
++component: inventory-api
++variants:
++    - name: dev
++      source_inputs:
++        - src/main/resources/application-dev.yaml
++      rendered_proof: confighub/inventory-api-dev.yaml
++    - name: prod
++      source_inputs:
++        - src/main/resources/application-prod.yaml
++      rendered_proof: confighub/inventory-api-prod.yaml
++    - name: stage
++      source_inputs:
++        - src/main/resources/application-stage.yaml
++      rendered_proof: confighub/inventory-api-stage.yaml
+diff --git a/.cub-gen/normalize/owner-annotations.yaml b/.cub-gen/normalize/owner-annotations.yaml
+new file mode 100644
+index 0000000..0000000
+--- /dev/null
++++ b/.cub-gen/normalize/owner-annotations.yaml
+@@ -0,0 +1,52 @@
++schema_version: cub.confighub.io/owner-annotation-plan/v1
++annotations:
++    - scope: rendered
++      kind: ConfigMap
++      name: inventory-api-config
++      namespace: apps
++      owner: platform-runtime
++      annotation: cub.confighub.io/owner=platform-runtime
++    - scope: rendered
++      kind: Deployment
++      name: inventory-api
++      namespace: apps
++      owner: platform-runtime
++      annotation: cub.confighub.io/owner=platform-runtime
++    - scope: rendered
++      kind: Kustomization
++      name: springboot-paas
++      namespace: apps
++      owner: platform-runtime
++      annotation: cub.confighub.io/owner=platform-runtime
++    - scope: rendered
++      kind: Service
++      name: inventory-api
++      namespace: apps
++      owner: platform-runtime
++      annotation: cub.confighub.io/owner=platform-runtime
++    - scope: rendered
++      kind: ServiceAccount
++      name: inventory-api
++      namespace: apps
++      owner: platform-runtime
++      annotation: cub.confighub.io/owner=platform-runtime
++    - scope: source
++      path: src/main/resources/application-dev.yaml
++      owner: app-team
++      annotation: cub.confighub.io/owner=app-team
++    - scope: source
++      path: src/main/resources/application-prod.yaml
++      owner: app-team
++      annotation: cub.confighub.io/owner=app-team
++    - scope: source
++      path: src/main/resources/application-stage.yaml
++      owner: app-team
++      annotation: cub.confighub.io/owner=app-team
++    - scope: source
++      path: src/main/resources/application.yaml
++      owner: app-team
++      annotation: cub.confighub.io/owner=app-team
++    - scope: source
++      path: pom.xml
++      owner: platform-engineer
++      annotation: cub.confighub.io/owner=platform-engineer
+diff --git a/.cub-gen/normalize/secret-references.yaml b/.cub-gen/normalize/secret-references.yaml
+new file mode 100644
+index 0000000..0000000
+--- /dev/null
++++ b/.cub-gen/normalize/secret-references.yaml
+@@ -0,0 +1,12 @@
++schema_version: cub.confighub.io/secret-reference-proposal/v1
++references:
++    - resource: Deployment/inventory-api
++      namespace: apps
++      container: inventory-api
++      env: SPRING_DATASOURCE_URL
++      owner: platform-engineering
++      current: literal-value
++      proposed_ref:
++        key: url
++        secret_name: inventory-api-datasource
++      review: replace env.value with env.valueFrom.secretKeyRef only after the secret lifecycle is owned and audited

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -11,6 +11,7 @@ START HERE:
   change impact     See which rendered fields a DRY path can affect
   change preview    Preview a safe repo change
   enrich preview    Propose sidecar proof metadata for PR review
+  normalize preview  Propose governed rewrite patches for review
   platform import   Read a multi-repo platform estate as a graph
   platform fanout   Emit one proof bundle per deployable variant
   detect            Detect generators in a repo
@@ -31,6 +32,7 @@ FIRST RUNS:
   cub-gen platform fanout --variant dev --json ./testdata/variant-fanout/platform.yaml
   cub-gen change explain --space my-space --owner app-team ./examples/scoredev-paas
   cub-gen enrich preview --space my-space ./examples/helm-paas
+  cub-gen normalize preview --space my-space ./examples/springboot-paas
   cub-gen publish --space my-space ./examples/helm-paas | cub-gen verify --in -
   cub-gen publish --space my-space ./examples/helm-paas | cub-gen attest --in - --verifier ci-bot
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -17,6 +17,7 @@ not cluster/runtime ones.
 | Which rendered fields would this DRY path affect? | `change impact` |
 | What evidence bundle and safe next step should I prepare? | `change preview` |
 | How do I add provenance to a PR without editing manifests? | `enrich preview`, then optionally `enrich write` |
+| How do I turn implicit platform rules into reviewable config proposals? | `normalize preview` |
 | How do I see a multi-repo platform estate? | `platform import` |
 | How do I emit one proof bundle per environment or tenant? | `platform fanout` |
 | What evidence bundle should I verify or ship? | `publish -> verify -> attest` |
@@ -201,6 +202,44 @@ cub-gen enrich write --space <space> [--where-resource <expr>] <target-path> [<r
 `enrich write` creates only sidecar files under `.cub-gen/enrichment/`. It does
 not annotate or rewrite app manifests. It refuses to overwrite an existing
 sidecar so provenance updates stay explicit and reviewable.
+
+---
+
+## Normalize
+
+### `normalize preview`
+
+Preview governed config rewrite proposals without applying them.
+
+```
+cub-gen normalize preview --space <space> [--json|--patch] [--where-resource <expr>] <target-path> [<render-target-path>]
+```
+
+Use this after import/enrichment when the generator works but important product
+boundaries are still implicit. The command emits one reviewable patch set under
+`.cub-gen/normalize/`; it does not edit app source, platform source, rendered
+manifests, or ConfigHub Units.
+
+Current proposal types:
+
+| Transform | What it makes explicit |
+|---|---|
+| `add-route-policy-annotation` | ConfigHub Unit route policy annotations from field-route metadata |
+| `lift-generated-patch-to-source` | source files that should receive durable changes instead of generated YAML |
+| `split-env-values-into-variants` | Deployable Variant inventory from environment/profile files |
+| `add-missing-owners` | owner annotations from generator provenance and rendered resources |
+| `replace-implicit-secret-wiring` | explicit secret-reference proposals for literal secret-shaped env values |
+
+Example:
+
+```
+cub-gen normalize preview --patch --space platform ./examples/springboot-paas
+```
+
+The Spring Boot example produces proposals for route enforcement,
+lift-upstream cache changes, dev/stage/prod variants, owner annotations, and a
+datasource SecretReference candidate. Unknown repos degrade to a no-op preview
+with a `NO_KNOWN_PATTERNS` diagnostic.
 
 ---
 

--- a/docs/plans/2026-04-30-platform-generator-product-worklist.md
+++ b/docs/plans/2026-04-30-platform-generator-product-worklist.md
@@ -19,7 +19,6 @@ Open issues checked on 2026-05-01:
 |---|---|---|
 | [#287](https://github.com/confighub/cub-gen/issues/287) | make cub-gen role and value obvious | parent roadmap issue keeping the product story coherent |
 | [#283](https://github.com/confighub/cub-gen/issues/283) | enforce generator route metadata server-side | route ownership must become an authoritative backend decision |
-| [#281](https://github.com/confighub/cub-gen/issues/281) | propose governed config rewrites | import should lead to reviewable improvements, not magic rewrites |
 | [#277](https://github.com/confighub/cub-gen/issues/277) | OpenChoreo adapter | external platform-family proof needs upstream conformance |
 | [#236](https://github.com/confighub/cub-gen/issues/236) | ship cub-gen as `cub gen` plugin | product workflow should feel like one platform, not a sidecar binary |
 | [#213](https://github.com/confighub/cub-gen/issues/213) | GUI provenance trace | click-field-to-source is the core teaching moment |
@@ -247,6 +246,11 @@ Definition of done:
 
 Problem: `springboot init` scaffolds starter material, but there is no general
 "make this config better" proposal engine.
+
+Status: implemented by `cub-gen normalize preview`. The Spring Boot example now
+produces one review-only patch set with route policy annotations,
+lift-upstream source routing, Deployable Variant inventory, owner annotations,
+and explicit secret-reference proposals.
 
 Deterministic success criteria:
 

--- a/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
+++ b/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
@@ -183,7 +183,7 @@ Subtasks:
 
 - [x] [#282](https://github.com/confighub/cub-gen/issues/282) Productize GitHub PR to ConfigHub MR linkage
 - [ ] [#283](https://github.com/confighub/cub-gen/issues/283) Enforce generator route metadata server-side
-- [ ] [#281](https://github.com/confighub/cub-gen/issues/281) Propose governed config rewrites
+- [x] [#281](https://github.com/confighub/cub-gen/issues/281) Propose governed config rewrites
 - [ ] [#212](https://github.com/confighub/cub-gen/issues/212) GUI regeneration/refresh preview
 
 Likely sequence:
@@ -201,8 +201,10 @@ without asking users to reason through implementation layers.
 Current state: `cub-gen bridge link` is now the single-command PR/MR
 correlation path. It derives `change_id` from a verified publish bundle, emits
 canonical local evidence, and can POST the link to ConfigHub with a deterministic
-idempotency key. Server-side route enforcement and rewrite proposals remain the
-core open governance work.
+idempotency key. `cub-gen normalize preview` now produces review-only sidecar
+patch sets for route policy annotations, lift-upstream source routing,
+deployable variants, owner annotations, and explicit secret references.
+Server-side route enforcement remains the core open governance work.
 
 ### Phase 6: Product Integration
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,9 @@ If you are unsure, start with `helm-paas` for the platform view or
   covers source-side provenance, governed change, layered Helm/ApplicationSet
   proof, and a paired live runtime wrapper.
 - [`springboot-paas`](./springboot-paas/) is the strongest standalone
-  end-to-end app example today.
+  end-to-end app example today. It also demonstrates `normalize preview` for
+  turning route rules, variants, owners, and secret wiring into reviewable
+  sidecar proposals.
 - [`scoredev-paas`](./scoredev-paas/) is the strongest Score end-to-end path
   today.
 - [`live-reconcile`](./live-reconcile/) is the runtime harness. Pair it with

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -292,6 +292,30 @@ field route when `--routes` is provided.
 
 This is a client-side gate. Integrate it into CI/CD to enforce the boundary before mutations reach ConfigHub.
 
+## Normalize preview
+
+`normalize preview` shows how cub-gen turns this example's implicit platform
+rules into a reviewable patch set:
+
+```bash
+cub-gen normalize preview --patch --space platform ./examples/springboot-paas
+```
+
+The preview creates sidecar proposals under `.cub-gen/normalize/`; it does not
+change app code, platform code, rendered YAML, or ConfigHub state.
+
+| Proposal | Why it matters |
+|----------|----------------|
+| route-policy annotation | turns `operational/field-routes.yaml` into ConfigHub Unit metadata for apply-here / lift-upstream / generator-owned decisions |
+| lift-upstream routes | tells reviewers which rendered edits should become source PRs |
+| deployable variants | makes dev/stage/prod profile files visible as Deployable Variants |
+| owner annotations | carries app/platform ownership into reviewable metadata |
+| secret references | replaces literal datasource wiring with an explicit SecretReference proposal |
+
+This is the "clean generator" path in miniature: keep the Component source,
+name the Deployable Variants, route changes to the right layer, and produce
+Proof before anything is applied.
+
 ## Real Kubernetes deployment
 
 Deploy the real app to a Kind cluster and verify via HTTP:
@@ -350,6 +374,7 @@ HTTP-level tests verify both dev profile (optimistic mode, no cache) and prod pr
 | Structural proof (verify.sh) | Real |
 | Lift-upstream Redis bundle | Real (bundle only, no automated PR) |
 | Block/escalate boundary | Real (documented, not server-enforced) |
+| Normalize preview patch set | Real (review-only sidecar proposals) |
 | Refresh-survival preview | Real (client-side simulation) |
 | Generator visibility (explain-field) | Real |
 | Cross-environment comparison | Real (with fixture fallback) |

--- a/internal/normalize/normalize.go
+++ b/internal/normalize/normalize.go
@@ -1,0 +1,1165 @@
+package normalize
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
+	"github.com/confighub/cub-gen/internal/springboot"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	PlanSchemaVersion = "cub.confighub.io/normalize-plan/v1"
+
+	TransformRoutePolicy    = "add-route-policy-annotation"
+	TransformLiftUpstream   = "lift-generated-patch-to-source"
+	TransformVariantSplit   = "split-env-values-into-variants"
+	TransformOwnerLabels    = "add-missing-owners"
+	TransformSecretRefs     = "replace-implicit-secret-wiring"
+	ActionCreate            = "create"
+	ActionReviewPatch       = "review-patch"
+	RiskLow                 = "low"
+	RiskMedium              = "medium"
+	RiskHigh                = "high"
+	routePolicyAnnotation   = "confighub.io/generator-route-policy"
+	routePolicyRequiredAnno = "confighub.io/generator-route-policy-required"
+)
+
+// Plan is a read-only set of governed rewrite proposals. It never means cub-gen
+// has mutated app, platform, or rendered manifests.
+type Plan struct {
+	SchemaVersion    string       `json:"schema_version"`
+	Space            string       `json:"space"`
+	TargetSlug       string       `json:"target_slug"`
+	TargetPath       string       `json:"target_path,omitempty"`
+	RenderTargetSlug string       `json:"render_target_slug"`
+	RenderTargetPath string       `json:"render_target_path,omitempty"`
+	Ref              string       `json:"ref"`
+	GeneratedAt      string       `json:"generated_at"`
+	Summary          Summary      `json:"summary"`
+	PatchSet         PatchSet     `json:"patch_set"`
+	Diagnostics      []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+type Summary struct {
+	ProposalCount   int            `json:"proposal_count"`
+	PatchCount      int            `json:"patch_count"`
+	TransformCount  int            `json:"transform_count"`
+	RiskCounts      map[string]int `json:"risk_counts,omitempty"`
+	DiagnosticCount int            `json:"diagnostic_count"`
+}
+
+type PatchSet struct {
+	ID         string     `json:"id"`
+	Title      string     `json:"title"`
+	ReviewMode string     `json:"review_mode"`
+	Proposals  []Proposal `json:"proposals"`
+}
+
+type Proposal struct {
+	ID             string           `json:"id"`
+	Transform      string           `json:"transform"`
+	Title          string           `json:"title"`
+	SourcePath     string           `json:"source_path"`
+	Owner          string           `json:"owner"`
+	Risk           string           `json:"risk"`
+	Review         string           `json:"review"`
+	Why            string           `json:"why"`
+	RenderedImpact []RenderedImpact `json:"rendered_impact"`
+	Patch          Patch            `json:"patch"`
+}
+
+type RenderedImpact struct {
+	ResourceType string `json:"resource_type"`
+	ResourceName string `json:"resource_name,omitempty"`
+	Path         string `json:"path"`
+	Action       string `json:"action"`
+	Explanation  string `json:"explanation"`
+}
+
+type Patch struct {
+	Path        string `json:"path"`
+	Action      string `json:"action"`
+	ContentType string `json:"content_type"`
+	Content     string `json:"content"`
+}
+
+type Diagnostic struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Path    string `json:"path,omitempty"`
+}
+
+type manifestDoc struct {
+	RelPath    string            `yaml:"-"`
+	APIVersion string            `yaml:"apiVersion"`
+	Kind       string            `yaml:"kind"`
+	Metadata   manifestMetadata  `yaml:"metadata"`
+	Data       map[string]string `yaml:"data"`
+	Spec       deploymentSpec    `yaml:"spec"`
+}
+
+type manifestMetadata struct {
+	Name        string            `yaml:"name"`
+	Namespace   string            `yaml:"namespace"`
+	Annotations map[string]string `yaml:"annotations"`
+	Labels      map[string]string `yaml:"labels"`
+}
+
+type deploymentSpec struct {
+	Replicas *int             `yaml:"replicas"`
+	Template deploymentPodTpl `yaml:"template"`
+}
+
+type deploymentPodTpl struct {
+	Spec deploymentPodSpec `yaml:"spec"`
+}
+
+type deploymentPodSpec struct {
+	Containers []containerSpec `yaml:"containers"`
+}
+
+type containerSpec struct {
+	Name string    `yaml:"name"`
+	Env  []envSpec `yaml:"env"`
+}
+
+type envSpec struct {
+	Name      string         `yaml:"name"`
+	Value     string         `yaml:"value"`
+	ValueFrom map[string]any `yaml:"valueFrom"`
+}
+
+type routePolicyProposal struct {
+	SchemaVersion string            `json:"schema_version"`
+	AppliesTo     annotationTarget  `json:"applies_to"`
+	Annotations   map[string]string `json:"annotations"`
+	Policy        routePolicy       `json:"policy"`
+}
+
+type annotationTarget struct {
+	Space      string `json:"space"`
+	TargetSlug string `json:"target_slug"`
+}
+
+type routePolicy struct {
+	SchemaVersion string            `json:"schema_version"`
+	Routes        []routePolicyRule `json:"routes"`
+}
+
+type routePolicyRule struct {
+	ResourceType string `json:"resource_type,omitempty"`
+	ResourceName string `json:"resource_name,omitempty"`
+	Path         string `json:"path,omitempty"`
+	WetPath      string `json:"wet_path,omitempty"`
+	Route        string `json:"route"`
+	Owner        string `json:"owner"`
+	SourcePath   string `json:"source_path"`
+	ProposalHint string `json:"proposal_hint"`
+}
+
+type liftUpstreamProposal struct {
+	SchemaVersion string            `json:"schema_version"`
+	Routes        []liftUpstreamRow `json:"routes"`
+}
+
+type liftUpstreamRow struct {
+	FieldPattern     string   `json:"field_pattern"`
+	Owner            string   `json:"owner"`
+	Reason           string   `json:"reason"`
+	SourceCandidates []string `json:"source_candidates"`
+	RenderedPaths    []string `json:"rendered_paths"`
+}
+
+type variantPlan struct {
+	SchemaVersion string       `yaml:"schema_version"`
+	Component     string       `yaml:"component"`
+	Variants      []variantRow `yaml:"variants"`
+}
+
+type variantRow struct {
+	Name          string   `yaml:"name"`
+	SourceInputs  []string `yaml:"source_inputs"`
+	RenderedProof string   `yaml:"rendered_proof,omitempty"`
+}
+
+type ownerAnnotationPlan struct {
+	SchemaVersion string            `yaml:"schema_version"`
+	Annotations   []ownerAnnotation `yaml:"annotations"`
+}
+
+type ownerAnnotation struct {
+	Scope      string `yaml:"scope"`
+	Path       string `yaml:"path,omitempty"`
+	Kind       string `yaml:"kind,omitempty"`
+	Name       string `yaml:"name,omitempty"`
+	Namespace  string `yaml:"namespace,omitempty"`
+	Owner      string `yaml:"owner"`
+	Annotation string `yaml:"annotation"`
+}
+
+type secretReferencePlan struct {
+	SchemaVersion string            `yaml:"schema_version"`
+	References    []secretReference `yaml:"references"`
+}
+
+type secretReference struct {
+	Resource    string            `yaml:"resource"`
+	Namespace   string            `yaml:"namespace,omitempty"`
+	Container   string            `yaml:"container,omitempty"`
+	Env         string            `yaml:"env"`
+	Owner       string            `yaml:"owner"`
+	Current     string            `yaml:"current"`
+	ProposedRef map[string]string `yaml:"proposed_ref"`
+	Review      string            `yaml:"review"`
+}
+
+// BuildPlan creates a deterministic preview-only normalize plan from an import
+// result and local repo files.
+func BuildPlan(imported gitopsflow.ImportFlowResult) (Plan, error) {
+	targetPath := strings.TrimSpace(imported.TargetPath)
+	if targetPath == "" {
+		targetPath = strings.TrimSpace(imported.TargetSlug)
+	}
+	if targetPath == "" {
+		return Plan{}, errors.New("target path is required")
+	}
+	root, err := filepath.Abs(targetPath)
+	if err != nil {
+		return Plan{}, fmt.Errorf("resolve target path: %w", err)
+	}
+
+	plan := Plan{
+		SchemaVersion:    PlanSchemaVersion,
+		Space:            imported.Space,
+		TargetSlug:       imported.TargetSlug,
+		TargetPath:       imported.TargetPath,
+		RenderTargetSlug: imported.RenderTargetSlug,
+		RenderTargetPath: imported.RenderTargetPath,
+		Ref:              imported.Ref,
+		GeneratedAt:      imported.ImportedAt,
+		PatchSet: PatchSet{
+			ID:         "normalize-" + sanitizeID(imported.TargetSlug),
+			Title:      "Governed config rewrite preview",
+			ReviewMode: ActionReviewPatch,
+		},
+	}
+	if plan.PatchSet.ID == "normalize-" {
+		plan.PatchSet.ID = "normalize-" + sanitizeID(filepath.Base(root))
+	}
+
+	docs, err := readManifestDocs(root)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	routes, routesPath, err := readSpringRoutes(root)
+	if err != nil {
+		return Plan{}, err
+	}
+	if routes != nil && len(routes.Routes) > 0 {
+		if proposal, ok, err := buildRoutePolicyProposal(plan, *routes, routesPath, docs); err != nil {
+			return Plan{}, err
+		} else if ok {
+			plan.PatchSet.Proposals = append(plan.PatchSet.Proposals, proposal)
+		}
+		if proposal, ok, err := buildLiftUpstreamProposal(*routes, routesPath, root, docs); err != nil {
+			return Plan{}, err
+		} else if ok {
+			plan.PatchSet.Proposals = append(plan.PatchSet.Proposals, proposal)
+		}
+	}
+
+	if proposal, ok, err := buildVariantProposal(root); err != nil {
+		return Plan{}, err
+	} else if ok {
+		plan.PatchSet.Proposals = append(plan.PatchSet.Proposals, proposal)
+	}
+
+	if proposal, ok, err := buildOwnerAnnotationProposal(imported, docs); err != nil {
+		return Plan{}, err
+	} else if ok {
+		plan.PatchSet.Proposals = append(plan.PatchSet.Proposals, proposal)
+	}
+
+	if routes != nil {
+		if proposal, ok, err := buildSecretReferenceProposal(*routes, docs); err != nil {
+			return Plan{}, err
+		} else if ok {
+			plan.PatchSet.Proposals = append(plan.PatchSet.Proposals, proposal)
+		}
+	}
+
+	sort.Slice(plan.PatchSet.Proposals, func(i, j int) bool {
+		return plan.PatchSet.Proposals[i].ID < plan.PatchSet.Proposals[j].ID
+	})
+	if len(plan.PatchSet.Proposals) == 0 {
+		plan.Diagnostics = append(plan.Diagnostics, Diagnostic{
+			Code:    "NO_KNOWN_PATTERNS",
+			Message: "no supported normalize proposals found; preview is a no-op",
+			Path:    filepath.ToSlash(targetPath),
+		})
+	}
+	RefreshSummary(&plan)
+	return plan, nil
+}
+
+func RefreshSummary(plan *Plan) {
+	if plan == nil {
+		return
+	}
+	risks := map[string]int{}
+	transforms := map[string]bool{}
+	patches := 0
+	for _, proposal := range plan.PatchSet.Proposals {
+		transforms[proposal.Transform] = true
+		if proposal.Risk != "" {
+			risks[proposal.Risk]++
+		}
+		if proposal.Patch.Path != "" {
+			patches++
+		}
+	}
+	plan.Summary = Summary{
+		ProposalCount:   len(plan.PatchSet.Proposals),
+		PatchCount:      patches,
+		TransformCount:  len(transforms),
+		RiskCounts:      risks,
+		DiagnosticCount: len(plan.Diagnostics),
+	}
+	if len(plan.Summary.RiskCounts) == 0 {
+		plan.Summary.RiskCounts = nil
+	}
+}
+
+func RenderPatch(plan Plan) (string, error) {
+	var out strings.Builder
+	for _, proposal := range plan.PatchSet.Proposals {
+		patch := proposal.Patch
+		if patch.Action != ActionCreate || strings.TrimSpace(patch.Path) == "" {
+			continue
+		}
+		text := strings.TrimSuffix(patch.Content, "\n")
+		lines := []string{}
+		if text != "" {
+			lines = strings.Split(text, "\n")
+		}
+		fmt.Fprintf(&out, "diff --git a/%s b/%s\n", patch.Path, patch.Path)
+		fmt.Fprintln(&out, "new file mode 100644")
+		fmt.Fprintln(&out, "index 0000000..0000000")
+		fmt.Fprintln(&out, "--- /dev/null")
+		fmt.Fprintf(&out, "+++ b/%s\n", patch.Path)
+		fmt.Fprintf(&out, "@@ -0,0 +1,%d @@\n", len(lines))
+		for _, line := range lines {
+			fmt.Fprintf(&out, "+%s\n", line)
+		}
+	}
+	return out.String(), nil
+}
+
+func buildRoutePolicyProposal(plan Plan, routes springboot.FieldRoutes, sourcePath string, docs []manifestDoc) (Proposal, bool, error) {
+	configMapName := firstResourceName(docs, "ConfigMap")
+	deploymentName := firstResourceName(docs, "Deployment")
+	rules := make([]routePolicyRule, 0, len(routes.Routes)*2)
+	for _, route := range routes.Routes {
+		match := strings.TrimSpace(route.Match)
+		owner := strings.TrimSpace(route.Owner)
+		if match == "" || owner == "" {
+			continue
+		}
+		policyRoute := policyRouteFor(route.DefaultAction)
+		if policyRoute == "" {
+			continue
+		}
+		hint := proposalHintFor(route)
+		if strings.HasPrefix(match, "securityContext.") {
+			rules = append(rules, routePolicyRule{
+				ResourceType: "Deployment",
+				ResourceName: deploymentName,
+				Path:         "spec.template.spec." + match,
+				WetPath:      "Deployment/spec/template/spec/" + strings.ReplaceAll(match, ".", "/"),
+				Route:        policyRoute,
+				Owner:        owner,
+				SourcePath:   sourcePath,
+				ProposalHint: hint,
+			})
+			continue
+		}
+		rules = append(rules, routePolicyRule{
+			ResourceType: "ConfigMap",
+			ResourceName: configMapName,
+			Path:         "data.application*.yaml:" + match,
+			WetPath:      "ConfigMap/data/application*.yaml:" + match,
+			Route:        policyRoute,
+			Owner:        owner,
+			SourcePath:   sourcePath,
+			ProposalHint: hint,
+		})
+		if envPattern := envPatternForFieldPattern(match); envPattern != "" && deploymentName != "" {
+			rules = append(rules, routePolicyRule{
+				ResourceType: "Deployment",
+				ResourceName: deploymentName,
+				Path:         "spec.template.spec.containers[*].env[" + envPattern + "].value",
+				WetPath:      "Deployment/spec/template/spec/containers[*]/env[" + envPattern + "]/value",
+				Route:        policyRoute,
+				Owner:        owner,
+				SourcePath:   sourcePath,
+				ProposalHint: hint,
+			})
+		}
+	}
+	if len(rules) == 0 {
+		return Proposal{}, false, nil
+	}
+	sort.Slice(rules, func(i, j int) bool {
+		if rules[i].Route != rules[j].Route {
+			return rules[i].Route < rules[j].Route
+		}
+		if rules[i].Owner != rules[j].Owner {
+			return rules[i].Owner < rules[j].Owner
+		}
+		if rules[i].ResourceType != rules[j].ResourceType {
+			return rules[i].ResourceType < rules[j].ResourceType
+		}
+		if rules[i].ResourceName != rules[j].ResourceName {
+			return rules[i].ResourceName < rules[j].ResourceName
+		}
+		return rules[i].Path < rules[j].Path
+	})
+	policy := routePolicy{
+		SchemaVersion: "cub.confighub.io/generator-route-policy/v1",
+		Routes:        rules,
+	}
+	compactPolicy, err := json.Marshal(policy)
+	if err != nil {
+		return Proposal{}, false, fmt.Errorf("marshal route policy: %w", err)
+	}
+	body := routePolicyProposal{
+		SchemaVersion: "cub.confighub.io/unit-annotation-proposal/v1",
+		AppliesTo: annotationTarget{
+			Space:      plan.Space,
+			TargetSlug: plan.TargetSlug,
+		},
+		Annotations: map[string]string{
+			routePolicyRequiredAnno: "true",
+			routePolicyAnnotation:   string(compactPolicy),
+		},
+		Policy: policy,
+	}
+	content, err := marshalJSON(body)
+	if err != nil {
+		return Proposal{}, false, err
+	}
+	return Proposal{
+		ID:         "01-route-policy-annotation",
+		Transform:  TransformRoutePolicy,
+		Title:      "Add ConfigHub route-policy annotations",
+		SourcePath: sourcePath,
+		Owner:      joinSorted(uniqueRouteOwners(routes.Routes)),
+		Risk:       RiskMedium,
+		Review:     "Apply these annotations to the ConfigHub Unit after review; do not mutate rendered Kubernetes YAML directly.",
+		Why:        "field-routes.yaml already says which app config paths are apply-here, lift-upstream, or generator-owned; this proposal makes that boundary enforceable by ConfigHub.",
+		RenderedImpact: []RenderedImpact{{
+			ResourceType: "ConfigHub Unit",
+			ResourceName: plan.TargetSlug,
+			Path:         "metadata.annotations[" + routePolicyAnnotation + "]",
+			Action:       "gate-future-mutations",
+			Explanation:  "future rendered-config edits can be routed to apply-here, lift-upstream, or generator-owned decisions before a Unit revision is accepted",
+		}},
+		Patch: Patch{
+			Path:        ".cub-gen/normalize/confighub-route-policy.annotation.json",
+			Action:      ActionCreate,
+			ContentType: "application/json",
+			Content:     content,
+		},
+	}, true, nil
+}
+
+func buildLiftUpstreamProposal(routes springboot.FieldRoutes, sourcePath, root string, docs []manifestDoc) (Proposal, bool, error) {
+	candidates := springSourceCandidates(root)
+	rows := []liftUpstreamRow{}
+	for _, route := range routes.Routes {
+		if route.DefaultAction != springboot.ActionLiftUpstream {
+			continue
+		}
+		rows = append(rows, liftUpstreamRow{
+			FieldPattern:     route.Match,
+			Owner:            route.Owner,
+			Reason:           route.Reason,
+			SourceCandidates: candidates,
+			RenderedPaths:    renderedPathsForRoute(route, docs),
+		})
+	}
+	if len(rows) == 0 {
+		return Proposal{}, false, nil
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].FieldPattern < rows[j].FieldPattern
+	})
+	content, err := marshalJSON(liftUpstreamProposal{
+		SchemaVersion: "cub.confighub.io/lift-upstream-proposal/v1",
+		Routes:        rows,
+	})
+	if err != nil {
+		return Proposal{}, false, err
+	}
+	return Proposal{
+		ID:         "02-lift-upstream-routes",
+		Transform:  TransformLiftUpstream,
+		Title:      "Route generated patches back to source",
+		SourcePath: sourcePath,
+		Owner:      joinSorted(uniqueLiftOwners(routes.Routes)),
+		Risk:       RiskMedium,
+		Review:     "Use this as a PR checklist when a generated ConfigMap or Deployment edit should become an upstream app-source change.",
+		Why:        "lift-upstream fields are not durable as one-off rendered edits; the source repo must carry the intent.",
+		RenderedImpact: []RenderedImpact{{
+			ResourceType: "ConfigMap/Deployment",
+			Path:         "fields matching lift-upstream routes",
+			Action:       "convert-rendered-edit-to-source-pr",
+			Explanation:  "reviewers get the source candidate files before accepting a rendered change that would otherwise be overwritten",
+		}},
+		Patch: Patch{
+			Path:        ".cub-gen/normalize/lift-upstream.proposals.json",
+			Action:      ActionCreate,
+			ContentType: "application/json",
+			Content:     content,
+		},
+	}, true, nil
+}
+
+func buildVariantProposal(root string) (Proposal, bool, error) {
+	profilePaths, err := filepath.Glob(filepath.Join(root, "src", "main", "resources", "application-*.yaml"))
+	if err != nil {
+		return Proposal{}, false, fmt.Errorf("scan spring profiles: %w", err)
+	}
+	if len(profilePaths) == 0 {
+		return Proposal{}, false, nil
+	}
+	sort.Strings(profilePaths)
+	component := componentName(root)
+	rows := []variantRow{}
+	for _, profilePath := range profilePaths {
+		env := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(profilePath), "application-"), ".yaml")
+		if env == "" {
+			continue
+		}
+		relProfile := mustRel(root, profilePath)
+		rendered := findRenderedProofForEnv(root, env)
+		row := variantRow{
+			Name:          env,
+			SourceInputs:  []string{relProfile},
+			RenderedProof: rendered,
+		}
+		rows = append(rows, row)
+	}
+	if len(rows) < 2 {
+		return Proposal{}, false, nil
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].Name < rows[j].Name
+	})
+	content, err := marshalYAML(variantPlan{
+		SchemaVersion: "cub.confighub.io/deployable-variant-plan/v1",
+		Component:     component,
+		Variants:      rows,
+	})
+	if err != nil {
+		return Proposal{}, false, err
+	}
+	return Proposal{
+		ID:         "03-deployable-variants",
+		Transform:  TransformVariantSplit,
+		Title:      "Make environment variants explicit",
+		SourcePath: "src/main/resources/application-*.yaml",
+		Owner:      "app-team",
+		Risk:       RiskLow,
+		Review:     "Review the generated variant inventory before wiring it into platform import or fanout.",
+		Why:        "profile files already encode deployable variants; making the variants explicit lets ConfigHub reason about dev, stage, and prod separately.",
+		RenderedImpact: []RenderedImpact{{
+			ResourceType: "Deployable Variant",
+			ResourceName: component,
+			Path:         "variants[*]",
+			Action:       "make-variant-boundaries-visible",
+			Explanation:  "each profile gets a concrete deployable variant with its source inputs and rendered proof path",
+		}},
+		Patch: Patch{
+			Path:        ".cub-gen/normalize/deployable-variants.yaml",
+			Action:      ActionCreate,
+			ContentType: "application/yaml",
+			Content:     content,
+		},
+	}, true, nil
+}
+
+func buildOwnerAnnotationProposal(imported gitopsflow.ImportFlowResult, docs []manifestDoc) (Proposal, bool, error) {
+	annotations := []ownerAnnotation{}
+	seen := map[string]bool{}
+	for _, input := range imported.DryInputs {
+		owner := strings.TrimSpace(input.Owner)
+		p := strings.TrimSpace(input.Path)
+		if owner == "" || p == "" {
+			continue
+		}
+		key := "source|" + p + "|" + owner
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		annotations = append(annotations, ownerAnnotation{
+			Scope:      "source",
+			Path:       p,
+			Owner:      owner,
+			Annotation: "cub.confighub.io/owner=" + owner,
+		})
+	}
+	renderedOwnersByKind, defaultRenderedOwner := renderedOwnerHints(imported)
+	if len(docs) > 0 {
+		for _, doc := range docs {
+			if strings.TrimSpace(doc.Kind) == "" || strings.TrimSpace(doc.Metadata.Name) == "" {
+				continue
+			}
+			owner := renderedOwnersByKind[doc.Kind]
+			if owner == "" {
+				owner = defaultRenderedOwner
+			}
+			if owner == "" {
+				continue
+			}
+			key := "rendered|" + doc.Kind + "|" + doc.Metadata.Namespace + "|" + doc.Metadata.Name + "|" + owner
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			annotations = append(annotations, ownerAnnotation{
+				Scope:      "rendered",
+				Kind:       doc.Kind,
+				Name:       doc.Metadata.Name,
+				Namespace:  doc.Metadata.Namespace,
+				Owner:      owner,
+				Annotation: "cub.confighub.io/owner=" + owner,
+			})
+		}
+	}
+	for _, target := range imported.WetManifestTargets {
+		owner := strings.TrimSpace(target.Owner)
+		if owner == "" || strings.TrimSpace(target.Kind) == "" || strings.TrimSpace(target.Name) == "" {
+			continue
+		}
+		key := "rendered|" + target.Kind + "|" + target.Namespace + "|" + target.Name + "|" + owner
+		if seen[key] {
+			continue
+		}
+		if len(docs) > 0 && hasRenderedKind(docs, target.Kind) {
+			continue
+		}
+		seen[key] = true
+		annotations = append(annotations, ownerAnnotation{
+			Scope:      "rendered",
+			Kind:       target.Kind,
+			Name:       target.Name,
+			Namespace:  target.Namespace,
+			Owner:      owner,
+			Annotation: "cub.confighub.io/owner=" + owner,
+		})
+	}
+	if len(annotations) == 0 {
+		return Proposal{}, false, nil
+	}
+	sort.Slice(annotations, func(i, j int) bool {
+		if annotations[i].Scope != annotations[j].Scope {
+			return annotations[i].Scope < annotations[j].Scope
+		}
+		if annotations[i].Owner != annotations[j].Owner {
+			return annotations[i].Owner < annotations[j].Owner
+		}
+		if annotations[i].Path != annotations[j].Path {
+			return annotations[i].Path < annotations[j].Path
+		}
+		if annotations[i].Kind != annotations[j].Kind {
+			return annotations[i].Kind < annotations[j].Kind
+		}
+		return annotations[i].Name < annotations[j].Name
+	})
+	content, err := marshalYAML(ownerAnnotationPlan{
+		SchemaVersion: "cub.confighub.io/owner-annotation-plan/v1",
+		Annotations:   annotations,
+	})
+	if err != nil {
+		return Proposal{}, false, err
+	}
+	return Proposal{
+		ID:         "04-owner-annotations",
+		Transform:  TransformOwnerLabels,
+		Title:      "Add missing owner annotations",
+		SourcePath: "imported provenance",
+		Owner:      joinSorted(uniqueAnnotationOwners(annotations)),
+		Risk:       RiskLow,
+		Review:     "Review owners before applying labels or annotations to sidecars, Units, or rendered artifacts.",
+		Why:        "ownership exists in the generator proof but is easy to miss in normal YAML review.",
+		RenderedImpact: []RenderedImpact{{
+			ResourceType: "source/rendered artifacts",
+			Path:         "metadata.annotations[cub.confighub.io/owner]",
+			Action:       "make-review-owner-visible",
+			Explanation:  "reviewers can see who owns each source input and rendered target without reading generator internals",
+		}},
+		Patch: Patch{
+			Path:        ".cub-gen/normalize/owner-annotations.yaml",
+			Action:      ActionCreate,
+			ContentType: "application/yaml",
+			Content:     content,
+		},
+	}, true, nil
+}
+
+func buildSecretReferenceProposal(routes springboot.FieldRoutes, docs []manifestDoc) (Proposal, bool, error) {
+	refs := []secretReference{}
+	seen := map[string]bool{}
+	for _, doc := range docs {
+		if doc.Kind != "Deployment" {
+			continue
+		}
+		for _, container := range doc.Spec.Template.Spec.Containers {
+			for _, env := range container.Env {
+				if strings.TrimSpace(env.Value) == "" || len(env.ValueFrom) > 0 || !looksSecretLike(env.Name, env.Value) {
+					continue
+				}
+				owner := routeOwnerForEnv(routes, env.Name)
+				if owner == "" {
+					owner = "platform-engineering"
+				}
+				key := doc.Kind + "/" + doc.Metadata.Namespace + "/" + doc.Metadata.Name + "/" + container.Name + "/" + env.Name
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				refs = append(refs, secretReference{
+					Resource:  doc.Kind + "/" + doc.Metadata.Name,
+					Namespace: doc.Metadata.Namespace,
+					Container: container.Name,
+					Env:       env.Name,
+					Owner:     owner,
+					Current:   "literal-value",
+					ProposedRef: map[string]string{
+						"secret_name": secretNameFor(doc.Metadata.Name, env.Name),
+						"key":         secretKeyFor(env.Name),
+					},
+					Review: "replace env.value with env.valueFrom.secretKeyRef only after the secret lifecycle is owned and audited",
+				})
+			}
+		}
+	}
+	if len(refs) == 0 {
+		return Proposal{}, false, nil
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].Resource != refs[j].Resource {
+			return refs[i].Resource < refs[j].Resource
+		}
+		return refs[i].Env < refs[j].Env
+	})
+	content, err := marshalYAML(secretReferencePlan{
+		SchemaVersion: "cub.confighub.io/secret-reference-proposal/v1",
+		References:    refs,
+	})
+	if err != nil {
+		return Proposal{}, false, err
+	}
+	return Proposal{
+		ID:         "05-secret-references",
+		Transform:  TransformSecretRefs,
+		Title:      "Replace implicit secret wiring with explicit references",
+		SourcePath: "rendered Deployment env",
+		Owner:      joinSorted(uniqueSecretOwners(refs)),
+		Risk:       RiskHigh,
+		Review:     "Do not apply automatically; confirm the secret owner, key name, and rotation path first.",
+		Why:        "literal datasource, token, password, or secret-shaped env values should have an explicit SecretReference contract before platform automation owns them.",
+		RenderedImpact: []RenderedImpact{{
+			ResourceType: "Deployment",
+			Path:         "spec.template.spec.containers[*].env[*].valueFrom.secretKeyRef",
+			Action:       "replace-literal-with-explicit-reference",
+			Explanation:  "generated Deployments can use auditable secret references instead of implicit literal wiring",
+		}},
+		Patch: Patch{
+			Path:        ".cub-gen/normalize/secret-references.yaml",
+			Action:      ActionCreate,
+			ContentType: "application/yaml",
+			Content:     content,
+		},
+	}, true, nil
+}
+
+func readSpringRoutes(root string) (*springboot.FieldRoutes, string, error) {
+	rel := filepath.ToSlash(filepath.Join("operational", "field-routes.yaml"))
+	p := filepath.Join(root, filepath.FromSlash(rel))
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, "", nil
+		}
+		return nil, "", fmt.Errorf("read field routes: %w", err)
+	}
+	var routes springboot.FieldRoutes
+	if err := yaml.Unmarshal(raw, &routes); err != nil {
+		return nil, "", fmt.Errorf("parse field routes: %w", err)
+	}
+	return &routes, rel, nil
+}
+
+func readManifestDocs(root string) ([]manifestDoc, error) {
+	patterns := []string{
+		filepath.Join(root, "operational", "*.yaml"),
+		filepath.Join(root, "confighub", "*.yaml"),
+	}
+	paths := []string{}
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("scan manifests: %w", err)
+		}
+		paths = append(paths, matches...)
+	}
+	sort.Strings(paths)
+	docs := []manifestDoc{}
+	for _, p := range paths {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("read manifest %s: %w", p, err)
+		}
+		rel := mustRel(root, p)
+		dec := yaml.NewDecoder(bytes.NewReader(raw))
+		for {
+			var doc manifestDoc
+			err := dec.Decode(&doc)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("parse manifest %s: %w", rel, err)
+			}
+			if strings.TrimSpace(doc.Kind) == "" {
+				continue
+			}
+			doc.RelPath = rel
+			docs = append(docs, doc)
+		}
+	}
+	return docs, nil
+}
+
+func policyRouteFor(action springboot.RouteAction) string {
+	switch action {
+	case springboot.ActionMutableInCH:
+		return "apply-here"
+	case springboot.ActionLiftUpstream:
+		return "lift-upstream"
+	case springboot.ActionGeneratorOwned:
+		return "generator-owned"
+	default:
+		return ""
+	}
+}
+
+func proposalHintFor(route springboot.FieldRoute) string {
+	switch route.DefaultAction {
+	case springboot.ActionMutableInCH:
+		return "allow local ConfigHub mutation and preserve it across generator refresh"
+	case springboot.ActionLiftUpstream:
+		return "create a source PR before accepting this as a durable change"
+	case springboot.ActionGeneratorOwned:
+		return "block direct mutation and escalate to the platform owner"
+	default:
+		return strings.TrimSpace(route.Reason)
+	}
+}
+
+func renderedPathsForRoute(route springboot.FieldRoute, docs []manifestDoc) []string {
+	match := strings.TrimSpace(route.Match)
+	if match == "" {
+		return nil
+	}
+	out := []string{"ConfigMap/data/application*.yaml:" + match}
+	if envPattern := envPatternForFieldPattern(match); envPattern != "" && firstResourceName(docs, "Deployment") != "" {
+		out = append(out, "Deployment/spec/template/spec/containers[*]/env["+envPattern+"]/value")
+	}
+	sort.Strings(out)
+	return out
+}
+
+func firstResourceName(docs []manifestDoc, kind string) string {
+	for _, doc := range docs {
+		if doc.Kind == kind && strings.TrimSpace(doc.Metadata.Name) != "" {
+			return doc.Metadata.Name
+		}
+	}
+	return ""
+}
+
+func hasRenderedKind(docs []manifestDoc, kind string) bool {
+	for _, doc := range docs {
+		if doc.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func renderedOwnerHints(imported gitopsflow.ImportFlowResult) (map[string]string, string) {
+	ownersByKind := map[string]string{}
+	counts := map[string]int{}
+	for _, target := range imported.WetManifestTargets {
+		kind := strings.TrimSpace(target.Kind)
+		owner := strings.TrimSpace(target.Owner)
+		if kind == "" || owner == "" {
+			continue
+		}
+		if ownersByKind[kind] == "" {
+			ownersByKind[kind] = owner
+		}
+		counts[owner]++
+	}
+	defaultOwner := ""
+	defaultCount := 0
+	for owner, count := range counts {
+		if count > defaultCount || (count == defaultCount && owner < defaultOwner) {
+			defaultOwner = owner
+			defaultCount = count
+		}
+	}
+	return ownersByKind, defaultOwner
+}
+
+func springSourceCandidates(root string) []string {
+	patterns := []string{
+		filepath.Join(root, "src", "main", "resources", "application.yaml"),
+		filepath.Join(root, "src", "main", "resources", "application-*.yaml"),
+	}
+	var out []string
+	for _, pattern := range patterns {
+		matches, _ := filepath.Glob(pattern)
+		sort.Strings(matches)
+		for _, match := range matches {
+			out = append(out, mustRel(root, match))
+		}
+	}
+	return uniqueStrings(out)
+}
+
+func componentName(root string) string {
+	appPath := filepath.Join(root, "src", "main", "resources", "application.yaml")
+	raw, err := os.ReadFile(appPath)
+	if err == nil {
+		var doc map[string]any
+		if yaml.Unmarshal(raw, &doc) == nil {
+			if name := nestedString(doc, "spring", "application", "name"); name != "" {
+				return name
+			}
+		}
+	}
+	return filepath.Base(root)
+}
+
+func nestedString(m map[string]any, keys ...string) string {
+	var cur any = m
+	for _, key := range keys {
+		next, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur, ok = next[key]
+		if !ok {
+			return ""
+		}
+	}
+	if s, ok := cur.(string); ok {
+		return strings.TrimSpace(s)
+	}
+	return ""
+}
+
+func findRenderedProofForEnv(root, env string) string {
+	matches, _ := filepath.Glob(filepath.Join(root, "confighub", "*-"+env+".yaml"))
+	sort.Strings(matches)
+	if len(matches) == 0 {
+		return ""
+	}
+	return mustRel(root, matches[0])
+}
+
+func envPatternForFieldPattern(pattern string) string {
+	p := strings.TrimSpace(pattern)
+	if p == "" {
+		return ""
+	}
+	p = strings.TrimSuffix(p, ".*")
+	p = strings.ReplaceAll(p, ".", "_")
+	p = strings.ToUpper(p)
+	if strings.HasSuffix(pattern, ".*") {
+		return p + "_*"
+	}
+	return p
+}
+
+func routeOwnerForEnv(routes springboot.FieldRoutes, envName string) string {
+	field := strings.ToLower(strings.ReplaceAll(envName, "_", "."))
+	for _, route := range routes.Routes {
+		ok, err := path.Match(strings.TrimSpace(route.Match), field)
+		if err == nil && ok {
+			return strings.TrimSpace(route.Owner)
+		}
+	}
+	return ""
+}
+
+func looksSecretLike(name, value string) bool {
+	upperName := strings.ToUpper(strings.TrimSpace(name))
+	lowerValue := strings.ToLower(strings.TrimSpace(value))
+	if strings.Contains(upperName, "PASSWORD") || strings.Contains(upperName, "TOKEN") || strings.Contains(upperName, "SECRET") {
+		return true
+	}
+	if strings.Contains(upperName, "DATASOURCE") && strings.Contains(lowerValue, "jdbc:") {
+		return true
+	}
+	return false
+}
+
+func secretNameFor(resourceName, envName string) string {
+	base := strings.ToLower(resourceName)
+	base = strings.Trim(base, "-_ .")
+	env := strings.ToLower(envName)
+	switch {
+	case strings.Contains(env, "datasource"):
+		return base + "-datasource"
+	case strings.Contains(env, "token"):
+		return base + "-token"
+	case strings.Contains(env, "password"):
+		return base + "-password"
+	default:
+		return base + "-secret"
+	}
+}
+
+func secretKeyFor(envName string) string {
+	env := strings.ToLower(envName)
+	parts := strings.Split(env, "_")
+	if len(parts) > 0 {
+		last := parts[len(parts)-1]
+		if last != "" {
+			return strings.ReplaceAll(last, "-", "_")
+		}
+	}
+	return "value"
+}
+
+func uniqueRouteOwners(routes []springboot.FieldRoute) []string {
+	out := []string{}
+	for _, route := range routes {
+		if owner := strings.TrimSpace(route.Owner); owner != "" {
+			out = append(out, owner)
+		}
+	}
+	return uniqueStrings(out)
+}
+
+func uniqueLiftOwners(routes []springboot.FieldRoute) []string {
+	out := []string{}
+	for _, route := range routes {
+		if route.DefaultAction == springboot.ActionLiftUpstream && strings.TrimSpace(route.Owner) != "" {
+			out = append(out, route.Owner)
+		}
+	}
+	return uniqueStrings(out)
+}
+
+func uniqueAnnotationOwners(annotations []ownerAnnotation) []string {
+	out := []string{}
+	for _, annotation := range annotations {
+		if annotation.Owner != "" {
+			out = append(out, annotation.Owner)
+		}
+	}
+	return uniqueStrings(out)
+}
+
+func uniqueSecretOwners(refs []secretReference) []string {
+	out := []string{}
+	for _, ref := range refs {
+		if ref.Owner != "" {
+			out = append(out, ref.Owner)
+		}
+	}
+	return uniqueStrings(out)
+}
+
+func uniqueStrings(in []string) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, raw := range in {
+		s := strings.TrimSpace(raw)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func joinSorted(values []string) string {
+	values = uniqueStrings(values)
+	return strings.Join(values, ",")
+}
+
+func sanitizeID(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "\\", "/")
+	value = strings.Trim(value, "/")
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func mustRel(root, p string) string {
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return filepath.ToSlash(p)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func marshalJSON(v any) (string, error) {
+	raw, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal normalize proposal: %w", err)
+	}
+	return string(append(raw, '\n')), nil
+}
+
+func marshalYAML(v any) (string, error) {
+	raw, err := yaml.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("marshal normalize proposal: %w", err)
+	}
+	return string(raw), nil
+}

--- a/internal/normalize/normalize_test.go
+++ b/internal/normalize/normalize_test.go
@@ -1,0 +1,137 @@
+package normalize
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
+	"github.com/confighub/cub-gen/internal/model"
+)
+
+func TestBuildPlanSpringBootGovernedPatchSet(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "examples", "springboot-paas"))
+	if err != nil {
+		t.Fatalf("resolve spring example: %v", err)
+	}
+	plan, err := BuildPlan(exampleImportResult(root))
+	if err != nil {
+		t.Fatalf("build normalize plan: %v", err)
+	}
+
+	if plan.Summary.ProposalCount != 5 {
+		t.Fatalf("expected 5 proposals, got %+v", plan.Summary)
+	}
+	if plan.Summary.TransformCount != 5 {
+		t.Fatalf("expected 5 transforms, got %+v", plan.Summary)
+	}
+	if plan.Summary.RiskCounts[RiskHigh] != 1 || plan.Summary.RiskCounts[RiskMedium] != 2 || plan.Summary.RiskCounts[RiskLow] != 2 {
+		t.Fatalf("unexpected risk counts: %+v", plan.Summary.RiskCounts)
+	}
+
+	byID := proposalsByID(plan)
+	routePolicy := byID["01-route-policy-annotation"]
+	if routePolicy.Transform != TransformRoutePolicy {
+		t.Fatalf("missing route policy proposal: %+v", routePolicy)
+	}
+	if routePolicy.SourcePath != "operational/field-routes.yaml" {
+		t.Fatalf("unexpected route policy source: %q", routePolicy.SourcePath)
+	}
+	if !strings.Contains(routePolicy.Patch.Content, routePolicyAnnotation) {
+		t.Fatalf("route policy content missing annotation key:\n%s", routePolicy.Patch.Content)
+	}
+	if !strings.Contains(routePolicy.Patch.Content, `"route": "generator-owned"`) {
+		t.Fatalf("route policy content missing generator-owned route:\n%s", routePolicy.Patch.Content)
+	}
+
+	secretRefs := byID["05-secret-references"]
+	if secretRefs.Transform != TransformSecretRefs {
+		t.Fatalf("missing secret reference proposal: %+v", secretRefs)
+	}
+	if !strings.Contains(secretRefs.Patch.Content, "SPRING_DATASOURCE_URL") {
+		t.Fatalf("secret proposal does not name datasource env:\n%s", secretRefs.Patch.Content)
+	}
+	if count := strings.Count(secretRefs.Patch.Content, "SPRING_DATASOURCE_URL"); count != 1 {
+		t.Fatalf("expected deduped datasource env once, got %d:\n%s", count, secretRefs.Patch.Content)
+	}
+}
+
+func TestBuildPlanUnknownRepoNoops(t *testing.T) {
+	root := t.TempDir()
+	plan, err := BuildPlan(gitopsflow.ImportFlowResult{
+		Space:            "platform",
+		TargetSlug:       "unknown",
+		TargetPath:       root,
+		RenderTargetSlug: "unknown",
+		RenderTargetPath: root,
+		Ref:              "HEAD",
+		ImportedAt:       "2026-04-30T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("build normalize plan: %v", err)
+	}
+	if plan.Summary.ProposalCount != 0 {
+		t.Fatalf("expected no proposals, got %+v", plan.Summary)
+	}
+	if len(plan.Diagnostics) != 1 || plan.Diagnostics[0].Code != "NO_KNOWN_PATTERNS" {
+		t.Fatalf("expected no-op diagnostic, got %+v", plan.Diagnostics)
+	}
+}
+
+func TestRenderPatchIncludesAllCreateProposals(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "examples", "springboot-paas"))
+	if err != nil {
+		t.Fatalf("resolve spring example: %v", err)
+	}
+	plan, err := BuildPlan(exampleImportResult(root))
+	if err != nil {
+		t.Fatalf("build normalize plan: %v", err)
+	}
+	patch, err := RenderPatch(plan)
+	if err != nil {
+		t.Fatalf("render patch: %v", err)
+	}
+	for _, expected := range []string{
+		".cub-gen/normalize/confighub-route-policy.annotation.json",
+		".cub-gen/normalize/lift-upstream.proposals.json",
+		".cub-gen/normalize/deployable-variants.yaml",
+		".cub-gen/normalize/owner-annotations.yaml",
+		".cub-gen/normalize/secret-references.yaml",
+	} {
+		if !strings.Contains(patch, "+++ b/"+expected) {
+			t.Fatalf("patch missing %s:\n%s", expected, patch)
+		}
+	}
+}
+
+func proposalsByID(plan Plan) map[string]Proposal {
+	out := map[string]Proposal{}
+	for _, proposal := range plan.PatchSet.Proposals {
+		out[proposal.ID] = proposal
+	}
+	return out
+}
+
+func exampleImportResult(root string) gitopsflow.ImportFlowResult {
+	return gitopsflow.ImportFlowResult{
+		Space:            "platform",
+		TargetSlug:       "springboot-paas",
+		TargetPath:       root,
+		RenderTargetSlug: "springboot-paas",
+		RenderTargetPath: root,
+		Ref:              "HEAD",
+		ImportedAt:       "2026-04-30T00:00:00Z",
+		DryInputs: []model.DryInputRef{
+			{GeneratorID: "gen_spring", Profile: "springboot-paas", Role: "build-config", Owner: "platform-engineer", Path: "pom.xml", Required: true},
+			{GeneratorID: "gen_spring", Profile: "springboot-paas", Role: "app-config-base", Owner: "app-team", Path: "src/main/resources/application.yaml", Required: true},
+			{GeneratorID: "gen_spring", Profile: "springboot-paas", Role: "app-config-profile", Owner: "app-team", Path: "src/main/resources/application-dev.yaml", Required: true},
+			{GeneratorID: "gen_spring", Profile: "springboot-paas", Role: "app-config-profile", Owner: "app-team", Path: "src/main/resources/application-prod.yaml", Required: true},
+			{GeneratorID: "gen_spring", Profile: "springboot-paas", Role: "app-config-profile", Owner: "app-team", Path: "src/main/resources/application-stage.yaml", Required: true},
+		},
+		WetManifestTargets: []model.WetManifestTarget{
+			{GeneratorID: "gen_spring", Kind: "Kustomization", Name: "springboot-paas", Namespace: "apps", Owner: "platform-runtime"},
+			{GeneratorID: "gen_spring", Kind: "Deployment", Name: "springboot-paas", Namespace: "apps", Owner: "platform-runtime"},
+			{GeneratorID: "gen_spring", Kind: "ConfigMap", Name: "springboot-paas-config", Namespace: "apps", Owner: "platform-runtime"},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add `cub-gen normalize preview` with JSON and patch output for governed rewrite proposals
- generate a review-only Spring patch set for route policy annotations, lift-upstream source routing, Deployable Variant inventory, owner annotations, and explicit secret-reference proposals
- document the normalize workflow in the README, CLI reference, Spring example, examples index, and v0.4 roadmap

Closes #281.

## Validation
- `make ci`
- `/tmp/cub-gen-mkdocs/bin/mkdocs build --strict`