### PR TITLE
[codex] Clarify Target-derived Variant model

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,20 @@ Component family. A **Base Variant** is not deployed. A **Deployment Variant**
 is the concrete deployed copy for one environment, tenant, region, customer, or
 cluster.
 
+In ConfigHub today, the practical discriminator is Target presence: no Target
+means Base Variant, and a Target means Deployment Variant. `cub-gen` exposes
+that as `variant_kind` in platform output so the distinction is easy to query.
+An explicit kind may appear later, but it does not change the model.
+
 `cub-gen` helps explain how a Variant was generated, whether it is a base or a
 deployment when the repo makes that clear, and where a proposed change should
 land.
+
+A Variant is the whole config context for that Component: in ConfigHub terms, a
+space containing units. Base Variants can contain placeholders. Newly cloned
+Deployment Variants can also contain placeholders until they are adapted for
+their Target; apply gates such as `vet-placeholders` should stop them from
+being applied until those placeholders are replaced.
 
 A **Change** is any proposed edit to the source or rendered config. **Proof**
 is the field-origin, owner, route, and decision evidence that makes the change

--- a/docs/agentic-gitops/02-design/10-generators-prd.md
+++ b/docs/agentic-gitops/02-design/10-generators-prd.md
@@ -29,6 +29,14 @@ delta, wiring, or operation is AI-assisted and governed. Generator contracts
 are the implementation mechanism that lets the product derive variants, targets,
 connections, changes, and proof from existing repos.
 
+Current ConfigHub behavior derives Base vs Deployment from Target presence: no
+Target means Base Variant, and Target means Deployment Variant. A Variant is a
+space containing units, and the units in that space are the total config for
+that Variant. Base Variants may contain placeholders. Newly cloned Deployment
+Variants may also contain placeholders until adapted for their Target; apply
+gates such as `vet-placeholders` should prevent apply until adaptation is
+complete.
+
 Plain-English thesis: many app platforms are generators. They take app source
 config, environment context, and platform contracts, then produce deployable config. The
 product does not need to replace those platforms first. It needs to import them,
@@ -40,6 +48,8 @@ The product must let teams:
 2. convert them into DRY/WET + generator contracts,
 3. run AI-assisted changes through ConfigHub MR governance,
 4. promote reusable app changes into platform base DRY safely.
+5. adapt newly cloned Deployment Variants with reviewable patches instead of
+   one-off manual edits or hidden scripts.
 
 This is an adoption bridge, not a reconciler replacement. Flux/Argo stay in place.
 

--- a/docs/agentic-gitops/02-design/90-platform-generators-manifesto.md
+++ b/docs/agentic-gitops/02-design/90-platform-generators-manifesto.md
@@ -37,6 +37,14 @@ The vocabulary should stay small:
 This is the product surface people should understand first. The generator model
 explains how `cub-gen` can produce that surface from existing repos.
 
+In ConfigHub today, Base vs Deployment is determined by Target presence: no
+Target means Base Variant, and Target means Deployment Variant. A Variant is the
+whole config context for a Component, implemented as a space containing units.
+Base Variants may contain placeholders. A newly cloned Deployment Variant may
+also contain placeholders until it has been adapted for its Target; apply gates
+such as `vet-placeholders` should prevent applying it until that adaptation is
+done.
+
 The manifesto is the clean version of what the early `cub-gen` planning docs
 were already reaching for:
 
@@ -130,6 +138,7 @@ ConfigMap payloads for allowed app-owned fields, and has connected/live proof.
 | App-of-apps adapter | fixture-backed initial adapter | broader root/child app catalog analysis |
 | Automatic annotation/enrichment | not generic | generate sidecar provenance and optional PRs for annotations |
 | "Better config" generation | limited to Spring starter scaffolding | propose normalized variants, secret references, ownership metadata, and source lifts |
+| Cloned deployment adaptation | manual/scripted outside ConfigHub today | clone Variant, add Target, detect placeholder gates, propose reviewed adaptation patches |
 | Multi-env/tenant fanout | no one-command fanout | one invocation emits one bundle per env/tenant/app variant |
 | PR/MR magic | contracts, commands, and demos exist | seamless creation/linkage with evidence attached |
 | Server-side policy enforcement | client-side proof is stronger than backend enforcement | ConfigHub rejects/blocks governed writes authoritatively |

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,13 @@ where a Deployment Variant runs or reconciles. **Connections** are what it is
 wired to. A **Change** is what someone wants to alter. **Proof** shows where it
 came from, who owns it, what changed, and whether the change is allowed.
 
+Today ConfigHub answers "base or deployment?" from Target presence: no Target
+means Base Variant, and Target means Deployment Variant. A Variant is the whole
+config context for that Component, implemented as a space containing units.
+Base Variants may contain placeholders. Newly cloned Deployment Variants may
+also contain placeholders until they are adapted for their Target, and apply
+gates should prevent applying them too early.
+
 An **AI Variant** is a Variant whose delta, wiring, or operation is
 AI-assisted and governed.
 

--- a/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
+++ b/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
@@ -60,6 +60,15 @@ a Variant can be a Base Variant or a Deployment Variant. The older phrase
 Deployable Variant means the Deployment Variant side of that model, not every
 ConfigHub Variant.
 
+Current ConfigHub behavior keeps the discriminator simple: no Target means Base
+Variant, and Target means Deployment Variant. A Variant is implemented as a
+space containing units; those units are the total config for that Variant. Base
+Variants may contain placeholders. Newly cloned Deployment Variants may also
+contain placeholders until they are adapted for the new Target, and
+`vet-placeholders`-style gates should stop apply until the adaptation is done.
+The adaptation workflow is now tracked as future product work in
+[#308](https://github.com/confighub/cub-gen/issues/308).
+
 The generator model remains the implementation explanation underneath this user
 model. Users should not need to understand DRY/WET/generator contracts before
 they understand why `cub-gen` is useful.
@@ -74,7 +83,7 @@ they understand why `cub-gen` is useful.
 | 3 | Add concrete platform families | OpenChoreo and Argo app-of-apps become runnable proof families, with OpenChoreo treated as a quality gate | [#277](https://github.com/confighub/cub-gen/issues/277), [#291](https://github.com/confighub/cub-gen/issues/291), [#292](https://github.com/confighub/cub-gen/issues/292), [#278](https://github.com/confighub/cub-gen/issues/278) |
 | 4 | Make Proof visible | Provenance, route badges, and history are visible where users work | [#280](https://github.com/confighub/cub-gen/issues/280), [#213](https://github.com/confighub/cub-gen/issues/213), [#209](https://github.com/confighub/cub-gen/issues/209), [#211](https://github.com/confighub/cub-gen/issues/211) |
 | 5 | Govern Changes | PR/MR linkage, backend route enforcement, and rewrite proposals become product workflows | [#282](https://github.com/confighub/cub-gen/issues/282), [#283](https://github.com/confighub/cub-gen/issues/283), [#281](https://github.com/confighub/cub-gen/issues/281), [#212](https://github.com/confighub/cub-gen/issues/212) |
-| 6 | Product integration | The command surface, comparison UI, and one flagship quickstart feel like one ConfigHub product | [#236](https://github.com/confighub/cub-gen/issues/236), [#210](https://github.com/confighub/cub-gen/issues/210), [#307](https://github.com/confighub/cub-gen/issues/307) |
+| 6 | Product integration | The command surface, comparison UI, deployment adaptation flow, and one flagship quickstart feel like one ConfigHub product | [#236](https://github.com/confighub/cub-gen/issues/236), [#210](https://github.com/confighub/cub-gen/issues/210), [#307](https://github.com/confighub/cub-gen/issues/307), [#308](https://github.com/confighub/cub-gen/issues/308) |
 
 ## Sequencing
 
@@ -230,11 +239,14 @@ Subtasks:
 - [ ] [#236](https://github.com/confighub/cub-gen/issues/236) Ship cub-gen as `cub gen` plugin
 - [ ] [#210](https://github.com/confighub/cub-gen/issues/210) GUI multi-environment comparison view
 - [x] [#307](https://github.com/confighub/cub-gen/issues/307) Pick and polish the flagship v0.4 quickstart
+- [ ] [#308](https://github.com/confighub/cub-gen/issues/308) Adapt cloned Deployment Variants before apply
 
 Done means the user sees one ConfigHub product surface and can compare
 Deployment Variants without learning repository structure first. It also means
 a new reader has one obvious first run that answers "where do I fix this
-deployed field?" in under 10 minutes.
+deployed field?" in under 10 minutes. Follow-on adaptation work should turn the
+manual clone -> add Target -> replace placeholders process into a reviewable
+function on config data, not a hidden write.
 
 Current state: the repo now carries the `cub gen` readiness contract and an
 updated `skills/cub-gen/SKILL.md`. Actual closure still depends on the external

--- a/docs/releases/v0.4-integration-beta.md
+++ b/docs/releases/v0.4-integration-beta.md
@@ -20,6 +20,11 @@ Component
       -> Deployment Variant  # deployed; connected to Target/live address
 ```
 
+Today the Base/Deployment distinction is derived from Target presence: no
+Target means Base Variant, and Target means Deployment Variant. `cub-gen`
+reports that as `variant_kind` for easier querying. Explicit kind metadata may
+come later, but it must agree with the Target rule.
+
 `cub-gen` still runs locally first. It does not deploy and does not replace
 Helm, Score, Spring, Argo, Flux, or OpenChoreo. It makes their Generator
 behavior explicit so ConfigHub can reason about source config, rendered config,
@@ -39,7 +44,8 @@ ownership, edit routes, and proof.
    - `platform import` emits Components, Variants, Deployment Variants, Targets,
      Generators, and diagnostics.
    - `variant_kind` makes Base Variants and Deployment Variants explicit when
-     the manifest declares them or a Target makes the role clear.
+     the manifest declares them or, today, Target presence makes the role clear.
+     Contradictory explicit values degrade to `unknown` with diagnostics.
    - `testdata/variant-topology` shows one Component with a Base Variant and a
      Deployment Variant.
 
@@ -90,6 +96,7 @@ make ci-connected
 
 - full upstream OpenChoreo estate support,
 - automatic rewriting of every platform/app repo,
+- an elegant cloned-deployment adaptation or placeholder vending-machine flow,
 - generic AI-managed platform operation,
 - that every ConfigHub Variant is deployable,
 - server-side governance until ConfigHub route enforcement is merged,

--- a/testdata/variant-topology/README.md
+++ b/testdata/variant-topology/README.md
@@ -15,6 +15,17 @@ placeholder-like defaults, but it is not meant to deploy.
 `checkout-api/prod-us` is a Deployment Variant. It has concrete values and a
 `prod-us` Target, so its rendered resources can be mapped to a live address.
 
+The fixture deliberately relies on the current ConfigHub rule:
+
+```text
+no Target -> Base Variant
+Target    -> Deployment Variant
+```
+
+`cub-gen` emits `variant_kind` as an explanatory label in import/fanout output.
+If a manifest supplies an explicit kind later, it must still agree with Target
+presence.
+
 Run:
 
 ```bash
@@ -22,5 +33,5 @@ Run:
   | jq '.variants'
 ```
 
-Expected lesson: both entries are real Variants of the same Component, but only
-the Deployment Variant has a Target.
+Expected lesson: both entries are real Variants of the same Component. The Base
+Variant has no Target. The Deployment Variant has a Target.

--- a/testdata/variant-topology/platform.yaml
+++ b/testdata/variant-topology/platform.yaml
@@ -9,12 +9,10 @@ repos:
     owner: platform-team
     component: checkout-api
     variant: base
-    variant_kind: base
   - id: checkout-prod-us
     role: app
     path: prod-us
     owner: app-team
     component: checkout-api
     variant: prod-us
-    variant_kind: deployment
     target: prod-us


### PR DESCRIPTION
## Summary

- Clarify that ConfigHub currently derives Base vs Deployment Variant from Target presence: no Target means Base Variant, Target means Deployment Variant.
- Update the topology fixture so it no longer declares `variant_kind`; `cub-gen` emits `variant_kind` as explanatory/query output derived from the model.
- Add the placeholder/apply-gate/adaptation framing from the #2985 discussion to README, docs, roadmap, and release notes, with the future adaptation workflow tracked in #308.

## Why

Jesper clarified that the current ConfigHub model does not require an explicit kind field. A Variant is a space containing units, and the units are the total config for that Variant. Base Variants and newly cloned Deployment Variants may contain placeholders; deployment adaptation is the missing workflow after clone + Target assignment and before apply.

This keeps cub-gen aligned with ConfigHub as it exists today while preserving the future option to add explicit kind metadata later.

## Validation

- `go test ./internal/platform -count=1`
- `make test-v04-quickstart`
- `git diff --check`
- `/tmp/cub-gen-docs-venv/bin/mkdocs build --strict`
- `make ci`

No changes were made to `/Users/alexis/code/confighub`.