### PR TITLE
[codex] Add Base and Deployment Variant topology proof

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ go build ./cmd/cub-gen
 ./cub-gen gitops import --space platform ./examples/scoredev-paas
 ./cub-gen change explain --space platform --owner app-team ./examples/springboot-paas
 ./cub-gen platform import --json ./testdata/platform-estate/platform.yaml
+./cub-gen platform import --json ./testdata/variant-topology/platform.yaml
 ./cub-gen platform fanout --json ./testdata/variant-fanout/platform.yaml
 ./cub-gen enrich preview --space platform --json ./testdata/app-of-apps-standalone
 ./cub-gen normalize preview --space platform --patch ./examples/springboot-paas

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
+.PHONY: build test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-v04-quickstart test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -22,6 +22,9 @@ test-examples:
 
 test-change-api-http:
 	./examples/demo/change-api-http-e2e.sh
+
+test-v04-quickstart:
+	SKIP_BUILD=1 ./examples/demo/v0.4-quickstart.sh
 
 test-connected-smoke:
 	SKIP_BUILD=1 ./examples/demo/run-connected-smoke.sh
@@ -101,7 +104,7 @@ update-goldens:
 sync-triple-styles:
 	go run ./cmd/cub-gen-style-sync
 
-ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
+ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http test-v04-quickstart lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 
 ci-connected: build test-connected-smoke check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ go build -o cub-gen ./cmd/cub-gen
 
 ## Use Your Repo in 3 Commands
 
+For the v0.4 release path, start with the local proof script:
+
+```bash
+./examples/demo/v0.4-quickstart.sh
+```
+
+It prints the Generator, Component, Base/Deployment Variants, Target, one field
+origin, one route decision, and a verified proof bundle.
+
 ```bash
 REPO=/path/to/your/repo
 ./cub-gen gitops discover --space platform "$REPO"
@@ -254,6 +263,7 @@ These run locally and do not require a login:
 | Score.dev | [scoredev-paas](examples/scoredev-paas/) | Which `score.yaml` field produced this runtime value? |
 | Spring Boot services | [springboot-paas](examples/springboot-paas/) | Should I edit app config or platform config? |
 | Multi-repo platform | [platform-estate fixture](testdata/platform-estate/) | Which Components, Variants, Deployment Variants, Generators, and gaps exist before any rewrite? |
+| Base/deployment topology | [variant-topology fixture](testdata/variant-topology/) | Which Variants are reusable bases, and which are deployments with Targets? |
 | Multi-env or tenant variants | [variant-fanout fixture](testdata/variant-fanout/) | Can I produce one governed proof bundle for every Deployment Variant? |
 | A running cluster first | ConfigHub GitOps import + [cub-scout](https://github.com/confighub/cub-scout) + then `cub-gen` | What is running, and what source produced it? |
 
@@ -363,8 +373,9 @@ controllers running in kind.
 | Latest shipped | `v0.3.0` was released on 2026-04-12 |
 | Strong now | Repo-first CLI is stable; 11 generator families ship on this branch; the main examples have local, connected, and live proof paths |
 | In progress | Working `v0.4` roadmap: make cub-gen's role clear as Component -> Variant -> Base/Deployment -> Target/Connections/Change/Proof |
-| Current release target | GitHub release tracker [#302](https://github.com/confighub/cub-gen/issues/302), topology alignment [#304](https://github.com/confighub/cub-gen/issues/304), and the [v0.4 working roadmap](docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md) |
+| Current release target | GitHub release tracker [#302](https://github.com/confighub/cub-gen/issues/302), topology alignment [#304](https://github.com/confighub/cub-gen/issues/304), flagship quickstart [#307](https://github.com/confighub/cub-gen/issues/307), and the [v0.4 working roadmap](docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md) |
 | Latest release notes | See [docs/releases/v0.3.0.md](docs/releases/v0.3.0.md) |
+| Draft next release notes | See [docs/releases/v0.4-integration-beta.md](docs/releases/v0.4-integration-beta.md) |
 | Previous release notes | See [docs/releases/v0.2-preview.2.md](docs/releases/v0.2-preview.2.md) |
 | Example quality | Flagship example blockers and Helm depth blockers are closed on `main` |
 | CLI/docs follow-on | `#275`, `#219`, `#236`, `#209`-`#213`, `#276`-`#285` |

--- a/cmd/cub-gen/testdata/parity/platform-fanout.golden.json
+++ b/cmd/cub-gen/testdata/parity/platform-fanout.golden.json
@@ -334,7 +334,8 @@
       "variant_inputs": [
         "--set image.tag=dev",
         "--set replicaCount=1"
-      ]
+      ],
+      "variant_kind": "deployment"
     },
     {
       "bundle": {
@@ -657,7 +658,8 @@
       "variant_inputs": [
         "--set image.tag=prod",
         "--set replicaCount=4"
-      ]
+      ],
+      "variant_kind": "deployment"
     },
     {
       "bundle": {
@@ -980,7 +982,8 @@
       "variant_inputs": [
         "--set image.tag=stage",
         "--set replicaCount=2"
-      ]
+      ],
+      "variant_kind": "deployment"
     },
     {
       "bundle": {
@@ -1259,7 +1262,8 @@
       "variant_inputs": [
         "score.yaml#metadata.name",
         "score.yaml#resources"
-      ]
+      ],
+      "variant_kind": "deployment"
     },
     {
       "bundle": {
@@ -1538,7 +1542,8 @@
       "variant_inputs": [
         "score.yaml#metadata.name",
         "score.yaml#resources"
-      ]
+      ],
+      "variant_kind": "deployment"
     },
     {
       "bundle": {
@@ -1817,7 +1822,8 @@
       "variant_inputs": [
         "score.yaml#metadata.name",
         "score.yaml#resources"
-      ]
+      ],
+      "variant_kind": "deployment"
     },
     {
       "bundle": {
@@ -2142,7 +2148,8 @@
       "variant_inputs": [
         "src/main/resources/application.yaml#server.port",
         "src/main/resources/application.yaml#spring.datasource.url"
-      ]
+      ],
+      "variant_kind": "deployment"
     },
     {
       "bundle": {
@@ -2467,7 +2474,8 @@
       "variant_inputs": [
         "src/main/resources/application.yaml#server.port",
         "src/main/resources/application.yaml#spring.datasource.url"
-      ]
+      ],
+      "variant_kind": "deployment"
     },
     {
       "bundle": {
@@ -2792,7 +2800,8 @@
       "variant_inputs": [
         "src/main/resources/application.yaml#server.port",
         "src/main/resources/application.yaml#spring.datasource.url"
-      ]
+      ],
+      "variant_kind": "deployment"
     }
   ]
 }

--- a/cmd/cub-gen/testdata/parity/platform-import.golden.json
+++ b/cmd/cub-gen/testdata/parity/platform-import.golden.json
@@ -24,6 +24,7 @@
       "owner": "app-team",
       "component": "catalog-api",
       "variant": "dev",
+      "variant_kind": "deployment",
       "target": "dev-us",
       "exists": true,
       "generator_count": 1
@@ -44,6 +45,7 @@
       "owner": "app-team",
       "component": "ghost-api",
       "variant": "dev",
+      "variant_kind": "deployment",
       "target": "dev-us",
       "exists": false,
       "generator_count": 0
@@ -54,6 +56,7 @@
       "path": "apps/orders-api",
       "component": "orders-api",
       "variant": "dev",
+      "variant_kind": "deployment",
       "target": "dev-us",
       "exists": true,
       "generator_count": 1
@@ -100,6 +103,7 @@
       "id": "catalog-api/dev",
       "name": "dev",
       "component": "catalog-api",
+      "variant_kind": "deployment",
       "target": "dev-us",
       "owner": "app-team",
       "repo_id": "catalog-api"
@@ -108,6 +112,7 @@
       "id": "ghost-api/dev",
       "name": "dev",
       "component": "ghost-api",
+      "variant_kind": "deployment",
       "target": "dev-us",
       "owner": "app-team",
       "repo_id": "ghost-api"
@@ -116,6 +121,7 @@
       "id": "orders-api/dev",
       "name": "dev",
       "component": "orders-api",
+      "variant_kind": "deployment",
       "target": "dev-us",
       "repo_id": "orders-api"
     }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -59,7 +59,7 @@ The manifest names app, platform, environment, and rendered repos. The command
 imports each existing local repo read-only and emits:
 
 - `repos`: manifest entries with owner, role, component, variant, and target metadata
-- `components` and `variants`: the small product model users should see first
+- `components` and `variants`: the small product model users should see first, including whether a Variant is `base` or `deployment`
 - `generators`: detected generator families per repo
 - `dry_inputs` and `wet_targets`: source inputs and rendered targets from each generator
 - `connections`: repo -> generator -> input/target and component -> variant -> target links
@@ -69,6 +69,7 @@ Example:
 
 ```
 cub-gen platform import --json ./testdata/platform-estate/platform.yaml
+cub-gen platform import --json ./testdata/variant-topology/platform.yaml
 ```
 
 This command does not rewrite repos, deploy, or contact ConfigHub. Use it before

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,12 +6,18 @@ This guide is for teams that already have:
 
 - a source repo in GitHub or Git,
 - Helm, Score, Spring Boot, or workflow config as authoring input,
-- Flux or Argo CD handling WET to LIVE reconciliation.
+- Flux or Argo CD reconciling rendered config to the cluster.
 
 `cub-gen` answers repo-side GitOps questions: what this repo renders, where a
 rendered field came from, and what to edit. ConfigHub adds shared governance
 and evidence. [`cub-scout`](https://github.com/confighub/cub-scout) adds
 cluster-side inspection.
+
+The shortest useful question is:
+
+```text
+If this deployed field is wrong, where do I fix it?
+```
 
 ## Start from the setup you already have
 
@@ -28,8 +34,8 @@ cluster-side inspection.
 | Question | Answer |
 |----------|--------|
 | What type of project is this? | Generator detection (Helm, Score, Spring Boot, etc.) |
-| Which files are human-editable intent? | DRY source classification |
-| Which files are rendered output? | WET manifest classification |
+| Which files are the source config? | Human-editable config such as `values.yaml`, `score.yaml`, or `application.yaml` |
+| Which files are rendered config? | Kubernetes manifests or other deployable output |
 | For any deployed field, where do I edit it? | Field-origin tracing + inverse-edit guidance |
 | How do I prove what changed? | Verification, attestation, and evidence bundles |
 
@@ -37,25 +43,29 @@ cluster-side inspection.
 
 | Tool | Starts from | What it answers first |
 |------|-------------|-----------------------|
-| `cub-gen` | Source repo | Which DRY file/path produced this rendered field? |
+| `cub-gen` | Source repo | Which source file/path produced this rendered field? |
 | [`cub-scout`](https://github.com/confighub/cub-scout) | Cluster and controller reality | What is running and where is drift? |
-| ConfigHub | Shared intended/evidence/governance state | What changed, what was approved, and what evidence exists? |
+| ConfigHub | Shared config/evidence/governance state | What changed, what was approved, and what evidence exists? |
 
-## The DRY → WET model
+## Source config to rendered config
 
 ```
-DRY source (what you author)     →  Generator  →  WET manifests (what gets deployed)
-  values.yaml                         Helm           deployment.yaml
-  score.yaml                          Score          service.yaml
-  application.yaml                    Spring Boot    configmap.yaml
+source config you edit      →  Generator  →  rendered config that deploys
+  values.yaml                    Helm          deployment.yaml
+  score.yaml                     Score         service.yaml
+  application.yaml               Spring Boot   configmap.yaml
 ```
 
-- **DRY**: The human-editable source of truth (e.g., `values.yaml`)
-- **WET**: The expanded, hydrated output (e.g., rendered Kubernetes manifests)
-- **Generator**: The tool that transforms DRY to WET (Helm, Score, etc.)
+- **source config**: the file/path a team edits, such as `values.yaml`
+- **rendered config**: the deployable output, such as a Kubernetes Deployment
+- **Generator**: the tool or platform rule that turns source config into
+  rendered config
 
-`cub-gen` traces this transformation so you always know which DRY file to edit
-when you need to change a deployed value.
+Some older docs call this DRY -> WET. The plain meaning is source config ->
+rendered config.
+
+`cub-gen` traces this transformation so you know which source file and path to
+edit when you need to change a deployed value.
 
 ## Prerequisites
 
@@ -85,6 +95,16 @@ go build -o cub-gen ./cmd/cub-gen
 
 ## Use your own repo in 3 commands
 
+If you want the v0.4 release path first, run:
+
+```bash
+./examples/demo/v0.4-quickstart.sh
+```
+
+That prints the Generator, Component, Base/Deployment Variants, Target, one
+field origin, one route decision, and a verified proof bundle without requiring
+a ConfigHub login.
+
 ```bash
 REPO=/path/to/your/repo
 ./cub-gen gitops discover --space platform "$REPO"
@@ -92,6 +112,8 @@ REPO=/path/to/your/repo
   | jq '{profile: .discovered[0].generator_profile, dry_inputs, wet_manifest_targets}'
 ./cub-gen change preview --space platform "$REPO"
 ```
+
+That gives you a local answer before anything is deployed or written back.
 
 Connected smoke first:
 
@@ -118,13 +140,13 @@ endpoints.
 
 The three core repo-first commands are:
 
-### 1. Discover generator roots
+### 1. Discover Generator roots
 
 ```bash
 ./cub-gen gitops discover --space platform ./examples/helm-paas
 ```
 
-This scans the repo and classifies it as a Helm generator (`helm-paas` profile).
+This scans the repo and classifies it as a Helm Generator (`helm-paas` profile).
 
 ### 2. Import with provenance
 
@@ -135,9 +157,9 @@ This scans the repo and classifies it as a Helm generator (`helm-paas` profile).
 
 The import output includes:
 
-- **`generator_profile`** — which generator family was detected
-- **`dry_inputs`** — the human-editable source files (Chart.yaml, values.yaml)
-- **`wet_manifest_targets`** — the rendered deployment artifacts
+- **`generator_profile`** — which Generator family was detected
+- **`dry_inputs`** — source files such as Chart.yaml and values.yaml
+- **`wet_manifest_targets`** — rendered deployment artifacts
 - **`provenance`** — field-origin map and inverse-edit pointers
 
 ### 3. Clean up discover state
@@ -165,7 +187,7 @@ The key value of cub-gen is the provenance trail. Focus on the inverse-edit poin
     }'
 ```
 
-This tells you: for any WET field, where is the DRY source to edit it safely.
+This tells you which source file/path controls a rendered field.
 
 ## Why this matters right after import
 
@@ -183,9 +205,9 @@ That is why the first useful sequence is:
 3. build or verify evidence,
 4. compare that answer with runtime inspection.
 
-## Try other generators
+## Try other Generators
 
-Each generator follows the same three-command flow:
+Each Generator follows the same three-command flow:
 
 === "Score.dev"
 
@@ -245,8 +267,8 @@ Emit an attestation record:
 
 Use ConfigHub GitOps import and [`cub-scout`](https://github.com/confighub/cub-scout)
 first when your first question is "what is running?" rather than "what source
-produced this?" Then come back to `cub-gen` when you want the source-side DRY to
-WET answer for the field or workload you found.
+produced this?" Then come back to `cub-gen` when you want the source-to-rendered
+answer for the field or workload you found.
 
 ## What happens after import? (Day-2)
 
@@ -260,7 +282,7 @@ Import is day 1. The real value shows on day 2:
 
 After import, your next steps are:
 
-1. **Make a governed change**: Edit a DRY file, run `publish`, and see the decision
+1. **Make a governed change**: Edit a source file, run `publish`, and see the decision
 2. **Connect to ConfigHub**: Verify the connected smoke path first, then use the deeper bridge path if your backend exposes it
 3. **Enable promotion**: Use ConfigHub to promote patterns to reusable base config
 
@@ -289,14 +311,14 @@ Or all at once:
 
 What stays unchanged:
 
-- Flux/Argo remains the reconciler for WET &rarr; LIVE
+- Flux/Argo remains the reconciler from rendered config to live cluster state
 - Git/OCI remains the transport path
 - Existing cluster/controller permissions and PR workflow stay in place
 
 What you add:
 
-- `cub-gen gitops discover` to classify generator roots
-- `cub-gen gitops import` to emit DRY/WET contracts + provenance/inverse pointers
+- `cub-gen gitops discover` to classify Generator roots
+- `cub-gen gitops import` to emit source/rendered contracts plus provenance and inverse-edit pointers
 - `cub-gen gitops cleanup` to clear local discover state
 - ConfigHub for shared evidence and governed decisions
 - `cub-scout` for cluster-side inspection after reconciliation
@@ -304,7 +326,7 @@ What you add:
 Current delivery status:
 
 - `gitops discover|import|cleanup` are stable and good for first-run local use
-- `publish`, `verify`, `attest`, and `verify-attestation` are stable across all supported generators
+- `publish`, `verify`, `attest`, and `verify-attestation` are stable across all supported Generators
 - local mode uses file-backed state and artifacts instead of server-side units
 - deeper bridge commands exist, but the recommended connected first run is still the smoke wrappers and example `demo-connected.sh` paths
 
@@ -312,12 +334,12 @@ Current delivery status:
 
 | Term | Meaning in cub-gen |
 |------|-------------------|
-| DRY source | Human-editable app/platform intent (`values.yaml`, `score.yaml`, `application.yaml`) |
-| WET rendered units | Explicit rendered deployment-facing units/manifests |
-| Generator | Tool that transforms DRY to WET (Helm, Score, Spring Boot, etc.) |
-| Provenance | Record of DRY inputs, rendered outputs, field-origin map, inverse-edit pointers |
-| Inverse map | Guidance from changed WET field → where to edit DRY safely |
-| Pre-sync | `cub-gen` stops before WET→LIVE; Flux/Argo own reconciliation |
+| Source config | Human-editable app/platform config (`values.yaml`, `score.yaml`, `application.yaml`) |
+| Rendered config | Explicit deployment-facing units/manifests |
+| Generator | Tool or platform rule that transforms source config to rendered config |
+| Provenance | Record of source inputs, rendered outputs, field-origin map, inverse-edit pointers |
+| Inverse map | Guidance from changed rendered field to the source file/path to edit safely |
+| Pre-sync | `cub-gen` stops before rendered config reaches the live cluster; Flux/Argo own reconciliation |
 | Verification | Cryptographic proof that a bundle is intact |
 | Attestation | Record of who verified a bundle and when |
 | Governance | Policy enforcement (ALLOW/ESCALATE/BLOCK) via ConfigHub decision engine |
@@ -327,6 +349,6 @@ Current delivery status:
 
 - [The ConfigHub Platform](platform.md) — how cub-gen connects to ConfigHub, bridge workers, and Flux/ArgoCD
 - [CLI Reference](cli-reference.md) — full command and flag documentation
-- [Architecture](agentic-gitops/02-design/00-agentic-gitops-design.md) — DRY/WET model, contract triples, governed execution
+- [Architecture](agentic-gitops/02-design/00-agentic-gitops-design.md) — source/rendered model, contract triples, governed execution
 - [Worked Examples](agentic-gitops/03-worked-examples/01-scoredev-dry-wet-unit-worked-example.md) — end-to-end Score.dev walkthrough
 - [Adoption Path & FAQ](agentic-gitops/05-rollout/40-adoption-and-reference.md) — progressive adoption ladder

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@
 **Start from a repo, see what it renders, and know what to edit.**
 
 `cub-gen` is the repo-side traceability CLI for GitOps config. It detects which
-generators your repo uses, renders them locally, and records provenance so
-every deployed field traces back to a source file, line, and owner.
+Generators your repo uses, renders them locally, and records provenance so
+every deployed field traces back to a source file, path, and owner.
 
 The user model is intentionally small:
 
@@ -40,11 +40,11 @@ brew install confighub/tap/cub-gen
 
 Or download a release artifact from [GitHub release `v0.3.0`](https://github.com/confighub/cub-gen/releases/tag/v0.3.0).
 
-**gen = generator.** This is the implementation explanation. A generator is a
-function that maps DRY source (`values.yaml`, `score.yaml`, `application.yaml`)
-to WET rendered output (the manifests that reach your cluster).
+**gen = Generator.** A Generator is a function on config data. It maps source
+config such as `values.yaml`, `score.yaml`, or `application.yaml` to rendered
+config: the manifests or other deployable output that reach your cluster.
 
-Many app platforms are generators in this sense. A Spring platform, Score.dev,
+Many app platforms are Generators in this sense. A Spring platform, Score.dev,
 Helm platform, OpenChoreo-style component model, Argo ApplicationSet,
 app-of-apps catalog, or app-config manager all take source config plus
 environment/platform context and produce deployable config. `cub-gen` starts by
@@ -85,7 +85,7 @@ cub-gen adds the import/provenance layer that answers these questions while keep
 ConfigHub now has three complementary import stories:
 
 - `cub gitops import` imports existing ArgoCD/Flux application resources from a cluster or worker target into ConfigHub.
-- `cub-gen gitops import` reads source-side generators such as Helm, Score.dev, Spring Boot, and workflow config, then emits provenance, inverse-edit guidance, and evidence.
+- `cub-gen gitops import` reads source-side Generators such as Helm, Score.dev, Spring Boot, and workflow config, then emits provenance, inverse-edit guidance, and evidence.
 - `cub-gen platform import` reads a local multi-repo manifest and emits a read-only Component -> Variant -> Target graph before rewrites.
 
 Use them for different jobs:
@@ -96,18 +96,23 @@ Use them for different jobs:
 
 ## What cub-gen is not
 
-- Not a Kubernetes reconciler — Flux/Argo still own WET→LIVE
+- Not a Kubernetes reconciler -- Flux/Argo still reconcile rendered config to the live cluster
 - Not a Flux/Argo replacement
 - Not an OCI replacement
 
-DRY→WET is a one-way deterministic transform. There is no automatic LIVE→DRY path. But there is an outer loop: observe live state → decide what to change → edit DRY → re-render WET → reconcile to LIVE. cub-gen makes that outer loop safe by tracing every field back to its source and gating changes through governed decisions. See [Two loops, not a triangle](platform.md#two-loops-not-a-triangle).
+Source config -> rendered config is a one-way deterministic transform. There is
+no automatic live-cluster -> source-config path. There is an outer loop: observe
+live state, decide what to change, edit the source config, re-render, and let
+Flux or Argo reconcile. cub-gen makes that loop safer by tracing every field
+back to its source and gating changes through governed decisions. See [Two
+loops, not a triangle](platform.md#two-loops-not-a-triangle).
 
 ---
 
-## Supported generators
+## Supported Generators
 
-| Generator | Profile | DRY source | Status |
-|-----------|---------|------------|--------|
+| Generator | Profile | Source config | Status |
+|-----------|---------|---------------|--------|
 | Helm | `helm-paas` | `Chart.yaml` + `values.yaml` | Stable |
 | ApplicationSet | `applicationset` | `applicationset.yaml` + pinned inventory | v0.2 preview |
 | App-of-apps | `app-of-apps` | root `Application` + child app catalog | v0.4 fixture-backed |
@@ -133,13 +138,13 @@ ConfigHub backend OSS is available today:
 
 - [confighubai/confighub](https://github.com/confighubai/confighub)
 
-1. **DRY** app source config lives in Git (`Chart.yaml`, `score.yaml`, `application.yaml`, etc.)
-2. **cub-gen** classifies DRY inputs + WET targets and emits provenance with field-origin tracing
+1. App source config lives in Git (`Chart.yaml`, `score.yaml`, `application.yaml`, etc.)
+2. **cub-gen** classifies source inputs and rendered targets, then emits provenance with field-origin tracing
 3. **cub-gen enrich** can write reviewable sidecar proof under `.cub-gen/enrichment/`
 4. **cub-gen publish** produces ConfigHub-ready change bundles with digest verification
 5. **ConfigHub** ingests bundles, enforces governed decision state, manages units with revision history
 6. **Bridge workers** connect ConfigHub to clusters via HTTP/2 SSE
-7. **Flux/Argo** continue to reconcile WET to LIVE — unchanged
+7. **Flux/Argo** continue to reconcile rendered config to the live cluster -- unchanged
 
 This is why the import surfaces both exist:
 
@@ -153,8 +158,8 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 ## Three invariants (never waived)
 
 1. **Nothing implicit ever deploys** — every deployed artifact is explicit, diffable, traceable
-2. **Nothing observed silently overwrites intent** — cluster changes produce governed proposals, not silent overwrites
-3. **Configuration is data, not code** — output from generators is literal values, queryable and diffable
+2. **Nothing observed silently overwrites source config** — cluster changes produce governed proposals, not silent overwrites
+3. **Configuration is data, not code** — output from Generators is literal values, queryable and diffable
 
 ---
 
@@ -195,7 +200,7 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 
 -   **Add Your Generator**
 
-    If your platform has its own framework or layered generator chain, start
+    If your platform has its own framework or layered Generator chain, start
     with the user-facing onboarding path.
 
     [Platform Generators Manifesto](agentic-gitops/02-design/90-platform-generators-manifesto.md) · [Custom Generator Onboarding](workflows/custom-generator-onboarding.md)
@@ -215,7 +220,7 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 
 -   **Explore the architecture**
 
-    DRY/WET model, field-origin maps, governed execution, contract triples.
+    Source/rendered model, field-origin maps, governed execution, contract triples.
 
     [Architecture](agentic-gitops/02-design/00-agentic-gitops-design.md)
 
@@ -239,11 +244,11 @@ Teams can start with cub-gen locally today and connect to ConfigHub when they ne
 
 | Term | Meaning |
 |------|---------|
-| **DRY source** | Human-editable app/platform intent (`values.yaml`, `score.yaml`, `application.yaml`) |
-| **WET rendered units** | Explicit rendered deployment-facing units/manifests |
-| **Provenance** | Record of DRY inputs, rendered outputs, field-origin map, inverse-edit pointers |
-| **Inverse map** | Guidance from changed WET field to where to edit DRY safely |
-| **Pre-sync** | cub-gen stops before WET-to-LIVE; Flux/Argo own reconciliation |
+| **Source config** | Human-editable app/platform config (`values.yaml`, `score.yaml`, `application.yaml`) |
+| **Rendered config** | Explicit deployment-facing units/manifests |
+| **Provenance** | Record of source inputs, rendered outputs, field-origin map, inverse-edit pointers |
+| **Inverse map** | Guidance from changed rendered field to the source file/path to edit safely |
+| **Pre-sync** | cub-gen stops before rendered config reaches the live cluster; Flux/Argo own reconciliation |
 | **Contract triple** | GeneratorContract + ProvenanceRecord + InverseTransformPlan |
 
 ---
@@ -257,7 +262,7 @@ Component -> Variant -> Base/Deployment -> Target/Connections/Change/Proof.
 
 - repo-first CLI and contract coverage remain green,
 - the shipped release includes a first-class standalone `applicationset`
-  generator family,
+  Generator family,
 - flagship Helm, Score, Spring, and Swamp examples carry explicit
   `AI_START_HERE.md`, `prompts.md`, and `contracts.md` bundles,
 - connected release status is backed by the repo's `ConfigHub Smoke` lane,
@@ -275,6 +280,6 @@ For the active sequence, see the
 - Core flow commands (`discover`, `import`, `cleanup`) frozen and golden-tested
 - Platform graph command (`platform import`) emits read-only multi-repo Component/Variant graphs with diagnostics
 - Enrichment commands (`enrich preview`, `enrich write`) produce sidecar proof without manifest rewrites
-- Bridge artifacts (`publish`, `verify`, `attest`, `verify-attestation`) symmetric across all 11 generators
+- Bridge artifacts (`publish`, `verify`, `attest`, `verify-attestation`) symmetric across all 11 Generators
 - Generator catalog (`generators`) with filtering, details, and markdown output
 - Local-first: works standalone, connects to [ConfigHub](platform.md) for governed execution

--- a/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
+++ b/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
@@ -74,7 +74,7 @@ they understand why `cub-gen` is useful.
 | 3 | Add concrete platform families | OpenChoreo and Argo app-of-apps become runnable proof families, with OpenChoreo treated as a quality gate | [#277](https://github.com/confighub/cub-gen/issues/277), [#291](https://github.com/confighub/cub-gen/issues/291), [#292](https://github.com/confighub/cub-gen/issues/292), [#278](https://github.com/confighub/cub-gen/issues/278) |
 | 4 | Make Proof visible | Provenance, route badges, and history are visible where users work | [#280](https://github.com/confighub/cub-gen/issues/280), [#213](https://github.com/confighub/cub-gen/issues/213), [#209](https://github.com/confighub/cub-gen/issues/209), [#211](https://github.com/confighub/cub-gen/issues/211) |
 | 5 | Govern Changes | PR/MR linkage, backend route enforcement, and rewrite proposals become product workflows | [#282](https://github.com/confighub/cub-gen/issues/282), [#283](https://github.com/confighub/cub-gen/issues/283), [#281](https://github.com/confighub/cub-gen/issues/281), [#212](https://github.com/confighub/cub-gen/issues/212) |
-| 6 | Product integration | The command surface and comparison UI feel like one ConfigHub product | [#236](https://github.com/confighub/cub-gen/issues/236), [#210](https://github.com/confighub/cub-gen/issues/210) |
+| 6 | Product integration | The command surface, comparison UI, and one flagship quickstart feel like one ConfigHub product | [#236](https://github.com/confighub/cub-gen/issues/236), [#210](https://github.com/confighub/cub-gen/issues/210), [#307](https://github.com/confighub/cub-gen/issues/307) |
 
 ## Sequencing
 
@@ -229,9 +229,12 @@ Subtasks:
 
 - [ ] [#236](https://github.com/confighub/cub-gen/issues/236) Ship cub-gen as `cub gen` plugin
 - [ ] [#210](https://github.com/confighub/cub-gen/issues/210) GUI multi-environment comparison view
+- [x] [#307](https://github.com/confighub/cub-gen/issues/307) Pick and polish the flagship v0.4 quickstart
 
 Done means the user sees one ConfigHub product surface and can compare
-Deployment Variants without learning repository structure first.
+Deployment Variants without learning repository structure first. It also means
+a new reader has one obvious first run that answers "where do I fix this
+deployed field?" in under 10 minutes.
 
 Current state: the repo now carries the `cub gen` readiness contract and an
 updated `skills/cub-gen/SKILL.md`. Actual closure still depends on the external

--- a/docs/releases/v0.4-integration-beta.md
+++ b/docs/releases/v0.4-integration-beta.md
@@ -1,0 +1,116 @@
+# cub-gen v0.4 Integration Beta
+
+Status: draft release notes for the next `0.x` release.
+Target tracker: [#302](https://github.com/confighub/cub-gen/issues/302)
+
+## Summary
+
+`v0.4` is the release where `cub-gen` should become obvious:
+
+```text
+repo in -> Generator -> Component -> Variant -> Change -> Proof
+```
+
+The central product model is aligned with ConfigHub:
+
+```text
+Component
+  -> Variant
+      -> Base Variant        # not deployed; no Target/live address
+      -> Deployment Variant  # deployed; connected to Target/live address
+```
+
+`cub-gen` still runs locally first. It does not deploy and does not replace
+Helm, Score, Spring, Argo, Flux, or OpenChoreo. It makes their Generator
+behavior explicit so ConfigHub can reason about source config, rendered config,
+ownership, edit routes, and proof.
+
+## What Is New Since v0.3.0
+
+1. The public model is clearer.
+   - README, docs, CLI help, examples, and agent guidance now use
+     `Component -> Variant -> Base/Deployment` language.
+   - `Deployable Variant` is treated as plain English for `Deployment Variant`,
+     not as the whole ConfigHub Variant model.
+   - User-facing docs avoid vague `source intent` language and use `source
+     config` or exact file names instead.
+
+2. Platform import has real topology proof.
+   - `platform import` emits Components, Variants, Deployment Variants, Targets,
+     Generators, and diagnostics.
+   - `variant_kind` makes Base Variants and Deployment Variants explicit when
+     the manifest declares them or a Target makes the role clear.
+   - `testdata/variant-topology` shows one Component with a Base Variant and a
+     Deployment Variant.
+
+3. Platform fanout is more explicit.
+   - `platform fanout` still emits one governed proof bundle per Deployment
+     Variant.
+   - Fanout output now labels those bundles as `variant_kind: deployment`.
+
+4. Generator families have stronger teaching fixtures.
+   - OpenChoreo and Argo app-of-apps/ApplicationSet are fixture-backed worked
+     examples.
+   - Spring, Helm, and Score remain the core local demo paths.
+
+5. The review and governance path is more connected.
+   - Enrichment sidecars, normalize previews, PR/MR link evidence, bundle
+     publish/verify/attest, and connected smoke guards are in place.
+
+## Validation Bar
+
+Before cutting the release, run:
+
+```bash
+make ci
+/tmp/cub-gen-docs-venv/bin/mkdocs build --strict
+./examples/demo/v0.4-quickstart.sh
+./examples/helm-paas/demo-local.sh
+./examples/scoredev-paas/demo-local.sh
+./examples/springboot-paas/demo-local.sh
+```
+
+The first-run release path is:
+
+```bash
+./examples/demo/v0.4-quickstart.sh
+```
+
+It is local-only and should print the Generator, Component, Base/Deployment
+Variants, Target, field origin, route decision, and proof bundle without
+requiring ConfigHub login.
+
+For connected release confidence, also run:
+
+```bash
+make ci-connected
+```
+
+## Do Not Claim Yet
+
+- full upstream OpenChoreo estate support,
+- automatic rewriting of every platform/app repo,
+- generic AI-managed platform operation,
+- that every ConfigHub Variant is deployable,
+- server-side governance until ConfigHub route enforcement is merged,
+- `cub gen` as a shipped product command until the external plugin surface
+  exists.
+
+## Remaining External Gates
+
+These are outside a cub-gen-only release:
+
+- ConfigHub server-side route enforcement: [#283](https://github.com/confighub/cub-gen/issues/283)
+- ConfigHub proof UI: [#209](https://github.com/confighub/cub-gen/issues/209),
+  [#210](https://github.com/confighub/cub-gen/issues/210),
+  [#211](https://github.com/confighub/cub-gen/issues/211),
+  [#212](https://github.com/confighub/cub-gen/issues/212),
+  [#213](https://github.com/confighub/cub-gen/issues/213)
+- external `cub gen` product command surface: [#236](https://github.com/confighub/cub-gen/issues/236)
+
+## Remaining cub-gen Release Polish
+
+The first flagship quickstart is now present. Before release, rerun it from a
+fresh checkout and decide whether it is the final public path or whether Helm,
+Spring, or OpenChoreo should replace it as the headline demo. Tracking:
+[#307](https://github.com/confighub/cub-gen/issues/307).

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,7 @@ become full runnable adapters.
 | Argo ApplicationSet | [Argo Generators](../docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md) | selectors, inventory, and templates generate child Applications | bounded support exists |
 | Argo app-of-apps | [Argo Generators](../docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md) | root app plus child app catalog behaves like a generator | fixture-backed initial adapter |
 | Multi-repo platform estate | [`platform-estate`](../testdata/platform-estate/) | read-only manifest import before rewrites or fanout | fixture-backed graph proof |
+| Base/Deployment Variants | [`variant-topology`](../testdata/variant-topology/) | Component -> Variant -> Base or Deployment, with Target only on Deployment | fixture-backed topology proof |
 
 These examples are intentionally diagram-heavy. They are meant to help users see
 that `cub-gen` is importing generator systems, not arguing that every team must

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -9,8 +9,15 @@ detect → import → publish → verify → attest
                                           → (optional, deep) bridge ingest/query
 ```
 
-If you are new, do not start with "run everything." Start with one concrete
-adoption path that matches what you already run.
+If you are new, do not start with "run everything." Start with the v0.4
+quickstart or one concrete adoption path that matches what you already run.
+
+```bash
+./examples/demo/v0.4-quickstart.sh
+```
+
+That local script prints the Generator, Component, Base/Deployment Variants,
+Target, one field origin, one route decision, and a verified proof bundle.
 
 ## Proof ladder
 
@@ -78,6 +85,9 @@ See also: [Domain POV Matrix](../../docs/workflows/domain-pov-matrix.md) | [Pers
 
 ```bash
 go build -o ./cub-gen ./cmd/cub-gen
+
+# v0.4 release path
+./examples/demo/v0.4-quickstart.sh
 
 # Platform-first first run
 ./examples/demo/start-platform-first.sh

--- a/examples/demo/v0.4-quickstart.sh
+++ b/examples/demo/v0.4-quickstart.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required for the v0.4 quickstart" >&2
+  echo "hint: install jq, then rerun ./examples/demo/v0.4-quickstart.sh" >&2
+  exit 1
+fi
+
+if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
+  echo "[v0.4] build cub-gen"
+  go build -o ./cub-gen ./cmd/cub-gen
+fi
+
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/.tmp/v0.4-quickstart}"
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+echo
+echo "[v0.4] question"
+echo "If this deployed field is wrong, where do I fix it?"
+
+echo
+echo "[v0.4] 1. Component and Variant topology"
+TOPOLOGY="$OUT_DIR/variant-topology.json"
+./cub-gen platform import --json ./testdata/variant-topology/platform.yaml >"$TOPOLOGY"
+
+jq -e '((.diagnostics // []) | length) == 0' "$TOPOLOGY" >/dev/null
+jq -e '.components[] | select(.id == "checkout-api")' "$TOPOLOGY" >/dev/null
+jq -e '.variants[] | select(.id == "checkout-api/base" and .variant_kind == "base")' "$TOPOLOGY" >/dev/null
+jq -e '.variants[] | select(.id == "checkout-api/prod-us" and .variant_kind == "deployment" and .target == "prod-us")' "$TOPOLOGY" >/dev/null
+
+jq -r '
+  "Component: " + (.components[0].id) + " owner=" + (.components[0].owner // "-"),
+  "Generators: " + ([.generators[].profile] | unique | join(", ")),
+  (.variants[] | "Variant: " + .id + " kind=" + .variant_kind + " target=" + (.target // "-") + " owner=" + (.owner // "-"))
+' "$TOPOLOGY"
+
+echo
+echo "[v0.4] 2. Rendered field provenance"
+IMPORT="$OUT_DIR/helm-import.json"
+./cub-gen gitops import --space platform --json ./examples/helm-paas >"$IMPORT"
+
+jq -e '.provenance[0].field_origin_map[0].source_path != null' "$IMPORT" >/dev/null
+jq -r '
+  .provenance[0].field_origin_map[0] as $origin |
+  .provenance[0].inverse_edit_pointers[0] as $edit |
+  "Generator: " + .discovered[0].generator_profile,
+  "Rendered field: " + $origin.wet_path,
+  "Source file/path: " + $origin.source_path + "#" + $origin.dry_path,
+  "Owner: " + $edit.owner,
+  "Edit hint: " + $edit.edit_hint
+' "$IMPORT"
+
+echo
+echo "[v0.4] 3. Change route proof"
+ALLOW="$OUT_DIR/spring-allow.json"
+BLOCK="$OUT_DIR/spring-block.json"
+./cub-gen springboot validate-mutation \
+  --routes ./examples/springboot-paas/operational/field-routes.yaml \
+  --json feature.inventory.reservationMode >"$ALLOW"
+
+set +e
+./cub-gen springboot validate-mutation \
+  --routes ./examples/springboot-paas/operational/field-routes.yaml \
+  --json spring.datasource.url >"$BLOCK" 2>"$OUT_DIR/spring-block.err"
+block_status=$?
+set -e
+
+if [[ "$block_status" -eq 0 ]]; then
+  echo "error: expected spring.datasource.url to be blocked" >&2
+  exit 1
+fi
+
+jq -e '.allowed == true and .action == "mutable-in-ch"' "$ALLOW" >/dev/null
+jq -e '.allowed == false and .action == "generator-owned"' "$BLOCK" >/dev/null
+jq -r '
+  "Apply here: " + .field_path + " action=" + .action + " owner=" + .owner + " reason=" + .reason
+' "$ALLOW"
+jq -r '
+  "Block/escalate: " + .field_path + " action=" + .action + " owner=" + .owner + " reason=" + .reason
+' "$BLOCK"
+
+echo
+echo "[v0.4] 4. Proof bundle"
+BUNDLE="$OUT_DIR/helm-bundle.json"
+VERIFY="$OUT_DIR/helm-verify.txt"
+./cub-gen publish --space platform --pretty ./examples/helm-paas >"$BUNDLE"
+./cub-gen verify --in "$BUNDLE" >"$VERIFY"
+
+jq -e '.change_id != "" and .bundle_digest != ""' "$BUNDLE" >/dev/null
+jq -r '
+  "Change: " + .change_id,
+  "Proof bundle: " + .bundle_digest,
+  "Proof file: '"$BUNDLE"'"
+' "$BUNDLE"
+cat "$VERIFY"
+
+echo
+echo "[v0.4] done"
+echo "Local proof is in $OUT_DIR"
+echo "Connected handoff: cub auth login, then run ./examples/demo/run-connected-smoke.sh"

--- a/internal/platform/fanout.go
+++ b/internal/platform/fanout.go
@@ -47,6 +47,7 @@ type FanoutVariant struct {
 	VariantID         string               `json:"variant_id"`
 	Component         string               `json:"component"`
 	Variant           string               `json:"variant"`
+	VariantKind       string               `json:"variant_kind"`
 	Target            string               `json:"target,omitempty"`
 	RepoID            string               `json:"repo_id"`
 	RepoPath          string               `json:"repo_path"`
@@ -117,6 +118,7 @@ func BuildFanout(absManifestPath string, manifest Manifest, opts FanoutOptions) 
 		if target == "" {
 			target = strings.TrimSpace(repo.Target)
 		}
+		variantKind, variantKindInvalid := resolveVariantKind(spec.VariantKind, target)
 		if spec.Component != "" {
 			componentSet[spec.Component] = struct{}{}
 		}
@@ -133,6 +135,15 @@ func BuildFanout(absManifestPath string, manifest Manifest, opts FanoutOptions) 
 			continue
 		}
 		repoPath := normalizeRelPath(repo.Path)
+		if variantKindInvalid {
+			result.Diagnostics = append(result.Diagnostics, Diagnostic{
+				Severity: "warning",
+				Code:     "invalid_variant_kind",
+				RepoID:   repo.ID,
+				Path:     repoPath,
+				Message:  fmt.Sprintf("variant %s variant_kind %q is not supported or is inconsistent with target %q; expected base without a target or deployment with a target", spec.ID, strings.TrimSpace(spec.VariantKind), target),
+			})
+		}
 		absRepo := filepath.Join(baseDir, filepath.FromSlash(repoPath))
 		info, statErr := os.Stat(absRepo)
 		if statErr != nil || !info.IsDir() {
@@ -189,6 +200,7 @@ func BuildFanout(absManifestPath string, manifest Manifest, opts FanoutOptions) 
 			VariantID:         spec.ID,
 			Component:         spec.Component,
 			Variant:           spec.Variant,
+			VariantKind:       variantKind,
 			Target:            target,
 			RepoID:            repo.ID,
 			RepoPath:          repoPath,
@@ -265,11 +277,12 @@ func ResolveFanoutVariants(manifest Manifest) ([]ManifestVariant, error) {
 		}
 		repo := entries[0]
 		variants = append(variants, ManifestVariant{
-			ID:        key,
-			Component: strings.TrimSpace(repo.Component),
-			Variant:   strings.TrimSpace(repo.Variant),
-			Target:    strings.TrimSpace(repo.Target),
-			Repo:      strings.TrimSpace(repo.ID),
+			ID:          key,
+			Component:   strings.TrimSpace(repo.Component),
+			Variant:     strings.TrimSpace(repo.Variant),
+			VariantKind: strings.TrimSpace(repo.VariantKind),
+			Target:      strings.TrimSpace(repo.Target),
+			Repo:        strings.TrimSpace(repo.ID),
 		})
 	}
 	return sortedFanoutVariants(variants), nil
@@ -283,6 +296,7 @@ func normalizeExplicitFanoutVariants(in []ManifestVariant) ([]ManifestVariant, e
 		spec.ID = strings.TrimSpace(spec.ID)
 		spec.Component = strings.TrimSpace(spec.Component)
 		spec.Variant = strings.TrimSpace(spec.Variant)
+		spec.VariantKind = strings.TrimSpace(spec.VariantKind)
 		spec.Target = strings.TrimSpace(spec.Target)
 		spec.Repo = strings.TrimSpace(spec.Repo)
 		if spec.Component == "" {

--- a/internal/platform/fanout_test.go
+++ b/internal/platform/fanout_test.go
@@ -47,6 +47,9 @@ func TestBuildFanoutEmitsStableBundlesPerVariant(t *testing.T) {
 		if variant.ChangeID == "" {
 			t.Fatalf("variant %s has no change_id", variant.VariantID)
 		}
+		if variant.VariantKind != "deployment" {
+			t.Fatalf("fanout should only emit Deployment Variants, got %+v", variant)
+		}
 		if _, ok := seenChanges[variant.ChangeID]; ok {
 			t.Fatalf("duplicate change_id %s for variant %s", variant.ChangeID, variant.VariantID)
 		}
@@ -82,6 +85,50 @@ func TestBuildFanoutCanFilterByVariantName(t *testing.T) {
 			t.Fatalf("expected only dev variants, got %+v", result.Variants)
 		}
 	}
+}
+
+func TestBuildFanoutReportsInvalidVariantKind(t *testing.T) {
+	manifest, absPath, err := LoadManifest(variantFanoutManifestPath(t))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	manifest.Variants[0].VariantKind = "shared"
+	result, err := BuildFanout(absPath, manifest, FanoutOptions{
+		GeneratedAt:   "2026-04-30T12:00:00Z",
+		VariantFilter: "checkout-api/dev",
+	})
+	if err != nil {
+		t.Fatalf("build fanout: %v", err)
+	}
+	if len(result.Variants) != 1 {
+		t.Fatalf("expected one variant, got %+v", result.Variants)
+	}
+	if result.Variants[0].VariantKind != "unknown" {
+		t.Fatalf("invalid variant kind should degrade to unknown, got %+v", result.Variants[0])
+	}
+	assertFanoutDiagnostic(t, result, "invalid_variant_kind", "helm-checkout")
+}
+
+func TestBuildFanoutReportsContradictoryVariantKindAndTarget(t *testing.T) {
+	manifest, absPath, err := LoadManifest(variantFanoutManifestPath(t))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	manifest.Variants[0].VariantKind = "base"
+	result, err := BuildFanout(absPath, manifest, FanoutOptions{
+		GeneratedAt:   "2026-04-30T12:00:00Z",
+		VariantFilter: "checkout-api/dev",
+	})
+	if err != nil {
+		t.Fatalf("build fanout: %v", err)
+	}
+	if len(result.Variants) != 1 {
+		t.Fatalf("expected one variant, got %+v", result.Variants)
+	}
+	if result.Variants[0].VariantKind != "unknown" {
+		t.Fatalf("base variant with target should degrade to unknown, got %+v", result.Variants[0])
+	}
+	assertFanoutDiagnostic(t, result, "invalid_variant_kind", "helm-checkout")
 }
 
 func TestBuildFanoutSeparatesSharedAndVariantInputs(t *testing.T) {
@@ -148,4 +195,14 @@ func containsString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func assertFanoutDiagnostic(t *testing.T, result FanoutResult, code, repoID string) {
+	t.Helper()
+	for _, diagnostic := range result.Diagnostics {
+		if diagnostic.Code == code && diagnostic.RepoID == repoID {
+			return
+		}
+	}
+	t.Fatalf("missing diagnostic code=%s repo=%s in %+v", code, repoID, result.Diagnostics)
 }

--- a/internal/platform/graph.go
+++ b/internal/platform/graph.go
@@ -29,19 +29,21 @@ type Manifest struct {
 }
 
 type ManifestRepo struct {
-	ID        string `json:"id" yaml:"id"`
-	Role      string `json:"role" yaml:"role"`
-	Path      string `json:"path" yaml:"path"`
-	Owner     string `json:"owner,omitempty" yaml:"owner,omitempty"`
-	Component string `json:"component,omitempty" yaml:"component,omitempty"`
-	Variant   string `json:"variant,omitempty" yaml:"variant,omitempty"`
-	Target    string `json:"target,omitempty" yaml:"target,omitempty"`
+	ID          string `json:"id" yaml:"id"`
+	Role        string `json:"role" yaml:"role"`
+	Path        string `json:"path" yaml:"path"`
+	Owner       string `json:"owner,omitempty" yaml:"owner,omitempty"`
+	Component   string `json:"component,omitempty" yaml:"component,omitempty"`
+	Variant     string `json:"variant,omitempty" yaml:"variant,omitempty"`
+	VariantKind string `json:"variant_kind,omitempty" yaml:"variant_kind,omitempty"`
+	Target      string `json:"target,omitempty" yaml:"target,omitempty"`
 }
 
 type ManifestVariant struct {
 	ID            string   `json:"id,omitempty" yaml:"id,omitempty"`
 	Component     string   `json:"component" yaml:"component"`
 	Variant       string   `json:"variant" yaml:"variant"`
+	VariantKind   string   `json:"variant_kind,omitempty" yaml:"variant_kind,omitempty"`
 	Target        string   `json:"target,omitempty" yaml:"target,omitempty"`
 	Repo          string   `json:"repo" yaml:"repo"`
 	SharedInputs  []string `json:"shared_inputs,omitempty" yaml:"shared_inputs,omitempty"`
@@ -93,6 +95,7 @@ type RepoNode struct {
 	Owner          string `json:"owner,omitempty"`
 	Component      string `json:"component,omitempty"`
 	Variant        string `json:"variant,omitempty"`
+	VariantKind    string `json:"variant_kind,omitempty"`
 	Target         string `json:"target,omitempty"`
 	Exists         bool   `json:"exists"`
 	GeneratorCount int    `json:"generator_count"`
@@ -106,12 +109,13 @@ type ComponentNode struct {
 }
 
 type VariantNode struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Component string `json:"component"`
-	Target    string `json:"target,omitempty"`
-	Owner     string `json:"owner,omitempty"`
-	RepoID    string `json:"repo_id"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Component   string `json:"component"`
+	VariantKind string `json:"variant_kind"`
+	Target      string `json:"target,omitempty"`
+	Owner       string `json:"owner,omitempty"`
+	RepoID      string `json:"repo_id"`
 }
 
 type TargetNode struct {
@@ -237,14 +241,30 @@ func BuildGraph(absManifestPath string, manifest Manifest, opts ImportOptions) (
 
 	repos := normalizeRepos(manifest.Repos)
 	for _, repo := range repos {
+		variantName := strings.TrimSpace(repo.Variant)
+		variantKind := ""
+		variantKindInvalid := false
+		if variantName != "" {
+			variantKind, variantKindInvalid = resolveVariantKind(repo.VariantKind, repo.Target)
+		}
 		repoNode := RepoNode{
-			ID:        repo.ID,
-			Role:      normalizeToken(repo.Role, "repo"),
-			Path:      normalizeRelPath(repo.Path),
-			Owner:     strings.TrimSpace(repo.Owner),
-			Component: strings.TrimSpace(repo.Component),
-			Variant:   strings.TrimSpace(repo.Variant),
-			Target:    strings.TrimSpace(repo.Target),
+			ID:          repo.ID,
+			Role:        normalizeToken(repo.Role, "repo"),
+			Path:        normalizeRelPath(repo.Path),
+			Owner:       strings.TrimSpace(repo.Owner),
+			Component:   strings.TrimSpace(repo.Component),
+			Variant:     variantName,
+			VariantKind: variantKind,
+			Target:      strings.TrimSpace(repo.Target),
+		}
+		if variantKindInvalid {
+			graph.Diagnostics = append(graph.Diagnostics, Diagnostic{
+				Severity: "warning",
+				Code:     "invalid_variant_kind",
+				RepoID:   repoNode.ID,
+				Path:     repoNode.Path,
+				Message:  fmt.Sprintf("repo variant_kind %q is not supported or is inconsistent with target %q; expected base without a target or deployment with a target", strings.TrimSpace(repo.VariantKind), repoNode.Target),
+			})
 		}
 		if repoNode.Owner == "" {
 			graph.Diagnostics = append(graph.Diagnostics, Diagnostic{
@@ -286,12 +306,13 @@ func BuildGraph(absManifestPath string, manifest Manifest, opts ImportOptions) (
 			} else {
 				variantID := repoNode.Component + "/" + repoNode.Variant
 				variantByID[variantID] = VariantNode{
-					ID:        variantID,
-					Name:      repoNode.Variant,
-					Component: repoNode.Component,
-					Target:    repoNode.Target,
-					Owner:     repoNode.Owner,
-					RepoID:    repoNode.ID,
+					ID:          variantID,
+					Name:        repoNode.Variant,
+					Component:   repoNode.Component,
+					VariantKind: repoNode.VariantKind,
+					Target:      repoNode.Target,
+					Owner:       repoNode.Owner,
+					RepoID:      repoNode.ID,
 				}
 				graph.Connections = append(graph.Connections, Connection{
 					FromType: "component",
@@ -592,6 +613,34 @@ func targetOwnerRank(role string) int {
 	default:
 		return 0
 	}
+}
+
+func inferVariantKind(explicitKind, target string) string {
+	kind, _ := resolveVariantKind(explicitKind, target)
+	return kind
+}
+
+func resolveVariantKind(explicitKind, target string) (string, bool) {
+	clean := normalizeToken(explicitKind, "")
+	hasTarget := strings.TrimSpace(target) != ""
+	switch clean {
+	case "base":
+		if hasTarget {
+			return "unknown", true
+		}
+		return clean, false
+	case "deployment":
+		if !hasTarget {
+			return "unknown", true
+		}
+		return clean, false
+	case "":
+		if !hasTarget {
+			return "base", false
+		}
+		return "deployment", false
+	}
+	return "unknown", true
 }
 
 func normalizeRelPath(path string) string {

--- a/internal/platform/graph_test.go
+++ b/internal/platform/graph_test.go
@@ -49,11 +49,91 @@ func TestBuildGraphIsStableAndReportsDiagnostics(t *testing.T) {
 	assertDiagnostic(t, first, "unsupported_generator", "platform-base")
 }
 
+func TestBuildGraphClassifiesBaseAndDeploymentVariants(t *testing.T) {
+	manifest, absPath, err := LoadManifest(variantTopologyManifestPath(t))
+	if err != nil {
+		t.Fatalf("load topology manifest: %v", err)
+	}
+	graph, err := BuildGraph(absPath, manifest, ImportOptions{GeneratedAt: "2026-05-02T12:00:00Z"})
+	if err != nil {
+		t.Fatalf("build topology graph: %v", err)
+	}
+	if graph.Summary.ComponentCount != 1 || graph.Summary.VariantCount != 2 || graph.Summary.TargetCount != 1 {
+		t.Fatalf("unexpected topology summary: %+v", graph.Summary)
+	}
+	base := findVariant(t, graph, "checkout-api/base")
+	if base.VariantKind != "base" {
+		t.Fatalf("expected checkout-api/base to be a base variant, got %+v", base)
+	}
+	if base.Target != "" {
+		t.Fatalf("base variant should not have a target, got %+v", base)
+	}
+	deployment := findVariant(t, graph, "checkout-api/prod-us")
+	if deployment.VariantKind != "deployment" || deployment.Target != "prod-us" {
+		t.Fatalf("expected checkout-api/prod-us to be a deployment variant with target, got %+v", deployment)
+	}
+	assertConnection(t, graph, "component", "checkout-api", "variant", "checkout-api/base", "has-variant")
+	assertConnection(t, graph, "component", "checkout-api", "variant", "checkout-api/prod-us", "has-variant")
+	assertConnection(t, graph, "variant", "checkout-api/prod-us", "target", "prod-us", "deploys-to")
+	assertNoConnection(t, graph, "variant", "checkout-api/base", "target", "prod-us", "deploys-to")
+}
+
+func TestBuildGraphReportsInvalidVariantKind(t *testing.T) {
+	manifest, absPath, err := LoadManifest(variantTopologyManifestPath(t))
+	if err != nil {
+		t.Fatalf("load topology manifest: %v", err)
+	}
+	manifest.Repos[0].VariantKind = "shared"
+	graph, err := BuildGraph(absPath, manifest, ImportOptions{GeneratedAt: "2026-05-02T12:00:00Z"})
+	if err != nil {
+		t.Fatalf("build topology graph: %v", err)
+	}
+	base := findVariant(t, graph, "checkout-api/base")
+	if base.VariantKind != "unknown" {
+		t.Fatalf("invalid variant kind should degrade to unknown, got %+v", base)
+	}
+	assertDiagnostic(t, graph, "invalid_variant_kind", "checkout-base")
+}
+
+func TestBuildGraphReportsContradictoryVariantKindAndTarget(t *testing.T) {
+	manifest, absPath, err := LoadManifest(variantTopologyManifestPath(t))
+	if err != nil {
+		t.Fatalf("load topology manifest: %v", err)
+	}
+	manifest.Repos[0].VariantKind = "base"
+	manifest.Repos[0].Target = "prod-us"
+	manifest.Repos[1].VariantKind = "deployment"
+	manifest.Repos[1].Target = ""
+	graph, err := BuildGraph(absPath, manifest, ImportOptions{GeneratedAt: "2026-05-02T12:00:00Z"})
+	if err != nil {
+		t.Fatalf("build topology graph: %v", err)
+	}
+	base := findVariant(t, graph, "checkout-api/base")
+	if base.VariantKind != "unknown" {
+		t.Fatalf("base with a target should degrade to unknown, got %+v", base)
+	}
+	deployment := findVariant(t, graph, "checkout-api/prod-us")
+	if deployment.VariantKind != "unknown" {
+		t.Fatalf("deployment with no target should degrade to unknown, got %+v", deployment)
+	}
+	assertDiagnostic(t, graph, "invalid_variant_kind", "checkout-base")
+	assertDiagnostic(t, graph, "invalid_variant_kind", "checkout-prod-us")
+}
+
 func fixtureManifestPath(t *testing.T) string {
 	t.Helper()
 	path, err := filepath.Abs(filepath.Join("..", "..", "testdata", "platform-estate", "platform.yaml"))
 	if err != nil {
 		t.Fatalf("resolve fixture path: %v", err)
+	}
+	return path
+}
+
+func variantTopologyManifestPath(t *testing.T) string {
+	t.Helper()
+	path, err := filepath.Abs(filepath.Join("..", "..", "testdata", "variant-topology", "platform.yaml"))
+	if err != nil {
+		t.Fatalf("resolve variant topology fixture path: %v", err)
 	}
 	return path
 }
@@ -75,4 +155,42 @@ func assertDiagnostic(t *testing.T, graph Graph, code, repoID string) {
 		}
 	}
 	t.Fatalf("missing diagnostic code=%s repo=%s in %+v", code, repoID, graph.Diagnostics)
+}
+
+func findVariant(t *testing.T, graph Graph, id string) VariantNode {
+	t.Helper()
+	for _, variant := range graph.Variants {
+		if variant.ID == id {
+			return variant
+		}
+	}
+	t.Fatalf("missing variant %s in %+v", id, graph.Variants)
+	return VariantNode{}
+}
+
+func assertConnection(t *testing.T, graph Graph, fromType, fromID, toType, toID, kind string) {
+	t.Helper()
+	if !hasConnection(graph, fromType, fromID, toType, toID, kind) {
+		t.Fatalf("missing connection %s/%s --%s--> %s/%s in %+v", fromType, fromID, kind, toType, toID, graph.Connections)
+	}
+}
+
+func assertNoConnection(t *testing.T, graph Graph, fromType, fromID, toType, toID, kind string) {
+	t.Helper()
+	if hasConnection(graph, fromType, fromID, toType, toID, kind) {
+		t.Fatalf("unexpected connection %s/%s --%s--> %s/%s in %+v", fromType, fromID, kind, toType, toID, graph.Connections)
+	}
+}
+
+func hasConnection(graph Graph, fromType, fromID, toType, toID, kind string) bool {
+	for _, conn := range graph.Connections {
+		if conn.FromType == fromType &&
+			conn.FromID == fromID &&
+			conn.ToType == toType &&
+			conn.ToID == toID &&
+			conn.Kind == kind {
+			return true
+		}
+	}
+	return false
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -196,6 +196,7 @@ nav:
           - "App/Deployment Concepts": testing/app-deployment-concepts.md
       - "Contract Drift Checklist": testing/contract-drift-checklist.md
       - "Release Notes (v0.3.0)": releases/v0.3.0.md
+      - "Draft Release Notes (v0.4 Integration Beta)": releases/v0.4-integration-beta.md
       - "Archived Release Plan (v0.2-preview.2)": releases/v0.2-preview.2-plan.md
       - "Archived Ship Checklist (v0.2-preview.2)": releases/v0.2-preview.2-ship-checklist.md
       - "Release Notes (v0.2-preview.2)": releases/v0.2-preview.2.md

--- a/testdata/variant-topology/README.md
+++ b/testdata/variant-topology/README.md
@@ -1,0 +1,26 @@
+# Base and Deployment Variant Fixture
+
+This fixture shows the ConfigHub topology language directly:
+
+```text
+Component
+  -> Variant
+      -> Base Variant        # no Target, no live address
+      -> Deployment Variant  # has Target and live address
+```
+
+`checkout-api/base` is a Base Variant. It keeps the reusable Helm shape and
+placeholder-like defaults, but it is not meant to deploy.
+
+`checkout-api/prod-us` is a Deployment Variant. It has concrete values and a
+`prod-us` Target, so its rendered resources can be mapped to a live address.
+
+Run:
+
+```bash
+./cub-gen platform import --json ./testdata/variant-topology/platform.yaml \
+  | jq '.variants'
+```
+
+Expected lesson: both entries are real Variants of the same Component, but only
+the Deployment Variant has a Target.

--- a/testdata/variant-topology/base/Chart.yaml
+++ b/testdata/variant-topology/base/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: checkout-api
+version: 0.1.0
+appVersion: "1.0.0"
+type: application

--- a/testdata/variant-topology/base/templates/deployment.yaml
+++ b/testdata/variant-topology/base/templates/deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-api
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    spec:
+      containers:
+        - name: checkout-api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.service.port }}

--- a/testdata/variant-topology/base/values.yaml
+++ b/testdata/variant-topology/base/values.yaml
@@ -1,0 +1,6 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/example/checkout-api
+  tag: "${IMAGE_TAG}"
+service:
+  port: 8080

--- a/testdata/variant-topology/platform.yaml
+++ b/testdata/variant-topology/platform.yaml
@@ -1,0 +1,20 @@
+schema_version: cub.confighub.io/platform-import-manifest/v1
+name: checkout-variant-topology
+space: platform
+ref: HEAD
+repos:
+  - id: checkout-base
+    role: platform
+    path: base
+    owner: platform-team
+    component: checkout-api
+    variant: base
+    variant_kind: base
+  - id: checkout-prod-us
+    role: app
+    path: prod-us
+    owner: app-team
+    component: checkout-api
+    variant: prod-us
+    variant_kind: deployment
+    target: prod-us

--- a/testdata/variant-topology/prod-us/Chart.yaml
+++ b/testdata/variant-topology/prod-us/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: checkout-api
+version: 0.1.0
+appVersion: "1.0.0"
+type: application

--- a/testdata/variant-topology/prod-us/templates/deployment.yaml
+++ b/testdata/variant-topology/prod-us/templates/deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-api
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    spec:
+      containers:
+        - name: checkout-api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.service.port }}

--- a/testdata/variant-topology/prod-us/values.yaml
+++ b/testdata/variant-topology/prod-us/values.yaml
@@ -1,0 +1,6 @@
+replicaCount: 4
+image:
+  repository: ghcr.io/example/checkout-api
+  tag: v1.2.3
+service:
+  port: 8080


### PR DESCRIPTION
## Summary
- add `variant_kind` to platform import/fanout output so cub-gen can name Base and Deployment Variants directly
- align the topology fixture with ConfigHub current behavior: no Target = Base Variant, Target = Deployment Variant
- add a small `testdata/variant-topology` worked fixture with one Component, one Base Variant, and one Deployment Variant with a Target
- degrade bad or contradictory explicit `variant_kind` values to `unknown` with an `invalid_variant_kind` diagnostic
- add `./examples/demo/v0.4-quickstart.sh`, a one-command local path for Generator -> Component -> Variant -> Target -> Change -> Proof
- document the Variant-as-space model, placeholder apply gates, and follow-up cloned-deployment adaptation work (#308)
- update README/example/docs/goldens and add draft v0.4 integration-beta release notes
- simplify first-run docs so they say source config/rendered config before DRY/WET shorthand

Closes #304
Closes #307

## Validation
- `go build ./cmd/cub-gen`
- `go test ./internal/platform ./cmd/cub-gen -run '^(TestBuildGraphClassifiesBaseAndDeploymentVariants|TestBuildGraphReportsInvalidVariantKind|TestBuildGraphReportsContradictoryVariantKindAndTarget|TestBuildFanoutEmitsStableBundlesPerVariant|TestBuildFanoutReportsInvalidVariantKind|TestBuildFanoutReportsContradictoryVariantKindAndTarget|TestPlatformImportGolden|TestPlatformFanoutGolden|TestTopLevelCommandGoldenHelp|TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v`\n- `go test ./internal/platform -count=1`\n- `make test-v04-quickstart`\n- `/tmp/cub-gen-docs-venv/bin/mkdocs build --strict`\n- `make ci`\n- `./cub-gen platform import --json ./testdata/variant-topology/platform.yaml | jq '{summary, variants, diagnostics}'`