### PR TITLE
[codex] Align cub-gen variant language with ConfigHub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,13 @@ The product model is:
 
 ```text
 Component
-  -> Deployable Variant
-      -> Target
-      -> Connections
-      -> Change
-      -> Proof
+  -> Variant
+      -> Base Variant
+      -> Deployment Variant
+          -> Target
+          -> Connections
+          -> Change
+          -> Proof
 ```
 
 Keep this simple. Do not explain cub-gen first as DRY/WET, generator contracts,
@@ -56,8 +58,13 @@ Use these terms:
 
 - **Generator**: a function on config data.
 - **Component**: the reusable app/service/platform thing.
-- **Deployable Variant**: a concrete deployable copy for an environment, tenant,
-  region, customer, or cluster.
+- **Variant**: a member of a Component family.
+- **Base Variant**: a Variant that is not deployed and has no Target/live
+  address.
+- **Deployment Variant**: a Variant that is deployed to a Target and has live
+  addressable config/resources.
+- **Deployable Variant**: only use this as plain English for Deployment Variant,
+  not as the whole ConfigHub Variant model.
 - **Change**: a proposed edit to source or rendered config.
 - **Proof**: field origin, owner, route, and decision evidence.
 
@@ -97,9 +104,9 @@ A change is complete only when:
 
 - `gitops discover/import`: repo-first detection and import with `cub gitops`
   command-shape parity.
-- `platform import`: read several app/platform repos as Components, Deployable
-  Variants, Targets, Generators, and diagnostics.
-- `platform fanout`: emit one proof bundle per declared deployable variant.
+- `platform import`: read several app/platform repos as Components, Variants,
+  Deployment Variants, Targets, Generators, and diagnostics.
+- `platform fanout`: emit one proof bundle per declared Deployment Variant.
 - `enrich preview/write`: create sidecar provenance proof without manifest
   rewrites.
 - `normalize preview`: propose reviewable cleanup patches without touching

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ settings, and secret references. They return deployable Kubernetes config.
 
 `cub-gen` makes those functions explicit so ConfigHub can reason about inputs,
 outputs, provenance, ownership, and inverse edit paths. It can show which
-Component produced which Deployable Variants, where each variant deploys, what
-it connects to, and which source field owns each rendered field.
+Component produced which Variants, which Variants are deployable, where those
+Deployment Variants deploy, what they connect to, and which source field owns
+each rendered field.
 
 When someone changes generated config, `cub-gen` can route the edit: apply it
 here, lift it back to the source file, or block/escalate it because the platform
@@ -68,7 +69,7 @@ still builds `cub-gen`. The plugin migration details are in
 | Who owns the field? | App, environment, platform, security, or workflow owner |
 | Where should the edit go? | Apply here, lift upstream, or block/escalate |
 | What changed? | A reviewable before/after bundle |
-| Which variants need proof? | One governed bundle per environment, tenant, or region |
+| Which variants need proof? | One governed bundle per Deployment Variant: environment, tenant, or region |
 | How do I prove it? | Field-origin map, edit hint, proof bundle, and optional ConfigHub decision |
 
 The output is useful locally, in GitHub PRs, and in connected ConfigHub flows.
@@ -130,15 +131,22 @@ The simple product model is:
 
 ```text
 Component
-  -> Deployable Variant
-      -> Target
-      -> Connections
-      -> Proof
+  -> Variant
+      -> Base Variant
+      -> Deployment Variant
+          -> Target
+          -> Connections
+          -> Change
+          -> Proof
 ```
 
-A **Component** is the reusable thing. A **Deployable Variant** is the concrete
-copy of it for one environment, tenant, region, customer, or cluster. `cub-gen`
-helps explain how that variant was generated and where a proposed change should
+A **Component** is the reusable thing. A **Variant** is a member of that
+Component family. A **Base Variant** is not deployed. A **Deployment Variant**
+is the concrete deployed copy for one environment, tenant, region, customer, or
+cluster.
+
+`cub-gen` helps explain how a Variant was generated, whether it is a base or a
+deployment when the repo makes that clear, and where a proposed change should
 land.
 
 A **Change** is any proposed edit to the source or rendered config. **Proof**
@@ -209,7 +217,7 @@ To propose reviewable cleanup patches without touching source or rendered YAML:
 
 `normalize preview` emits review-only sidecar proposals under
 `.cub-gen/normalize/`. In the Spring example it proposes route policy
-annotations, lift-upstream source routing, dev/stage/prod Deployable Variants,
+annotations, lift-upstream source routing, dev/stage/prod Deployment Variants,
 owner annotations, and an explicit datasource SecretReference candidate.
 
 ## Core capabilities
@@ -218,8 +226,8 @@ owner annotations, and an explicit datasource SecretReference candidate.
 |---|---|
 | Detect | Find the generator style used by the repo |
 | Render/import | Produce or read the deployable config |
-| Platform graph | Read several app/platform repos as Components, Deployable Variants, Targets, Generators, and diagnostics |
-| Variant fanout | Emit one ConfigHub-ready proof bundle per environment, tenant, region, or cluster variant |
+| Platform graph | Read several app/platform repos as Components, Variants, Deployment Variants, Targets, Generators, and diagnostics |
+| Variant fanout | Emit one ConfigHub-ready proof bundle per deployment environment, tenant, region, or cluster variant |
 | Trace | Map rendered fields back to source files |
 | Explain | Say who owns the field and where to edit it |
 | Enrich | Create PR-friendly sidecar proof with source links, owners, route badges, and PR/MR link metadata |
@@ -245,8 +253,8 @@ These run locally and do not require a login:
 | Argo app-of-apps | [app-of-apps fixture](testdata/app-of-apps-standalone/) + [Argo worked example](docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md) | Which root app path or child Application catalog entry owns this app? |
 | Score.dev | [scoredev-paas](examples/scoredev-paas/) | Which `score.yaml` field produced this runtime value? |
 | Spring Boot services | [springboot-paas](examples/springboot-paas/) | Should I edit app config or platform config? |
-| Multi-repo platform | [platform-estate fixture](testdata/platform-estate/) | Which Components, Deployable Variants, Generators, and gaps exist before any rewrite? |
-| Multi-env or tenant variants | [variant-fanout fixture](testdata/variant-fanout/) | Can I produce one governed proof bundle for every deployable variant? |
+| Multi-repo platform | [platform-estate fixture](testdata/platform-estate/) | Which Components, Variants, Deployment Variants, Generators, and gaps exist before any rewrite? |
+| Multi-env or tenant variants | [variant-fanout fixture](testdata/variant-fanout/) | Can I produce one governed proof bundle for every Deployment Variant? |
 | A running cluster first | ConfigHub GitOps import + [cub-scout](https://github.com/confighub/cub-scout) + then `cub-gen` | What is running, and what source produced it? |
 
 ## Supported Inputs
@@ -354,14 +362,14 @@ controllers running in kind.
 |---|---|
 | Latest shipped | `v0.3.0` was released on 2026-04-12 |
 | Strong now | Repo-first CLI is stable; 11 generator families ship on this branch; the main examples have local, connected, and live proof paths |
-| In progress | Working `v0.4` roadmap: make cub-gen's role clear as Component -> Deployable Variant -> Target/Connections/Change/Proof |
-| Current release target | [v0.4 working roadmap](docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md) and GitHub parent issue [#287](https://github.com/confighub/cub-gen/issues/287) |
+| In progress | Working `v0.4` roadmap: make cub-gen's role clear as Component -> Variant -> Base/Deployment -> Target/Connections/Change/Proof |
+| Current release target | GitHub release tracker [#302](https://github.com/confighub/cub-gen/issues/302), topology alignment [#304](https://github.com/confighub/cub-gen/issues/304), and the [v0.4 working roadmap](docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md) |
 | Latest release notes | See [docs/releases/v0.3.0.md](docs/releases/v0.3.0.md) |
 | Previous release notes | See [docs/releases/v0.2-preview.2.md](docs/releases/v0.2-preview.2.md) |
 | Example quality | Flagship example blockers and Helm depth blockers are closed on `main` |
 | CLI/docs follow-on | `#275`, `#219`, `#236`, `#209`-`#213`, `#276`-`#285` |
 | Release gate | `v0.3.0` was cut from green `main`; rerun ConfigHub smoke before the next release |
-| Actively tracked | [#287](https://github.com/confighub/cub-gen/issues/287) plus milestone [v0.4: Component -> Deployable Variant -> Proof](https://github.com/confighub/cub-gen/milestone/4) |
+| Actively tracked | [#302](https://github.com/confighub/cub-gen/issues/302) plus milestone [v0.4: Component -> Variant -> Proof](https://github.com/confighub/cub-gen/milestone/4) |
 
 For exact per-example counts and classifications, use the generated
 [Example Truth Matrix](docs/testing/example-truth-matrix.md). It is built from

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -1047,7 +1047,7 @@ func printUsage(out io.Writer) {
 				"  enrich preview    Propose sidecar proof metadata for PR review",
 				"  normalize preview  Propose governed rewrite patches for review",
 				"  platform import   Read a multi-repo platform estate as a graph",
-				"  platform fanout   Emit one proof bundle per deployable variant",
+				"  platform fanout   Emit one proof bundle per Deployment Variant",
 				"  detect            Detect generators in a repo",
 				"  generators        List supported generators (Helm, Score, Spring Boot, ...)",
 			},

--- a/cmd/cub-gen/normalize.go
+++ b/cmd/cub-gen/normalize.go
@@ -125,7 +125,7 @@ func printNormalizeUsage(out io.Writer) {
 			Lines: []string{
 				"  - add-route-policy-annotation: turn field-route metadata into ConfigHub Unit route policy annotations",
 				"  - lift-generated-patch-to-source: show where rendered edits should become source PRs",
-				"  - split-env-values-into-variants: expose environment/profile files as Deployable Variants",
+				"  - split-env-values-into-variants: expose environment/profile files as Deployment Variants",
 				"  - add-missing-owners: propose owner labels from generator provenance",
 				"  - replace-implicit-secret-wiring: propose explicit SecretReference records for literal secret-shaped env values",
 			},

--- a/cmd/cub-gen/platform.go
+++ b/cmd/cub-gen/platform.go
@@ -88,8 +88,8 @@ func printPlatformUsage(out io.Writer) {
 		out,
 		"cub-gen platform: import estates and emit variant bundles without deploying",
 		[]string{
-			"Use platform import when app intent, platform contracts, environment bindings, and rendered output live in separate repos.",
-			"The command reads a manifest, imports each local repo, and emits Components, Deployable Variants, Targets, generator inputs, WET targets, connections, and diagnostics.",
+			"Use platform import when app source config, platform contracts, environment bindings, and rendered output live in separate repos.",
+			"The command reads a manifest, imports each local repo, and emits Components, Variants, Deployment Variants, Targets, generator inputs, WET targets, connections, and diagnostics.",
 			"Use platform fanout when the same Component has dev/stage/prod or tenant variants and each needs its own governed ConfigHub bundle.",
 		},
 		helpSection{

--- a/cmd/cub-gen/testdata/parity/enrich-preview-app-of-apps.golden.json
+++ b/cmd/cub-gen/testdata/parity/enrich-preview-app-of-apps.golden.json
@@ -90,7 +90,7 @@
             "key": "cub.confighub.io/source-paths",
             "value": "apps/catalog-api.yaml,apps/orders-api.yaml,apps/payments-api.yaml,root-application.yaml",
             "applies_to": "sidecar",
-            "reason": "show which source files feed the deployable variant"
+            "reason": "show which source files feed the Deployment Variant"
           }
         ],
         "source_links": [

--- a/cmd/cub-gen/testdata/parity/enrich-preview-app-of-apps.patch.golden.diff
+++ b/cmd/cub-gen/testdata/parity/enrich-preview-app-of-apps.patch.golden.diff
@@ -67,7 +67,7 @@ index 0000000..0000000
 +      "key": "cub.confighub.io/source-paths",
 +      "value": "apps/catalog-api.yaml,apps/orders-api.yaml,apps/payments-api.yaml,root-application.yaml",
 +      "applies_to": "sidecar",
-+      "reason": "show which source files feed the deployable variant"
++      "reason": "show which source files feed the Deployment Variant"
 +    }
 +  ],
 +  "source_links": [

--- a/cmd/cub-gen/testdata/parity/normalize-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/normalize-help.stdout.golden.txt
@@ -13,6 +13,6 @@ Examples:
 Transforms:
   - add-route-policy-annotation: turn field-route metadata into ConfigHub Unit route policy annotations
   - lift-generated-patch-to-source: show where rendered edits should become source PRs
-  - split-env-values-into-variants: expose environment/profile files as Deployable Variants
+  - split-env-values-into-variants: expose environment/profile files as Deployment Variants
   - add-missing-owners: propose owner labels from generator provenance
   - replace-implicit-secret-wiring: propose explicit SecretReference records for literal secret-shaped env values

--- a/cmd/cub-gen/testdata/parity/platform-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/platform-help.stdout.golden.txt
@@ -1,7 +1,7 @@
 cub-gen platform: import estates and emit variant bundles without deploying
 
-Use platform import when app intent, platform contracts, environment bindings, and rendered output live in separate repos.
-The command reads a manifest, imports each local repo, and emits Components, Deployable Variants, Targets, generator inputs, WET targets, connections, and diagnostics.
+Use platform import when app source config, platform contracts, environment bindings, and rendered output live in separate repos.
+The command reads a manifest, imports each local repo, and emits Components, Variants, Deployment Variants, Targets, generator inputs, WET targets, connections, and diagnostics.
 Use platform fanout when the same Component has dev/stage/prod or tenant variants and each needs its own governed ConfigHub bundle.
 
 Usage:

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -13,7 +13,7 @@ START HERE:
   enrich preview    Propose sidecar proof metadata for PR review
   normalize preview  Propose governed rewrite patches for review
   platform import   Read a multi-repo platform estate as a graph
-  platform fanout   Emit one proof bundle per deployable variant
+  platform fanout   Emit one proof bundle per Deployment Variant
   detect            Detect generators in a repo
   generators        List supported generators (Helm, Score, Spring Boot, ...)
 

--- a/docs/agentic-gitops/01-vision/02-next-gen-gitops-ai-era.md
+++ b/docs/agentic-gitops/01-vision/02-next-gen-gitops-ai-era.md
@@ -63,7 +63,7 @@ Typical unit:
 
 Combined result:
 
-1. app intent and agent behavior are linked in one audit path.
+1. app source config and agent behavior are linked in one audit path.
 
 ## LIVE-Origin Change Path (Kargo-Style, Governed)
 

--- a/docs/agentic-gitops/01-vision/03-front-door-and-authority.md
+++ b/docs/agentic-gitops/01-vision/03-front-door-and-authority.md
@@ -290,7 +290,7 @@ Examples:
 - patching a downstream YAML instead of the platform policy that should own it
 - hotfixing a live object that gets silently reverted by reconciliation
 
-This is how app intent and operational truth drift apart.
+This is how app source config and operational truth drift apart.
 
 ### Problem 3: too many version axes
 
@@ -395,7 +395,7 @@ A platform team naturally wants to own:
 
 That gives us a simple model:
 
-1. The app author writes app intent.
+1. The app author writes app source config.
 2. The platform defines the contract, defaults, and guardrails.
 3. A generator or platform control plane combines both into deployable
    operational state.
@@ -404,14 +404,14 @@ That gives us a simple model:
 This is what we mean by the app platform model.
 
 It is not "developers stop owning apps."
-It is "developers own app intent, while the platform owns how that intent is
+It is "developers own app source config, while the platform owns how that config is
 made safe and operable."
 
 This model lines up with current industry practice:
 
 - Spring itself expects separate operational concerns such as probes,
   graceful shutdown, and externalized config
-- platform frameworks expect app intent to be smaller and more stable than the
+- platform frameworks expect app source config to be smaller and more stable than the
   rendered deployment bundle
 - AI workflows make it even more valuable to separate proposal from authority
 
@@ -532,7 +532,7 @@ shared platform contract.
 In practice, this helps explain:
 
 - why some changes are direct app mutations
-- why some changes must be lifted upstream into app intent
+- why some changes must be lifted upstream into app source config
 - why some changes are generator-owned or platform-owned and should be blocked
 
 We should treat this as an experimental refinement, not as a breaking rename.

--- a/docs/agentic-gitops/02-design/10-generators-prd.md
+++ b/docs/agentic-gitops/02-design/10-generators-prd.md
@@ -14,20 +14,23 @@ User-facing doctrine:
 
 ```text
 Component
-  -> Deployable Variant
-      -> Target
-      -> Connections
-      -> Proof
+  -> Variant
+      -> Base Variant
+      -> Deployment Variant
+          -> Target
+          -> Connections
+          -> Proof
 ```
 
-A Component is the reusable base. A Deployable Variant is a concrete deployable
-copy or context of that Component. An AI Variant is a Deployable Variant whose
+A Component is the reusable base. A Variant is a member of that Component
+family. A Base Variant is not deployed. A Deployment Variant is the concrete
+deployed copy or context of that Component. An AI Variant is a Variant whose
 delta, wiring, or operation is AI-assisted and governed. Generator contracts
 are the implementation mechanism that lets the product derive variants, targets,
 connections, changes, and proof from existing repos.
 
-Plain-English thesis: many app platforms are generators. They take app intent,
-environment context, and platform contracts, then produce deployable config. The
+Plain-English thesis: many app platforms are generators. They take app source
+config, environment context, and platform contracts, then produce deployable config. The
 product does not need to replace those platforms first. It needs to import them,
 record their generator contract, and route changes to the right source layer.
 
@@ -97,7 +100,7 @@ No contract triple, no governed import.
 2. As a Spring Boot team, I can keep framework config as DRY input and get explicit WET manifests with field-origin mapping for critical ops fields.
 3. As a Score.dev user, I can preserve my workload abstraction and still get governed dry/wet lineage in ConfigHub.
 4. As an app-config platform user (for example feature-flag/runtime config repos), I can import literal WET config into the same governance model.
-5. As an ops engineer, I can trace a production config field to source intent quickly enough for incident response.
+5. As an ops engineer, I can trace a production config field to source config quickly enough for incident response.
 6. As a platform lead, I can onboard mixed Git teams with a single cognitive-simple path: detect -> import -> explain -> evaluate.
 7. As a CI-centric platform team, I can call ConfigHub mutation/query APIs from existing pipelines and avoid repo/file-path scripting.
 8. As a platform owner, I can evolve labels and taxonomy (app/service/target) without repo surgery and without breaking operational queries.

--- a/docs/agentic-gitops/02-design/90-platform-generators-manifesto.md
+++ b/docs/agentic-gitops/02-design/90-platform-generators-manifesto.md
@@ -11,10 +11,13 @@ Start with the user model, not the implementation model:
 
 ```text
 Component
-  -> Deployable Variant
-      -> Target
-      -> Connections
-      -> Proof
+  -> Variant
+      -> Base Variant
+      -> Deployment Variant
+          -> Target
+          -> Connections
+          -> Change
+          -> Proof
 ```
 
 The vocabulary should stay small:
@@ -22,8 +25,10 @@ The vocabulary should stay small:
 | Term | Plain-English meaning |
 |---|---|
 | Component | reusable app, service, workflow, or platform base |
-| Deployable Variant | concrete deployable copy/context of a Component: env, region, tenant, customer, cluster |
-| AI Variant | Deployable Variant whose delta, wiring, or operation is AI-assisted and governed |
+| Variant | member of a Component family |
+| Base Variant | non-deployed Variant with no Target/live address |
+| Deployment Variant | deployable Variant for an environment, region, tenant, customer, or cluster |
+| AI Variant | Variant whose delta, wiring, or operation is AI-assisted and governed |
 | Target | place the variant runs or reconciles |
 | Connection | dependency, secret, database, API, service binding, or platform contract the variant is wired to |
 | Change | requested alteration to source, rendered config, wiring, or operation |
@@ -36,7 +41,7 @@ The manifesto is the clean version of what the early `cub-gen` planning docs
 were already reaching for:
 
 1. Import existing platform and app repos, not replace them.
-2. Model them as generators from source intent to deployable config.
+2. Model them as generators from source config to deployable config.
 3. Preserve provenance and inverse edit paths.
 4. Route changes as apply-here, lift-upstream, or block/escalate.
 5. Link GitHub PRs and ConfigHub MRs with one `change_id`.
@@ -50,7 +55,7 @@ to govern the generator boundary.
 Many "platform abstractions" are actually generators:
 
 ```text
-source intent + environment context + platform contract -> deployable config
+source config + environment context + platform contract -> deployable config
 ```
 
 That matters because a generator can be inspected. A bad abstraction hides
@@ -159,7 +164,7 @@ The goal is not a perfect abstraction. The goal is a governed escape path.
 | Platform style | Generator input | WET output | Notes |
 |---|---|---|---|
 | Helm platform | chart, values, overlays, invocation args | Kubernetes manifests | broadest adoption, hardest provenance |
-| Score.dev | `score.yaml` plus platform contracts | Kubernetes manifests | clean app intent |
+| Score.dev | `score.yaml` plus platform contracts | Kubernetes manifests | clean app source config |
 | Spring Boot platform | `application*.yaml`, build metadata, platform policy | Deployment, Service, ConfigMap | strongest route teaching |
 | OpenChoreo | Workload, ReleaseBinding, SecretReference, ComponentType | RenderedRelease and K8s resources | fixture-backed initial adapter; not full upstream conformance |
 | Argo ApplicationSet | selectors, list/git/cluster generators, template | Argo Applications | already partially supported |

--- a/docs/agentic-gitops/03-worked-examples/01-scoredev-dry-wet-unit-worked-example.md
+++ b/docs/agentic-gitops/03-worked-examples/01-scoredev-dry-wet-unit-worked-example.md
@@ -34,7 +34,7 @@ No controller replacement is required.
 
 | Concept | Flux/Argo dry/wet pipeline | Score.dev equivalent |
 |---|---|---|
-| DRY authoring input | Kustomization/Application source intent | `score.yaml` + environment parameters |
+| DRY authoring input | Kustomization/Application source config | `score.yaml` + environment parameters |
 | Renderer | Flux/Argo renderer worker | Score->K8s generator + controller renderer worker |
 | WET deployment contract | Fully rendered manifests | Fully rendered manifests from Score intent |
 | Reconciler | FluxCD or ArgoCD | FluxCD or ArgoCD (unchanged) |

--- a/docs/agentic-gitops/03-worked-examples/03-spring-boot-dry-wet-unit-worked-example.md
+++ b/docs/agentic-gitops/03-worked-examples/03-spring-boot-dry-wet-unit-worked-example.md
@@ -56,7 +56,7 @@ acme-platform-gitops/
 
 Two repos are common in practice:
 
-1. app intent repo (developer-facing DRY),
+1. app source config repo (developer-facing DRY),
 2. GitOps deploy repo (controller-facing WET contract).
 
 ---

--- a/docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md
+++ b/docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md
@@ -26,7 +26,7 @@ The answer is not "make a perfect abstraction." The answer is to recognize when
 the platform is really a generator:
 
 ```text
-app intent + environment context + platform contract -> deployable config
+app source config + environment context + platform contract -> deployable config
 ```
 
 If that function is deterministic and ownership boundaries are visible, a
@@ -41,7 +41,7 @@ already named.
 ```mermaid
 flowchart LR
   subgraph DRY["OpenChoreo source objects"]
-    W["Workload<br/>app-owned runtime intent"]
+    W["Workload<br/>app-owned runtime config"]
     RB["ReleaseBinding<br/>environment variant overrides"]
     SR["SecretReference<br/>platform/security secret pointer"]
     CT["ComponentType<br/>platform renderer contract"]
@@ -81,10 +81,10 @@ flowchart LR
 
 | OpenChoreo object | Role in the generator | cub-gen classification | Typical owner |
 |---|---|---|---|
-| `Workload` | Describes what the component consumes | DRY app intent | app team |
+| `Workload` | Describes what the component consumes | DRY app source config | app team |
 | `ReleaseBinding` | Binds a release to an environment with overrides | DRY variant input | environment owner or app team |
 | `SecretReference` | Points at external secret material without storing values | DRY platform/security reference | platform or security |
-| `ComponentType` | Defines how app intent becomes Kubernetes resources | generator contract / platform template | platform team |
+| `ComponentType` | Defines how app source config becomes Kubernetes resources | generator contract / platform template | platform team |
 | `RenderedRelease` | Final rendered component release for an environment | WET output bundle | platform runtime |
 | `Deployment`, `ConfigMap`, `ExternalSecret` | Kubernetes-facing resources | WET targets | platform runtime |
 | live `Secret`, pods, services | Runtime state | LIVE state | reconciler / cluster |

--- a/docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md
+++ b/docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md
@@ -270,7 +270,7 @@ Proof commands for the bounded support:
 
 | Thesis | ApplicationSet | App-of-apps |
 |---|---|---|
-| platform inputs are source intent | selector, template, list, cluster inventory | root app and child app catalog |
+| platform inputs are source config | selector, template, list, cluster inventory | root app and child app catalog |
 | generator produces deployable config | child `Application` objects | child `Application` objects |
 | downstream generators still matter | Helm/Kustomize below each child app | Helm/Kustomize below each child app |
 | trace-back is necessary but not enough | selector/template owner decides route | child catalog owner decides route |

--- a/docs/agentic-gitops/05-rollout/20-cub-track-internal-decision-memo.md
+++ b/docs/agentic-gitops/05-rollout/20-cub-track-internal-decision-memo.md
@@ -188,7 +188,7 @@ Typical unit:
 
 Combined result:
 
-1. app intent and agent behavior are linked in one audit path.
+1. app source config and agent behavior are linked in one audit path.
 
 ## Practical Boundary by Component
 

--- a/docs/agentic-gitops/cub-track-internal-decision-memo.md
+++ b/docs/agentic-gitops/cub-track-internal-decision-memo.md
@@ -188,7 +188,7 @@ Typical unit:
 
 Combined result:
 
-1. app intent and agent behavior are linked in one audit path.
+1. app source config and agent behavior are linked in one audit path.
 
 ## Practical Boundary by Component
 

--- a/docs/agentic-gitops/next-gen-gitops-ai-era.md
+++ b/docs/agentic-gitops/next-gen-gitops-ai-era.md
@@ -63,7 +63,7 @@ Typical unit:
 
 Combined result:
 
-1. app intent and agent behavior are linked in one audit path.
+1. app source config and agent behavior are linked in one audit path.
 
 ## LIVE-Origin Change Path (Kargo-Style, Governed)
 

--- a/docs/agentic-gitops/scoredev-dry-wet-unit-worked-example.md
+++ b/docs/agentic-gitops/scoredev-dry-wet-unit-worked-example.md
@@ -34,7 +34,7 @@ No controller replacement is required.
 
 | Concept | Flux/Argo dry/wet pipeline | Score.dev equivalent |
 |---|---|---|
-| DRY authoring input | Kustomization/Application source intent | `score.yaml` + environment parameters |
+| DRY authoring input | Kustomization/Application source config | `score.yaml` + environment parameters |
 | Renderer | Flux/Argo renderer worker | Score->K8s generator + controller renderer worker |
 | WET deployment contract | Fully rendered manifests | Fully rendered manifests from Score intent |
 | Reconciler | FluxCD or ArgoCD | FluxCD or ArgoCD (unchanged) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -49,7 +49,7 @@ paths.
 ### `platform import`
 
 Read a local manifest for a multi-repo platform estate and emit one stable
-Component/Deployable Variant graph.
+Component/Variant graph.
 
 ```
 cub-gen platform import --json <manifest>
@@ -78,7 +78,7 @@ to understand the estate shape.
 ### `platform fanout`
 
 Read the same platform manifest and emit one ConfigHub-ready change bundle per
-Deployable Variant.
+Deployment Variant.
 
 ```
 cub-gen platform fanout --json <manifest>
@@ -230,7 +230,7 @@ Current proposal types:
 |---|---|
 | `add-route-policy-annotation` | ConfigHub Unit route policy annotations from field-route metadata |
 | `lift-generated-patch-to-source` | source files that should receive durable changes instead of generated YAML |
-| `split-env-values-into-variants` | Deployable Variant inventory from environment/profile files |
+| `split-env-values-into-variants` | Deployment Variant inventory from environment/profile files |
 | `add-missing-owners` | owner annotations from generator provenance and rendered resources |
 | `replace-implicit-secret-wiring` | explicit secret-reference proposals for literal secret-shaped env values |
 
@@ -528,7 +528,7 @@ Current status: explicit variant fanout plus generator-specific overlays.
 What works today:
 
 - One `gitops import` / `publish` invocation works on one repo path pair.
-- `platform fanout` reads a platform manifest and emits one ConfigHub-ready bundle per declared deployable variant.
+- `platform fanout` reads a platform manifest and emits one ConfigHub-ready bundle per declared Deployment Variant.
 - `platform fanout --variant dev` scopes output to one environment name across Components; `--variant checkout-api/prod` scopes to one concrete variant.
 - `change explain --change-id ID --bundle fanout.json --variant checkout-api/prod` can explain a selected variant bundle from fanout output.
 - Supported generators can pick up overlay files that already live in that repo, such as Helm `values-prod.yaml`, Spring `application-dev.yaml`, and generator-specific overlay files.

--- a/docs/cub-gen-plugin.md
+++ b/docs/cub-gen-plugin.md
@@ -42,7 +42,7 @@ When `cub gen` ships:
 | `cub-gen gitops discover` | `cub gen discover` | drop nested `gitops`; source-side is implied |
 | `cub-gen gitops import` | `cub gen import` or `cub gen render` | final verb needs product choice |
 | `cub-gen platform import` | `cub gen platform import` | multi-repo estate graph |
-| `cub-gen platform fanout` | `cub gen fanout` | Component to Deployable Variant bundles |
+| `cub-gen platform fanout` | `cub gen fanout` | Component to Deployment Variant bundles |
 | `cub-gen enrich preview` | `cub gen enrich preview` | sidecar provenance proposal |
 | `cub-gen normalize preview` | `cub gen normalize preview` | review-only config rewrite proposal |
 | `cub-gen publish` | `cub gen bundle` | evidence bundle creation |

--- a/docs/decisions/2026-03-06-sprint-2-go-no-go.md
+++ b/docs/decisions/2026-03-06-sprint-2-go-no-go.md
@@ -74,7 +74,7 @@ Evidence:
 
 1. Canonical boundary doc: `docs/contracts/canonical-triple-and-storage-boundary.md`.
 2. Boundary remains explicit:
-   - Git: DRY source intent + linkage receipts.
+   - Git: DRY source config + linkage receipts.
    - ConfigHub: WET governance state + policy/attestation authority.
    - Flux/Argo: WET -> LIVE reconciliation.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,19 +10,23 @@ The user model is intentionally small:
 
 ```text
 Component
-  -> Deployable Variant
-      -> Target
-      -> Connections
-      -> Proof
+  -> Variant
+      -> Base Variant
+      -> Deployment Variant
+          -> Target
+          -> Connections
+          -> Change
+          -> Proof
 ```
 
-A **Component** is the reusable base. A **Deployable Variant** is a concrete
-copy or context of that Component. A **Target** is where it runs or reconciles.
-**Connections** are what it is wired to. A **Change** is what someone wants to
-alter. **Proof** shows where it came from, who owns it, what changed, and
-whether the change is allowed.
+A **Component** is the reusable base. A **Variant** is a member of that
+Component family. A **Base Variant** is not deployed. A **Deployment Variant**
+is the concrete deployed copy or context of that Component. A **Target** is
+where a Deployment Variant runs or reconciles. **Connections** are what it is
+wired to. A **Change** is what someone wants to alter. **Proof** shows where it
+came from, who owns it, what changed, and whether the change is allowed.
 
-An **AI Variant** is a Deployable Variant whose delta, wiring, or operation is
+An **AI Variant** is a Variant whose delta, wiring, or operation is
 AI-assisted and governed.
 
 `cub-gen` exists to make those variants explainable before Flux, Argo, or a
@@ -42,7 +46,7 @@ to WET rendered output (the manifests that reach your cluster).
 
 Many app platforms are generators in this sense. A Spring platform, Score.dev,
 Helm platform, OpenChoreo-style component model, Argo ApplicationSet,
-app-of-apps catalog, or app-config manager all take source intent plus
+app-of-apps catalog, or app-config manager all take source config plus
 environment/platform context and produce deployable config. `cub-gen` starts by
 importing and explaining that shape, not by replacing the platform.
 
@@ -56,7 +60,7 @@ It adds what those layers do not provide by default:
 
 - source-to-live field traceability (`which file/path controls this field?`)
 - ownership-aware edit routing (`who should edit this?`)
-- multi-repo platform graphs (`which Components and Deployable Variants exist?`)
+- multi-repo platform graphs (`which Components and Variants exist, and which Variants deploy?`)
 - PR-friendly proof sidecars (`enrich preview` / `enrich write`)
 - governed safety decisions before deploy (`ALLOW/ESCALATE/BLOCK`)
 
@@ -82,7 +86,7 @@ ConfigHub now has three complementary import stories:
 
 - `cub gitops import` imports existing ArgoCD/Flux application resources from a cluster or worker target into ConfigHub.
 - `cub-gen gitops import` reads source-side generators such as Helm, Score.dev, Spring Boot, and workflow config, then emits provenance, inverse-edit guidance, and evidence.
-- `cub-gen platform import` reads a local multi-repo manifest and emits a read-only Component -> Deployable Variant -> Target graph before rewrites.
+- `cub-gen platform import` reads a local multi-repo manifest and emits a read-only Component -> Variant -> Target graph before rewrites.
 
 Use them for different jobs:
 
@@ -129,7 +133,7 @@ ConfigHub backend OSS is available today:
 
 - [confighubai/confighub](https://github.com/confighubai/confighub)
 
-1. **DRY** app intent lives in Git (`Chart.yaml`, `score.yaml`, `application.yaml`, etc.)
+1. **DRY** app source config lives in Git (`Chart.yaml`, `score.yaml`, `application.yaml`, etc.)
 2. **cub-gen** classifies DRY inputs + WET targets and emits provenance with field-origin tracing
 3. **cub-gen enrich** can write reviewable sidecar proof under `.cub-gen/enrichment/`
 4. **cub-gen publish** produces ConfigHub-ready change bundles with digest verification
@@ -249,7 +253,7 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 **Latest shipped:** `v0.3.0` (2026-04-12)
 
 **Current target:** working `v0.4` roadmap: make `cub-gen`'s role obvious as
-Component -> Deployable Variant -> Target/Connections/Change/Proof.
+Component -> Variant -> Base/Deployment -> Target/Connections/Change/Proof.
 
 - repo-first CLI and contract coverage remain green,
 - the shipped release includes a first-class standalone `applicationset`

--- a/docs/plans/2026-04-30-platform-generator-product-worklist.md
+++ b/docs/plans/2026-04-30-platform-generator-product-worklist.md
@@ -8,8 +8,8 @@ combines the current open roadmap items with the gaps exposed by the
 OpenChoreo, ApplicationSet, and app-of-apps discussion.
 
 For the sequenced roadmap that organizes this issue pack into workstreams, see
-[v0.4 Working Roadmap: Component -> Deployable Variant -> Proof](2026-04-30-v0.4-obvious-value-roadmap.md)
-and GitHub parent issue [#287](https://github.com/confighub/cub-gen/issues/287).
+[v0.4 Working Roadmap: Component -> Variant -> Proof](2026-04-30-v0.4-obvious-value-roadmap.md)
+and GitHub release tracker [#302](https://github.com/confighub/cub-gen/issues/302).
 
 ## Current Open Roadmap Touchpoints
 
@@ -62,12 +62,12 @@ GitHub issues created on 2026-04-30:
 ### PG-01: Generic Platform Import Graph
 
 Problem: `cub-gen` import is still repo/generator oriented. Platform estates
-often spread app intent, platform contracts, environment bindings, and rendered
+often spread app source config, platform contracts, environment bindings, and rendered
 output across multiple repos.
 
 Status: landed in PR #286 via `cub-gen platform import --json <manifest>`.
 The command reads a local manifest, imports each existing repo read-only, emits
-Components, Deployable Variants, Targets, generator inputs, WET targets, and
+Components, Variants, Deployment Variants, Targets, generator inputs, WET targets, and
 connections, and reports missing repo, missing owner, and unsupported generator
 diagnostics explicitly.
 
@@ -103,7 +103,7 @@ upstream estate validation and multi-repo OpenChoreo import remain follow-on
 adoption work.
 
 Problem: OpenChoreo is a clean candidate generator. `cub-gen` now reads the
-hard platform case from an OpenChoreo-shaped repo: app intent, deployable
+hard platform case from an OpenChoreo-shaped repo: app source config, deployable
 variant bindings, platform contracts, secret references, rendered releases, and
 generated Kubernetes resources with ownership proof.
 
@@ -121,13 +121,13 @@ Deterministic success criteria:
 
 1. Given Workload, ReleaseBinding, SecretReference, ComponentType, and
    RenderedRelease fixtures, `cub-gen gitops import` detects `openchoreo`.
-2. Import emits DRY roles for app intent, variant binding, secret reference,
+2. Import emits DRY roles for app source config, variant binding, secret reference,
    component type, rendered release, and generated manifests.
 3. Field-origin map routes env vars, mounted files, secret refs, image,
    service port, resource limits, and platform defaults.
 4. Generated Kubernetes resources can be identified as platform/controller
    owned where applicable.
-5. At least two deployable variants are represented.
+5. At least two Deployment Variants are represented.
 6. `gitops discover --adoption-report` emits a read-only platform adoption
    report before any rewrite.
 
@@ -253,7 +253,7 @@ Problem: `springboot init` scaffolds starter material, but there is no general
 
 Status: implemented by `cub-gen normalize preview`. The Spring Boot example now
 produces one review-only patch set with route policy annotations,
-lift-upstream source routing, Deployable Variant inventory, owner annotations,
+lift-upstream source routing, Deployment Variant inventory, owner annotations,
 and explicit secret-reference proposals.
 
 Deterministic success criteria:

--- a/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
+++ b/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
@@ -1,9 +1,10 @@
-# v0.4 Working Roadmap: Component -> Deployable Variant -> Proof
+# v0.4 Working Roadmap: Component -> Variant -> Proof
 
 Status: post-PR #297 roadmap; connected trust, PR/MR linkage, teaching QA, OpenChoreo, app-of-apps, platform graph, fanout, and enrichment slices landed on main
-Date: 2026-05-01
-GitHub milestone: [v0.4: Component -> Deployable Variant -> Proof](https://github.com/confighub/cub-gen/milestone/4)
-GitHub parent issue: [#287](https://github.com/confighub/cub-gen/issues/287)
+Date: 2026-05-02
+GitHub milestone: [v0.4: Component -> Variant -> Proof](https://github.com/confighub/cub-gen/milestone/4)
+GitHub release tracker: [#302](https://github.com/confighub/cub-gen/issues/302)
+ConfigHub topology alignment gate: [#304](https://github.com/confighub/cub-gen/issues/304)
 
 This is a working title, not golden ConfigHub product language. The goal is
 simpler than the title: make `cub-gen`'s role and value obvious.
@@ -34,21 +35,30 @@ PR #138 aligned the older `spring-platform` teaching repo with the productized
 
 ```text
 Component
-  -> Deployable Variant
-      -> Target
-      -> Connections
-      -> Change
-      -> Proof
+  -> Variant
+      -> Base Variant
+      -> Deployment Variant
+          -> Target
+          -> Connections
+          -> Change
+          -> Proof
 ```
 
 In plain English:
 
 1. what reusable thing exists,
-2. what concrete deployable copies or contexts it has,
-3. where each copy runs or reconciles,
-4. what each copy is wired to,
-5. what change is being proposed,
-6. what proof explains origin, ownership, impact, and decision.
+2. what Variants exist in that family,
+3. which Variants are bases and which are deployments,
+4. where each Deployment Variant runs or reconciles,
+5. what each Deployment Variant is wired to,
+6. what change is being proposed,
+7. what proof explains origin, ownership, impact, and decision.
+
+This update follows ConfigHub issue
+[confighubai/confighub#2985](https://github.com/confighubai/confighub/issues/2985):
+a Variant can be a Base Variant or a Deployment Variant. The older phrase
+Deployable Variant means the Deployment Variant side of that model, not every
+ConfigHub Variant.
 
 The generator model remains the implementation explanation underneath this user
 model. Users should not need to understand DRY/WET/generator contracts before
@@ -58,9 +68,9 @@ they understand why `cub-gen` is useful.
 
 | Phase | Workstream | Outcome | Issues |
 |---|---|---|---|
-| 0 | Make the story obvious | README, docs, examples, and GitHub all say the same simple thing without overclaiming OpenChoreo | [#286](https://github.com/confighub/cub-gen/pull/286), [#284](https://github.com/confighub/cub-gen/issues/284), [#285](https://github.com/confighub/cub-gen/issues/285), [#288](https://github.com/confighub/cub-gen/issues/288), [#289](https://github.com/confighub/cub-gen/issues/289) |
+| 0 | Make the story obvious | README, docs, examples, and GitHub all say the same simple thing without overclaiming OpenChoreo or flattening Base/Deployment Variants | [#286](https://github.com/confighub/cub-gen/pull/286), [#284](https://github.com/confighub/cub-gen/issues/284), [#285](https://github.com/confighub/cub-gen/issues/285), [#288](https://github.com/confighub/cub-gen/issues/288), [#289](https://github.com/confighub/cub-gen/issues/289), [#304](https://github.com/confighub/cub-gen/issues/304) |
 | 1 | Restore connected trust | Connected demos do not fail in the default path, and worker status is trustworthy | [#275](https://github.com/confighub/cub-gen/issues/275), [#219](https://github.com/confighub/cub-gen/issues/219) |
-| 2 | Build the Component/Variant spine | Import can describe a platform estate, its deployable variants, and an adoption report before rewrites | [#276](https://github.com/confighub/cub-gen/issues/276), [#290](https://github.com/confighub/cub-gen/issues/290), [#279](https://github.com/confighub/cub-gen/issues/279) |
+| 2 | Build the Component/Variant spine | Import can describe a platform estate, its Deployment Variants, and an adoption report before rewrites | [#276](https://github.com/confighub/cub-gen/issues/276), [#290](https://github.com/confighub/cub-gen/issues/290), [#279](https://github.com/confighub/cub-gen/issues/279) |
 | 3 | Add concrete platform families | OpenChoreo and Argo app-of-apps become runnable proof families, with OpenChoreo treated as a quality gate | [#277](https://github.com/confighub/cub-gen/issues/277), [#291](https://github.com/confighub/cub-gen/issues/291), [#292](https://github.com/confighub/cub-gen/issues/292), [#278](https://github.com/confighub/cub-gen/issues/278) |
 | 4 | Make Proof visible | Provenance, route badges, and history are visible where users work | [#280](https://github.com/confighub/cub-gen/issues/280), [#213](https://github.com/confighub/cub-gen/issues/213), [#209](https://github.com/confighub/cub-gen/issues/209), [#211](https://github.com/confighub/cub-gen/issues/211) |
 | 5 | Govern Changes | PR/MR linkage, backend route enforcement, and rewrite proposals become product workflows | [#282](https://github.com/confighub/cub-gen/issues/282), [#283](https://github.com/confighub/cub-gen/issues/283), [#281](https://github.com/confighub/cub-gen/issues/281), [#212](https://github.com/confighub/cub-gen/issues/212) |
@@ -79,6 +89,7 @@ Subtasks:
 - [x] [#285](https://github.com/confighub/cub-gen/issues/285) Align spring-platform teaching docs with springboot-paas product path
 - [x] [#288](https://github.com/confighub/cub-gen/issues/288) Make README OpenChoreo claims honest and explicit
 - [x] [#289](https://github.com/confighub/cub-gen/issues/289) Add an OpenChoreo-shaped field trace example
+- [ ] [#304](https://github.com/confighub/cub-gen/issues/304) Align cub-gen wording with ConfigHub Base/Deployment Variant topology
 
 Done means a new reader can explain `cub-gen` in one minute without starting
 from "generator contracts", and an OpenChoreo reader can tell whether support is
@@ -116,7 +127,7 @@ Dependency:
 #276 platform graph -> #290 adoption report -> #279 variant fanout
 ```
 
-Done means `cub-gen` can show Components and Deployable Variants as product
+Done means `cub-gen` can show Components, Variants, and Deployment Variants as product
 objects, not only as generator internals, and can start with a read-only report
 for an existing platform before proposing annotations or rewrites. The merged
 implementation emits one standard change bundle per declared variant and lets
@@ -207,7 +218,7 @@ correlation path. It derives `change_id` from a verified publish bundle, emits
 canonical local evidence, and can POST the link to ConfigHub with a deterministic
 idempotency key. `cub-gen normalize preview` now produces review-only sidecar
 patch sets for route policy annotations, lift-upstream source routing,
-deployable variants, owner annotations, and explicit secret references.
+Deployment Variants, owner annotations, and explicit secret references.
 Server-side route enforcement remains the core open governance work.
 
 ### Phase 6: Product Integration
@@ -220,7 +231,7 @@ Subtasks:
 - [ ] [#210](https://github.com/confighub/cub-gen/issues/210) GUI multi-environment comparison view
 
 Done means the user sees one ConfigHub product surface and can compare
-Deployable Variants without learning repository structure first.
+Deployment Variants without learning repository structure first.
 
 Current state: the repo now carries the `cub gen` readiness contract and an
 updated `skills/cub-gen/SKILL.md`. Actual closure still depends on the external
@@ -253,8 +264,8 @@ The roadmap is ready when:
 
 1. the README, docs index, examples index, and GitHub issue queue all tell the
    same story,
-2. a user can start with a repo and discover Components, Deployable Variants,
-   Targets, Connections, Changes, and Proof,
+2. a user can start with a repo and discover Components, Variants, which
+   Variants are Deployments, Targets, Connections, Changes, and Proof,
 3. at least one connected path proves the PR/MR and decision story without
    special backend surprises,
 4. implemented examples distinguish product proof from worked-example teaching,

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -80,7 +80,7 @@ Local CLI that runs against any Git repo. No backend required.
 | `gitops discover` | Scans repo, classifies generator roots |
 | `gitops import` | Emits DRY/WET classification with provenance and inverse-edit guidance |
 | `gitops cleanup` | Removes local discover state |
-| `platform import` | Reads a multi-repo estate as Components, Deployable Variants, Targets, and diagnostics |
+| `platform import` | Reads a multi-repo estate as Components, Variants, Deployment Variants, Targets, and diagnostics |
 | `platform fanout` | Emits one ConfigHub-ready change bundle per deployable environment, tenant, region, or cluster variant |
 | `publish` | Produces a deterministic change bundle (JSON envelope with SHA-256 digest) |
 | `verify` | Validates bundle schema and digest integrity |
@@ -182,7 +182,7 @@ connected walkthrough or a bridge-only capability gap.
 # Build a change bundle from your repo
 ./cub-gen publish --space platform ./examples/helm-paas > bundle.json
 
-# Or build one bundle per deployable variant from a platform manifest
+# Or build one bundle per Deployment Variant from a platform manifest
 ./cub-gen platform fanout --json --out fanout.json \
   ./testdata/variant-fanout/platform.yaml
 

--- a/docs/research/2026-03-30-spring-boot-kubernetes-platform-landscape.md
+++ b/docs/research/2026-03-30-spring-boot-kubernetes-platform-landscape.md
@@ -182,7 +182,7 @@ Score's abstraction is an environment-agnostic workload spec:
 
 Good fit:
 
-- Spring teams describe app intent and dependencies without owning raw manifests
+- Spring teams describe app source config and dependencies without owning raw manifests
 - strong alignment with DRY intent feeding rendered WET output
 
 Important boundary:
@@ -283,7 +283,7 @@ Less relevant to `cub-gen`'s core differentiation:
 | Tool | Primary layer | Main abstraction | Best fit for Spring teams | Relevance to `cub-gen` |
 | --- | --- | --- | --- | --- |
 | Backstage | Portal and scaffolding | Catalog entities and templates | Golden paths, repo generation, ownership, docs | Strong complement |
-| Score | Workload spec | `score.yaml` | Environment-agnostic app intent | Strong complement |
+| Score | Workload spec | `score.yaml` | Environment-agnostic app source config | Strong complement |
 | Kratix | Platform framework | Promise plus workflows | Self-service APIs with built-in governance | Strong conceptual peer |
 | Crossplane | Control plane framework | XRD/XR plus composition | Kubernetes-native custom APIs across app and infra | Adjacent peer |
 | Humanitec PO | Orchestration layer | Manifest plus module and rule orchestration | Keep existing Terraform/OpenTofu and CI/CD | Useful comparator |
@@ -316,7 +316,7 @@ Its value is less in the manual YAML examples and more in showing what an opinio
 
 ## Implications for `cub-gen`
 
-### 1. Keep Spring Boot as app intent, not the platform runtime contract
+### 1. Keep Spring Boot as app source config, not the platform runtime contract
 
 The Spring docs reinforce the direction already present in `examples/springboot-paas`:
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -402,8 +402,8 @@ See: `e2e-live-reconcile-*.sh` and `e2e-connected-governed-reconcile-helm.sh` fo
 | Status | What is true today |
 |--------|--------------------|
 | Strong now | Story scripts exist for stories 1-13; Flux and Argo live reconcile proofs exist; connected lifecycle and PR/MR flow scripts are in the demo surface |
-| In progress | Working `v0.4` roadmap: make cub-gen's role obvious as Component -> Deployable Variant -> Target/Connections/Change/Proof |
-| Actively tracked | [#287](https://github.com/confighub/cub-gen/issues/287) plus milestone [v0.4: Component -> Deployable Variant -> Proof](https://github.com/confighub/cub-gen/milestone/4) |
+| In progress | Working `v0.4` roadmap: make cub-gen's role obvious as Component -> Variant -> Base/Deployment -> Target/Connections/Change/Proof |
+| Actively tracked | [#302](https://github.com/confighub/cub-gen/issues/302) plus milestone [v0.4: Component -> Variant -> Proof](https://github.com/confighub/cub-gen/milestone/4) |
 
 For the per-example truth behind those claims, use the generated [Example Truth Matrix](../../docs/testing/example-truth-matrix.md). It is derived from the example catalog, connected runners, source-side tests, and live proof scripts.
 

--- a/examples/helm-paas/README.md
+++ b/examples/helm-paas/README.md
@@ -184,7 +184,7 @@ this deployed field?" without manual chart archaeology.
 
 | Existing Helm concept | cub-gen concept | Why it matters |
 |------|------|------|
-| `values.yaml` / `values-prod.yaml` | DRY app intent | Keep app-team edits in values files, not rendered manifests. |
+| `values.yaml` / `values-prod.yaml` | DRY app source config | Keep app-team edits in values files, not rendered manifests. |
 | `templates/*.yaml` | DRY platform contract | Platform structure stays explicit and reviewable. |
 | Rendered Kubernetes objects | WET targets with provenance | Every WET field is traced back to values or templates with confidence. |
 | Flux/Argo applying Helm output | LIVE state | Existing runtime path stays unchanged; only governance visibility is added. |

--- a/examples/just-apps-no-platform-config/README.md
+++ b/examples/just-apps-no-platform-config/README.md
@@ -137,7 +137,7 @@ field origins, ownership boundaries, and evidence artifacts over plain app confi
 
 | Existing provider-config model | cub-gen concept | Why it matters |
 |------|------|------|
-| `no-config-platform*.yaml` | DRY app intent | Teams keep editing familiar provider config files. |
+| `no-config-platform*.yaml` | DRY app source config | Teams keep editing familiar provider config files. |
 | Rendered provider payloads | WET targets with provenance | Every live-impacting field can be traced back to source. |
 | Optional future `platform/` rules | Governance layer | You can add policy later without replacing authoring workflow. |
 | Provider sync/runtime | LIVE state | Runtime remains external; cub-gen focuses on safe config change flow. |

--- a/examples/scoredev-paas/README.md
+++ b/examples/scoredev-paas/README.md
@@ -174,7 +174,7 @@ If you are already a ConfigHub user, the framing is slightly different:
 
 | Existing Score concept | cub-gen concept | Why it matters |
 |------|------|------|
-| `score.yaml` | DRY app intent | Teams keep writing one high-level workload spec. |
+| `score.yaml` | DRY app source config | Teams keep writing one high-level workload spec. |
 | Score-to-K8s expansion | WET targets with lineage | Rendered manifests stop being opaque. |
 | Platform contracts/policies | Governance layer | Rules run before deploy, not as after-the-fact review. |
 | Flux/Argo deployment loop | LIVE state | Runtime remains unchanged while visibility improves. |

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -308,12 +308,12 @@ change app code, platform code, rendered YAML, or ConfigHub state.
 |----------|----------------|
 | route-policy annotation | turns `operational/field-routes.yaml` into ConfigHub Unit metadata for apply-here / lift-upstream / generator-owned decisions |
 | lift-upstream routes | tells reviewers which rendered edits should become source PRs |
-| deployable variants | makes dev/stage/prod profile files visible as Deployable Variants |
+| deployment variants | makes dev/stage/prod profile files visible as Deployment Variants |
 | owner annotations | carries app/platform ownership into reviewable metadata |
 | secret references | replaces literal datasource wiring with an explicit SecretReference proposal |
 
 This is the "clean generator" path in miniature: keep the Component source,
-name the Deployable Variants, route changes to the right layer, and produce
+name the Deployment Variants, route changes to the right layer, and produce
 Proof before anything is applied.
 
 ## Real Kubernetes deployment

--- a/internal/enrich/enrich.go
+++ b/internal/enrich/enrich.go
@@ -531,7 +531,7 @@ func buildProposedAnnotations(record generatorIndexRecord, prov model.Provenance
 			Key:       "cub.confighub.io/source-paths",
 			Value:     joinSourcePaths(sources),
 			AppliesTo: "sidecar",
-			Reason:    "show which source files feed the deployable variant",
+			Reason:    "show which source files feed the Deployment Variant",
 		})
 	}
 	if len(owners) > 0 {

--- a/internal/normalize/normalize.go
+++ b/internal/normalize/normalize.go
@@ -583,13 +583,13 @@ func buildVariantProposal(root string) (Proposal, bool, error) {
 		Owner:      "app-team",
 		Risk:       RiskLow,
 		Review:     "Review the generated variant inventory before wiring it into platform import or fanout.",
-		Why:        "profile files already encode deployable variants; making the variants explicit lets ConfigHub reason about dev, stage, and prod separately.",
+		Why:        "profile files already encode Deployment Variants; making the variants explicit lets ConfigHub reason about dev, stage, and prod separately.",
 		RenderedImpact: []RenderedImpact{{
-			ResourceType: "Deployable Variant",
+			ResourceType: "Deployment Variant",
 			ResourceName: component,
 			Path:         "variants[*]",
 			Action:       "make-variant-boundaries-visible",
-			Explanation:  "each profile gets a concrete deployable variant with its source inputs and rendered proof path",
+			Explanation:  "each profile gets a concrete Deployment Variant with its source inputs and rendered proof path",
 		}},
 		Patch: Patch{
 			Path:        ".cub-gen/normalize/deployable-variants.yaml",

--- a/internal/openchoreo/analysis.go
+++ b/internal/openchoreo/analysis.go
@@ -228,7 +228,7 @@ func (a *Analysis) finalize() {
 	if a.HasWorkload() && !a.hasRole("release-binding") {
 		a.Diagnostics = append(a.Diagnostics, Diagnostic{
 			Code:    "missing_release_binding",
-			Message: "OpenChoreo Workload found but no ReleaseBinding was found; deployable variants are unknown",
+			Message: "OpenChoreo Workload found but no ReleaseBinding was found; Deployment Variants are unknown",
 		})
 	}
 	if a.HasWorkload() && !a.hasRole("rendered-release") {

--- a/skills/cub-gen/SKILL.md
+++ b/skills/cub-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cub-gen
-description: Use when working in the cub-gen repo or when explaining cub-gen's source-side role versus ConfigHub cub and cub-scout. Covers generator discovery, Component -> Deployable Variant proof, DRY/WET field-origin tracing, inverse-edit routing, platform import/fanout, enrichment/normalization previews, publish/verify/attest bundles, and ConfigHub bridge workflows.
+description: Use when working in the cub-gen repo or when explaining cub-gen's source-side role versus ConfigHub cub and cub-scout. Covers generator discovery, Component -> Variant -> Base/Deployment proof, DRY/WET field-origin tracing, inverse-edit routing, platform import/fanout, enrichment/normalization previews, publish/verify/attest bundles, and ConfigHub bridge workflows.
 tier: plugin-candidate
 plugin: cub-gen
 canonical_command: cub-gen
@@ -14,7 +14,7 @@ Use this skill when the task is about:
 - what `cub-gen` does today
 - how `cub-gen` differs from `cub`, `cub gitops`, and `cub-scout`
 - generator detection and supported generator families
-- Component, Deployable Variant, Target, Connection, Change, and Proof mapping
+- Component, Variant, Base Variant, Deployment Variant, Target, Connection, Change, and Proof mapping
 - field-origin tracing, confidence scores, and inverse-edit guidance
 - platform estate import, variant fanout, enrichment, and normalization previews
 - publish, verify, attest, and verify-attestation bundles
@@ -36,7 +36,7 @@ When the user wants you to use `cub-gen` against a real source repo, prefer
 ## Product Value In One Breath
 
 `cub-gen` is the repo-side traceability and governed-change tool. It starts
-from source/config repos, maps source intent to rendered deployable config,
+from source/config repos, maps source config to rendered deployable config,
 records field-level provenance with confidence scores, and emits inverse-edit
 hints so app, platform, environment, and security owners know where a change
 belongs.
@@ -45,11 +45,13 @@ The user model should stay small:
 
 ```text
 Component
-  -> Deployable Variant
-      -> Target
-      -> Connections
-      -> Change
-      -> Proof
+  -> Variant
+      -> Base Variant
+      -> Deployment Variant
+          -> Target
+          -> Connections
+          -> Change
+          -> Proof
 ```
 
 ## Command Status

--- a/testdata/variant-fanout/README.md
+++ b/testdata/variant-fanout/README.md
@@ -4,9 +4,10 @@ This fixture proves the v0.4 spine:
 
 ```text
 Component
-  -> Deployable Variant
-      -> Target
-      -> Proof bundle
+  -> Variant
+      -> Deployment Variant
+          -> Target
+          -> Proof bundle
 ```
 
 `platform.yaml` declares three Components:


### PR DESCRIPTION
## Summary

- align cub-gen public language with ConfigHub's Component -> Variant -> Base/Deployment model
- update README, AGENTS, docs, examples, skill text, CLI help, and goldens away from the old Deployable Variant-only shorthand
- replace vague source/app intent wording with source config / app source config in user-facing docs

## Why

ConfigHub issue confighubai/confighub#2985 now makes the safer model clear: a Variant can be a Base Variant or a Deployment Variant. cub-gen can still talk about deployable variants, but only as Deployment Variants, not as every ConfigHub Variant.

Refs #304.

## Validation

- `make ci`
- `go build ./cmd/cub-gen`
- `go test ./...`
- `go test ./cmd/cub-gen -run '^(TestTopLevelCommandGoldenHelp|TestGitOpsParityGoldenHelp|TestEnrichPreviewAppOfAppsGolden|TestEnrichPreviewPatchGolden|TestNormalizePreviewSpringJSON|TestNormalizePreviewSpringPatchGolden|TestPlatformImportGolden|TestPlatformFanoutGolden)$' -count=1`
- `git diff --check`
- `/tmp/cub-gen-docs-venv/bin/mkdocs build --strict`
- `./examples/helm-paas/demo-local.sh`
- `./examples/scoredev-paas/demo-local.sh`
- `./examples/springboot-paas/demo-local.sh`
