### PR TITLE
Add traceable proof events

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ being applied until those placeholders are replaced.
 
 A **Change** is any proposed edit to the source or rendered config. **Proof**
 is the field-origin, owner, route, and decision evidence that makes the change
-reviewable. Bundle and attestation artifacts also carry `proof_events[]`: small
-JSON records with `trace_id`, `change_id`, artifact digests, and parent digest
-links so Pilot, validation, and attestation logs can join the chain later. Use
-`cub-gen proof events --in bundle.json --ndjson` when a log pipeline needs just
-those records.
+reviewable. Bundle, attestation, and governed decision artifacts also carry
+`proof_events[]`: small JSON records with `trace_id`, `change_id`, artifact
+digests, parent links, and decision state so Pilot, validation, and attestation
+logs can join the chain later. Use `cub-gen proof events --in bundle.json --ndjson`
+when a log pipeline needs just those records.
 
 The short version is **repo in, explanation out**.
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ A **Change** is any proposed edit to the source or rendered config. **Proof**
 is the field-origin, owner, route, and decision evidence that makes the change
 reviewable. Bundle and attestation artifacts also carry `proof_events[]`: small
 JSON records with `trace_id`, `change_id`, artifact digests, and parent digest
-links so Pilot, validation, and attestation logs can join the chain later.
+links so Pilot, validation, and attestation logs can join the chain later. Use
+`cub-gen proof events --in bundle.json --ndjson` when a log pipeline needs just
+those records.
 
 The short version is **repo in, explanation out**.
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ being applied until those placeholders are replaced.
 
 A **Change** is any proposed edit to the source or rendered config. **Proof**
 is the field-origin, owner, route, and decision evidence that makes the change
-reviewable.
+reviewable. Bundle and attestation artifacts also carry `proof_events[]`: small
+JSON records with `trace_id`, `change_id`, artifact digests, and parent digest
+links so Pilot, validation, and attestation logs can join the chain later.
 
 The short version is **repo in, explanation out**.
 
@@ -392,6 +394,7 @@ controllers running in kind.
 - [Example Truth Matrix](docs/testing/example-truth-matrix.md) - generated status for examples
 - [v0.4 Working Roadmap](docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md) - sequenced plan to make cub-gen obvious
 - [Platform Generators Manifesto](docs/agentic-gitops/02-design/90-platform-generators-manifesto.md) - the plain-English thesis
+- [Proof Events and Traceability](docs/contracts/proof-events-and-traceability.md) - loggable proof-event contract
 - [OpenChoreo Worked Example](docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md) - OpenChoreo mapped as a generator
 - [Argo Generators Worked Example](docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md) - ApplicationSet and app-of-apps
 

--- a/cmd/cub-gen/attest_parity_test.go
+++ b/cmd/cub-gen/attest_parity_test.go
@@ -30,8 +30,10 @@ func TestAttestGoldenJSON(t *testing.T) {
 	replaceString(got, "bundle_digest", "<bundle_digest>")
 	replaceString(got, "attestation_digest", "<attestation_digest>")
 	replaceString(got, "change_id", "<change_id>")
+	replaceString(got, "trace_id", "<trace_id>")
 	replaceString(got, "target_path", "<target_path>")
 	replaceString(got, "render_target_path", "<render_target_path>")
+	normalizeProofEvents(got, "<attestation_digest>", "<bundle_digest>")
 	assertGoldenJSON(t, "testdata/parity/attest.json.golden.json", got)
 }
 

--- a/cmd/cub-gen/bridge_command_test.go
+++ b/cmd/cub-gen/bridge_command_test.go
@@ -152,6 +152,15 @@ func TestBridgeDecisionLifecycleCommands(t *testing.T) {
 	if rec.DecisionReason != "policy checks passed" {
 		t.Fatalf("unexpected decision reason %q", rec.DecisionReason)
 	}
+	if rec.TraceID != bundle.ChangeID {
+		t.Fatalf("expected trace_id %q, got %q", bundle.ChangeID, rec.TraceID)
+	}
+	if len(rec.ProofEvents) != 3 {
+		t.Fatalf("expected three proof events, got %d", len(rec.ProofEvents))
+	}
+	if rec.ProofEvents[2].EventType != "governed_decision.applied" || rec.ProofEvents[2].DecisionState != "ALLOW" {
+		t.Fatalf("unexpected applied proof event: %+v", rec.ProofEvents[2])
+	}
 }
 
 func TestBridgePromoteLifecycleCommands(t *testing.T) {

--- a/cmd/cub-gen/change_api_server_test.go
+++ b/cmd/cub-gen/change_api_server_test.go
@@ -41,6 +41,10 @@ func TestChangeAPIHTTPRunLifecycleGolden(t *testing.T) {
 	if !strings.HasPrefix(changeID, "chg_") {
 		t.Fatalf("expected change_id prefix chg_, got %q", changeID)
 	}
+	traceID := nestedString(t, postResp, "change", "trace_id")
+	if traceID != changeID {
+		t.Fatalf("expected trace_id to match change_id, got trace_id=%q change_id=%q", traceID, changeID)
+	}
 
 	status, getResp := mustJSONRequest(t, http.MethodGet, srv.URL+"/v1/changes/"+changeID, nil)
 	if status != http.StatusOK {
@@ -188,6 +192,9 @@ func normalizeChangeAPIHTTPRunSnapshot(snapshot map[string]any) {
 		if change, ok := obj["change"].(map[string]any); ok {
 			if id, ok := change["change_id"].(string); ok && strings.HasPrefix(id, "chg_") {
 				change["change_id"] = "chg_REDACTED"
+			}
+			if id, ok := change["trace_id"].(string); ok && strings.HasPrefix(id, "chg_") {
+				change["trace_id"] = "chg_REDACTED"
 			}
 			if digest, ok := change["bundle_digest"].(string); ok && strings.HasPrefix(digest, "sha256:") {
 				change["bundle_digest"] = "sha256:REDACTED"

--- a/cmd/cub-gen/change_command_test.go
+++ b/cmd/cub-gen/change_command_test.go
@@ -40,6 +40,9 @@ func TestChangePreviewJSON(t *testing.T) {
 	if changeID, ok := change["change_id"].(string); !ok || !strings.HasPrefix(changeID, "chg_") {
 		t.Fatalf("unexpected change_id: %v", change["change_id"])
 	}
+	if traceID, ok := change["trace_id"].(string); !ok || !strings.HasPrefix(traceID, "chg_") {
+		t.Fatalf("unexpected trace_id: %v", change["trace_id"])
+	}
 	if digest, ok := change["bundle_digest"].(string); !ok || !strings.HasPrefix(digest, "sha256:") {
 		t.Fatalf("unexpected bundle_digest: %v", change["bundle_digest"])
 	}
@@ -128,6 +131,17 @@ func TestChangeRunLocalJSON(t *testing.T) {
 	}
 	if mode, ok := got["mode"].(string); !ok || mode != "local" {
 		t.Fatalf("expected mode=local, got %v", got["mode"])
+	}
+	preview, ok := got["preview"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected preview object, got %T", got["preview"])
+	}
+	change, ok := preview["change"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected preview.change object, got %T", preview["change"])
+	}
+	if traceID, ok := change["trace_id"].(string); !ok || !strings.HasPrefix(traceID, "chg_") {
+		t.Fatalf("unexpected preview change trace_id: %v", change["trace_id"])
 	}
 	decision, ok := got["decision"].(map[string]any)
 	if !ok {
@@ -644,6 +658,9 @@ func TestChangeDiffJSON(t *testing.T) {
 	}
 	if result.Query.AfterRef != secondRef {
 		t.Fatalf("expected after_ref=%s, got %v", secondRef, result.Query.AfterRef)
+	}
+	if result.Before.Change.TraceID == "" || result.After.Change.TraceID == "" {
+		t.Fatalf("expected before/after trace ids, got before=%q after=%q", result.Before.Change.TraceID, result.After.Change.TraceID)
 	}
 
 	if len(result.Diffs) == 0 {

--- a/cmd/cub-gen/command_surface_parity_test.go
+++ b/cmd/cub-gen/command_surface_parity_test.go
@@ -39,6 +39,11 @@ func TestTopLevelCommandGoldenHelp(t *testing.T) {
 			stderrGolden: filepath.Join("testdata", "parity", "verify-attestation-help.stderr.golden.txt"),
 		},
 		{
+			name:         "proof-help",
+			args:         []string{"proof", "--help"},
+			stdoutGolden: filepath.Join("testdata", "parity", "proof-help.stdout.golden.txt"),
+		},
+		{
 			name:         "generators-help",
 			args:         []string{"generators", "--help"},
 			stderrGolden: filepath.Join("testdata", "parity", "generators-help.stderr.golden.txt"),
@@ -116,6 +121,16 @@ func TestTopLevelCommandErrorModes(t *testing.T) {
 			name: "verify-attestation-extra-arg",
 			args: []string{"verify-attestation", "extra"},
 			sub:  "usage: cub-gen verify-attestation",
+		},
+		{
+			name: "proof-missing-subcommand",
+			args: []string{"proof"},
+			sub:  "proof subcommand required",
+		},
+		{
+			name: "proof-events-extra-arg",
+			args: []string{"proof", "events", "extra"},
+			sub:  "usage: cub-gen proof events",
 		},
 		{
 			name: "generators-extra-arg",

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -856,10 +856,12 @@ func runVerify(args []string) error {
 
 	if *jsonOut {
 		return writeJSON(os.Stdout, map[string]any{
-			"valid":            true,
-			"digest_algorithm": bundle.DigestAlgorithm,
-			"bundle_digest":    bundle.BundleDigest,
-			"change_id":        bundle.ChangeID,
+			"valid":             true,
+			"digest_algorithm":  bundle.DigestAlgorithm,
+			"bundle_digest":     bundle.BundleDigest,
+			"change_id":         bundle.ChangeID,
+			"trace_id":          bundle.TraceID,
+			"proof_event_count": len(bundle.ProofEvents),
 		}, *pretty)
 	}
 
@@ -983,6 +985,8 @@ func runVerifyAttestation(args []string) error {
 			"attestation_digest":  rec.AttestationDigest,
 			"bundle_digest":       rec.BundleDigest,
 			"change_id":           rec.ChangeID,
+			"trace_id":            rec.TraceID,
+			"proof_event_count":   len(rec.ProofEvents),
 		}, *pretty)
 	}
 

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -49,6 +49,8 @@ func run(args []string) error {
 		return runAttest(args[1:])
 	case "verify-attestation":
 		return runVerifyAttestation(args[1:])
+	case "proof":
+		return runProof(args[1:])
 	case "change":
 		return runChange(args[1:])
 	case "enrich":
@@ -1065,6 +1067,7 @@ func printUsage(out io.Writer) {
 				"  publish           Build a provenance bundle from a repo or import output",
 				"  verify            Verify a provenance bundle",
 				"  attest            Sign a provenance bundle",
+				"  proof events      Extract loggable proof events from a bundle or attestation",
 			},
 		},
 		helpSection{

--- a/cmd/cub-gen/plugin_mode.go
+++ b/cmd/cub-gen/plugin_mode.go
@@ -55,6 +55,8 @@ func normalizePluginArgs(args []string) []string {
 		return prependPluginCommand("bridge", args)
 	case "bundle":
 		return normalizePluginBundleArgs(args)
+	case "proof":
+		return normalizePluginProofArgs(args)
 	default:
 		return args
 	}
@@ -84,6 +86,11 @@ func normalizePluginBundleArgs(args []string) []string {
 		return normalizePluginBundleSubcommandArgs("attest", args[2:])
 	case "verify-attestation":
 		return normalizePluginBundleSubcommandArgs("verify-attestation", args[2:])
+	case "events":
+		if len(args) == 3 && args[2] == "help" {
+			return []string{"proof", "events", "--help"}
+		}
+		return append([]string{"proof", "events"}, args[2:]...)
 	default:
 		return append([]string{"publish"}, args[1:]...)
 	}
@@ -94,6 +101,16 @@ func normalizePluginBundleSubcommandArgs(command string, args []string) []string
 		return []string{command, "--help"}
 	}
 	return append([]string{command}, args...)
+}
+
+func normalizePluginProofArgs(args []string) []string {
+	if len(args) == 2 && args[1] == "help" {
+		return []string{"proof", "--help"}
+	}
+	if len(args) >= 3 && args[1] == "events" && args[2] == "help" {
+		return append([]string{"proof", "events", "--help"}, args[3:]...)
+	}
+	return args
 }
 
 func defaultConfigHubBaseURL() string {

--- a/cmd/cub-gen/plugin_mode_test.go
+++ b/cmd/cub-gen/plugin_mode_test.go
@@ -99,6 +99,11 @@ func TestPluginModeBundleHelpRoutesToCommandHelp(t *testing.T) {
 			args:      []string{"bundle", "verify", "help"},
 			wantTitle: "Usage of verify:",
 		},
+		{
+			name:      "bundle events help",
+			args:      []string{"bundle", "events", "help"},
+			wantTitle: "Usage of proof events:",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/cub-gen/proof.go
+++ b/cmd/cub-gen/proof.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/confighub/cub-gen/internal/attest"
+	"github.com/confighub/cub-gen/internal/proof"
+	"github.com/confighub/cub-gen/internal/publish"
+)
+
+const (
+	proofLogSchema          = "cub.confighub.io/proof-log/v1"
+	changeBundleSchema      = "cub.confighub.io/change-bundle/v1"
+	attestationRecordSchema = "cub.confighub.io/attestation/v1"
+)
+
+type proofLog struct {
+	SchemaVersion        string        `json:"schema_version"`
+	TraceID              string        `json:"trace_id,omitempty"`
+	SourceArtifactKind   string        `json:"source_artifact_kind"`
+	SourceArtifactDigest string        `json:"source_artifact_digest,omitempty"`
+	EventCount           int           `json:"event_count"`
+	Events               []proof.Event `json:"events"`
+}
+
+func runProof(args []string) error {
+	if len(args) == 0 {
+		printProofUsage(os.Stderr)
+		return errors.New("proof subcommand required")
+	}
+	switch args[0] {
+	case "help", "-h", "--help":
+		printProofUsage(os.Stdout)
+		return nil
+	case "events":
+		return runProofEvents(args[1:])
+	default:
+		printProofUsage(os.Stderr)
+		return fmt.Errorf("unknown proof subcommand: %s", args[0])
+	}
+}
+
+func runProofEvents(args []string) error {
+	fs := flag.NewFlagSet("proof events", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	in := fs.String("in", "-", "Bundle or attestation JSON input path, or '-' for stdin")
+	bundlePath := fs.String("bundle", "", "Optional bundle JSON path when input is an attestation")
+	ndjson := fs.Bool("ndjson", false, "Emit one compact proof event per line")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: cub-gen proof events [--in <path>|-] [--bundle <bundle.json>] [--ndjson] [--pretty]")
+	}
+
+	inputBytes, err := readFileOrStdin(*in)
+	if err != nil {
+		return err
+	}
+	log, err := buildProofLog(inputBytes, strings.TrimSpace(*bundlePath))
+	if err != nil {
+		return err
+	}
+	if *ndjson {
+		return writeProofEventsNDJSON(os.Stdout, log.Events)
+	}
+	return writeJSON(os.Stdout, log, *pretty)
+}
+
+func buildProofLog(inputBytes []byte, bundlePath string) (proofLog, error) {
+	var header struct {
+		SchemaVersion string `json:"schema_version"`
+	}
+	if err := json.Unmarshal(inputBytes, &header); err != nil {
+		return proofLog{}, fmt.Errorf("parse proof input json: %w", err)
+	}
+	switch header.SchemaVersion {
+	case changeBundleSchema:
+		var bundle publish.ChangeBundle
+		if err := json.Unmarshal(inputBytes, &bundle); err != nil {
+			return proofLog{}, fmt.Errorf("parse bundle json: %w", err)
+		}
+		if err := publish.VerifyBundle(bundle); err != nil {
+			return proofLog{}, err
+		}
+		return proofLog{
+			SchemaVersion:        proofLogSchema,
+			TraceID:              bundle.TraceID,
+			SourceArtifactKind:   proof.ArtifactKindChangeBundle,
+			SourceArtifactDigest: bundle.BundleDigest,
+			EventCount:           len(bundle.ProofEvents),
+			Events:               bundle.ProofEvents,
+		}, nil
+	case attestationRecordSchema:
+		var rec attest.Record
+		if err := json.Unmarshal(inputBytes, &rec); err != nil {
+			return proofLog{}, fmt.Errorf("parse attestation json: %w", err)
+		}
+		if bundlePath == "" {
+			if err := attest.VerifyRecord(rec); err != nil {
+				return proofLog{}, err
+			}
+		} else {
+			bundleBytes, err := os.ReadFile(bundlePath)
+			if err != nil {
+				return proofLog{}, fmt.Errorf("read bundle file: %w", err)
+			}
+			var bundle publish.ChangeBundle
+			if err := json.Unmarshal(bundleBytes, &bundle); err != nil {
+				return proofLog{}, fmt.Errorf("parse bundle json: %w", err)
+			}
+			if err := attest.VerifyRecordAgainstBundle(rec, bundle); err != nil {
+				return proofLog{}, err
+			}
+		}
+		return proofLog{
+			SchemaVersion:        proofLogSchema,
+			TraceID:              rec.TraceID,
+			SourceArtifactKind:   proof.ArtifactKindAttestation,
+			SourceArtifactDigest: rec.AttestationDigest,
+			EventCount:           len(rec.ProofEvents),
+			Events:               rec.ProofEvents,
+		}, nil
+	default:
+		return proofLog{}, fmt.Errorf("unsupported proof input schema_version %q", header.SchemaVersion)
+	}
+}
+
+func readFileOrStdin(path string) ([]byte, error) {
+	if strings.TrimSpace(path) == "-" {
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("read stdin: %w", err)
+		}
+		return b, nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read input file: %w", err)
+	}
+	return b, nil
+}
+
+func writeProofEventsNDJSON(out io.Writer, events []proof.Event) error {
+	enc := json.NewEncoder(out)
+	for _, event := range events {
+		if err := enc.Encode(event); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printProofUsage(out io.Writer) {
+	printCommandHelp(
+		out,
+		"cub-gen proof: extract loggable proof records",
+		[]string{
+			"Proof events are JSON records that can be copied into Pilot, CI, validation, or audit logs.",
+		},
+		helpSection{
+			Title: "COMMANDS",
+			Lines: []string{
+				"  events    Verify a bundle or attestation and emit its proof_events",
+			},
+		},
+		helpSection{
+			Title: "EXAMPLES",
+			Lines: []string{
+				"  cub-gen proof events --in bundle.json",
+				"  cub-gen proof events --in attestation.json --bundle bundle.json --ndjson",
+			},
+		},
+	)
+}

--- a/cmd/cub-gen/proof.go
+++ b/cmd/cub-gen/proof.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/confighub/cub-gen/internal/attest"
+	bridgeflow "github.com/confighub/cub-gen/internal/bridge"
 	"github.com/confighub/cub-gen/internal/proof"
 	"github.com/confighub/cub-gen/internal/publish"
 )
@@ -18,6 +19,7 @@ const (
 	proofLogSchema          = "cub.confighub.io/proof-log/v1"
 	changeBundleSchema      = "cub.confighub.io/change-bundle/v1"
 	attestationRecordSchema = "cub.confighub.io/attestation/v1"
+	decisionRecordSchema    = "cub.confighub.io/governed-decision-state/v1"
 )
 
 type proofLog struct {
@@ -131,6 +133,24 @@ func buildProofLog(inputBytes []byte, bundlePath string) (proofLog, error) {
 			EventCount:           len(rec.ProofEvents),
 			Events:               rec.ProofEvents,
 		}, nil
+	case decisionRecordSchema:
+		var rec bridgeflow.DecisionRecord
+		if err := json.Unmarshal(inputBytes, &rec); err != nil {
+			return proofLog{}, fmt.Errorf("parse decision json: %w", err)
+		}
+		if err := bridgeflow.ValidateDecisionRecord(rec); err != nil {
+			return proofLog{}, err
+		}
+		if len(rec.ProofEvents) == 0 {
+			return proofLog{}, fmt.Errorf("decision record missing proof_events")
+		}
+		return proofLog{
+			SchemaVersion:      proofLogSchema,
+			TraceID:            rec.TraceID,
+			SourceArtifactKind: proof.ArtifactKindDecision,
+			EventCount:         len(rec.ProofEvents),
+			Events:             rec.ProofEvents,
+		}, nil
 	default:
 		return proofLog{}, fmt.Errorf("unsupported proof input schema_version %q", header.SchemaVersion)
 	}
@@ -179,6 +199,7 @@ func printProofUsage(out io.Writer) {
 			Lines: []string{
 				"  cub-gen proof events --in bundle.json",
 				"  cub-gen proof events --in attestation.json --bundle bundle.json --ndjson",
+				"  cub-gen proof events --in decision.json --ndjson",
 			},
 		},
 	)

--- a/cmd/cub-gen/proof_command_test.go
+++ b/cmd/cub-gen/proof_command_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProofEventsFromBundleJSON(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"proof", "events", "--in", "-"}, bundleJSON)
+	if err != nil {
+		t.Fatalf("proof events returned error: %v\nstderr=%s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal proof events output: %v\noutput=%s", err, out)
+	}
+	if got["schema_version"] != "cub.confighub.io/proof-log/v1" {
+		t.Fatalf("unexpected schema_version: %v", got["schema_version"])
+	}
+	if got["source_artifact_kind"] != "change_bundle" {
+		t.Fatalf("unexpected source artifact kind: %v", got["source_artifact_kind"])
+	}
+	if got["event_count"] != float64(1) {
+		t.Fatalf("expected one proof event, got %v", got["event_count"])
+	}
+	events, ok := got["events"].([]any)
+	if !ok || len(events) != 1 {
+		t.Fatalf("expected one event, got %v", got["events"])
+	}
+	event, ok := events[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected event object, got %v", events[0])
+	}
+	if event["event_type"] != "change_bundle.published" {
+		t.Fatalf("unexpected event_type: %v", event["event_type"])
+	}
+	if event["trace_id"] != got["trace_id"] {
+		t.Fatalf("expected event trace_id to match log trace_id")
+	}
+}
+
+func TestProofEventsNDJSONFromAttestationLinked(t *testing.T) {
+	setupAliases(t)
+
+	attJSON, bundleJSON, err := generateAttestationJSON("ci-bot")
+	if err != nil {
+		t.Fatalf("generate attestation: %v", err)
+	}
+
+	dir := t.TempDir()
+	attPath := filepath.Join(dir, "attestation.json")
+	bundlePath := filepath.Join(dir, "bundle.json")
+	if err := os.WriteFile(attPath, []byte(attJSON), 0o644); err != nil {
+		t.Fatalf("write attestation: %v", err)
+	}
+	if err := os.WriteFile(bundlePath, []byte(bundleJSON), 0o644); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{"proof", "events", "--in", attPath, "--bundle", bundlePath, "--ndjson"})
+	if err != nil {
+		t.Fatalf("proof events ndjson returned error: %v\nstderr=%s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected one NDJSON line, got %d: %q", len(lines), out)
+	}
+	var event map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &event); err != nil {
+		t.Fatalf("unmarshal NDJSON event: %v\nline=%s", err, lines[0])
+	}
+	if event["event_type"] != "attestation.verified" {
+		t.Fatalf("unexpected event_type: %v", event["event_type"])
+	}
+	if event["parent_artifact_kind"] != "change_bundle" {
+		t.Fatalf("unexpected parent_artifact_kind: %v", event["parent_artifact_kind"])
+	}
+}
+
+func TestProofEventsRejectsTamperedBundle(t *testing.T) {
+	setupAliases(t)
+
+	bundleJSON, err := generateBundleJSON()
+	if err != nil {
+		t.Fatalf("generate bundle: %v", err)
+	}
+	var bundle map[string]any
+	if err := json.Unmarshal([]byte(bundleJSON), &bundle); err != nil {
+		t.Fatalf("unmarshal bundle: %v", err)
+	}
+	bundle["space"] = "tampered"
+	tamperedBytes, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal tampered bundle: %v", err)
+	}
+
+	_, _, err = runWithCapturedIOAndStdin([]string{"proof", "events", "--in", "-"}, string(tamperedBytes))
+	if err == nil {
+		t.Fatal("expected proof events to reject tampered bundle")
+	}
+	if !strings.Contains(err.Error(), "bundle digest mismatch") {
+		t.Fatalf("expected bundle digest mismatch, got %v", err)
+	}
+}

--- a/cmd/cub-gen/proof_command_test.go
+++ b/cmd/cub-gen/proof_command_test.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	bridgeflow "github.com/confighub/cub-gen/internal/bridge"
+	"github.com/confighub/cub-gen/internal/publish"
 )
 
 func TestProofEventsFromBundleJSON(t *testing.T) {
@@ -118,5 +122,87 @@ func TestProofEventsRejectsTamperedBundle(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bundle digest mismatch") {
 		t.Fatalf("expected bundle digest mismatch, got %v", err)
+	}
+}
+
+func TestProofEventsFromDecisionRecord(t *testing.T) {
+	setupAliases(t)
+
+	attJSON, bundleJSON, err := generateAttestationJSON("ci-bot")
+	if err != nil {
+		t.Fatalf("generate attestation: %v", err)
+	}
+
+	var bundle publish.ChangeBundle
+	if err := json.Unmarshal([]byte(bundleJSON), &bundle); err != nil {
+		t.Fatalf("unmarshal bundle: %v", err)
+	}
+	ingestBytes, err := json.Marshal(bridgeflow.IngestResult{
+		StatusCode:     http.StatusCreated,
+		ArtifactID:     "wet_art_123",
+		Status:         "created",
+		ChangeID:       bundle.ChangeID,
+		BundleDigest:   bundle.BundleDigest,
+		IdempotencyKey: bundle.ChangeID + ":" + bundle.BundleDigest,
+	})
+	if err != nil {
+		t.Fatalf("marshal ingest: %v", err)
+	}
+
+	createOut, createErr, err := runWithCapturedIOAndStdin([]string{"bridge", "decision", "create", "--ingest", "-"}, string(ingestBytes))
+	if err != nil {
+		t.Fatalf("decision create returned error: %v\nstderr=%s", err, createErr)
+	}
+
+	attPath := filepath.Join(t.TempDir(), "attestation.json")
+	if err := os.WriteFile(attPath, []byte(attJSON), 0o644); err != nil {
+		t.Fatalf("write attestation: %v", err)
+	}
+	attachOut, attachErr, err := runWithCapturedIOAndStdin([]string{"bridge", "decision", "attach", "--decision", "-", "--attestation", attPath}, createOut)
+	if err != nil {
+		t.Fatalf("decision attach returned error: %v\nstderr=%s", err, attachErr)
+	}
+	applyOut, applyErr, err := runWithCapturedIOAndStdin([]string{
+		"bridge", "decision", "apply",
+		"--decision", "-",
+		"--state", "ALLOW",
+		"--approved-by", "platform-owner",
+		"--reason", "policy checks passed",
+	}, attachOut)
+	if err != nil {
+		t.Fatalf("decision apply returned error: %v\nstderr=%s", err, applyErr)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"proof", "events", "--in", "-"}, applyOut)
+	if err != nil {
+		t.Fatalf("proof events returned error: %v\nstderr=%s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal proof log: %v\noutput=%s", err, out)
+	}
+	if got["source_artifact_kind"] != "governed_decision" {
+		t.Fatalf("unexpected source artifact kind: %v", got["source_artifact_kind"])
+	}
+	if got["trace_id"] != bundle.ChangeID {
+		t.Fatalf("expected trace id %q, got %v", bundle.ChangeID, got["trace_id"])
+	}
+	if got["event_count"] != float64(3) {
+		t.Fatalf("expected three decision events, got %v", got["event_count"])
+	}
+	events, ok := got["events"].([]any)
+	if !ok || len(events) != 3 {
+		t.Fatalf("expected three event objects, got %v", got["events"])
+	}
+	applied, ok := events[2].(map[string]any)
+	if !ok {
+		t.Fatalf("expected applied event object, got %T", events[2])
+	}
+	if applied["event_type"] != "governed_decision.applied" || applied["decision_state"] != "ALLOW" {
+		t.Fatalf("unexpected applied event: %+v", applied)
 	}
 }

--- a/cmd/cub-gen/publish_parity_test.go
+++ b/cmd/cub-gen/publish_parity_test.go
@@ -142,9 +142,11 @@ func assertPublishDirectGolden(t *testing.T, target, golden string) {
 func normalizePublish(m map[string]any) {
 	replaceString(m, "generated_at", "<timestamp>")
 	replaceString(m, "change_id", "<change_id>")
+	replaceString(m, "trace_id", "<trace_id>")
 	replaceString(m, "bundle_digest", "<bundle_digest>")
 	replaceString(m, "target_path", "<target_path>")
 	replaceString(m, "render_target_path", "<render_target_path>")
+	normalizeProofEvents(m, "<bundle_digest>", "")
 
 	for _, item := range asSlice(m["contracts"]) {
 		replaceString(item, "source_repo", "<target_path>")
@@ -164,5 +166,21 @@ func normalizePublish(m map[string]any) {
 		replaceString(item, "plan_id", "<plan_id>")
 		replaceString(item, "change_id", "<change_id>")
 		replaceString(item, "created_at", "<timestamp>")
+	}
+}
+
+func normalizeProofEvents(m map[string]any, artifactDigest, parentArtifactDigest string) {
+	for _, event := range asSlice(m["proof_events"]) {
+		replaceString(event, "event_id", "<event_id>")
+		replaceString(event, "event_time", "<timestamp>")
+		replaceString(event, "trace_id", "<trace_id>")
+		replaceString(event, "change_id", "<change_id>")
+		replaceString(event, "target_path", "<target_path>")
+		replaceString(event, "render_target_path", "<render_target_path>")
+		replaceString(event, "artifact_digest", artifactDigest)
+		replaceString(event, "parent_event_id", "<parent_event_id>")
+		if parentArtifactDigest != "" {
+			replaceString(event, "parent_artifact_digest", parentArtifactDigest)
+		}
 	}
 }

--- a/cmd/cub-gen/testdata/parity/attest.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/attest.json.golden.json
@@ -4,6 +4,29 @@
   "change_id": "\u003cchange_id\u003e",
   "digest_algorithm": "sha256",
   "generated_at": "\u003ctimestamp\u003e",
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cattestation_digest\u003e",
+      "artifact_kind": "attestation",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "attestation.verified",
+      "parent_artifact_digest": "\u003cbundle_digest\u003e",
+      "parent_artifact_kind": "change_bundle",
+      "parent_event_id": "\u003cparent_event_id\u003e",
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "verified_bundles": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "helm",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "render_target_slug": "render-target",
   "schema_version": "cub.confighub.io/attestation/v1",
   "source": "cub-gen",
@@ -11,5 +34,6 @@
   "status": "verified",
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "helm",
+  "trace_id": "\u003ctrace_id\u003e",
   "verifier": "ci-bot"
 }

--- a/cmd/cub-gen/testdata/parity/change-api-http-run.golden.json
+++ b/cmd/cub-gen/testdata/parity/change-api-http-run.golden.json
@@ -3,7 +3,8 @@
     "change": {
       "attestation_digest": "sha256:REDACTED",
       "bundle_digest": "sha256:REDACTED",
-      "change_id": "chg_REDACTED"
+      "change_id": "chg_REDACTED",
+      "trace_id": "chg_REDACTED"
     },
     "explanation": {
       "confidence": 0.94,
@@ -39,7 +40,8 @@
     "change": {
       "attestation_digest": "sha256:REDACTED",
       "bundle_digest": "sha256:REDACTED",
-      "change_id": "chg_REDACTED"
+      "change_id": "chg_REDACTED",
+      "trace_id": "chg_REDACTED"
     },
     "decision": {
       "authority": "ci-bot",
@@ -77,7 +79,8 @@
     "change": {
       "attestation_digest": "sha256:REDACTED",
       "bundle_digest": "sha256:REDACTED",
-      "change_id": "chg_REDACTED"
+      "change_id": "chg_REDACTED",
+      "trace_id": "chg_REDACTED"
     },
     "decision": {
       "authority": "ci-bot",

--- a/cmd/cub-gen/testdata/parity/platform-fanout.golden.json
+++ b/cmd/cub-gen/testdata/parity/platform-fanout.golden.json
@@ -148,6 +148,39 @@
             "wet_unit_id": "wet_b4595877225309fc"
           }
         ],
+        "proof_events": [
+          {
+            "artifact_digest": "\u003cbundle_digest\u003e",
+            "artifact_kind": "change_bundle",
+            "change_id": "\u003cchange_id\u003e",
+            "event_id": "\u003cevent_id\u003e",
+            "event_time": "\u003ctimestamp\u003e",
+            "event_type": "change_bundle.published",
+            "generator_profiles": [
+              "helm-paas"
+            ],
+            "render_target_path": "\u003crender_target_path\u003e",
+            "render_target_slug": "checkout-api/dev",
+            "schema_version": "cub.confighub.io/proof-event/v1",
+            "source": "cub-gen",
+            "space": "platform",
+            "summary_counts": {
+              "contracts": 1,
+              "discovered_resources": 1,
+              "dry_inputs": 4,
+              "dry_units": 1,
+              "generator_units": 1,
+              "inverse_transform_plans": 1,
+              "links": 1,
+              "provenance_records": 1,
+              "wet_manifest_targets": 3,
+              "wet_units": 1
+            },
+            "target_path": "\u003ctarget_path\u003e",
+            "target_slug": "checkout-api/dev",
+            "trace_id": "\u003ctrace_id\u003e"
+          }
+        ],
         "provenance": [
           {
             "change_id": "\u003cchange_id\u003e",
@@ -281,6 +314,7 @@
         },
         "target_path": "\u003ctarget_path\u003e",
         "target_slug": "checkout-api/dev",
+        "trace_id": "\u003ctrace_id\u003e",
         "wet_manifest_targets": [
           {
             "generator_id": "gen_635643e45fbf3410",
@@ -472,6 +506,39 @@
             "wet_unit_id": "wet_b4595877225309fc"
           }
         ],
+        "proof_events": [
+          {
+            "artifact_digest": "\u003cbundle_digest\u003e",
+            "artifact_kind": "change_bundle",
+            "change_id": "\u003cchange_id\u003e",
+            "event_id": "\u003cevent_id\u003e",
+            "event_time": "\u003ctimestamp\u003e",
+            "event_type": "change_bundle.published",
+            "generator_profiles": [
+              "helm-paas"
+            ],
+            "render_target_path": "\u003crender_target_path\u003e",
+            "render_target_slug": "checkout-api/prod",
+            "schema_version": "cub.confighub.io/proof-event/v1",
+            "source": "cub-gen",
+            "space": "platform",
+            "summary_counts": {
+              "contracts": 1,
+              "discovered_resources": 1,
+              "dry_inputs": 4,
+              "dry_units": 1,
+              "generator_units": 1,
+              "inverse_transform_plans": 1,
+              "links": 1,
+              "provenance_records": 1,
+              "wet_manifest_targets": 3,
+              "wet_units": 1
+            },
+            "target_path": "\u003ctarget_path\u003e",
+            "target_slug": "checkout-api/prod",
+            "trace_id": "\u003ctrace_id\u003e"
+          }
+        ],
         "provenance": [
           {
             "change_id": "\u003cchange_id\u003e",
@@ -605,6 +672,7 @@
         },
         "target_path": "\u003ctarget_path\u003e",
         "target_slug": "checkout-api/prod",
+        "trace_id": "\u003ctrace_id\u003e",
         "wet_manifest_targets": [
           {
             "generator_id": "gen_635643e45fbf3410",
@@ -796,6 +864,39 @@
             "wet_unit_id": "wet_b4595877225309fc"
           }
         ],
+        "proof_events": [
+          {
+            "artifact_digest": "\u003cbundle_digest\u003e",
+            "artifact_kind": "change_bundle",
+            "change_id": "\u003cchange_id\u003e",
+            "event_id": "\u003cevent_id\u003e",
+            "event_time": "\u003ctimestamp\u003e",
+            "event_type": "change_bundle.published",
+            "generator_profiles": [
+              "helm-paas"
+            ],
+            "render_target_path": "\u003crender_target_path\u003e",
+            "render_target_slug": "checkout-api/stage",
+            "schema_version": "cub.confighub.io/proof-event/v1",
+            "source": "cub-gen",
+            "space": "platform",
+            "summary_counts": {
+              "contracts": 1,
+              "discovered_resources": 1,
+              "dry_inputs": 4,
+              "dry_units": 1,
+              "generator_units": 1,
+              "inverse_transform_plans": 1,
+              "links": 1,
+              "provenance_records": 1,
+              "wet_manifest_targets": 3,
+              "wet_units": 1
+            },
+            "target_path": "\u003ctarget_path\u003e",
+            "target_slug": "checkout-api/stage",
+            "trace_id": "\u003ctrace_id\u003e"
+          }
+        ],
         "provenance": [
           {
             "change_id": "\u003cchange_id\u003e",
@@ -929,6 +1030,7 @@
         },
         "target_path": "\u003ctarget_path\u003e",
         "target_slug": "checkout-api/stage",
+        "trace_id": "\u003ctrace_id\u003e",
         "wet_manifest_targets": [
           {
             "generator_id": "gen_635643e45fbf3410",
@@ -1090,6 +1192,39 @@
             "wet_unit_id": "wet_3b630d8a9fb3502c"
           }
         ],
+        "proof_events": [
+          {
+            "artifact_digest": "\u003cbundle_digest\u003e",
+            "artifact_kind": "change_bundle",
+            "change_id": "\u003cchange_id\u003e",
+            "event_id": "\u003cevent_id\u003e",
+            "event_time": "\u003ctimestamp\u003e",
+            "event_type": "change_bundle.published",
+            "generator_profiles": [
+              "scoredev-paas"
+            ],
+            "render_target_path": "\u003crender_target_path\u003e",
+            "render_target_slug": "score-checkout/dev",
+            "schema_version": "cub.confighub.io/proof-event/v1",
+            "source": "cub-gen",
+            "space": "platform",
+            "summary_counts": {
+              "contracts": 1,
+              "discovered_resources": 1,
+              "dry_inputs": 1,
+              "dry_units": 1,
+              "generator_units": 1,
+              "inverse_transform_plans": 1,
+              "links": 1,
+              "provenance_records": 1,
+              "wet_manifest_targets": 3,
+              "wet_units": 1
+            },
+            "target_path": "\u003ctarget_path\u003e",
+            "target_slug": "score-checkout/dev",
+            "trace_id": "\u003ctrace_id\u003e"
+          }
+        ],
         "provenance": [
           {
             "change_id": "\u003cchange_id\u003e",
@@ -1210,6 +1345,7 @@
         },
         "target_path": "\u003ctarget_path\u003e",
         "target_slug": "score-checkout/dev",
+        "trace_id": "\u003ctrace_id\u003e",
         "wet_manifest_targets": [
           {
             "generator_id": "gen_5813cd3820138512",
@@ -1370,6 +1506,39 @@
             "wet_unit_id": "wet_3b630d8a9fb3502c"
           }
         ],
+        "proof_events": [
+          {
+            "artifact_digest": "\u003cbundle_digest\u003e",
+            "artifact_kind": "change_bundle",
+            "change_id": "\u003cchange_id\u003e",
+            "event_id": "\u003cevent_id\u003e",
+            "event_time": "\u003ctimestamp\u003e",
+            "event_type": "change_bundle.published",
+            "generator_profiles": [
+              "scoredev-paas"
+            ],
+            "render_target_path": "\u003crender_target_path\u003e",
+            "render_target_slug": "score-checkout/prod",
+            "schema_version": "cub.confighub.io/proof-event/v1",
+            "source": "cub-gen",
+            "space": "platform",
+            "summary_counts": {
+              "contracts": 1,
+              "discovered_resources": 1,
+              "dry_inputs": 1,
+              "dry_units": 1,
+              "generator_units": 1,
+              "inverse_transform_plans": 1,
+              "links": 1,
+              "provenance_records": 1,
+              "wet_manifest_targets": 3,
+              "wet_units": 1
+            },
+            "target_path": "\u003ctarget_path\u003e",
+            "target_slug": "score-checkout/prod",
+            "trace_id": "\u003ctrace_id\u003e"
+          }
+        ],
         "provenance": [
           {
             "change_id": "\u003cchange_id\u003e",
@@ -1490,6 +1659,7 @@
         },
         "target_path": "\u003ctarget_path\u003e",
         "target_slug": "score-checkout/prod",
+        "trace_id": "\u003ctrace_id\u003e",
         "wet_manifest_targets": [
           {
             "generator_id": "gen_5813cd3820138512",
@@ -1650,6 +1820,39 @@
             "wet_unit_id": "wet_3b630d8a9fb3502c"
           }
         ],
+        "proof_events": [
+          {
+            "artifact_digest": "\u003cbundle_digest\u003e",
+            "artifact_kind": "change_bundle",
+            "change_id": "\u003cchange_id\u003e",
+            "event_id": "\u003cevent_id\u003e",
+            "event_time": "\u003ctimestamp\u003e",
+            "event_type": "change_bundle.published",
+            "generator_profiles": [
+              "scoredev-paas"
+            ],
+            "render_target_path": "\u003crender_target_path\u003e",
+            "render_target_slug": "score-checkout/stage",
+            "schema_version": "cub.confighub.io/proof-event/v1",
+            "source": "cub-gen",
+            "space": "platform",
+            "summary_counts": {
+              "contracts": 1,
+              "discovered_resources": 1,
+              "dry_inputs": 1,
+              "dry_units": 1,
+              "generator_units": 1,
+              "inverse_transform_plans": 1,
+              "links": 1,
+              "provenance_records": 1,
+              "wet_manifest_targets": 3,
+              "wet_units": 1
+            },
+            "target_path": "\u003ctarget_path\u003e",
+            "target_slug": "score-checkout/stage",
+            "trace_id": "\u003ctrace_id\u003e"
+          }
+        ],
         "provenance": [
           {
             "change_id": "\u003cchange_id\u003e",
@@ -1770,6 +1973,7 @@
         },
         "target_path": "\u003ctarget_path\u003e",
         "target_slug": "score-checkout/stage",
+        "trace_id": "\u003ctrace_id\u003e",
         "wet_manifest_targets": [
           {
             "generator_id": "gen_5813cd3820138512",
@@ -1962,6 +2166,39 @@
             "wet_unit_id": "wet_24b4f9e96079fa9a"
           }
         ],
+        "proof_events": [
+          {
+            "artifact_digest": "\u003cbundle_digest\u003e",
+            "artifact_kind": "change_bundle",
+            "change_id": "\u003cchange_id\u003e",
+            "event_id": "\u003cevent_id\u003e",
+            "event_time": "\u003ctimestamp\u003e",
+            "event_type": "change_bundle.published",
+            "generator_profiles": [
+              "springboot-paas"
+            ],
+            "render_target_path": "\u003crender_target_path\u003e",
+            "render_target_slug": "spring-checkout/dev",
+            "schema_version": "cub.confighub.io/proof-event/v1",
+            "source": "cub-gen",
+            "space": "platform",
+            "summary_counts": {
+              "contracts": 1,
+              "discovered_resources": 1,
+              "dry_inputs": 2,
+              "dry_units": 1,
+              "generator_units": 1,
+              "inverse_transform_plans": 1,
+              "links": 1,
+              "provenance_records": 1,
+              "wet_manifest_targets": 3,
+              "wet_units": 1
+            },
+            "target_path": "\u003ctarget_path\u003e",
+            "target_slug": "spring-checkout/dev",
+            "trace_id": "\u003ctrace_id\u003e"
+          }
+        ],
         "provenance": [
           {
             "change_id": "\u003cchange_id\u003e",
@@ -2095,6 +2332,7 @@
         },
         "target_path": "\u003ctarget_path\u003e",
         "target_slug": "spring-checkout/dev",
+        "trace_id": "\u003ctrace_id\u003e",
         "wet_manifest_targets": [
           {
             "generator_id": "gen_73ed79c3c8b65360",
@@ -2288,6 +2526,39 @@
             "wet_unit_id": "wet_24b4f9e96079fa9a"
           }
         ],
+        "proof_events": [
+          {
+            "artifact_digest": "\u003cbundle_digest\u003e",
+            "artifact_kind": "change_bundle",
+            "change_id": "\u003cchange_id\u003e",
+            "event_id": "\u003cevent_id\u003e",
+            "event_time": "\u003ctimestamp\u003e",
+            "event_type": "change_bundle.published",
+            "generator_profiles": [
+              "springboot-paas"
+            ],
+            "render_target_path": "\u003crender_target_path\u003e",
+            "render_target_slug": "spring-checkout/prod",
+            "schema_version": "cub.confighub.io/proof-event/v1",
+            "source": "cub-gen",
+            "space": "platform",
+            "summary_counts": {
+              "contracts": 1,
+              "discovered_resources": 1,
+              "dry_inputs": 2,
+              "dry_units": 1,
+              "generator_units": 1,
+              "inverse_transform_plans": 1,
+              "links": 1,
+              "provenance_records": 1,
+              "wet_manifest_targets": 3,
+              "wet_units": 1
+            },
+            "target_path": "\u003ctarget_path\u003e",
+            "target_slug": "spring-checkout/prod",
+            "trace_id": "\u003ctrace_id\u003e"
+          }
+        ],
         "provenance": [
           {
             "change_id": "\u003cchange_id\u003e",
@@ -2421,6 +2692,7 @@
         },
         "target_path": "\u003ctarget_path\u003e",
         "target_slug": "spring-checkout/prod",
+        "trace_id": "\u003ctrace_id\u003e",
         "wet_manifest_targets": [
           {
             "generator_id": "gen_73ed79c3c8b65360",
@@ -2614,6 +2886,39 @@
             "wet_unit_id": "wet_24b4f9e96079fa9a"
           }
         ],
+        "proof_events": [
+          {
+            "artifact_digest": "\u003cbundle_digest\u003e",
+            "artifact_kind": "change_bundle",
+            "change_id": "\u003cchange_id\u003e",
+            "event_id": "\u003cevent_id\u003e",
+            "event_time": "\u003ctimestamp\u003e",
+            "event_type": "change_bundle.published",
+            "generator_profiles": [
+              "springboot-paas"
+            ],
+            "render_target_path": "\u003crender_target_path\u003e",
+            "render_target_slug": "spring-checkout/stage",
+            "schema_version": "cub.confighub.io/proof-event/v1",
+            "source": "cub-gen",
+            "space": "platform",
+            "summary_counts": {
+              "contracts": 1,
+              "discovered_resources": 1,
+              "dry_inputs": 2,
+              "dry_units": 1,
+              "generator_units": 1,
+              "inverse_transform_plans": 1,
+              "links": 1,
+              "provenance_records": 1,
+              "wet_manifest_targets": 3,
+              "wet_units": 1
+            },
+            "target_path": "\u003ctarget_path\u003e",
+            "target_slug": "spring-checkout/stage",
+            "trace_id": "\u003ctrace_id\u003e"
+          }
+        ],
         "provenance": [
           {
             "change_id": "\u003cchange_id\u003e",
@@ -2747,6 +3052,7 @@
         },
         "target_path": "\u003ctarget_path\u003e",
         "target_slug": "spring-checkout/stage",
+        "trace_id": "\u003ctrace_id\u003e",
         "wet_manifest_targets": [
           {
             "generator_id": "gen_73ed79c3c8b65360",

--- a/cmd/cub-gen/testdata/parity/proof-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/proof-help.stdout.golden.txt
@@ -8,3 +8,4 @@ COMMANDS:
 EXAMPLES:
   cub-gen proof events --in bundle.json
   cub-gen proof events --in attestation.json --bundle bundle.json --ndjson
+  cub-gen proof events --in decision.json --ndjson

--- a/cmd/cub-gen/testdata/parity/proof-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/proof-help.stdout.golden.txt
@@ -1,0 +1,10 @@
+cub-gen proof: extract loggable proof records
+
+Proof events are JSON records that can be copied into Pilot, CI, validation, or audit logs.
+
+COMMANDS:
+  events    Verify a bundle or attestation and emit its proof_events
+
+EXAMPLES:
+  cub-gen proof events --in bundle.json
+  cub-gen proof events --in attestation.json --bundle bundle.json --ndjson

--- a/cmd/cub-gen/testdata/parity/publish-direct-app-of-apps.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-app-of-apps.golden.json
@@ -163,6 +163,38 @@
       "wet_unit_id": "wet_969f79bc8fac994b"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "app-of-apps"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 4,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 4,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "app-of-apps",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "app_of_apps_analysis": {
@@ -473,6 +505,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "app-of-apps",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_d78223f487aceee1",

--- a/cmd/cub-gen/testdata/parity/publish-direct-backstage.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-backstage.golden.json
@@ -125,6 +125,38 @@
       "wet_unit_id": "wet_ed93b23fac4bc5cf"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "backstage-idp"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 2,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 2,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "backstage",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -229,6 +261,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "backstage",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_e2b1e1884db80431",

--- a/cmd/cub-gen/testdata/parity/publish-direct-c3agent.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-c3agent.golden.json
@@ -170,6 +170,38 @@
       "wet_unit_id": "wet_ea7663e9658ea39e"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "c3agent"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 2,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 11,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "c3agent",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -454,6 +486,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "c3agent",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_99a106ccc35809e5",

--- a/cmd/cub-gen/testdata/parity/publish-direct-helm.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-helm.golden.json
@@ -200,6 +200,38 @@
       "wet_unit_id": "wet_b4595877225309fc"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "helm-paas"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 8,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 3,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "helm",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -387,6 +419,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "helm",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_635643e45fbf3410",

--- a/cmd/cub-gen/testdata/parity/publish-direct-no-config-platform.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-no-config-platform.golden.json
@@ -125,6 +125,38 @@
       "wet_unit_id": "wet_0aa71d8de9fa91e9"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "no-config-platform"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 2,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 2,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "no-config-platform",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -243,6 +275,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "no-config-platform",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_7e61057fca5184ad",

--- a/cmd/cub-gen/testdata/parity/publish-direct-openchoreo.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-openchoreo.golden.json
@@ -326,6 +326,38 @@
       "wet_unit_id": "wet_47c8fd199c1b376e"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "openchoreo"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 13,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 10,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "openchoreo",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -657,6 +689,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "openchoreo",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_4a0a30075a9aed02",

--- a/cmd/cub-gen/testdata/parity/publish-direct-ops.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-ops.golden.json
@@ -125,6 +125,38 @@
       "wet_unit_id": "wet_3205fbba6ea72363"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "ops-workflow"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 2,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 2,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "ops",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -285,6 +317,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "ops",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_2242fb51feab67d2",

--- a/cmd/cub-gen/testdata/parity/publish-direct-score.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-score.golden.json
@@ -102,6 +102,38 @@
       "wet_unit_id": "wet_3b630d8a9fb3502c"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "scoredev-paas"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 1,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 3,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "score",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -221,6 +253,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "score",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_5813cd3820138512",

--- a/cmd/cub-gen/testdata/parity/publish-direct-spring.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-spring.golden.json
@@ -176,6 +176,38 @@
       "wet_unit_id": "wet_24b4f9e96079fa9a"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "springboot-paas"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 5,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 3,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "spring",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -333,6 +365,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "spring",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_73ed79c3c8b65360",

--- a/cmd/cub-gen/testdata/parity/publish-direct-swamp.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-direct-swamp.golden.json
@@ -148,6 +148,38 @@
       "wet_unit_id": "wet_41e643da966997f2"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "swamp"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 3,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 2,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "swamp",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -371,6 +403,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "swamp",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_124d7fbd01e19b49",

--- a/cmd/cub-gen/testdata/parity/publish-from-import-app-of-apps.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import-app-of-apps.golden.json
@@ -163,6 +163,38 @@
       "wet_unit_id": "wet_969f79bc8fac994b"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "app-of-apps"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 4,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 4,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "app-of-apps",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "app_of_apps_analysis": {
@@ -473,6 +505,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "app-of-apps",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_d78223f487aceee1",

--- a/cmd/cub-gen/testdata/parity/publish-from-import-backstage.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import-backstage.golden.json
@@ -125,6 +125,38 @@
       "wet_unit_id": "wet_ed93b23fac4bc5cf"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "backstage-idp"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 2,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 2,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "backstage",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -229,6 +261,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "backstage",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_e2b1e1884db80431",

--- a/cmd/cub-gen/testdata/parity/publish-from-import-c3agent.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import-c3agent.golden.json
@@ -170,6 +170,38 @@
       "wet_unit_id": "wet_ea7663e9658ea39e"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "c3agent"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 2,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 11,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "c3agent",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -454,6 +486,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "c3agent",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_99a106ccc35809e5",

--- a/cmd/cub-gen/testdata/parity/publish-from-import-no-config-platform.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import-no-config-platform.golden.json
@@ -125,6 +125,38 @@
       "wet_unit_id": "wet_0aa71d8de9fa91e9"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "no-config-platform"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 2,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 2,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "no-config-platform",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -243,6 +275,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "no-config-platform",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_7e61057fca5184ad",

--- a/cmd/cub-gen/testdata/parity/publish-from-import-openchoreo.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import-openchoreo.golden.json
@@ -326,6 +326,38 @@
       "wet_unit_id": "wet_47c8fd199c1b376e"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "openchoreo"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 13,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 10,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "openchoreo",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -657,6 +689,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "openchoreo",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_4a0a30075a9aed02",

--- a/cmd/cub-gen/testdata/parity/publish-from-import-ops.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import-ops.golden.json
@@ -125,6 +125,38 @@
       "wet_unit_id": "wet_3205fbba6ea72363"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "ops-workflow"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 2,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 2,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "ops",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -285,6 +317,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "ops",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_2242fb51feab67d2",

--- a/cmd/cub-gen/testdata/parity/publish-from-import-score.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import-score.golden.json
@@ -102,6 +102,38 @@
       "wet_unit_id": "wet_3b630d8a9fb3502c"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "scoredev-paas"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 1,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 3,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "score",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -221,6 +253,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "score",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_5813cd3820138512",

--- a/cmd/cub-gen/testdata/parity/publish-from-import-spring.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import-spring.golden.json
@@ -176,6 +176,38 @@
       "wet_unit_id": "wet_24b4f9e96079fa9a"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "springboot-paas"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 5,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 3,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "spring",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -333,6 +365,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "spring",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_73ed79c3c8b65360",

--- a/cmd/cub-gen/testdata/parity/publish-from-import-swamp.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import-swamp.golden.json
@@ -148,6 +148,38 @@
       "wet_unit_id": "wet_41e643da966997f2"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "swamp"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 3,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 2,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "swamp",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -371,6 +403,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "swamp",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_124d7fbd01e19b49",

--- a/cmd/cub-gen/testdata/parity/publish-from-import.golden.json
+++ b/cmd/cub-gen/testdata/parity/publish-from-import.golden.json
@@ -200,6 +200,38 @@
       "wet_unit_id": "wet_b4595877225309fc"
     }
   ],
+  "proof_events": [
+    {
+      "artifact_digest": "\u003cbundle_digest\u003e",
+      "artifact_kind": "change_bundle",
+      "change_id": "\u003cchange_id\u003e",
+      "event_id": "\u003cevent_id\u003e",
+      "event_time": "\u003ctimestamp\u003e",
+      "event_type": "change_bundle.published",
+      "generator_profiles": [
+        "helm-paas"
+      ],
+      "render_target_slug": "render-target",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "space": "platform",
+      "summary_counts": {
+        "contracts": 1,
+        "discovered_resources": 1,
+        "dry_inputs": 8,
+        "dry_units": 1,
+        "generator_units": 1,
+        "inverse_transform_plans": 1,
+        "links": 1,
+        "provenance_records": 1,
+        "wet_manifest_targets": 3,
+        "wet_units": 1
+      },
+      "target_path": "\u003ctarget_path\u003e",
+      "target_slug": "helm",
+      "trace_id": "\u003ctrace_id\u003e"
+    }
+  ],
   "provenance": [
     {
       "change_id": "\u003cchange_id\u003e",
@@ -387,6 +419,7 @@
   },
   "target_path": "\u003ctarget_path\u003e",
   "target_slug": "helm",
+  "trace_id": "\u003ctrace_id\u003e",
   "wet_manifest_targets": [
     {
       "generator_id": "gen_635643e45fbf3410",

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -22,6 +22,7 @@ BUILD EVIDENCE:
   publish           Build a provenance bundle from a repo or import output
   verify            Verify a provenance bundle
   attest            Sign a provenance bundle
+  proof events      Extract loggable proof events from a bundle or attestation
 
 ADVANCED CONNECTED:
   change run        Ask ConfigHub for a decision (does not deploy)

--- a/cmd/cub-gen/testdata/parity/verify-attestation-linked-backstage.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-linked-backstage.json.golden.json
@@ -3,5 +3,7 @@
   "bundle_digest": "\u003cbundle_digest\u003e",
   "change_id": "\u003cchange_id\u003e",
   "linked_bundle_check": true,
+  "proof_event_count": 1,
+  "trace_id": "\u003ctrace_id\u003e",
   "valid": true
 }

--- a/cmd/cub-gen/testdata/parity/verify-attestation-linked-helm.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-linked-helm.json.golden.json
@@ -3,5 +3,7 @@
   "bundle_digest": "\u003cbundle_digest\u003e",
   "change_id": "\u003cchange_id\u003e",
   "linked_bundle_check": true,
+  "proof_event_count": 1,
+  "trace_id": "\u003ctrace_id\u003e",
   "valid": true
 }

--- a/cmd/cub-gen/testdata/parity/verify-attestation-linked-no-config-platform.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-linked-no-config-platform.json.golden.json
@@ -3,5 +3,7 @@
   "bundle_digest": "\u003cbundle_digest\u003e",
   "change_id": "\u003cchange_id\u003e",
   "linked_bundle_check": true,
+  "proof_event_count": 1,
+  "trace_id": "\u003ctrace_id\u003e",
   "valid": true
 }

--- a/cmd/cub-gen/testdata/parity/verify-attestation-linked-ops.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-linked-ops.json.golden.json
@@ -3,5 +3,7 @@
   "bundle_digest": "\u003cbundle_digest\u003e",
   "change_id": "\u003cchange_id\u003e",
   "linked_bundle_check": true,
+  "proof_event_count": 1,
+  "trace_id": "\u003ctrace_id\u003e",
   "valid": true
 }

--- a/cmd/cub-gen/testdata/parity/verify-attestation-linked-score.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-linked-score.json.golden.json
@@ -3,5 +3,7 @@
   "bundle_digest": "\u003cbundle_digest\u003e",
   "change_id": "\u003cchange_id\u003e",
   "linked_bundle_check": true,
+  "proof_event_count": 1,
+  "trace_id": "\u003ctrace_id\u003e",
   "valid": true
 }

--- a/cmd/cub-gen/testdata/parity/verify-attestation-linked-spring.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation-linked-spring.json.golden.json
@@ -3,5 +3,7 @@
   "bundle_digest": "\u003cbundle_digest\u003e",
   "change_id": "\u003cchange_id\u003e",
   "linked_bundle_check": true,
+  "proof_event_count": 1,
+  "trace_id": "\u003ctrace_id\u003e",
   "valid": true
 }

--- a/cmd/cub-gen/testdata/parity/verify-attestation.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify-attestation.json.golden.json
@@ -3,5 +3,7 @@
   "bundle_digest": "\u003cbundle_digest\u003e",
   "change_id": "\u003cchange_id\u003e",
   "linked_bundle_check": false,
+  "proof_event_count": 1,
+  "trace_id": "\u003ctrace_id\u003e",
   "valid": true
 }

--- a/cmd/cub-gen/testdata/parity/verify.json.golden.json
+++ b/cmd/cub-gen/testdata/parity/verify.json.golden.json
@@ -2,5 +2,7 @@
   "bundle_digest": "\u003cbundle_digest\u003e",
   "change_id": "\u003cchange_id\u003e",
   "digest_algorithm": "sha256",
+  "proof_event_count": 1,
+  "trace_id": "\u003ctrace_id\u003e",
   "valid": true
 }

--- a/cmd/cub-gen/verify_attestation_parity_test.go
+++ b/cmd/cub-gen/verify_attestation_parity_test.go
@@ -31,6 +31,7 @@ func TestVerifyAttestationGoldenJSON(t *testing.T) {
 	replaceString(got, "attestation_digest", "<attestation_digest>")
 	replaceString(got, "bundle_digest", "<bundle_digest>")
 	replaceString(got, "change_id", "<change_id>")
+	replaceString(got, "trace_id", "<trace_id>")
 	assertGoldenJSON(t, "testdata/parity/verify-attestation.json.golden.json", got)
 }
 
@@ -116,5 +117,6 @@ func assertVerifyAttestationLinkedGolden(t *testing.T, target, goldenPath string
 	replaceString(got, "attestation_digest", "<attestation_digest>")
 	replaceString(got, "bundle_digest", "<bundle_digest>")
 	replaceString(got, "change_id", "<change_id>")
+	replaceString(got, "trace_id", "<trace_id>")
 	assertGoldenJSON(t, goldenPath, got)
 }

--- a/cmd/cub-gen/verify_parity_test.go
+++ b/cmd/cub-gen/verify_parity_test.go
@@ -51,6 +51,7 @@ func TestVerifyGoldenJSON(t *testing.T) {
 	}
 	replaceString(got, "bundle_digest", "<bundle_digest>")
 	replaceString(got, "change_id", "<change_id>")
+	replaceString(got, "trace_id", "<trace_id>")
 	assertGoldenJSON(t, "testdata/parity/verify.json.golden.json", got)
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -375,11 +375,13 @@ cub-gen verify-attestation --in <attestation.json> --bundle <bundle.json>
 
 ### `proof events`
 
-Verify a bundle or attestation and emit only its loggable proof events.
+Verify a bundle, attestation, or governed decision record and emit only its
+loggable proof events.
 
 ```
 cub-gen proof events --in <bundle.json>
 cub-gen proof events --in <attestation.json> --bundle <bundle.json> --ndjson
+cub-gen proof events --in <decision.json> --ndjson
 ```
 
 Default output is a small `proof-log/v1` JSON envelope. `--ndjson` emits one
@@ -416,6 +418,10 @@ cub-gen bridge decision create --ingest <ingest-result.json>
 cub-gen bridge decision attach --decision <decision.json> --attestation <attestation.json>
 cub-gen bridge decision apply --decision <decision.json> --state ALLOW --approved-by <who> --reason <why>
 ```
+
+Local decision records carry `trace_id` and `proof_events[]`, so the same
+`proof events` command can produce log-safe records for the decision lifecycle:
+created, attestation attached, and terminal decision applied.
 
 ### `bridge link`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -295,7 +295,14 @@ cub-gen gitops import ... | cub-gen publish --in - --out -
 cub-gen publish --space <space> [--set KEY=VALUE] [--set-string KEY=VALUE] [--set-file KEY=PATH] <target-path> [<render-target-path>]
 ```
 
-Output includes `digest_algorithm` (sha256) and `bundle_digest` for verification.
+Output includes:
+
+| Field | Meaning |
+|---|---|
+| `change_id` | Change lifecycle id |
+| `trace_id` | Log join key; normally the same value as `change_id` |
+| `bundle_digest` | sha256 digest for bundle verification |
+| `proof_events[]` | Log-safe proof records; publish emits `change_bundle.published` |
 
 ## Change Commands
 
@@ -332,12 +339,15 @@ Current scope:
 
 ### `verify`
 
-Verify bundle schema and digest integrity.
+Verify bundle schema, digest integrity, and proof-event linkage.
 
 ```
 cub-gen verify --in <bundle.json>
 cub-gen verify --in -          # stdin
 ```
+
+`--json` output includes `trace_id` and `proof_event_count` so validation jobs
+can log the proof chain without reopening the full bundle.
 
 Non-zero exit on integrity mismatch.
 
@@ -350,9 +360,13 @@ cub-gen attest --in <bundle.json> --verifier <verifier-id>
 cub-gen attest --in - --verifier ci-bot
 ```
 
+The attestation embeds an `attestation.verified` proof event. That event points
+back to the bundle with `parent_event_id` and `parent_artifact_digest`.
+
 ### `verify-attestation`
 
-Verify attestation integrity, optionally linked against a bundle.
+Verify attestation integrity and proof-event linkage, optionally linked against
+a bundle.
 
 ```
 cub-gen verify-attestation --in <attestation.json>

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -373,6 +373,19 @@ cub-gen verify-attestation --in <attestation.json>
 cub-gen verify-attestation --in <attestation.json> --bundle <bundle.json>
 ```
 
+### `proof events`
+
+Verify a bundle or attestation and emit only its loggable proof events.
+
+```
+cub-gen proof events --in <bundle.json>
+cub-gen proof events --in <attestation.json> --bundle <bundle.json> --ndjson
+```
+
+Default output is a small `proof-log/v1` JSON envelope. `--ndjson` emits one
+compact `proof_event/v1` record per line for Pilot, CI, validation, or audit
+logs.
+
 ---
 
 ## Bridge flow (advanced ConfigHub API path)

--- a/docs/contracts/change-api-v1.md
+++ b/docs/contracts/change-api-v1.md
@@ -32,11 +32,12 @@ Request fields:
 Response:
 
 - `input` (normalized repo identity: `target_path`, `render_target_path`, plus compatibility slugs)
-- `change` (`change_id`, `bundle_digest`, `attestation_digest`)
+- `change` (`change_id`, `trace_id`, `bundle_digest`, `attestation_digest`)
 - `edit_recommendation` (owner, paths, hint, confidence)
 - `verification` (bundle/attestation validity)
 - `decision` and `promotion_ready` when `action=run`
-- `artifacts` references for audit/debug
+- `artifacts` references for audit/debug, including proof-event-capable bundle
+  and attestation artifacts
 
 Schema:
 
@@ -136,6 +137,7 @@ Schema:
   },
   "change": {
     "change_id": "chg_01J...",
+    "trace_id": "chg_01J...",
     "bundle_digest": "sha256:...",
     "attestation_digest": "sha256:..."
   },

--- a/docs/contracts/change-cli-v1.md
+++ b/docs/contracts/change-cli-v1.md
@@ -34,6 +34,7 @@ Expected output fields (`ChangePreviewResult`):
 - `input.{target_path,render_target_path,target_slug,render_target_slug}`
 - `change_id`
 - `bundle_digest`
+- `trace_id`
 - `detected_profiles[]`
 - `top_edit_recommendation.{owner,wet_path,dry_path,edit_hint,confidence}`
 - `counts.{dry_inputs,wet_targets,inverse_patches}`
@@ -60,6 +61,7 @@ Expected output fields (`ChangeRunResult`):
 - `preview.input.{target_path,render_target_path,target_slug,render_target_slug}`
 - `change_id`
 - `bundle_digest`
+- `trace_id`
 - `decision.{state,authority,source}`
 - `verification.{bundle_valid,attestation_valid}`
 - `promotion_ready` (boolean)
@@ -204,7 +206,9 @@ Compatibility wrappers remain useful for demo packaging and story scripts:
 1. Same input repo+target produces stable output structure.
 2. `change_id` uniqueness is guaranteed per run.
 3. `bundle_digest` and `attestation_digest` are content-addressed and reproducible.
-4. Connected mode must record decision source (`confighub-backend` vs explicit fallback source).
+4. Proof events must carry `trace_id`, artifact digest, and parent digest
+   links where applicable.
+5. Connected mode must record decision source (`confighub-backend` vs explicit fallback source).
 
 ## Non-goals for v1
 

--- a/docs/contracts/decision-and-attestation-state.md
+++ b/docs/contracts/decision-and-attestation-state.md
@@ -25,20 +25,25 @@ Terminal states are `ALLOW | ESCALATE | BLOCK`.
 Every decision record (`cub.confighub.io/governed-decision-state/v1`) must carry:
 
 1. `change_id`
-2. `bundle_digest`
-3. `state`
-4. `updated_at`
+2. `trace_id` (normally the same value as `change_id`)
+3. `bundle_digest`
+4. `state`
+5. `updated_at`
+6. `proof_events[]`
 
 If state is `ATTESTED` or terminal, it must also carry:
 
 1. `attestation_digest` (digest-linked evidence)
 
-The bundle and attestation artifacts also carry `proof_events[]`. These are
-log-safe records for Pilot and validation flows:
+The bundle, attestation, and governed decision artifacts carry
+`proof_events[]`. These are log-safe records for Pilot and validation flows:
 
 1. bundle event: `change_bundle.published`
 2. attestation event: `attestation.verified`
-3. shared join fields: `trace_id`, `change_id`, artifact digest, and parent artifact digest
+3. decision events: `governed_decision.created`,
+   `governed_decision.attested`, and `governed_decision.applied`
+4. shared join fields: `trace_id`, `change_id`, artifact digest, parent
+   artifact digest, parent event id, and decision state
 
 If state is terminal, it must also carry:
 
@@ -62,6 +67,8 @@ Disallowed:
 1. Any terminal decision without attestation linkage.
 2. Any terminal decision without explicit authority.
 3. Any direct `INGESTED -> ALLOW|ESCALATE|BLOCK`.
+4. Any locally produced decision proof event that cannot be joined by
+   `trace_id` and `change_id`.
 
 ## Query by `change_id`
 

--- a/docs/contracts/decision-and-attestation-state.md
+++ b/docs/contracts/decision-and-attestation-state.md
@@ -33,6 +33,13 @@ If state is `ATTESTED` or terminal, it must also carry:
 
 1. `attestation_digest` (digest-linked evidence)
 
+The bundle and attestation artifacts also carry `proof_events[]`. These are
+log-safe records for Pilot and validation flows:
+
+1. bundle event: `change_bundle.published`
+2. attestation event: `attestation.verified`
+3. shared join fields: `trace_id`, `change_id`, artifact digest, and parent artifact digest
+
 If state is terminal, it must also carry:
 
 1. `decision_reason`
@@ -68,3 +75,4 @@ The response is validated against the decision-state contract and must return th
 
 1. Contract and transition enforcement: `internal/bridge/decision.go`
 2. End-to-end state/query tests: `internal/bridge/decision_test.go`
+3. Proof-event schema and validation: `internal/proof/event.go`, `internal/contracts/schemas/proof-event.v1.schema.json`

--- a/docs/contracts/proof-events-and-traceability.md
+++ b/docs/contracts/proof-events-and-traceability.md
@@ -39,6 +39,10 @@ Every proof event carries:
 | `parent_artifact_digest` | Digest of the parent artifact, such as the bundle an attestation verified |
 | `summary_counts` | Small log-friendly counters |
 | `generator_profiles` | Generator families involved in the proof |
+| `route_kind` | Optional route decision, for mutation apply gate events |
+| `owner` | Optional owner for routed mutation decisions |
+| `decision_state` | Optional governed decision state, such as `ALLOW` |
+| `decision_reason` | Optional short reason for the decision |
 
 Schema: [`proof-event.v1.schema.json`](schemas/proof-event.v1.schema.json)
 
@@ -48,6 +52,9 @@ Schema: [`proof-event.v1.schema.json`](schemas/proof-event.v1.schema.json)
 |---|---|---|---|
 | `change_bundle.published` | `publish` and `platform fanout` | `change_bundle` | none |
 | `attestation.verified` | `attest` | `attestation` | `change_bundle.published` |
+| `governed_decision.created` | `bridge decision create` | `governed_decision` | bundle digest |
+| `governed_decision.attested` | `bridge decision attach` | `governed_decision` | `attestation.verified` |
+| `governed_decision.applied` | `bridge decision apply` | `governed_decision` | previous decision event |
 
 ## CLI Extraction
 
@@ -57,11 +64,14 @@ records without carrying the whole bundle payload:
 ```bash
 cub-gen proof events --in bundle.json
 cub-gen proof events --in attestation.json --bundle bundle.json --ndjson
+cub-gen proof events --in decision.json --ndjson
 ```
 
 The command verifies the input first. Bundle input is checked with
 `verify`; attestation input is checked with `verify-attestation`, and the
-optional `--bundle` flag strengthens the parent-link check.
+optional `--bundle` flag strengthens the parent-link check. Decision input is
+checked against the governed decision-state contract and must carry
+`proof_events[]`.
 
 ## Trace Chain
 
@@ -69,11 +79,14 @@ optional `--bundle` flag strengthens the parent-link check.
 flowchart LR
   source["Source config + Generator"] --> bundle["Change bundle"]
   bundle --> attestation["Attestation"]
+  attestation --> decision["Governed decision"]
   bundle --> logs["Pilot / validation logs"]
   attestation --> logs
+  decision --> logs
 
   bundle -. "trace_id + bundle_digest" .-> logs
   attestation -. "trace_id + attestation_digest + parent bundle_digest" .-> logs
+  decision -. "trace_id + decision_state + parent event/digest" .-> logs
 ```
 
 The important join keys are:
@@ -84,6 +97,7 @@ The important join keys are:
 | Bundle integrity | `artifact_kind=change_bundle`, `artifact_digest=bundle_digest` |
 | Attestation integrity | `artifact_kind=attestation`, `artifact_digest=attestation_digest` |
 | Attestation to bundle | `parent_artifact_kind=change_bundle`, `parent_artifact_digest=bundle_digest` |
+| Decision lifecycle | `artifact_kind=governed_decision`, `decision_state`, `parent_event_id` |
 
 ## Digest Rules
 

--- a/docs/contracts/proof-events-and-traceability.md
+++ b/docs/contracts/proof-events-and-traceability.md
@@ -1,0 +1,115 @@
+# Proof Events and Traceability
+
+Proof needs to be a record we can log, query, validate, and attest.
+
+In cub-gen, a proof statement is a `proof_event`. It is a small JSON record
+embedded in generated artifacts and safe to copy into Pilot logs.
+
+## Why this exists
+
+The human question is still simple:
+
+```text
+If this deployed field is wrong, where do I fix it?
+```
+
+For Pilot, validation, and attestation, the machine question is stricter:
+
+```text
+Which exact artifact made this claim, and how do I join it to the rest of the change?
+```
+
+`proof_event/v1` answers that without scraping prose, filenames, or CLI output.
+
+## Event Shape
+
+Every proof event carries:
+
+| Field | Purpose |
+|---|---|
+| `event_id` | Deterministic id for this proof event |
+| `event_type` | What happened, such as `change_bundle.published` |
+| `event_time` | RFC3339 timestamp for logs and audit export |
+| `trace_id` | Cross-artifact join key; normally the `change_id` |
+| `change_id` | Change lifecycle id, when available |
+| `artifact_kind` | Artifact being described, such as `change_bundle` or `attestation` |
+| `artifact_digest` | Digest of the artifact carrying this event |
+| `parent_event_id` | Previous proof event in the chain, when known |
+| `parent_artifact_kind` | Parent artifact type, such as `change_bundle` |
+| `parent_artifact_digest` | Digest of the parent artifact, such as the bundle an attestation verified |
+| `summary_counts` | Small log-friendly counters |
+| `generator_profiles` | Generator families involved in the proof |
+
+Schema: [`proof-event.v1.schema.json`](schemas/proof-event.v1.schema.json)
+
+## Current Event Types
+
+| Event type | Emitted by | Artifact kind | Parent |
+|---|---|---|---|
+| `change_bundle.published` | `publish` and `platform fanout` | `change_bundle` | none |
+| `attestation.verified` | `attest` | `attestation` | `change_bundle.published` |
+
+## Trace Chain
+
+```mermaid
+flowchart LR
+  source["Source config + Generator"] --> bundle["Change bundle"]
+  bundle --> attestation["Attestation"]
+  bundle --> logs["Pilot / validation logs"]
+  attestation --> logs
+
+  bundle -. "trace_id + bundle_digest" .-> logs
+  attestation -. "trace_id + attestation_digest + parent bundle_digest" .-> logs
+```
+
+The important join keys are:
+
+| Join | Fields |
+|---|---|
+| Change lifecycle | `trace_id`, `change_id` |
+| Bundle integrity | `artifact_kind=change_bundle`, `artifact_digest=bundle_digest` |
+| Attestation integrity | `artifact_kind=attestation`, `artifact_digest=attestation_digest` |
+| Attestation to bundle | `parent_artifact_kind=change_bundle`, `parent_artifact_digest=bundle_digest` |
+
+## Digest Rules
+
+Proof events are embedded inside the artifact they describe. To avoid circular
+hashing:
+
+1. `artifact_digest` is excluded from the enclosing artifact digest.
+2. The enclosing artifact digest is computed.
+3. `artifact_digest` is filled with that digest.
+4. Verification checks both the artifact digest and the proof-event linkage.
+
+This means normal artifact tampering fails digest verification. Link tampering
+inside a proof event fails proof-event verification.
+
+## Example
+
+```json
+{
+  "schema_version": "cub.confighub.io/proof-event/v1",
+  "event_id": "evt_...",
+  "event_type": "attestation.verified",
+  "event_time": "2026-03-06T10:00:00Z",
+  "source": "cub-gen",
+  "trace_id": "chg_...",
+  "change_id": "chg_...",
+  "space": "platform",
+  "target_slug": "helm",
+  "artifact_kind": "attestation",
+  "artifact_digest": "sha256:...",
+  "parent_event_id": "evt_...",
+  "parent_artifact_kind": "change_bundle",
+  "parent_artifact_digest": "sha256:...",
+  "summary_counts": {
+    "verified_bundles": 1
+  }
+}
+```
+
+## Product Rule
+
+Any feature that claims proof should be able to emit or preserve a
+`proof_event/v1` record. If a feature cannot produce a proof event yet, it
+should say so in diagnostics instead of pretending the proof chain is complete.

--- a/docs/contracts/proof-events-and-traceability.md
+++ b/docs/contracts/proof-events-and-traceability.md
@@ -49,6 +49,20 @@ Schema: [`proof-event.v1.schema.json`](schemas/proof-event.v1.schema.json)
 | `change_bundle.published` | `publish` and `platform fanout` | `change_bundle` | none |
 | `attestation.verified` | `attest` | `attestation` | `change_bundle.published` |
 
+## CLI Extraction
+
+Use `proof events` when a Pilot, CI, validation, or audit step needs proof
+records without carrying the whole bundle payload:
+
+```bash
+cub-gen proof events --in bundle.json
+cub-gen proof events --in attestation.json --bundle bundle.json --ndjson
+```
+
+The command verifies the input first. Bundle input is checked with
+`verify`; attestation input is checked with `verify-attestation`, and the
+optional `--bundle` flag strengthens the parent-link check.
+
 ## Trace Chain
 
 ```mermaid

--- a/docs/contracts/schemas/proof-event.v1.schema.json
+++ b/docs/contracts/schemas/proof-event.v1.schema.json
@@ -57,7 +57,8 @@
       "type": "string",
       "enum": [
         "change_bundle",
-        "attestation"
+        "attestation",
+        "governed_decision"
       ]
     },
     "artifact_digest": {
@@ -87,6 +88,18 @@
       "items": {
         "type": "string"
       }
+    },
+    "route_kind": {
+      "type": "string"
+    },
+    "owner": {
+      "type": "string"
+    },
+    "decision_state": {
+      "type": "string"
+    },
+    "decision_reason": {
+      "type": "string"
     }
   },
   "additionalProperties": false

--- a/docs/contracts/schemas/proof-event.v1.schema.json
+++ b/docs/contracts/schemas/proof-event.v1.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cub.confighub.io/proof-event/v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_id",
+    "event_type",
+    "event_time",
+    "source",
+    "trace_id",
+    "artifact_kind"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "cub.confighub.io/proof-event/v1"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^evt_[a-f0-9]{24}$"
+    },
+    "event_type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "event_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "change_id": {
+      "type": "string"
+    },
+    "space": {
+      "type": "string"
+    },
+    "target_slug": {
+      "type": "string"
+    },
+    "target_path": {
+      "type": "string"
+    },
+    "render_target_slug": {
+      "type": "string"
+    },
+    "render_target_path": {
+      "type": "string"
+    },
+    "artifact_kind": {
+      "type": "string",
+      "enum": [
+        "change_bundle",
+        "attestation"
+      ]
+    },
+    "artifact_digest": {
+      "type": "string",
+      "pattern": "^sha256:"
+    },
+    "parent_event_id": {
+      "type": "string",
+      "pattern": "^evt_[a-f0-9]{24}$"
+    },
+    "parent_artifact_kind": {
+      "type": "string"
+    },
+    "parent_artifact_digest": {
+      "type": "string",
+      "pattern": "^sha256:"
+    },
+    "summary_counts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "generator_profiles": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/cub-gen-plugin.md
+++ b/docs/cub-gen-plugin.md
@@ -98,6 +98,7 @@ shorter aliases for the front-door `cub gen ...` shape.
 | `cub-gen verify` | `cub gen bundle verify` |
 | `cub-gen attest` | `cub gen bundle attest` |
 | `cub-gen verify-attestation` | `cub gen bundle verify-attestation` |
+| `cub-gen proof events` | `cub gen bundle events` or `cub gen proof events` |
 | `cub-gen change preview` | `cub gen preview` |
 | `cub-gen change run` | `cub gen run` |
 | `cub-gen change diff` | `cub gen diff` |

--- a/internal/attest/attest.go
+++ b/internal/attest/attest.go
@@ -172,6 +172,9 @@ func VerifyRecordAgainstBundle(rec Record, bundle publish.ChangeBundle) error {
 	if rec.ChangeID != "" && bundle.ChangeID != "" && rec.ChangeID != bundle.ChangeID {
 		return fmt.Errorf("change_id link mismatch: attestation=%s bundle=%s", rec.ChangeID, bundle.ChangeID)
 	}
+	if rec.TraceID != bundle.TraceID {
+		return fmt.Errorf("trace_id link mismatch: attestation=%s bundle=%s", rec.TraceID, bundle.TraceID)
+	}
 	if err := proof.ValidateArtifactEvents(rec.ProofEvents, proof.Expected{
 		EventType:            proof.EventTypeAttestationVerified,
 		EventTime:            rec.GeneratedAt,

--- a/internal/attest/attest.go
+++ b/internal/attest/attest.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/confighub/cub-gen/internal/proof"
 	"github.com/confighub/cub-gen/internal/publish"
 )
 
@@ -19,20 +20,22 @@ const (
 
 // Record is an attestation envelope for a verified change bundle.
 type Record struct {
-	SchemaVersion     string `json:"schema_version"`
-	Source            string `json:"source"`
-	GeneratedAt       string `json:"generated_at"`
-	Status            string `json:"status"`
-	Verifier          string `json:"verifier"`
-	DigestAlgorithm   string `json:"digest_algorithm"`
-	BundleDigest      string `json:"bundle_digest"`
-	ChangeID          string `json:"change_id,omitempty"`
-	Space             string `json:"space,omitempty"`
-	TargetSlug        string `json:"target_slug,omitempty"`
-	TargetPath        string `json:"target_path,omitempty"`
-	RenderTargetSlug  string `json:"render_target_slug,omitempty"`
-	RenderTargetPath  string `json:"render_target_path,omitempty"`
-	AttestationDigest string `json:"attestation_digest"`
+	SchemaVersion     string        `json:"schema_version"`
+	Source            string        `json:"source"`
+	GeneratedAt       string        `json:"generated_at"`
+	Status            string        `json:"status"`
+	Verifier          string        `json:"verifier"`
+	DigestAlgorithm   string        `json:"digest_algorithm"`
+	BundleDigest      string        `json:"bundle_digest"`
+	ChangeID          string        `json:"change_id,omitempty"`
+	Space             string        `json:"space,omitempty"`
+	TargetSlug        string        `json:"target_slug,omitempty"`
+	TargetPath        string        `json:"target_path,omitempty"`
+	RenderTargetSlug  string        `json:"render_target_slug,omitempty"`
+	RenderTargetPath  string        `json:"render_target_path,omitempty"`
+	AttestationDigest string        `json:"attestation_digest"`
+	TraceID           string        `json:"trace_id"`
+	ProofEvents       []proof.Event `json:"proof_events"`
 }
 
 // BuildAt verifies a bundle and emits an attestation record.
@@ -58,8 +61,29 @@ func BuildAt(bundle publish.ChangeBundle, at time.Time, verifier string) (Record
 		TargetPath:       bundle.TargetPath,
 		RenderTargetSlug: bundle.RenderTargetSlug,
 		RenderTargetPath: bundle.RenderTargetPath,
+		TraceID:          bundle.TraceID,
 	}
+	rec.ProofEvents = []proof.Event{proof.NewEvent(proof.Input{
+		EventType:            proof.EventTypeAttestationVerified,
+		EventTime:            at,
+		Source:               attestationSource,
+		ChangeID:             rec.ChangeID,
+		Space:                rec.Space,
+		TargetSlug:           rec.TargetSlug,
+		TargetPath:           rec.TargetPath,
+		RenderTargetSlug:     rec.RenderTargetSlug,
+		RenderTargetPath:     rec.RenderTargetPath,
+		Ref:                  bundle.Ref,
+		ArtifactKind:         proof.ArtifactKindAttestation,
+		ParentEventID:        proof.FindEventID(bundle.ProofEvents, proof.EventTypeChangeBundlePublished),
+		ParentArtifactKind:   proof.ArtifactKindChangeBundle,
+		ParentArtifactDigest: bundle.BundleDigest,
+		SummaryCounts: map[string]int{
+			"verified_bundles": 1,
+		},
+	})}
 	rec.AttestationDigest = computeAttestationDigest(rec)
+	rec.ProofEvents = proof.SetArtifactDigest(rec.ProofEvents, proof.ArtifactKindAttestation, rec.AttestationDigest)
 	return rec, nil
 }
 
@@ -72,6 +96,7 @@ func computeAttestationDigest(rec Record) string {
 	input := rec
 	input.AttestationDigest = ""
 	input.DigestAlgorithm = ""
+	input.ProofEvents = proof.BlankArtifactDigests(input.ProofEvents)
 
 	b, err := json.Marshal(input)
 	if err != nil {
@@ -111,6 +136,24 @@ func VerifyRecord(rec Record) error {
 	if rec.AttestationDigest != expected {
 		return fmt.Errorf("attestation digest mismatch: expected %s, got %s", expected, rec.AttestationDigest)
 	}
+	if err := proof.ValidateArtifactEvents(rec.ProofEvents, proof.Expected{
+		EventType:            proof.EventTypeAttestationVerified,
+		EventTime:            rec.GeneratedAt,
+		Source:               rec.Source,
+		TraceID:              rec.TraceID,
+		ChangeID:             rec.ChangeID,
+		Space:                rec.Space,
+		TargetSlug:           rec.TargetSlug,
+		TargetPath:           rec.TargetPath,
+		RenderTargetSlug:     rec.RenderTargetSlug,
+		RenderTargetPath:     rec.RenderTargetPath,
+		ArtifactKind:         proof.ArtifactKindAttestation,
+		ArtifactDigest:       rec.AttestationDigest,
+		ParentArtifactKind:   proof.ArtifactKindChangeBundle,
+		ParentArtifactDigest: rec.BundleDigest,
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -128,6 +171,25 @@ func VerifyRecordAgainstBundle(rec Record, bundle publish.ChangeBundle) error {
 	}
 	if rec.ChangeID != "" && bundle.ChangeID != "" && rec.ChangeID != bundle.ChangeID {
 		return fmt.Errorf("change_id link mismatch: attestation=%s bundle=%s", rec.ChangeID, bundle.ChangeID)
+	}
+	if err := proof.ValidateArtifactEvents(rec.ProofEvents, proof.Expected{
+		EventType:            proof.EventTypeAttestationVerified,
+		EventTime:            rec.GeneratedAt,
+		Source:               rec.Source,
+		TraceID:              rec.TraceID,
+		ChangeID:             rec.ChangeID,
+		Space:                rec.Space,
+		TargetSlug:           rec.TargetSlug,
+		TargetPath:           rec.TargetPath,
+		RenderTargetSlug:     rec.RenderTargetSlug,
+		RenderTargetPath:     rec.RenderTargetPath,
+		ArtifactKind:         proof.ArtifactKindAttestation,
+		ArtifactDigest:       rec.AttestationDigest,
+		ParentEventID:        proof.FindEventID(bundle.ProofEvents, proof.EventTypeChangeBundlePublished),
+		ParentArtifactKind:   proof.ArtifactKindChangeBundle,
+		ParentArtifactDigest: bundle.BundleDigest,
+	}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -161,3 +161,35 @@ func TestVerifyRecordAgainstBundle(t *testing.T) {
 		t.Fatalf("expected bundle digest link mismatch, got %v", err)
 	}
 }
+
+func TestVerifyRecordAgainstBundleRejectsTraceIDMismatchWithoutChangeID(t *testing.T) {
+	bundle := publish.BuildBundleAt(gitopsflow.ImportFlowResult{
+		Space:            "platform",
+		TargetSlug:       "custom",
+		TargetPath:       "/repo",
+		RenderTargetSlug: "render",
+		RenderTargetPath: "/repo/render",
+		Ref:              "HEAD",
+	}, time.Date(2026, 3, 6, 0, 0, 0, 0, time.UTC))
+	if bundle.ChangeID != "" {
+		t.Fatalf("expected empty change_id fixture, got %q", bundle.ChangeID)
+	}
+
+	rec, err := BuildAt(bundle, time.Date(2026, 3, 6, 1, 0, 0, 0, time.UTC), "ci-bot")
+	if err != nil {
+		t.Fatalf("BuildAt returned error: %v", err)
+	}
+	rec.TraceID = "trace_custom"
+	rec.ProofEvents = append([]proof.Event(nil), rec.ProofEvents...)
+	rec.ProofEvents[0].TraceID = rec.TraceID
+	rec.ProofEvents[0].EventID = proof.EventID(rec.ProofEvents[0])
+	rec.AttestationDigest = computeAttestationDigest(rec)
+	rec.ProofEvents = proof.SetArtifactDigest(rec.ProofEvents, proof.ArtifactKindAttestation, rec.AttestationDigest)
+
+	if err := VerifyRecord(rec); err != nil {
+		t.Fatalf("expected tampered record to remain internally valid, got %v", err)
+	}
+	if err := VerifyRecordAgainstBundle(rec, bundle); err == nil || !strings.Contains(err.Error(), "trace_id link mismatch") {
+		t.Fatalf("expected trace_id link mismatch, got %v", err)
+	}
+}

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
+	"github.com/confighub/cub-gen/internal/proof"
 	"github.com/confighub/cub-gen/internal/publish"
 )
 
@@ -49,6 +50,31 @@ func TestBuildAt(t *testing.T) {
 	}
 	if !strings.HasPrefix(rec.AttestationDigest, "sha256:") {
 		t.Fatalf("expected attestation digest sha256 prefix, got %q", rec.AttestationDigest)
+	}
+	if rec.TraceID != bundle.TraceID {
+		t.Fatalf("expected trace_id %q, got %q", bundle.TraceID, rec.TraceID)
+	}
+	if len(rec.ProofEvents) != 1 {
+		t.Fatalf("expected one proof event, got %d", len(rec.ProofEvents))
+	}
+	event := rec.ProofEvents[0]
+	if event.EventType != proof.EventTypeAttestationVerified {
+		t.Fatalf("unexpected proof event type: %q", event.EventType)
+	}
+	if event.TraceID != rec.TraceID {
+		t.Fatalf("expected proof event trace_id %q, got %q", rec.TraceID, event.TraceID)
+	}
+	if event.ArtifactKind != proof.ArtifactKindAttestation {
+		t.Fatalf("unexpected proof artifact kind: %q", event.ArtifactKind)
+	}
+	if event.ArtifactDigest != rec.AttestationDigest {
+		t.Fatalf("expected proof event artifact digest %q, got %q", rec.AttestationDigest, event.ArtifactDigest)
+	}
+	if event.ParentArtifactDigest != bundle.BundleDigest {
+		t.Fatalf("expected parent artifact digest %q, got %q", bundle.BundleDigest, event.ParentArtifactDigest)
+	}
+	if event.ParentEventID != bundle.ProofEvents[0].EventID {
+		t.Fatalf("expected parent event id %q, got %q", bundle.ProofEvents[0].EventID, event.ParentEventID)
 	}
 
 	again, err := BuildAt(bundle, time.Date(2026, 3, 6, 1, 0, 0, 0, time.UTC), "ci-bot")
@@ -93,6 +119,23 @@ func TestVerifyRecord(t *testing.T) {
 	missingDigest.AttestationDigest = ""
 	if err := VerifyRecord(missingDigest); err == nil || !strings.Contains(err.Error(), "missing attestation_digest") {
 		t.Fatalf("expected missing attestation digest error, got %v", err)
+	}
+
+	missingProof := rec
+	missingProof.ProofEvents = nil
+	missingProof.AttestationDigest = computeAttestationDigest(missingProof)
+	if err := VerifyRecord(missingProof); err == nil || !strings.Contains(err.Error(), "missing proof_events") {
+		t.Fatalf("expected missing proof_events error, got %v", err)
+	}
+
+	tamperedProof := rec
+	tamperedProof.ProofEvents = append([]proof.Event(nil), rec.ProofEvents...)
+	tamperedProof.ProofEvents[0].ParentArtifactDigest = "sha256:wrong"
+	tamperedProof.ProofEvents[0].EventID = proof.EventID(tamperedProof.ProofEvents[0])
+	tamperedProof.AttestationDigest = computeAttestationDigest(tamperedProof)
+	tamperedProof.ProofEvents = proof.SetArtifactDigest(tamperedProof.ProofEvents, proof.ArtifactKindAttestation, tamperedProof.AttestationDigest)
+	if err := VerifyRecord(tamperedProof); err == nil || !strings.Contains(err.Error(), "parent_artifact_digest mismatch") {
+		t.Fatalf("expected parent artifact digest mismatch, got %v", err)
 	}
 }
 

--- a/internal/bridge/decision.go
+++ b/internal/bridge/decision.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/confighub/cub-gen/internal/attest"
+	"github.com/confighub/cub-gen/internal/proof"
 )
 
 const (
@@ -43,6 +44,7 @@ const (
 type DecisionRecord struct {
 	SchemaVersion       string        `json:"schema_version"`
 	Source              string        `json:"source"`
+	TraceID             string        `json:"trace_id,omitempty"`
 	ChangeID            string        `json:"change_id"`
 	BundleDigest        string        `json:"bundle_digest"`
 	ArtifactID          string        `json:"artifact_id,omitempty"`
@@ -56,6 +58,7 @@ type DecisionRecord struct {
 	DecisionReason      string        `json:"decision_reason,omitempty"`
 	DecidedAt           string        `json:"decided_at,omitempty"`
 	UpdatedAt           string        `json:"updated_at"`
+	ProofEvents         []proof.Event `json:"proof_events,omitempty"`
 }
 
 // DecisionRequest applies a terminal governed decision.
@@ -94,6 +97,7 @@ func NewDecisionRecord(ingest IngestResult, at time.Time) (DecisionRecord, error
 	rec := DecisionRecord{
 		SchemaVersion:  decisionSchemaVersion,
 		Source:         decisionSource,
+		TraceID:        proof.TraceID(changeID, "", "", "", ""),
 		ChangeID:       changeID,
 		BundleDigest:   bundleDigest,
 		ArtifactID:     strings.TrimSpace(ingest.ArtifactID),
@@ -101,6 +105,15 @@ func NewDecisionRecord(ingest IngestResult, at time.Time) (DecisionRecord, error
 		State:          DecisionStateIngested,
 		UpdatedAt:      at.UTC().Format(time.RFC3339),
 	}
+	rec.ProofEvents = appendDecisionEvent(rec.ProofEvents, decisionEventInput{
+		EventType:            proof.EventTypeDecisionCreated,
+		EventTime:            at,
+		ChangeID:             rec.ChangeID,
+		TraceID:              rec.TraceID,
+		ParentArtifactKind:   proof.ArtifactKindChangeBundle,
+		ParentArtifactDigest: rec.BundleDigest,
+		DecisionState:        string(rec.State),
+	})
 	return rec, ValidateDecisionRecord(rec)
 }
 
@@ -130,6 +143,19 @@ func AttachAttestation(rec DecisionRecord, attestation attest.Record, at time.Ti
 	rec.AttestationVerifier = strings.TrimSpace(attestation.Verifier)
 	rec.AttestedAt = at.UTC().Format(time.RFC3339)
 	rec.UpdatedAt = rec.AttestedAt
+	if strings.TrimSpace(rec.TraceID) == "" {
+		rec.TraceID = proof.TraceID(rec.ChangeID, "", "", "", "")
+	}
+	rec.ProofEvents = appendDecisionEvent(rec.ProofEvents, decisionEventInput{
+		EventType:            proof.EventTypeDecisionAttested,
+		EventTime:            at,
+		ChangeID:             rec.ChangeID,
+		TraceID:              rec.TraceID,
+		ParentEventID:        proof.FindEventID(attestation.ProofEvents, proof.EventTypeAttestationVerified),
+		ParentArtifactKind:   proof.ArtifactKindAttestation,
+		ParentArtifactDigest: rec.AttestationDigest,
+		DecisionState:        string(rec.State),
+	})
 	return rec, ValidateDecisionRecord(rec)
 }
 
@@ -162,6 +188,20 @@ func ApplyDecision(rec DecisionRecord, req DecisionRequest, at time.Time) (Decis
 	rec.DecisionReason = reason
 	rec.DecidedAt = at.UTC().Format(time.RFC3339)
 	rec.UpdatedAt = rec.DecidedAt
+	if strings.TrimSpace(rec.TraceID) == "" {
+		rec.TraceID = proof.TraceID(rec.ChangeID, "", "", "", "")
+	}
+	rec.ProofEvents = appendDecisionEvent(rec.ProofEvents, decisionEventInput{
+		EventType:            proof.EventTypeDecisionApplied,
+		EventTime:            at,
+		ChangeID:             rec.ChangeID,
+		TraceID:              rec.TraceID,
+		ParentEventID:        latestDecisionEventID(rec.ProofEvents),
+		ParentArtifactKind:   proof.ArtifactKindDecision,
+		ParentArtifactDigest: "",
+		DecisionState:        string(rec.State),
+		DecisionReason:       rec.DecisionReason,
+	})
 	return rec, ValidateDecisionRecord(rec)
 }
 
@@ -208,6 +248,9 @@ func ValidateDecisionRecord(rec DecisionRecord) error {
 	}
 	if strings.TrimSpace(rec.UpdatedAt) == "" {
 		return fmt.Errorf("missing updated_at")
+	}
+	if err := validateDecisionProofEvents(rec); err != nil {
+		return err
 	}
 	return nil
 }
@@ -294,4 +337,74 @@ func resolveDecisionEndpoint(client DecisionClient, changeID string) (string, er
 
 func isTerminalDecision(state DecisionState) bool {
 	return state == DecisionStateAllow || state == DecisionStateEscalate || state == DecisionStateBlock
+}
+
+type decisionEventInput struct {
+	EventType            string
+	EventTime            time.Time
+	ChangeID             string
+	TraceID              string
+	ParentEventID        string
+	ParentArtifactKind   string
+	ParentArtifactDigest string
+	DecisionState        string
+	DecisionReason       string
+}
+
+func appendDecisionEvent(events []proof.Event, input decisionEventInput) []proof.Event {
+	traceID := strings.TrimSpace(input.TraceID)
+	if traceID == "" {
+		traceID = proof.TraceID(input.ChangeID, "", "", "", "")
+	}
+	event := proof.NewEvent(proof.Input{
+		EventType:            input.EventType,
+		EventTime:            input.EventTime,
+		Source:               decisionSource,
+		TraceID:              traceID,
+		ChangeID:             input.ChangeID,
+		ArtifactKind:         proof.ArtifactKindDecision,
+		ParentEventID:        input.ParentEventID,
+		ParentArtifactKind:   input.ParentArtifactKind,
+		ParentArtifactDigest: input.ParentArtifactDigest,
+		SummaryCounts: map[string]int{
+			"decision_records": 1,
+		},
+		DecisionState:  input.DecisionState,
+		DecisionReason: input.DecisionReason,
+	})
+	return append(append([]proof.Event(nil), events...), event)
+}
+
+func latestDecisionEventID(events []proof.Event) string {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].ArtifactKind == proof.ArtifactKindDecision {
+			return events[i].EventID
+		}
+	}
+	return ""
+}
+
+func validateDecisionProofEvents(rec DecisionRecord) error {
+	if len(rec.ProofEvents) == 0 {
+		return nil
+	}
+	traceID := strings.TrimSpace(rec.TraceID)
+	if traceID == "" {
+		return fmt.Errorf("proof_events require trace_id")
+	}
+	for i, event := range rec.ProofEvents {
+		if err := proof.ValidateEvent(event); err != nil {
+			return fmt.Errorf("proof_events[%d]: %w", i, err)
+		}
+		if event.ArtifactKind != proof.ArtifactKindDecision {
+			return fmt.Errorf("proof_events[%d]: artifact_kind mismatch: expected %q, got %q", i, proof.ArtifactKindDecision, event.ArtifactKind)
+		}
+		if event.TraceID != traceID {
+			return fmt.Errorf("proof_events[%d]: trace_id mismatch: expected %q, got %q", i, traceID, event.TraceID)
+		}
+		if event.ChangeID != rec.ChangeID {
+			return fmt.Errorf("proof_events[%d]: change_id mismatch: expected %q, got %q", i, rec.ChangeID, event.ChangeID)
+		}
+	}
+	return nil
 }

--- a/internal/bridge/decision_test.go
+++ b/internal/bridge/decision_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/confighub/cub-gen/internal/attest"
+	"github.com/confighub/cub-gen/internal/proof"
 )
 
 func TestNewDecisionRecordFromIngest(t *testing.T) {
@@ -40,6 +41,19 @@ func TestNewDecisionRecordFromIngest(t *testing.T) {
 	}
 	if rec.ChangeID != bundle.ChangeID || rec.BundleDigest != bundle.BundleDigest {
 		t.Fatalf("unexpected decision identity linkage: %+v", rec)
+	}
+	if rec.TraceID != bundle.ChangeID {
+		t.Fatalf("expected trace_id %q, got %q", bundle.ChangeID, rec.TraceID)
+	}
+	if len(rec.ProofEvents) != 1 {
+		t.Fatalf("expected one proof event, got %d", len(rec.ProofEvents))
+	}
+	event := rec.ProofEvents[0]
+	if event.EventType != proof.EventTypeDecisionCreated || event.DecisionState != string(DecisionStateIngested) {
+		t.Fatalf("unexpected decision proof event: %+v", event)
+	}
+	if event.ParentArtifactKind != proof.ArtifactKindChangeBundle || event.ParentArtifactDigest != bundle.BundleDigest {
+		t.Fatalf("unexpected decision proof parent: %+v", event)
 	}
 	if rec.UpdatedAt != ts.Format(time.RFC3339) {
 		t.Fatalf("expected updated_at %q, got %q", ts.Format(time.RFC3339), rec.UpdatedAt)
@@ -72,6 +86,12 @@ func TestAttachAttestationAndAllowDecision(t *testing.T) {
 	if attested.AttestationDigest != att.AttestationDigest {
 		t.Fatalf("expected attestation digest %q, got %q", att.AttestationDigest, attested.AttestationDigest)
 	}
+	if len(attested.ProofEvents) != 2 {
+		t.Fatalf("expected two proof events after attestation attach, got %d", len(attested.ProofEvents))
+	}
+	if event := attested.ProofEvents[1]; event.EventType != proof.EventTypeDecisionAttested || event.ParentArtifactDigest != att.AttestationDigest {
+		t.Fatalf("unexpected attested proof event: %+v", event)
+	}
 
 	decided, err := ApplyDecision(attested, DecisionRequest{
 		State:          DecisionStateAllow,
@@ -86,6 +106,12 @@ func TestAttachAttestationAndAllowDecision(t *testing.T) {
 	}
 	if decided.DecidedAt == "" || decided.DecisionReason == "" {
 		t.Fatalf("expected terminal decision fields to be set: %+v", decided)
+	}
+	if len(decided.ProofEvents) != 3 {
+		t.Fatalf("expected three proof events after terminal decision, got %d", len(decided.ProofEvents))
+	}
+	if event := decided.ProofEvents[2]; event.EventType != proof.EventTypeDecisionApplied || event.DecisionState != string(DecisionStateAllow) || event.DecisionReason != "policy checks passed" {
+		t.Fatalf("unexpected applied proof event: %+v", event)
 	}
 }
 

--- a/internal/change/query.go
+++ b/internal/change/query.go
@@ -64,6 +64,7 @@ func QueryContextFromBundle(bundle publish.ChangeBundle) QueryContext {
 		},
 		Change: PreviewSummary{
 			ChangeID:          bundle.ChangeID,
+			TraceID:           bundle.TraceID,
 			BundleDigest:      bundle.BundleDigest,
 			AttestationDigest: "",
 		},

--- a/internal/change/workflow.go
+++ b/internal/change/workflow.go
@@ -32,6 +32,7 @@ type PreviewInput struct {
 
 type PreviewSummary struct {
 	ChangeID          string `json:"change_id"`
+	TraceID           string `json:"trace_id"`
 	BundleDigest      string `json:"bundle_digest"`
 	AttestationDigest string `json:"attestation_digest"`
 }
@@ -202,6 +203,7 @@ func BuildPreviewResult(
 		},
 		Change: PreviewSummary{
 			ChangeID:          bundle.ChangeID,
+			TraceID:           bundle.TraceID,
 			BundleDigest:      bundle.BundleDigest,
 			AttestationDigest: attestationRecord.AttestationDigest,
 		},
@@ -313,12 +315,12 @@ func BuildDiffResult(targetSlug, renderTargetSlug string, opts DiffOptions) (Dif
 			MatchCount:    len(diffs),
 		},
 		Before: DiffSnapshot{
-			Change:             PreviewSummary{ChangeID: beforeBundle.ChangeID, BundleDigest: beforeBundle.BundleDigest, AttestationDigest: beforePreview.Change.AttestationDigest},
+			Change:             PreviewSummary{ChangeID: beforeBundle.ChangeID, TraceID: beforeBundle.TraceID, BundleDigest: beforeBundle.BundleDigest, AttestationDigest: beforePreview.Change.AttestationDigest},
 			GeneratorProfiles:  discoveredProfiles(beforeImported.Discovered),
 			DiscoveredResource: len(beforeImported.Discovered),
 		},
 		After: DiffSnapshot{
-			Change:             PreviewSummary{ChangeID: afterBundle.ChangeID, BundleDigest: afterBundle.BundleDigest, AttestationDigest: afterPreview.Change.AttestationDigest},
+			Change:             PreviewSummary{ChangeID: afterBundle.ChangeID, TraceID: afterBundle.TraceID, BundleDigest: afterBundle.BundleDigest, AttestationDigest: afterPreview.Change.AttestationDigest},
 			GeneratorProfiles:  discoveredProfiles(afterImported.Discovered),
 			DiscoveredResource: len(afterImported.Discovered),
 		},

--- a/internal/contracts/schemas/proof-event.v1.schema.json
+++ b/internal/contracts/schemas/proof-event.v1.schema.json
@@ -57,7 +57,8 @@
       "type": "string",
       "enum": [
         "change_bundle",
-        "attestation"
+        "attestation",
+        "governed_decision"
       ]
     },
     "artifact_digest": {
@@ -87,6 +88,18 @@
       "items": {
         "type": "string"
       }
+    },
+    "route_kind": {
+      "type": "string"
+    },
+    "owner": {
+      "type": "string"
+    },
+    "decision_state": {
+      "type": "string"
+    },
+    "decision_reason": {
+      "type": "string"
     }
   },
   "additionalProperties": false

--- a/internal/contracts/schemas/proof-event.v1.schema.json
+++ b/internal/contracts/schemas/proof-event.v1.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cub.confighub.io/proof-event/v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_id",
+    "event_type",
+    "event_time",
+    "source",
+    "trace_id",
+    "artifact_kind"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "cub.confighub.io/proof-event/v1"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^evt_[a-f0-9]{24}$"
+    },
+    "event_type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "event_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "change_id": {
+      "type": "string"
+    },
+    "space": {
+      "type": "string"
+    },
+    "target_slug": {
+      "type": "string"
+    },
+    "target_path": {
+      "type": "string"
+    },
+    "render_target_slug": {
+      "type": "string"
+    },
+    "render_target_path": {
+      "type": "string"
+    },
+    "artifact_kind": {
+      "type": "string",
+      "enum": [
+        "change_bundle",
+        "attestation"
+      ]
+    },
+    "artifact_digest": {
+      "type": "string",
+      "pattern": "^sha256:"
+    },
+    "parent_event_id": {
+      "type": "string",
+      "pattern": "^evt_[a-f0-9]{24}$"
+    },
+    "parent_artifact_kind": {
+      "type": "string"
+    },
+    "parent_artifact_digest": {
+      "type": "string",
+      "pattern": "^sha256:"
+    },
+    "summary_counts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "generator_profiles": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/contracts/validator.go
+++ b/internal/contracts/validator.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/confighub/cub-gen/internal/model"
+	"github.com/confighub/cub-gen/internal/proof"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
@@ -17,6 +18,7 @@ const (
 	generatorContractSchemaName = "schemas/generator-contract.v1.schema.json"
 	provenanceSchemaName        = "schemas/provenance.v1.schema.json"
 	inversePlanSchemaName       = "schemas/inverse-transform-plan.v1.schema.json"
+	proofEventSchemaName        = "schemas/proof-event.v1.schema.json"
 )
 
 //go:embed schemas/generator-contract.v1.schema.json
@@ -28,10 +30,14 @@ var provenanceSchemaJSON string
 //go:embed schemas/inverse-transform-plan.v1.schema.json
 var inversePlanSchemaJSON string
 
+//go:embed schemas/proof-event.v1.schema.json
+var proofEventSchemaJSON string
+
 type compiledSchemas struct {
 	generatorContract *jsonschema.Schema
 	provenanceRecord  *jsonschema.Schema
 	inversePlan       *jsonschema.Schema
+	proofEvent        *jsonschema.Schema
 }
 
 var (
@@ -112,6 +118,18 @@ func ValidateInverseTransformPlan(inversePlan model.InverseTransformPlan) error 
 	return validateRecord("inverse_transform_plan", s.inversePlan, inversePlan)
 }
 
+// ValidateProofEvent validates one log-safe proof event.
+func ValidateProofEvent(event proof.Event) error {
+	s, err := loadSchemas()
+	if err != nil {
+		return err
+	}
+	if err := validateRecord("proof_event", s.proofEvent, event); err != nil {
+		return err
+	}
+	return proof.ValidateEvent(event)
+}
+
 func loadSchemas() (compiledSchemas, error) {
 	schemasOnce.Do(func() {
 		schemas, schemasErr = compileSchemas()
@@ -133,6 +151,9 @@ func compileSchemas() (compiledSchemas, error) {
 	if err := compiler.AddResource(inversePlanSchemaName, strings.NewReader(inversePlanSchemaJSON)); err != nil {
 		return compiledSchemas{}, fmt.Errorf("add %s: %w", inversePlanSchemaName, err)
 	}
+	if err := compiler.AddResource(proofEventSchemaName, strings.NewReader(proofEventSchemaJSON)); err != nil {
+		return compiledSchemas{}, fmt.Errorf("add %s: %w", proofEventSchemaName, err)
+	}
 
 	generatorContract, err := compiler.Compile(generatorContractSchemaName)
 	if err != nil {
@@ -146,11 +167,16 @@ func compileSchemas() (compiledSchemas, error) {
 	if err != nil {
 		return compiledSchemas{}, fmt.Errorf("compile %s: %w", inversePlanSchemaName, err)
 	}
+	proofEvent, err := compiler.Compile(proofEventSchemaName)
+	if err != nil {
+		return compiledSchemas{}, fmt.Errorf("compile %s: %w", proofEventSchemaName, err)
+	}
 
 	return compiledSchemas{
 		generatorContract: generatorContract,
 		provenanceRecord:  provenanceRecord,
 		inversePlan:       inversePlan,
+		proofEvent:        proofEvent,
 	}, nil
 }
 

--- a/internal/contracts/validator_test.go
+++ b/internal/contracts/validator_test.go
@@ -3,8 +3,10 @@ package contracts
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/confighub/cub-gen/internal/model"
+	"github.com/confighub/cub-gen/internal/proof"
 )
 
 func TestValidateTripleSetValid(t *testing.T) {
@@ -112,6 +114,35 @@ func TestValidateInverseTransformPlanInvalid(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "inverse_transform_plan schema validation failed") {
 		t.Fatalf("expected inverse plan validation message, got: %v", err)
+	}
+}
+
+func TestValidateProofEvent(t *testing.T) {
+	event := proof.NewEvent(proof.Input{
+		EventType:      proof.EventTypeChangeBundlePublished,
+		EventTime:      time.Date(2026, 3, 6, 0, 0, 0, 0, time.UTC),
+		Source:         "cub-gen",
+		ChangeID:       "chg_123",
+		Space:          "platform",
+		TargetSlug:     "helm",
+		ArtifactKind:   proof.ArtifactKindChangeBundle,
+		ArtifactDigest: "sha256:abc",
+		SummaryCounts: map[string]int{
+			"provenance_records": 1,
+		},
+	})
+
+	if err := ValidateProofEvent(event); err != nil {
+		t.Fatalf("expected valid proof event, got error: %v", err)
+	}
+
+	event.TraceID = ""
+	err := ValidateProofEvent(event)
+	if err == nil {
+		t.Fatal("expected invalid proof event error, got nil")
+	}
+	if !strings.Contains(err.Error(), "proof_event schema validation failed") {
+		t.Fatalf("expected proof_event schema validation message, got: %v", err)
 	}
 }
 

--- a/internal/proof/event.go
+++ b/internal/proof/event.go
@@ -14,9 +14,13 @@ const (
 
 	EventTypeChangeBundlePublished = "change_bundle.published"
 	EventTypeAttestationVerified   = "attestation.verified"
+	EventTypeDecisionCreated       = "governed_decision.created"
+	EventTypeDecisionAttested      = "governed_decision.attested"
+	EventTypeDecisionApplied       = "governed_decision.applied"
 
 	ArtifactKindChangeBundle = "change_bundle"
 	ArtifactKindAttestation  = "attestation"
+	ArtifactKindDecision     = "governed_decision"
 
 	digestAlgorithm = "sha256"
 )
@@ -43,6 +47,10 @@ type Event struct {
 	ParentArtifactDigest string         `json:"parent_artifact_digest,omitempty"`
 	SummaryCounts        map[string]int `json:"summary_counts,omitempty"`
 	GeneratorProfiles    []string       `json:"generator_profiles,omitempty"`
+	RouteKind            string         `json:"route_kind,omitempty"`
+	Owner                string         `json:"owner,omitempty"`
+	DecisionState        string         `json:"decision_state,omitempty"`
+	DecisionReason       string         `json:"decision_reason,omitempty"`
 }
 
 // Input contains the stable fields used to create a proof event.
@@ -50,6 +58,7 @@ type Input struct {
 	EventType            string
 	EventTime            time.Time
 	Source               string
+	TraceID              string
 	ChangeID             string
 	Space                string
 	TargetSlug           string
@@ -64,6 +73,10 @@ type Input struct {
 	ParentArtifactDigest string
 	SummaryCounts        map[string]int
 	GeneratorProfiles    []string
+	RouteKind            string
+	Owner                string
+	DecisionState        string
+	DecisionReason       string
 }
 
 // NewEvent returns a deterministic proof event for a generated artifact.
@@ -75,7 +88,7 @@ func NewEvent(input Input) Event {
 		EventType:            strings.TrimSpace(input.EventType),
 		EventTime:            input.EventTime.UTC().Format(time.RFC3339),
 		Source:               strings.TrimSpace(input.Source),
-		TraceID:              TraceID(input.ChangeID, input.Space, input.TargetSlug, input.RenderTargetSlug, input.Ref),
+		TraceID:              inputTraceID(input),
 		ChangeID:             strings.TrimSpace(input.ChangeID),
 		Space:                strings.TrimSpace(input.Space),
 		TargetSlug:           strings.TrimSpace(input.TargetSlug),
@@ -89,6 +102,10 @@ func NewEvent(input Input) Event {
 		ParentArtifactDigest: strings.TrimSpace(input.ParentArtifactDigest),
 		SummaryCounts:        counts,
 		GeneratorProfiles:    profiles,
+		RouteKind:            strings.TrimSpace(input.RouteKind),
+		Owner:                strings.TrimSpace(input.Owner),
+		DecisionState:        strings.TrimSpace(input.DecisionState),
+		DecisionReason:       strings.TrimSpace(input.DecisionReason),
 	}
 	event.EventID = EventID(event)
 	return event
@@ -108,6 +125,13 @@ func TraceID(changeID, space, targetSlug, renderTargetSlug, ref string) string {
 	}
 	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
 	return "trace_" + hex.EncodeToString(sum[:])[:16]
+}
+
+func inputTraceID(input Input) string {
+	if traceID := strings.TrimSpace(input.TraceID); traceID != "" {
+		return traceID
+	}
+	return TraceID(input.ChangeID, input.Space, input.TargetSlug, input.RenderTargetSlug, input.Ref)
 }
 
 // EventID returns the deterministic event id. ArtifactDigest is deliberately

--- a/internal/proof/event.go
+++ b/internal/proof/event.go
@@ -1,0 +1,297 @@
+package proof
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	SchemaVersion = "cub.confighub.io/proof-event/v1"
+
+	EventTypeChangeBundlePublished = "change_bundle.published"
+	EventTypeAttestationVerified   = "attestation.verified"
+
+	ArtifactKindChangeBundle = "change_bundle"
+	ArtifactKindAttestation  = "attestation"
+
+	digestAlgorithm = "sha256"
+)
+
+// Event is a log-safe proof statement. It can be copied into Pilot logs,
+// validation output, or attestation stores without losing the change trace.
+type Event struct {
+	SchemaVersion        string         `json:"schema_version"`
+	EventID              string         `json:"event_id"`
+	EventType            string         `json:"event_type"`
+	EventTime            string         `json:"event_time"`
+	Source               string         `json:"source"`
+	TraceID              string         `json:"trace_id"`
+	ChangeID             string         `json:"change_id,omitempty"`
+	Space                string         `json:"space,omitempty"`
+	TargetSlug           string         `json:"target_slug,omitempty"`
+	TargetPath           string         `json:"target_path,omitempty"`
+	RenderTargetSlug     string         `json:"render_target_slug,omitempty"`
+	RenderTargetPath     string         `json:"render_target_path,omitempty"`
+	ArtifactKind         string         `json:"artifact_kind"`
+	ArtifactDigest       string         `json:"artifact_digest,omitempty"`
+	ParentEventID        string         `json:"parent_event_id,omitempty"`
+	ParentArtifactKind   string         `json:"parent_artifact_kind,omitempty"`
+	ParentArtifactDigest string         `json:"parent_artifact_digest,omitempty"`
+	SummaryCounts        map[string]int `json:"summary_counts,omitempty"`
+	GeneratorProfiles    []string       `json:"generator_profiles,omitempty"`
+}
+
+// Input contains the stable fields used to create a proof event.
+type Input struct {
+	EventType            string
+	EventTime            time.Time
+	Source               string
+	ChangeID             string
+	Space                string
+	TargetSlug           string
+	TargetPath           string
+	RenderTargetSlug     string
+	RenderTargetPath     string
+	Ref                  string
+	ArtifactKind         string
+	ArtifactDigest       string
+	ParentEventID        string
+	ParentArtifactKind   string
+	ParentArtifactDigest string
+	SummaryCounts        map[string]int
+	GeneratorProfiles    []string
+}
+
+// NewEvent returns a deterministic proof event for a generated artifact.
+func NewEvent(input Input) Event {
+	profiles := append([]string(nil), input.GeneratorProfiles...)
+	counts := copyCounts(input.SummaryCounts)
+	event := Event{
+		SchemaVersion:        SchemaVersion,
+		EventType:            strings.TrimSpace(input.EventType),
+		EventTime:            input.EventTime.UTC().Format(time.RFC3339),
+		Source:               strings.TrimSpace(input.Source),
+		TraceID:              TraceID(input.ChangeID, input.Space, input.TargetSlug, input.RenderTargetSlug, input.Ref),
+		ChangeID:             strings.TrimSpace(input.ChangeID),
+		Space:                strings.TrimSpace(input.Space),
+		TargetSlug:           strings.TrimSpace(input.TargetSlug),
+		TargetPath:           strings.TrimSpace(input.TargetPath),
+		RenderTargetSlug:     strings.TrimSpace(input.RenderTargetSlug),
+		RenderTargetPath:     strings.TrimSpace(input.RenderTargetPath),
+		ArtifactKind:         strings.TrimSpace(input.ArtifactKind),
+		ArtifactDigest:       strings.TrimSpace(input.ArtifactDigest),
+		ParentEventID:        strings.TrimSpace(input.ParentEventID),
+		ParentArtifactKind:   strings.TrimSpace(input.ParentArtifactKind),
+		ParentArtifactDigest: strings.TrimSpace(input.ParentArtifactDigest),
+		SummaryCounts:        counts,
+		GeneratorProfiles:    profiles,
+	}
+	event.EventID = EventID(event)
+	return event
+}
+
+// TraceID returns the cross-artifact trace key. When a change_id exists, it is
+// the trace key. Otherwise a stable fallback is derived from the local context.
+func TraceID(changeID, space, targetSlug, renderTargetSlug, ref string) string {
+	if changeID = strings.TrimSpace(changeID); changeID != "" {
+		return changeID
+	}
+	parts := []string{
+		strings.TrimSpace(space),
+		strings.TrimSpace(targetSlug),
+		strings.TrimSpace(renderTargetSlug),
+		strings.TrimSpace(ref),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return "trace_" + hex.EncodeToString(sum[:])[:16]
+}
+
+// EventID returns the deterministic event id. ArtifactDigest is deliberately
+// excluded so an event can identify the artifact digest it is embedded inside.
+func EventID(event Event) string {
+	input := event
+	input.EventID = ""
+	input.ArtifactDigest = ""
+	b, err := json.Marshal(input)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return "evt_" + hex.EncodeToString(sum[:])[:24]
+}
+
+// BlankArtifactDigests returns a deep copy with event artifact digests removed
+// before envelope digest calculation.
+func BlankArtifactDigests(events []Event) []Event {
+	copied := append([]Event(nil), events...)
+	for i := range copied {
+		copied[i].ArtifactDigest = ""
+		copied[i].SummaryCounts = copyCounts(copied[i].SummaryCounts)
+		copied[i].GeneratorProfiles = append([]string(nil), copied[i].GeneratorProfiles...)
+	}
+	return copied
+}
+
+// SetArtifactDigest returns a deep copy with the artifact digest set on every
+// event that belongs to the artifact kind.
+func SetArtifactDigest(events []Event, artifactKind, digest string) []Event {
+	copied := append([]Event(nil), events...)
+	for i := range copied {
+		copied[i].SummaryCounts = copyCounts(copied[i].SummaryCounts)
+		copied[i].GeneratorProfiles = append([]string(nil), copied[i].GeneratorProfiles...)
+		if copied[i].ArtifactKind == artifactKind {
+			copied[i].ArtifactDigest = strings.TrimSpace(digest)
+		}
+	}
+	return copied
+}
+
+// FindEventID returns the first event id for eventType.
+func FindEventID(events []Event, eventType string) string {
+	for _, event := range events {
+		if event.EventType == eventType {
+			return event.EventID
+		}
+	}
+	return ""
+}
+
+// Expected captures the envelope fields a proof event must link to.
+type Expected struct {
+	EventType            string
+	EventTime            string
+	Source               string
+	TraceID              string
+	ChangeID             string
+	Space                string
+	TargetSlug           string
+	TargetPath           string
+	RenderTargetSlug     string
+	RenderTargetPath     string
+	ArtifactKind         string
+	ArtifactDigest       string
+	ParentEventID        string
+	ParentArtifactKind   string
+	ParentArtifactDigest string
+}
+
+// ValidateArtifactEvents checks that an artifact carries at least one proof
+// event that can be logged and joined back to the artifact.
+func ValidateArtifactEvents(events []Event, expected Expected) error {
+	if len(events) == 0 {
+		return fmt.Errorf("missing proof_events")
+	}
+	found := false
+	for i, event := range events {
+		if err := ValidateEvent(event); err != nil {
+			return fmt.Errorf("proof_events[%d]: %w", i, err)
+		}
+		if event.EventType != expected.EventType {
+			continue
+		}
+		found = true
+		if err := validateExpected(event, expected); err != nil {
+			return fmt.Errorf("proof_events[%d]: %w", i, err)
+		}
+	}
+	if !found {
+		return fmt.Errorf("missing proof event_type %q", expected.EventType)
+	}
+	return nil
+}
+
+// ValidateEvent checks log-safety and deterministic identity for one event.
+func ValidateEvent(event Event) error {
+	if event.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("unsupported schema_version %q", event.SchemaVersion)
+	}
+	if strings.TrimSpace(event.EventID) == "" {
+		return fmt.Errorf("missing event_id")
+	}
+	if expected := EventID(event); event.EventID != expected {
+		return fmt.Errorf("event_id mismatch: expected %s, got %s", expected, event.EventID)
+	}
+	if strings.TrimSpace(event.EventType) == "" {
+		return fmt.Errorf("missing event_type")
+	}
+	if strings.TrimSpace(event.EventTime) == "" {
+		return fmt.Errorf("missing event_time")
+	}
+	if _, err := time.Parse(time.RFC3339, event.EventTime); err != nil {
+		return fmt.Errorf("invalid event_time %q", event.EventTime)
+	}
+	if strings.TrimSpace(event.Source) == "" {
+		return fmt.Errorf("missing source")
+	}
+	if strings.TrimSpace(event.TraceID) == "" {
+		return fmt.Errorf("missing trace_id")
+	}
+	if strings.TrimSpace(event.ArtifactKind) == "" {
+		return fmt.Errorf("missing artifact_kind")
+	}
+	if digest := strings.TrimSpace(event.ArtifactDigest); digest != "" && !strings.HasPrefix(digest, digestAlgorithm+":") {
+		return fmt.Errorf("artifact_digest must use %s prefix", digestAlgorithm)
+	}
+	if digest := strings.TrimSpace(event.ParentArtifactDigest); digest != "" && !strings.HasPrefix(digest, digestAlgorithm+":") {
+		return fmt.Errorf("parent_artifact_digest must use %s prefix", digestAlgorithm)
+	}
+	return nil
+}
+
+func validateExpected(event Event, expected Expected) error {
+	checks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"event_time", event.EventTime, expected.EventTime},
+		{"source", event.Source, expected.Source},
+		{"trace_id", event.TraceID, expected.TraceID},
+		{"change_id", event.ChangeID, expected.ChangeID},
+		{"space", event.Space, expected.Space},
+		{"target_slug", event.TargetSlug, expected.TargetSlug},
+		{"target_path", event.TargetPath, expected.TargetPath},
+		{"render_target_slug", event.RenderTargetSlug, expected.RenderTargetSlug},
+		{"render_target_path", event.RenderTargetPath, expected.RenderTargetPath},
+		{"artifact_kind", event.ArtifactKind, expected.ArtifactKind},
+		{"artifact_digest", event.ArtifactDigest, expected.ArtifactDigest},
+	}
+	for _, check := range checks {
+		if strings.TrimSpace(check.got) != strings.TrimSpace(check.want) {
+			return fmt.Errorf("%s mismatch: expected %q, got %q", check.name, check.want, check.got)
+		}
+	}
+	optionalChecks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"parent_event_id", event.ParentEventID, expected.ParentEventID},
+		{"parent_artifact_kind", event.ParentArtifactKind, expected.ParentArtifactKind},
+		{"parent_artifact_digest", event.ParentArtifactDigest, expected.ParentArtifactDigest},
+	}
+	for _, check := range optionalChecks {
+		if strings.TrimSpace(check.want) == "" {
+			continue
+		}
+		if strings.TrimSpace(check.got) != strings.TrimSpace(check.want) {
+			return fmt.Errorf("%s mismatch: expected %q, got %q", check.name, check.want, check.got)
+		}
+	}
+	return nil
+}
+
+func copyCounts(in map[string]int) map[string]int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/proof/event_test.go
+++ b/internal/proof/event_test.go
@@ -1,0 +1,108 @@
+package proof
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewEventIsTraceableAndDeterministic(t *testing.T) {
+	at := time.Date(2026, 3, 6, 10, 0, 0, 0, time.UTC)
+	event := NewEvent(Input{
+		EventType:      EventTypeChangeBundlePublished,
+		EventTime:      at,
+		Source:         "cub-gen",
+		ChangeID:       "chg_123",
+		Space:          "platform",
+		TargetSlug:     "helm-paas",
+		TargetPath:     "/repo",
+		ArtifactKind:   ArtifactKindChangeBundle,
+		ArtifactDigest: "sha256:abc",
+		SummaryCounts: map[string]int{
+			"provenance_records": 1,
+		},
+		GeneratorProfiles: []string{"helm-paas"},
+	})
+
+	if event.SchemaVersion != SchemaVersion {
+		t.Fatalf("unexpected schema_version: %q", event.SchemaVersion)
+	}
+	if event.TraceID != "chg_123" {
+		t.Fatalf("expected trace_id from change_id, got %q", event.TraceID)
+	}
+	if !strings.HasPrefix(event.EventID, "evt_") {
+		t.Fatalf("expected evt_ event id, got %q", event.EventID)
+	}
+
+	again := NewEvent(Input{
+		EventType:      EventTypeChangeBundlePublished,
+		EventTime:      at,
+		Source:         "cub-gen",
+		ChangeID:       "chg_123",
+		Space:          "platform",
+		TargetSlug:     "helm-paas",
+		TargetPath:     "/repo",
+		ArtifactKind:   ArtifactKindChangeBundle,
+		ArtifactDigest: "sha256:def",
+		SummaryCounts: map[string]int{
+			"provenance_records": 1,
+		},
+		GeneratorProfiles: []string{"helm-paas"},
+	})
+	if event.EventID != again.EventID {
+		t.Fatalf("expected event id to ignore artifact digest, got %q and %q", event.EventID, again.EventID)
+	}
+}
+
+func TestTraceIDFallback(t *testing.T) {
+	got := TraceID("", "platform", "target", "render", "HEAD")
+	again := TraceID("", "platform", "target", "render", "HEAD")
+	if got == "" || !strings.HasPrefix(got, "trace_") {
+		t.Fatalf("expected fallback trace id, got %q", got)
+	}
+	if got != again {
+		t.Fatalf("expected deterministic fallback trace id, got %q and %q", got, again)
+	}
+}
+
+func TestValidateArtifactEvents(t *testing.T) {
+	at := time.Date(2026, 3, 6, 10, 0, 0, 0, time.UTC)
+	event := NewEvent(Input{
+		EventType:      EventTypeAttestationVerified,
+		EventTime:      at,
+		Source:         "cub-gen",
+		ChangeID:       "chg_123",
+		Space:          "platform",
+		ArtifactKind:   ArtifactKindAttestation,
+		ArtifactDigest: "sha256:abc",
+	})
+
+	err := ValidateArtifactEvents([]Event{event}, Expected{
+		EventType:      EventTypeAttestationVerified,
+		EventTime:      "2026-03-06T10:00:00Z",
+		Source:         "cub-gen",
+		TraceID:        "chg_123",
+		ChangeID:       "chg_123",
+		Space:          "platform",
+		ArtifactKind:   ArtifactKindAttestation,
+		ArtifactDigest: "sha256:abc",
+	})
+	if err != nil {
+		t.Fatalf("ValidateArtifactEvents returned error: %v", err)
+	}
+
+	tampered := event
+	tampered.TraceID = "different"
+	if err := ValidateArtifactEvents([]Event{tampered}, Expected{
+		EventType:      EventTypeAttestationVerified,
+		EventTime:      "2026-03-06T10:00:00Z",
+		Source:         "cub-gen",
+		TraceID:        "chg_123",
+		ChangeID:       "chg_123",
+		Space:          "platform",
+		ArtifactKind:   ArtifactKindAttestation,
+		ArtifactDigest: "sha256:abc",
+	}); err == nil || !strings.Contains(err.Error(), "event_id mismatch") {
+		t.Fatalf("expected event id mismatch, got %v", err)
+	}
+}

--- a/internal/proof/event_test.go
+++ b/internal/proof/event_test.go
@@ -65,6 +65,30 @@ func TestTraceIDFallback(t *testing.T) {
 	}
 }
 
+func TestNewEventSupportsDecisionMetadata(t *testing.T) {
+	event := NewEvent(Input{
+		EventType:      EventTypeDecisionApplied,
+		EventTime:      time.Date(2026, 3, 6, 10, 3, 0, 0, time.UTC),
+		Source:         "cub-gen",
+		TraceID:        "trace_custom",
+		ChangeID:       "chg_123",
+		ArtifactKind:   ArtifactKindDecision,
+		DecisionState:  "ALLOW",
+		DecisionReason: "policy checks passed",
+		RouteKind:      "apply-here",
+		Owner:          "app-team",
+	})
+	if event.TraceID != "trace_custom" {
+		t.Fatalf("expected explicit trace id, got %q", event.TraceID)
+	}
+	if event.DecisionState != "ALLOW" || event.RouteKind != "apply-here" || event.Owner != "app-team" {
+		t.Fatalf("decision metadata was not preserved: %+v", event)
+	}
+	if err := ValidateEvent(event); err != nil {
+		t.Fatalf("ValidateEvent returned error: %v", err)
+	}
+}
+
 func TestValidateArtifactEvents(t *testing.T) {
 	at := time.Date(2026, 3, 6, 10, 0, 0, 0, time.UTC)
 	event := NewEvent(Input{

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -10,6 +10,7 @@ import (
 
 	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
 	"github.com/confighub/cub-gen/internal/model"
+	"github.com/confighub/cub-gen/internal/proof"
 )
 
 const (
@@ -33,6 +34,22 @@ type Summary struct {
 	GeneratorProfiles   []string `json:"generator_profiles"`
 }
 
+// Counts returns log-friendly summary counts for proof events.
+func (s Summary) Counts() map[string]int {
+	return map[string]int{
+		"discovered_resources":    s.DiscoveredResources,
+		"dry_units":               s.DryUnits,
+		"wet_units":               s.WetUnits,
+		"generator_units":         s.GeneratorUnits,
+		"links":                   s.Links,
+		"contracts":               s.Contracts,
+		"provenance_records":      s.ProvenanceRecords,
+		"inverse_transform_plans": s.InversePlans,
+		"dry_inputs":              s.DryInputs,
+		"wet_manifest_targets":    s.WetManifestTargets,
+	}
+}
+
 // ChangeBundle is a local bridge artifact that can be uploaded to ConfigHub
 // later without changing cub-gen's local-first behavior.
 type ChangeBundle struct {
@@ -48,7 +65,9 @@ type ChangeBundle struct {
 	RenderTargetPath   string                          `json:"render_target_path,omitempty"`
 	Ref                string                          `json:"ref"`
 	ChangeID           string                          `json:"change_id,omitempty"`
+	TraceID            string                          `json:"trace_id"`
 	Summary            Summary                         `json:"summary"`
+	ProofEvents        []proof.Event                   `json:"proof_events"`
 	Discovered         []gitopsflow.DiscoveredResource `json:"discovered"`
 	DryUnits           []model.UnitRef                 `json:"dry_units"`
 	WetUnits           []model.UnitRef                 `json:"wet_units"`
@@ -111,7 +130,24 @@ func BuildBundleAt(imported gitopsflow.ImportFlowResult, at time.Time) ChangeBun
 		DryInputs:          imported.DryInputs,
 		WetManifestTargets: imported.WetManifestTargets,
 	}
+	bundle.TraceID = proof.TraceID(bundle.ChangeID, bundle.Space, bundle.TargetSlug, bundle.RenderTargetSlug, bundle.Ref)
+	bundle.ProofEvents = []proof.Event{proof.NewEvent(proof.Input{
+		EventType:         proof.EventTypeChangeBundlePublished,
+		EventTime:         at,
+		Source:            changeBundleSource,
+		ChangeID:          bundle.ChangeID,
+		Space:             bundle.Space,
+		TargetSlug:        bundle.TargetSlug,
+		TargetPath:        bundle.TargetPath,
+		RenderTargetSlug:  bundle.RenderTargetSlug,
+		RenderTargetPath:  bundle.RenderTargetPath,
+		Ref:               bundle.Ref,
+		ArtifactKind:      proof.ArtifactKindChangeBundle,
+		SummaryCounts:     bundle.Summary.Counts(),
+		GeneratorProfiles: bundle.Summary.GeneratorProfiles,
+	})}
 	bundle.BundleDigest = computeBundleDigest(bundle)
+	bundle.ProofEvents = proof.SetArtifactDigest(bundle.ProofEvents, proof.ArtifactKindChangeBundle, bundle.BundleDigest)
 	return bundle
 }
 
@@ -139,6 +175,7 @@ func computeBundleDigest(bundle ChangeBundle) string {
 	digestInput := bundle
 	digestInput.BundleDigest = ""
 	digestInput.DigestAlgorithm = ""
+	digestInput.ProofEvents = proof.BlankArtifactDigests(digestInput.ProofEvents)
 
 	b, err := json.Marshal(digestInput)
 	if err != nil {
@@ -165,6 +202,22 @@ func VerifyBundle(bundle ChangeBundle) error {
 	expected := computeBundleDigest(bundle)
 	if bundle.BundleDigest != expected {
 		return fmt.Errorf("bundle digest mismatch: expected %s, got %s", expected, bundle.BundleDigest)
+	}
+	if err := proof.ValidateArtifactEvents(bundle.ProofEvents, proof.Expected{
+		EventType:        proof.EventTypeChangeBundlePublished,
+		EventTime:        bundle.GeneratedAt,
+		Source:           bundle.Source,
+		TraceID:          bundle.TraceID,
+		ChangeID:         bundle.ChangeID,
+		Space:            bundle.Space,
+		TargetSlug:       bundle.TargetSlug,
+		TargetPath:       bundle.TargetPath,
+		RenderTargetSlug: bundle.RenderTargetSlug,
+		RenderTargetPath: bundle.RenderTargetPath,
+		ArtifactKind:     proof.ArtifactKindChangeBundle,
+		ArtifactDigest:   bundle.BundleDigest,
+	}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -203,6 +203,10 @@ func VerifyBundle(bundle ChangeBundle) error {
 	if bundle.BundleDigest != expected {
 		return fmt.Errorf("bundle digest mismatch: expected %s, got %s", expected, bundle.BundleDigest)
 	}
+	expectedTraceID := proof.TraceID(bundle.ChangeID, bundle.Space, bundle.TargetSlug, bundle.RenderTargetSlug, bundle.Ref)
+	if bundle.TraceID != expectedTraceID {
+		return fmt.Errorf("trace_id mismatch: expected %s, got %s", expectedTraceID, bundle.TraceID)
+	}
 	if err := proof.ValidateArtifactEvents(bundle.ProofEvents, proof.Expected{
 		EventType:        proof.EventTypeChangeBundlePublished,
 		EventTime:        bundle.GeneratedAt,

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -8,6 +8,7 @@ import (
 
 	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
 	"github.com/confighub/cub-gen/internal/model"
+	"github.com/confighub/cub-gen/internal/proof"
 )
 
 func TestBuildBundleAtFromHelmImport(t *testing.T) {
@@ -47,6 +48,31 @@ func TestBuildBundleAtFromHelmImport(t *testing.T) {
 	if bundle.ChangeID == "" {
 		t.Fatal("expected non-empty change_id")
 	}
+	if bundle.TraceID != bundle.ChangeID {
+		t.Fatalf("expected trace_id to match change_id, got %q", bundle.TraceID)
+	}
+	if len(bundle.ProofEvents) != 1 {
+		t.Fatalf("expected one proof event, got %d", len(bundle.ProofEvents))
+	}
+	event := bundle.ProofEvents[0]
+	if event.EventType != proof.EventTypeChangeBundlePublished {
+		t.Fatalf("unexpected proof event type: %q", event.EventType)
+	}
+	if event.TraceID != bundle.TraceID {
+		t.Fatalf("expected proof event trace_id %q, got %q", bundle.TraceID, event.TraceID)
+	}
+	if event.ChangeID != bundle.ChangeID {
+		t.Fatalf("expected proof event change_id %q, got %q", bundle.ChangeID, event.ChangeID)
+	}
+	if event.ArtifactKind != proof.ArtifactKindChangeBundle {
+		t.Fatalf("unexpected proof artifact kind: %q", event.ArtifactKind)
+	}
+	if event.ArtifactDigest != bundle.BundleDigest {
+		t.Fatalf("expected proof event artifact digest %q, got %q", bundle.BundleDigest, event.ArtifactDigest)
+	}
+	if event.SummaryCounts["provenance_records"] != len(imported.Provenance) {
+		t.Fatalf("unexpected proof summary counts: %+v", event.SummaryCounts)
+	}
 	if bundle.Summary.DiscoveredResources != len(imported.Discovered) {
 		t.Fatalf("summary discovered mismatch: %d vs %d", bundle.Summary.DiscoveredResources, len(imported.Discovered))
 	}
@@ -75,6 +101,9 @@ func TestBuildBundleAtChangeIDFallbackToInversePlans(t *testing.T) {
 	if bundle.ChangeID != "chg_fallback" {
 		t.Fatalf("expected fallback change id chg_fallback, got %q", bundle.ChangeID)
 	}
+	if bundle.TraceID != "chg_fallback" {
+		t.Fatalf("expected fallback trace id chg_fallback, got %q", bundle.TraceID)
+	}
 }
 
 func TestVerifyBundle(t *testing.T) {
@@ -99,6 +128,20 @@ func TestVerifyBundle(t *testing.T) {
 	missingDigest.BundleDigest = ""
 	if err := VerifyBundle(missingDigest); err == nil || !strings.Contains(err.Error(), "missing bundle_digest") {
 		t.Fatalf("expected missing bundle_digest error, got %v", err)
+	}
+
+	missingProof := bundle
+	missingProof.ProofEvents = nil
+	missingProof.BundleDigest = computeBundleDigest(missingProof)
+	if err := VerifyBundle(missingProof); err == nil || !strings.Contains(err.Error(), "missing proof_events") {
+		t.Fatalf("expected missing proof_events error, got %v", err)
+	}
+
+	tamperedProof := bundle
+	tamperedProof.ProofEvents = append([]proof.Event(nil), bundle.ProofEvents...)
+	tamperedProof.ProofEvents[0].ArtifactDigest = "sha256:wrong"
+	if err := VerifyBundle(tamperedProof); err == nil || !strings.Contains(err.Error(), "artifact_digest mismatch") {
+		t.Fatalf("expected proof artifact digest mismatch, got %v", err)
 	}
 
 	unsupported := bundle

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -144,6 +144,17 @@ func TestVerifyBundle(t *testing.T) {
 		t.Fatalf("expected proof artifact digest mismatch, got %v", err)
 	}
 
+	tamperedTrace := bundle
+	tamperedTrace.TraceID = "trace_custom"
+	tamperedTrace.ProofEvents = append([]proof.Event(nil), bundle.ProofEvents...)
+	tamperedTrace.ProofEvents[0].TraceID = tamperedTrace.TraceID
+	tamperedTrace.ProofEvents[0].EventID = proof.EventID(tamperedTrace.ProofEvents[0])
+	tamperedTrace.BundleDigest = computeBundleDigest(tamperedTrace)
+	tamperedTrace.ProofEvents = proof.SetArtifactDigest(tamperedTrace.ProofEvents, proof.ArtifactKindChangeBundle, tamperedTrace.BundleDigest)
+	if err := VerifyBundle(tamperedTrace); err == nil || !strings.Contains(err.Error(), "trace_id mismatch") {
+		t.Fatalf("expected trace_id mismatch, got %v", err)
+	}
+
 	unsupported := bundle
 	unsupported.DigestAlgorithm = "sha512"
 	if err := VerifyBundle(unsupported); err == nil || !strings.Contains(err.Error(), "unsupported digest_algorithm") {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - "App-of-Apps Boundary": contracts/app-of-apps-generator-boundary.md
       - "Remote Stores & Projection Targets": contracts/remote-stores-and-projection-targets.md
       - "Decision & Attestation State": contracts/decision-and-attestation-state.md
+      - "Proof Events & Traceability": contracts/proof-events-and-traceability.md
       - "PR/MR Linkage & Promotion": contracts/pr-mr-linkage-and-dry-promotion.md
       - "Checkpoint Schemas": agentic-gitops/04-schemas/00-gitops-checkpoint-schemas.md
       - "Command Parity": parity.md


### PR DESCRIPTION
## Summary
- add a log-safe proof_event/v1 contract with deterministic event_id and trace_id fields
- embed proof_events in change bundles, attestations, and governed decision records
- link decision lifecycle events across create, attestation attach, and terminal ALLOW/ESCALATE/BLOCK decisions
- expose proof_event_count in verify outputs and trace_id in change summaries/API responses
- add cub-gen proof events / cub gen bundle events to extract verified proof events as JSON or NDJSON for Pilot, validation, and audit logs

## Validation
- make ci
- .tmp/mkdocs-venv/bin/mkdocs build --strict
- git diff --check