### PR TITLE
Add mutation apply gate decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ binary can now be staged as the `cub gen` plugin. The plugin details are in
 | Where should the edit go? | Apply here, lift upstream, or block/escalate |
 | What changed? | A reviewable before/after bundle |
 | Which variants need proof? | One governed bundle per Deployment Variant: environment, tenant, or region |
-| How do I prove it? | Field-origin map, edit hint, proof bundle, and optional ConfigHub decision |
+| How do I prove it? | Field-origin map, edit hint, mutation gate, proof bundle, and optional ConfigHub decision |
 
 The output is useful locally, in GitHub PRs, and in connected ConfigHub flows.
 
@@ -187,7 +187,7 @@ being applied until those placeholders are replaced.
 
 A **Change** is any proposed edit to the source or rendered config. **Proof**
 is the field-origin, owner, route, and decision evidence that makes the change
-reviewable. Bundle, attestation, and governed decision artifacts also carry
+reviewable. Bundle, attestation, mutation gate, and governed decision artifacts also carry
 `proof_events[]`: small JSON records with `trace_id`, `change_id`, artifact
 digests, parent links, and decision state so Pilot, validation, and attestation
 logs can join the chain later. Use `cub-gen proof events --in bundle.json --ndjson`
@@ -396,6 +396,7 @@ controllers running in kind.
 - [Example Truth Matrix](docs/testing/example-truth-matrix.md) - generated status for examples
 - [v0.4 Working Roadmap](docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md) - sequenced plan to make cub-gen obvious
 - [Platform Generators Manifesto](docs/agentic-gitops/02-design/90-platform-generators-manifesto.md) - the plain-English thesis
+- [Mutation Apply Gates](docs/agentic-gitops/02-design/35-mutation-apply-gates.md) - route generated-config edits to apply here, lift upstream, overlay, or block/escalate
 - [Proof Events and Traceability](docs/contracts/proof-events-and-traceability.md) - loggable proof-event contract
 - [OpenChoreo Worked Example](docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md) - OpenChoreo mapped as a generator
 - [Argo Generators Worked Example](docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md) - ApplicationSet and app-of-apps

--- a/cmd/cub-gen/command_surface_parity_test.go
+++ b/cmd/cub-gen/command_surface_parity_test.go
@@ -44,6 +44,11 @@ func TestTopLevelCommandGoldenHelp(t *testing.T) {
 			stdoutGolden: filepath.Join("testdata", "parity", "proof-help.stdout.golden.txt"),
 		},
 		{
+			name:         "gate-help",
+			args:         []string{"gate", "--help"},
+			stdoutGolden: filepath.Join("testdata", "parity", "gate-help.stdout.golden.txt"),
+		},
+		{
 			name:         "generators-help",
 			args:         []string{"generators", "--help"},
 			stderrGolden: filepath.Join("testdata", "parity", "generators-help.stderr.golden.txt"),
@@ -131,6 +136,16 @@ func TestTopLevelCommandErrorModes(t *testing.T) {
 			name: "proof-events-extra-arg",
 			args: []string{"proof", "events", "extra"},
 			sub:  "usage: cub-gen proof events",
+		},
+		{
+			name: "gate-missing-subcommand",
+			args: []string{"gate"},
+			sub:  "gate subcommand required",
+		},
+		{
+			name: "gate-mutation-missing-source",
+			args: []string{"gate", "mutation", "Deployment/spec/replicas"},
+			sub:  "gate mutation requires exactly one of --policy, --routes, or --bundle",
 		},
 		{
 			name: "generators-extra-arg",

--- a/cmd/cub-gen/gate.go
+++ b/cmd/cub-gen/gate.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-gen/internal/mutationgate"
+)
+
+func runGate(args []string) error {
+	if len(args) == 0 {
+		printGateUsage(os.Stderr)
+		return errors.New("gate subcommand required")
+	}
+	switch args[0] {
+	case "help", "-h", "--help":
+		printGateUsage(os.Stdout)
+		return nil
+	case "mutation":
+		return runGateMutation(args[1:])
+	default:
+		printGateUsage(os.Stderr)
+		return fmt.Errorf("unknown gate subcommand: %s", args[0])
+	}
+}
+
+func runGateMutation(args []string) error {
+	fs := flag.NewFlagSet("gate mutation", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), pluginHelpLine("Usage: cub-gen gate mutation [flags] <rendered-field>"))
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "Evaluate a proposed mutation with Generator route proof.")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "Exactly one proof source is required:")
+		fmt.Fprintln(fs.Output(), "  --policy FILE   generator-route-policy JSON, annotation proposal, or Unit YAML")
+		fmt.Fprintln(fs.Output(), "  --routes FILE   Spring field-routes.yaml")
+		fmt.Fprintln(fs.Output(), "  --bundle FILE   cub-gen change bundle with inverse edit pointers")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "Flags:")
+		fs.PrintDefaults()
+	}
+
+	policyPath := fs.String("policy", "", "Route policy JSON/YAML path")
+	routesPath := fs.String("routes", "", "Spring field-routes.yaml path")
+	bundlePath := fs.String("bundle", "", "cub-gen change bundle path")
+	field := fs.String("field", "", "Rendered field path to mutate")
+	resourceType := fs.String("resource-type", "", "Rendered resource type, such as Deployment or ConfigMap")
+	resourceName := fs.String("resource-name", "", "Rendered resource name")
+	space := fs.String("space", "", "ConfigHub space")
+	component := fs.String("component", "", "Component id/name")
+	variant := fs.String("variant", "", "Variant id/name")
+	target := fs.String("target", "", "Target id/name")
+	changeID := fs.String("change-id", "", "Change id")
+	origin := fs.String("origin", "confighub-initiative", "Mutation origin")
+	attemptedLayer := fs.String("attempted-layer", "rendered-config", "Attempted mutation layer")
+	newValue := fs.String("new-value", "", "Optional proposed value")
+	githubPRRepo := fs.String("github-pr-repo", "", "Optional GitHub repo for lift-upstream next action")
+	githubPR := fs.String("github-pr", "", "Optional GitHub PR URL/id to link")
+	confighubMR := fs.String("confighub-mr", "", "Optional ConfigHub MR URL/id to link")
+	sourceFiles := fs.String("source-files", "", "Comma-separated source files for lift-upstream next action")
+	atValue := fs.String("at", "", "RFC3339 evaluation time")
+	jsonOut := fs.Bool("json", false, "Output JSON")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	enforce := fs.Bool("enforce", false, "Return non-zero when decision.state is not ALLOW")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() > 1 {
+		return errors.New("usage: cub-gen gate mutation [flags] <rendered-field>")
+	}
+	renderedField := strings.TrimSpace(*field)
+	if renderedField == "" && fs.NArg() == 1 {
+		renderedField = fs.Arg(0)
+	}
+	if renderedField == "" {
+		return errors.New("gate mutation requires --field or <rendered-field>")
+	}
+
+	policy, policySource, bundleChangeID, err := loadGatePolicy(*policyPath, *routesPath, *bundlePath)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*changeID) == "" {
+		*changeID = bundleChangeID
+	}
+	if strings.TrimSpace(*changeID) == "" {
+		*changeID = mutationgate.StableChangeID(strings.Join([]string{policySource, renderedField, *resourceType, *resourceName}, "|"))
+	}
+	at, err := parseGateTime(*atValue)
+	if err != nil {
+		return err
+	}
+
+	var link *mutationgate.Link
+	if strings.TrimSpace(*githubPR) != "" || strings.TrimSpace(*confighubMR) != "" {
+		link = &mutationgate.Link{
+			Mode:        "paired",
+			GitHubPR:    strings.TrimSpace(*githubPR),
+			ConfigHubMR: strings.TrimSpace(*confighubMR),
+		}
+	}
+	decision, err := mutationgate.Evaluate(policy, mutationgate.Request{
+		ChangeID: strings.TrimSpace(*changeID),
+		Subject: mutationgate.Subject{
+			Space:        strings.TrimSpace(*space),
+			Component:    strings.TrimSpace(*component),
+			Variant:      strings.TrimSpace(*variant),
+			Target:       strings.TrimSpace(*target),
+			ResourceType: strings.TrimSpace(*resourceType),
+			ResourceName: strings.TrimSpace(*resourceName),
+		},
+		Mutation: mutationgate.Mutation{
+			Origin:         strings.TrimSpace(*origin),
+			RenderedField:  renderedField,
+			AttemptedLayer: strings.TrimSpace(*attemptedLayer),
+			NewValue:       strings.TrimSpace(*newValue),
+		},
+		Link:         link,
+		GitHubPRRepo: strings.TrimSpace(*githubPRRepo),
+		SourceFiles:  splitCSV(*sourceFiles),
+		EvaluatedAt:  at,
+		PolicySource: policySource,
+	})
+	if err != nil {
+		return err
+	}
+
+	if *jsonOut {
+		if err := writeJSON(os.Stdout, decision, *pretty); err != nil {
+			return err
+		}
+	} else {
+		printGateDecision(os.Stdout, decision)
+	}
+	if *enforce && decision.Decision.State != mutationgate.DecisionAllow {
+		return fmt.Errorf("mutation apply gate decision %s: %s", decision.Decision.State, decision.Decision.Reason)
+	}
+	return nil
+}
+
+func loadGatePolicy(policyPath, routesPath, bundlePath string) (mutationgate.Policy, string, string, error) {
+	count := 0
+	for _, value := range []string{policyPath, routesPath, bundlePath} {
+		if strings.TrimSpace(value) != "" {
+			count++
+		}
+	}
+	if count != 1 {
+		return mutationgate.Policy{}, "", "", errors.New("gate mutation requires exactly one of --policy, --routes, or --bundle")
+	}
+	if strings.TrimSpace(policyPath) != "" {
+		policy, source, err := mutationgate.LoadPolicyFile(policyPath)
+		return policy, source, "", err
+	}
+	if strings.TrimSpace(routesPath) != "" {
+		policy, source, err := mutationgate.LoadSpringRoutesFile(routesPath)
+		return policy, source, "", err
+	}
+	policy, source, changeID, err := mutationgate.LoadBundleFile(bundlePath)
+	return policy, source, changeID, err
+}
+
+func parseGateTime(value string) (time.Time, error) {
+	if strings.TrimSpace(value) == "" {
+		return time.Time{}, nil
+	}
+	at, err := time.Parse(time.RFC3339, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse --at: %w", err)
+	}
+	return at, nil
+}
+
+func splitCSV(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			out = append(out, strings.TrimSpace(part))
+		}
+	}
+	return out
+}
+
+func printGateDecision(out io.Writer, decision mutationgate.Decision) {
+	fmt.Fprintf(out, "Decision: %s\n", decision.Decision.State)
+	fmt.Fprintf(out, "Route:    %s\n", decision.Route.Kind)
+	fmt.Fprintf(out, "Field:    %s\n", decision.Mutation.RenderedField)
+	if decision.Proof.Owner != "" {
+		fmt.Fprintf(out, "Owner:    %s\n", decision.Proof.Owner)
+	}
+	fmt.Fprintf(out, "Reason:   %s\n", decision.Decision.Reason)
+	for _, action := range decision.NextActions {
+		fmt.Fprintf(out, "Next:     %s", action.Kind)
+		if action.Description != "" {
+			fmt.Fprintf(out, " - %s", action.Description)
+		}
+		fmt.Fprintln(out)
+	}
+}
+
+func printGateUsage(out io.Writer) {
+	printCommandHelp(
+		out,
+		"cub-gen gate: decide whether a proposed mutation may apply",
+		[]string{
+			"Mutation apply gates answer: if this deployed field is wrong, where do I fix it?",
+		},
+		helpSection{
+			Title: "COMMANDS",
+			Lines: []string{
+				"  mutation    Return route.kind, decision.state, next actions, and proof_events",
+			},
+		},
+		helpSection{
+			Title: "EXAMPLES",
+			Lines: []string{
+				"  cub-gen gate mutation --routes ./examples/springboot-paas/operational/field-routes.yaml feature.inventory.reservationMode",
+				"  cub-gen gate mutation --bundle bundle.json Deployment/spec/template/spec/containers[0]/image",
+			},
+		},
+	)
+}

--- a/cmd/cub-gen/gate_command_test.go
+++ b/cmd/cub-gen/gate_command_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-gen/internal/mutationgate"
+)
+
+func TestGateMutationSpringRoutesJSON(t *testing.T) {
+	setupAliases(t)
+	routesPath := filepath.Join("..", "..", "examples", "springboot-paas", "operational", "field-routes.yaml")
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"gate", "mutation",
+		"--routes", routesPath,
+		"--json",
+		"--at", "2026-05-02T12:00:00Z",
+		"feature.inventory.reservationMode",
+	})
+	if err != nil {
+		t.Fatalf("gate mutation returned error: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var allow mutationgate.Decision
+	if err := json.Unmarshal([]byte(out), &allow); err != nil {
+		t.Fatalf("unmarshal allow decision: %v\noutput=%s", err, out)
+	}
+	if allow.Route.Kind != mutationgate.RouteApplyHere || allow.Decision.State != mutationgate.DecisionAllow {
+		t.Fatalf("expected apply-here/ALLOW, got route=%s state=%s", allow.Route.Kind, allow.Decision.State)
+	}
+	if len(allow.ProofEvents) != 1 || allow.ProofEvents[0].EventType != "mutation_apply_gate.evaluated" {
+		t.Fatalf("unexpected proof events: %+v", allow.ProofEvents)
+	}
+
+	out, stderr, err = runWithCapturedIO([]string{
+		"gate", "mutation",
+		"--routes", routesPath,
+		"--json",
+		"--at", "2026-05-02T12:00:00Z",
+		"spring.datasource.url",
+	})
+	if err != nil {
+		t.Fatalf("gate mutation block returned error without --enforce: %v\nstderr=%s", err, stderr)
+	}
+	var block mutationgate.Decision
+	if err := json.Unmarshal([]byte(out), &block); err != nil {
+		t.Fatalf("unmarshal block decision: %v\noutput=%s", err, out)
+	}
+	if block.Route.Kind != mutationgate.RouteBlockEscalate || block.Decision.State != mutationgate.DecisionBlock {
+		t.Fatalf("expected block/escalate/BLOCK, got route=%s state=%s", block.Route.Kind, block.Decision.State)
+	}
+}
+
+func TestGateMutationSpringLiftGolden(t *testing.T) {
+	routesPath := filepath.Join("..", "..", "examples", "springboot-paas", "operational", "field-routes.yaml")
+	out, stderr, err := runWithCapturedIO([]string{
+		"gate", "mutation",
+		"--routes", routesPath,
+		"--json",
+		"--at", "2026-05-02T12:00:00Z",
+		"spring.cache.type",
+	})
+	if err != nil {
+		t.Fatalf("gate mutation returned error: %v\nstderr=%s", err, stderr)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal gate decision: %v\noutput=%s", err, out)
+	}
+	assertGoldenJSON(t, filepath.Join("testdata", "parity", "gate-mutation-spring-lift.golden.json"), got)
+}
+
+func TestGateMutationEnforceRejectsNonAllow(t *testing.T) {
+	routesPath := filepath.Join("..", "..", "examples", "springboot-paas", "operational", "field-routes.yaml")
+	out, stderr, err := runWithCapturedIO([]string{
+		"gate", "mutation",
+		"--routes", routesPath,
+		"--json",
+		"--enforce",
+		"spring.cache.type",
+	})
+	if err == nil {
+		t.Fatal("expected enforce mode to reject ESCALATE decision")
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("expected decision JSON before enforce error")
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(err.Error(), "ESCALATE") {
+		t.Fatalf("expected ESCALATE error, got %v", err)
+	}
+}
+
+func TestGateMutationBundleOpenChoreoJSON(t *testing.T) {
+	setupAliases(t)
+	ocPath := filepath.Join("..", "..", "testdata", "openchoreo-hardgate")
+	publishOut, publishErr, err := runWithCapturedIO([]string{"publish", "--space", "platform", ocPath})
+	if err != nil {
+		t.Fatalf("publish openchoreo returned error: %v\nstderr=%s", err, publishErr)
+	}
+	bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(bundlePath, []byte(publishOut), 0o644); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	out, stderr, err := runWithCapturedIO([]string{
+		"gate", "mutation",
+		"--bundle", bundlePath,
+		"--json",
+		"--github-pr-repo", "github.com/example/payments-api",
+		"Deployment/spec/template/spec/containers[name=main]/image",
+	})
+	if err != nil {
+		t.Fatalf("gate mutation openchoreo returned error: %v\nstderr=%s", err, stderr)
+	}
+	var got mutationgate.Decision
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal openchoreo decision: %v\noutput=%s", err, out)
+	}
+	if got.Route.Kind != mutationgate.RouteLiftUpstream || got.Decision.State != mutationgate.DecisionEscalate {
+		t.Fatalf("expected lift-upstream/ESCALATE, got route=%s state=%s", got.Route.Kind, got.Decision.State)
+	}
+	if got.Proof.Generator != "openchoreo" {
+		t.Fatalf("expected openchoreo proof, got %+v", got.Proof)
+	}
+	if len(got.NextActions) != 1 || got.NextActions[0].Repo != "github.com/example/payments-api" {
+		t.Fatalf("unexpected next actions: %+v", got.NextActions)
+	}
+}
+
+func TestGateMutationMissingRouteReviewRequired(t *testing.T) {
+	policyPath := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(policyPath, []byte(`{
+  "schema_version": "cub.confighub.io/generator-route-policy/v1",
+  "routes": [
+    {
+      "wet_path": "Deployment/spec/replicas",
+      "route": "apply-here",
+      "owner": "app-team"
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	out, stderr, err := runWithCapturedIO([]string{
+		"gate", "mutation",
+		"--policy", policyPath,
+		"--json",
+		"Deployment/spec/template/spec/securityContext/runAsUser",
+	})
+	if err != nil {
+		t.Fatalf("gate mutation missing route returned error: %v\nstderr=%s", err, stderr)
+	}
+	var got mutationgate.Decision
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal review-required decision: %v\noutput=%s", err, out)
+	}
+	if got.Route.Kind != mutationgate.RouteReview || got.Decision.State != mutationgate.DecisionEscalate {
+		t.Fatalf("expected review-required/ESCALATE, got route=%s state=%s", got.Route.Kind, got.Decision.State)
+	}
+}

--- a/cmd/cub-gen/main.go
+++ b/cmd/cub-gen/main.go
@@ -51,6 +51,8 @@ func run(args []string) error {
 		return runVerifyAttestation(args[1:])
 	case "proof":
 		return runProof(args[1:])
+	case "gate":
+		return runGate(args[1:])
 	case "change":
 		return runChange(args[1:])
 	case "enrich":
@@ -1052,6 +1054,7 @@ func printUsage(out io.Writer) {
 				"  change explain    Find the DRY file/path to edit for a rendered field",
 				"  change impact     See which rendered fields a DRY path can affect",
 				"  change preview    Preview a safe repo change",
+				"  gate mutation     Decide apply-here, lift-upstream, or block/escalate",
 				"  enrich preview    Propose sidecar proof metadata for PR review",
 				"  normalize preview  Propose governed rewrite patches for review",
 				"  platform import   Read a multi-repo platform estate as a graph",
@@ -1067,7 +1070,7 @@ func printUsage(out io.Writer) {
 				"  publish           Build a provenance bundle from a repo or import output",
 				"  verify            Verify a provenance bundle",
 				"  attest            Sign a provenance bundle",
-				"  proof events      Extract loggable proof events from a bundle or attestation",
+				"  proof events      Extract loggable proof events from evidence artifacts",
 			},
 		},
 		helpSection{
@@ -1085,6 +1088,7 @@ func printUsage(out io.Writer) {
 				"  cub-gen platform fanout --variant dev --json ./testdata/variant-fanout/platform.yaml",
 				"  cub-gen platform adapt --json ./testdata/deployment-adaptation/platform.yaml",
 				"  cub-gen change explain --space my-space --owner app-team ./examples/scoredev-paas",
+				"  cub-gen gate mutation --routes ./examples/springboot-paas/operational/field-routes.yaml feature.inventory.reservationMode",
 				"  cub-gen enrich preview --space my-space ./examples/helm-paas",
 				"  cub-gen normalize preview --space my-space ./examples/springboot-paas",
 				"  cub-gen publish --space my-space ./examples/helm-paas | cub-gen verify --in -",

--- a/cmd/cub-gen/proof.go
+++ b/cmd/cub-gen/proof.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/confighub/cub-gen/internal/attest"
 	bridgeflow "github.com/confighub/cub-gen/internal/bridge"
+	"github.com/confighub/cub-gen/internal/mutationgate"
 	"github.com/confighub/cub-gen/internal/proof"
 	"github.com/confighub/cub-gen/internal/publish"
 )
@@ -20,6 +21,7 @@ const (
 	changeBundleSchema      = "cub.confighub.io/change-bundle/v1"
 	attestationRecordSchema = "cub.confighub.io/attestation/v1"
 	decisionRecordSchema    = "cub.confighub.io/governed-decision-state/v1"
+	mutationGateSchema      = mutationgate.SchemaVersion
 )
 
 type proofLog struct {
@@ -51,7 +53,7 @@ func runProof(args []string) error {
 func runProofEvents(args []string) error {
 	fs := flag.NewFlagSet("proof events", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
-	in := fs.String("in", "-", "Bundle or attestation JSON input path, or '-' for stdin")
+	in := fs.String("in", "-", "Evidence artifact JSON input path, or '-' for stdin")
 	bundlePath := fs.String("bundle", "", "Optional bundle JSON path when input is an attestation")
 	ndjson := fs.Bool("ndjson", false, "Emit one compact proof event per line")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
@@ -151,6 +153,22 @@ func buildProofLog(inputBytes []byte, bundlePath string) (proofLog, error) {
 			EventCount:         len(rec.ProofEvents),
 			Events:             rec.ProofEvents,
 		}, nil
+	case mutationGateSchema:
+		var decision mutationgate.Decision
+		if err := json.Unmarshal(inputBytes, &decision); err != nil {
+			return proofLog{}, fmt.Errorf("parse mutation apply gate decision json: %w", err)
+		}
+		if err := mutationgate.ValidateDecisionRecord(decision); err != nil {
+			return proofLog{}, err
+		}
+		return proofLog{
+			SchemaVersion:        proofLogSchema,
+			TraceID:              decision.TraceID,
+			SourceArtifactKind:   proof.ArtifactKindMutationGate,
+			SourceArtifactDigest: decision.DecisionDigest,
+			EventCount:           len(decision.ProofEvents),
+			Events:               decision.ProofEvents,
+		}, nil
 	default:
 		return proofLog{}, fmt.Errorf("unsupported proof input schema_version %q", header.SchemaVersion)
 	}
@@ -191,7 +209,7 @@ func printProofUsage(out io.Writer) {
 		helpSection{
 			Title: "COMMANDS",
 			Lines: []string{
-				"  events    Verify a bundle or attestation and emit its proof_events",
+				"  events    Verify an evidence artifact and emit its proof_events",
 			},
 		},
 		helpSection{
@@ -200,6 +218,7 @@ func printProofUsage(out io.Writer) {
 				"  cub-gen proof events --in bundle.json",
 				"  cub-gen proof events --in attestation.json --bundle bundle.json --ndjson",
 				"  cub-gen proof events --in decision.json --ndjson",
+				"  cub-gen proof events --in mutation-gate-decision.json --ndjson",
 			},
 		},
 	)

--- a/cmd/cub-gen/proof_command_test.go
+++ b/cmd/cub-gen/proof_command_test.go
@@ -206,3 +206,52 @@ func TestProofEventsFromDecisionRecord(t *testing.T) {
 		t.Fatalf("unexpected applied event: %+v", applied)
 	}
 }
+
+func TestProofEventsFromMutationGateDecision(t *testing.T) {
+	setupAliases(t)
+
+	routesPath := filepath.Join("..", "..", "examples", "springboot-paas", "operational", "field-routes.yaml")
+	decisionJSON, decisionErr, err := runWithCapturedIO([]string{
+		"gate", "mutation",
+		"--routes", routesPath,
+		"--json",
+		"--at", "2026-05-02T12:00:00Z",
+		"feature.inventory.reservationMode",
+	})
+	if err != nil {
+		t.Fatalf("gate mutation returned error: %v\nstderr=%s", err, decisionErr)
+	}
+
+	out, stderr, err := runWithCapturedIOAndStdin([]string{"proof", "events", "--in", "-"}, decisionJSON)
+	if err != nil {
+		t.Fatalf("proof events returned error: %v\nstderr=%s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal proof log: %v\noutput=%s", err, out)
+	}
+	if got["source_artifact_kind"] != "mutation_apply_gate" {
+		t.Fatalf("unexpected source artifact kind: %v", got["source_artifact_kind"])
+	}
+	if got["source_artifact_digest"] == "" {
+		t.Fatalf("expected source_artifact_digest in proof log")
+	}
+	events, ok := got["events"].([]any)
+	if !ok || len(events) != 1 {
+		t.Fatalf("expected one event object, got %v", got["events"])
+	}
+	event, ok := events[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected event object, got %T", events[0])
+	}
+	if event["event_type"] != "mutation_apply_gate.evaluated" || event["decision_state"] != "ALLOW" || event["route_kind"] != "apply-here" {
+		t.Fatalf("unexpected gate event: %+v", event)
+	}
+	if event["artifact_digest"] != got["source_artifact_digest"] {
+		t.Fatalf("expected event digest to match source digest")
+	}
+}

--- a/cmd/cub-gen/testdata/parity/gate-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/gate-help.stdout.golden.txt
@@ -1,0 +1,10 @@
+cub-gen gate: decide whether a proposed mutation may apply
+
+Mutation apply gates answer: if this deployed field is wrong, where do I fix it?
+
+COMMANDS:
+  mutation    Return route.kind, decision.state, next actions, and proof_events
+
+EXAMPLES:
+  cub-gen gate mutation --routes ./examples/springboot-paas/operational/field-routes.yaml feature.inventory.reservationMode
+  cub-gen gate mutation --bundle bundle.json Deployment/spec/template/spec/containers[0]/image

--- a/cmd/cub-gen/testdata/parity/gate-mutation-spring-lift.golden.json
+++ b/cmd/cub-gen/testdata/parity/gate-mutation-spring-lift.golden.json
@@ -1,0 +1,69 @@
+{
+  "change_id": "chg_49442e92b2c2f14a",
+  "decision": {
+    "reason": "route lift-upstream blocks direct rendered mutation and asks for a source change",
+    "state": "ESCALATE"
+  },
+  "decision_digest": "sha256:2e54749977f092a3fecffccf78adb8bc819a222d3bc52e5ab7225fcc4b217bdb",
+  "gate": {
+    "name": "generator-route",
+    "version": "v1"
+  },
+  "kind": "MutationApplyGateDecision",
+  "mutation": {
+    "attempted_layer": "rendered-config",
+    "origin": "confighub-initiative",
+    "rendered_field": "spring.cache.type"
+  },
+  "next_actions": [
+    {
+      "description": "Cache adoption changes the app contract and should update upstream app inputs.",
+      "files": [
+        "../../examples/springboot-paas/operational/field-routes.yaml"
+      ],
+      "kind": "create-or-link-github-pr",
+      "owner": "app-team"
+    }
+  ],
+  "proof": {
+    "confidence": 0.94,
+    "generator": "springboot",
+    "matched_rule": "spring.cache.*",
+    "original_route": "lift-upstream",
+    "owner": "app-team",
+    "source": "../../examples/springboot-paas/operational/field-routes.yaml",
+    "source_field": "spring.cache.*",
+    "source_file": "../../examples/springboot-paas/operational/field-routes.yaml"
+  },
+  "proof_events": [
+    {
+      "artifact_digest": "sha256:2e54749977f092a3fecffccf78adb8bc819a222d3bc52e5ab7225fcc4b217bdb",
+      "artifact_kind": "mutation_apply_gate",
+      "change_id": "chg_49442e92b2c2f14a",
+      "decision_reason": "route lift-upstream blocks direct rendered mutation and asks for a source change",
+      "decision_state": "ESCALATE",
+      "event_id": "evt_481fdbb1adb70985319b0269",
+      "event_time": "2026-05-02T12:00:00Z",
+      "event_type": "mutation_apply_gate.evaluated",
+      "generator_profiles": [
+        "springboot"
+      ],
+      "owner": "app-team",
+      "route_kind": "lift-upstream",
+      "schema_version": "cub.confighub.io/proof-event/v1",
+      "source": "cub-gen",
+      "summary_counts": {
+        "mutation_apply_gate_decisions": 1
+      },
+      "trace_id": "chg_49442e92b2c2f14a"
+    }
+  ],
+  "route": {
+    "direct_rendered_mutation": "blocked",
+    "kind": "lift-upstream",
+    "reason": "Cache adoption changes the app contract and should update upstream app inputs."
+  },
+  "schema_version": "cub.confighub.io/mutation-apply-gate-decision/v1",
+  "subject": {},
+  "trace_id": "chg_49442e92b2c2f14a"
+}

--- a/cmd/cub-gen/testdata/parity/proof-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/proof-help.stdout.golden.txt
@@ -3,9 +3,10 @@ cub-gen proof: extract loggable proof records
 Proof events are JSON records that can be copied into Pilot, CI, validation, or audit logs.
 
 COMMANDS:
-  events    Verify a bundle or attestation and emit its proof_events
+  events    Verify an evidence artifact and emit its proof_events
 
 EXAMPLES:
   cub-gen proof events --in bundle.json
   cub-gen proof events --in attestation.json --bundle bundle.json --ndjson
   cub-gen proof events --in decision.json --ndjson
+  cub-gen proof events --in mutation-gate-decision.json --ndjson

--- a/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
+++ b/cmd/cub-gen/testdata/parity/top-help.stdout.golden.txt
@@ -10,6 +10,7 @@ START HERE:
   change explain    Find the DRY file/path to edit for a rendered field
   change impact     See which rendered fields a DRY path can affect
   change preview    Preview a safe repo change
+  gate mutation     Decide apply-here, lift-upstream, or block/escalate
   enrich preview    Propose sidecar proof metadata for PR review
   normalize preview  Propose governed rewrite patches for review
   platform import   Read a multi-repo platform estate as a graph
@@ -22,7 +23,7 @@ BUILD EVIDENCE:
   publish           Build a provenance bundle from a repo or import output
   verify            Verify a provenance bundle
   attest            Sign a provenance bundle
-  proof events      Extract loggable proof events from a bundle or attestation
+  proof events      Extract loggable proof events from evidence artifacts
 
 ADVANCED CONNECTED:
   change run        Ask ConfigHub for a decision (does not deploy)
@@ -34,6 +35,7 @@ FIRST RUNS:
   cub-gen platform fanout --variant dev --json ./testdata/variant-fanout/platform.yaml
   cub-gen platform adapt --json ./testdata/deployment-adaptation/platform.yaml
   cub-gen change explain --space my-space --owner app-team ./examples/scoredev-paas
+  cub-gen gate mutation --routes ./examples/springboot-paas/operational/field-routes.yaml feature.inventory.reservationMode
   cub-gen enrich preview --space my-space ./examples/helm-paas
   cub-gen normalize preview --space my-space ./examples/springboot-paas
   cub-gen publish --space my-space ./examples/helm-paas | cub-gen verify --in -

--- a/docs/agentic-gitops/02-design/35-mutation-apply-gates.md
+++ b/docs/agentic-gitops/02-design/35-mutation-apply-gates.md
@@ -521,6 +521,14 @@ Mutation apply gates for Generator route decisions.
 7. Treat missing proof as `ESCALATE`, not allow.
 8. Emit optional MR-PR link intent, but do not require automatic PR creation.
 
+Current cub-gen implementation: `gate mutation` emits this decision object from
+Spring `field-routes.yaml`, route-policy files, or published cub-gen bundles.
+It includes `decision_digest` plus `proof_events[]`, so Pilot, validation, and
+attestation tooling can log or extract the gate proof with `proof events`.
+ConfigHub Initiatives/apply gates can display the same object as the v0.4 UI
+surface; non-bypassable core write-path enforcement is a later hardening step
+if needed.
+
 ### Proof Matrix
 
 | Proof | Required for #283 MVP |
@@ -532,7 +540,7 @@ Mutation apply gates for Generator route decisions.
 | example | OpenChoreo rendered Deployment edit routes to CR/source/owner |
 | degradation | missing proof escalates to review-required |
 | docs | this spec plus Spring caveat update |
-| connected | one ConfigHub/Initiative gate smoke if Functions/apply gates support it |
+| connected | connected smoke records one mutation apply gate decision; ConfigHub Initiative/apply-gate display is the intended UI surface |
 
 ### Later Scope
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -20,6 +20,7 @@ plugin install shape and compatibility contract.
 | Which DRY file/path should I edit for a rendered field? | `change explain` |
 | Which rendered fields would this DRY path affect? | `change impact` |
 | What evidence bundle and safe next step should I prepare? | `change preview` |
+| Can this rendered-field change apply here, or should it move upstream? | `gate mutation` |
 | How do I add provenance to a PR without editing manifests? | `enrich preview`, then optionally `enrich write` |
 | How do I turn implicit platform rules into reviewable config proposals? | `normalize preview` |
 | How do I see a multi-repo platform estate? | `platform import` |
@@ -459,6 +460,68 @@ cub-gen bridge promote merge --flow <flow.json> --by <who>
 
 ---
 
+## Mutation Gates
+
+### `gate mutation`
+
+Decide whether a proposed rendered-field mutation may apply in the current
+layer, should become an overlay, should be lifted upstream to source config, or
+must be blocked/escalated.
+
+```bash
+cub-gen gate mutation [--policy <route-policy.json>] [--routes <field-routes.yaml>] [--bundle <bundle.json>] <rendered-field>
+```
+
+Exactly one proof source is required:
+
+| Proof source | Use when |
+|---|---|
+| `--policy` | You already have a `generator-route-policy/v1` JSON/YAML file or ConfigHub Unit annotation |
+| `--routes` | You are using the Spring example's `field-routes.yaml` |
+| `--bundle` | You have a `cub-gen publish` change bundle with inverse edit pointers |
+
+The output separates route from gate decision:
+
+| Output | Meaning |
+|---|---|
+| `route.kind` | `apply-here`, `overlay`, `lift-upstream`, `block/escalate`, or `review-required` |
+| `decision.state` | `ALLOW`, `ESCALATE`, or `BLOCK` |
+| `next_actions[]` | The plain next step: apply mutation, create/link source PR, review overlay, request owner review, or enrich proof |
+| `decision_digest` | Stable digest for the gate decision artifact |
+| `proof_events[]` | Loggable proof record for Pilot, validation, and later attestation |
+
+Examples:
+
+```bash
+./cub-gen gate mutation \
+  --routes ./examples/springboot-paas/operational/field-routes.yaml \
+  --json \
+  feature.inventory.reservationMode
+
+./cub-gen publish --space platform ./testdata/openchoreo-hardgate > bundle.json
+./cub-gen gate mutation \
+  --bundle bundle.json \
+  --json \
+  'Deployment/spec/template/spec/containers[name=main]/image'
+```
+
+Use `--enforce` when a script should return non-zero for any decision other
+than `ALLOW`. The command still writes the decision JSON first, so CI can keep
+the proof artifact.
+
+`gate mutation` is the cub-gen side of the #283 mutation apply gate design. In
+ConfigHub, the same decision object can be shown on an Initiative/MR apply gate:
+route, decision, owner, next action, optional PR/MR link, and proof event. It
+does not require cub-gen to modify ConfigHub core write paths.
+
+Proof extraction works on gate decisions too:
+
+```bash
+./cub-gen proof events --in mutation-gate-decision.json --ndjson
+```
+
+---
+
 ## Generator helper commands
 
 These helper groups are narrower than the main repo-first flow. Use them when a
@@ -490,6 +553,15 @@ Output:
 ### `springboot validate-mutation`
 
 Check whether a Spring field path stays inside the app-owned route map.
+
+For new flows, prefer the general mutation gate:
+
+```bash
+cub-gen gate mutation --routes <field-routes.yaml> <field-path>
+```
+
+`springboot validate-mutation` remains for older Spring example scripts and
+returns the legacy `ALLOWED` / `BLOCKED` shape.
 
 ```bash
 cub-gen springboot validate-mutation --routes <field-routes.yaml> <field-path>
@@ -523,7 +595,8 @@ Typical example path:
 ```
 
 Use `--routes` when you want the command to enforce the same app-owned versus
-platform-owned boundary as `validate-mutation` before writing the file.
+platform-owned boundary before writing the file. For route/decision/proof JSON,
+use `gate mutation`.
 
 ### `springboot init`
 

--- a/docs/contracts/proof-events-and-traceability.md
+++ b/docs/contracts/proof-events-and-traceability.md
@@ -55,6 +55,7 @@ Schema: [`proof-event.v1.schema.json`](schemas/proof-event.v1.schema.json)
 | `governed_decision.created` | `bridge decision create` | `governed_decision` | bundle digest |
 | `governed_decision.attested` | `bridge decision attach` | `governed_decision` | `attestation.verified` |
 | `governed_decision.applied` | `bridge decision apply` | `governed_decision` | previous decision event |
+| `mutation_apply_gate.evaluated` | `gate mutation` | `mutation_apply_gate` | none |
 
 ## CLI Extraction
 
@@ -65,28 +66,34 @@ records without carrying the whole bundle payload:
 cub-gen proof events --in bundle.json
 cub-gen proof events --in attestation.json --bundle bundle.json --ndjson
 cub-gen proof events --in decision.json --ndjson
+cub-gen proof events --in mutation-gate-decision.json --ndjson
 ```
 
 The command verifies the input first. Bundle input is checked with
 `verify`; attestation input is checked with `verify-attestation`, and the
 optional `--bundle` flag strengthens the parent-link check. Decision input is
 checked against the governed decision-state contract and must carry
-`proof_events[]`.
+`proof_events[]`. Mutation gate input is checked against the
+`mutation-apply-gate-decision/v1` contract, including the decision digest and
+the embedded `mutation_apply_gate.evaluated` event.
 
 ## Trace Chain
 
 ```mermaid
 flowchart LR
   source["Source config + Generator"] --> bundle["Change bundle"]
+  source --> gate["Mutation apply gate decision"]
   bundle --> attestation["Attestation"]
   attestation --> decision["Governed decision"]
   bundle --> logs["Pilot / validation logs"]
   attestation --> logs
   decision --> logs
+  gate --> logs
 
   bundle -. "trace_id + bundle_digest" .-> logs
   attestation -. "trace_id + attestation_digest + parent bundle_digest" .-> logs
   decision -. "trace_id + decision_state + parent event/digest" .-> logs
+  gate -. "trace_id + route_kind + decision_state + decision_digest" .-> logs
 ```
 
 The important join keys are:
@@ -98,6 +105,7 @@ The important join keys are:
 | Attestation integrity | `artifact_kind=attestation`, `artifact_digest=attestation_digest` |
 | Attestation to bundle | `parent_artifact_kind=change_bundle`, `parent_artifact_digest=bundle_digest` |
 | Decision lifecycle | `artifact_kind=governed_decision`, `decision_state`, `parent_event_id` |
+| Mutation apply gate | `artifact_kind=mutation_apply_gate`, `route_kind`, `decision_state`, `artifact_digest=decision_digest` |
 
 ## Digest Rules
 

--- a/docs/contracts/schemas/proof-event.v1.schema.json
+++ b/docs/contracts/schemas/proof-event.v1.schema.json
@@ -58,7 +58,8 @@
       "enum": [
         "change_bundle",
         "attestation",
-        "governed_decision"
+        "governed_decision",
+        "mutation_apply_gate"
       ]
     },
     "artifact_digest": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,7 @@ It adds what those layers do not provide by default:
 - ownership-aware edit routing (`who should edit this?`)
 - multi-repo platform graphs (`which Components and Variants exist, and which Variants deploy?`)
 - PR-friendly proof sidecars (`enrich preview` / `enrich write`)
+- mutation apply gates (`apply-here`, `lift-upstream`, `block/escalate`)
 - governed safety decisions before deploy (`ALLOW/ESCALATE/BLOCK`)
 
 ---

--- a/docs/plans/2026-04-30-platform-generator-product-worklist.md
+++ b/docs/plans/2026-04-30-platform-generator-product-worklist.md
@@ -18,7 +18,7 @@ Open and recently completed issues checked on 2026-05-02:
 | Issue | Title | Why it matters for the manifesto |
 |---|---|---|
 | [#287](https://github.com/confighub/cub-gen/issues/287) | make cub-gen role and value obvious | parent roadmap issue keeping the product story coherent |
-| [#283](https://github.com/confighub/cub-gen/issues/283) | mutation apply gates for generator routes | route ownership must become an authoritative apply decision with next actions |
+| [#283](https://github.com/confighub/cub-gen/issues/283) | mutation apply gates for generator routes | route ownership now has a cub-gen decision object with next actions, digest, and proof events for ConfigHub Initiative/apply-gate display |
 | [#236](https://github.com/confighub/cub-gen/issues/236) | ship cub-gen as `cub gen` plugin | product workflow should feel like one platform; plugin proof now works, next release artifact remains |
 | [#213](https://github.com/confighub/cub-gen/issues/213) | GUI provenance trace | click-field-to-source is the core teaching moment |
 | [#212](https://github.com/confighub/cub-gen/issues/212) | GUI regeneration/refresh preview | users need to see generated impact before merge/apply |
@@ -322,6 +322,14 @@ clear apply gate that returns both a route decision and a policy decision.
 The first useful version can run as an Initiative/apply gate. Later hardening
 can move the same contract into the direct ConfigHub write path.
 
+Status: cub-gen slice landed via `gate mutation`. The command evaluates route
+proof from Spring field routes, route policy files, or published bundles and
+emits a `MutationApplyGateDecision` with `route.kind`, `decision.state`, next
+actions, optional PR/MR link intent, `decision_digest`, and `proof_events[]`.
+Connected smoke now records one gate decision. ConfigHub can show this in the
+Initiatives/apply-gate GUI without requiring cub-gen to change ConfigHub core
+write paths.
+
 Deterministic success criteria:
 
 1. ConfigHub evaluates proposed mutations using route metadata from imported
@@ -338,7 +346,7 @@ Proof matrix:
 | Proof | Required |
 |---|---|
 | unit | route + decision evaluation |
-| integration | Initiative/apply gate blocks a routed mutation before apply |
+| integration | connected smoke records a mutation apply gate decision; ConfigHub Initiative/apply-gate display is the intended UI surface |
 | example | Spring Boot apply-here, lift-upstream, and datasource block |
 | example | Helm and OpenChoreo route matrices |
 | degradation | missing provenance downgrades to review-required, not allow |
@@ -346,7 +354,8 @@ Proof matrix:
 Definition of done:
 
 1. gate decision state is authoritative for the governed Initiative/apply flow,
-2. client-side validation remains a convenience, not the only gate,
+2. client-side validation remains a convenience; ConfigHub Initiatives/apply
+   gates are the first governed UI surface,
 3. direct rendered mutations for lift-upstream fields are blocked with next
    action instructions,
 4. docs update Spring caveat,

--- a/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
+++ b/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
@@ -206,7 +206,7 @@ This work converts proof into decisions and product workflows.
 Subtasks:
 
 - [x] [#282](https://github.com/confighub/cub-gen/issues/282) Productize GitHub PR to ConfigHub MR linkage
-- [ ] [#283](https://github.com/confighub/cub-gen/issues/283) Mutation apply gates for generator route decisions
+- [x] [#283](https://github.com/confighub/cub-gen/issues/283) Mutation apply gates for generator route decisions
 - [x] [#281](https://github.com/confighub/cub-gen/issues/281) Propose governed config rewrites
 - [ ] [#212](https://github.com/confighub/cub-gen/issues/212) GUI regeneration/refresh preview
 
@@ -218,6 +218,13 @@ Likely sequence:
 #283 route gates          -> #212 refresh preview
 #276/#279 model spine     -> #281 rewrite proposals
 ```
+
+Current #283 slice: `gate mutation` emits the `MutationApplyGateDecision`
+object with `route.kind`, `decision.state`, next actions, optional PR/MR link
+intent, `decision_digest`, and `proof_events[]`. This is designed to be shown
+by ConfigHub Initiatives/apply gates without requiring cub-gen to edit
+ConfigHub core write paths. Non-bypassable direct UI/API write-path hardening
+is a later ConfigHub decision if Initiative/apply gates are not enough.
 
 Done means changes can be routed as apply-here, lift-upstream, or block/escalate
 without asking users to reason through implementation layers.

--- a/docs/releases/v0.4-integration-beta.md
+++ b/docs/releases/v0.4-integration-beta.md
@@ -30,6 +30,14 @@ Helm, Score, Spring, Argo, Flux, or OpenChoreo. It makes their Generator
 behavior explicit so ConfigHub can reason about source config, rendered config,
 ownership, edit routes, and proof.
 
+The key new governance answer is a mutation apply gate:
+
+```text
+If this deployed field is wrong, where do I fix it?
+  -> apply here, keep as overlay, lift upstream, or block/escalate
+  -> ALLOW, ESCALATE, or BLOCK
+```
+
 ## What Is New Since v0.3.0
 
 1. The public model is clearer.
@@ -75,9 +83,19 @@ ownership, edit routes, and proof.
    - The standalone `cub-gen` binary can be staged as `$CUB_CONFIG/plugins/gen/main`.
    - Plugin mode renders help as `cub gen ...` and supports shorter aliases
      such as `cub gen import`, `cub gen fanout`, `cub gen adapt`, and
-     `cub gen explain`.
+   `cub gen explain`.
    - Connected commands can inherit `CUB_SERVER` and `CUB_TOKEN` from the `cub`
      host, while `CONFIGHUB_BASE_URL` and `CONFIGHUB_TOKEN` still work.
+
+8. Mutation apply gates have a first product slice.
+   - `gate mutation` evaluates a proposed rendered-field edit against route
+     proof from Spring `field-routes.yaml`, a route policy, or a published
+     cub-gen bundle.
+   - The decision object separates `route.kind` from `decision.state`, carries
+     next actions, optional PR/MR link intent, a stable `decision_digest`, and
+     `proof_events[]`.
+   - ConfigHub can show the same object on an Initiative/MR apply gate without
+     requiring cub-gen to change ConfigHub core write paths.
 
 ## Validation Bar
 
@@ -117,7 +135,7 @@ make ci-connected
   dry-run proof,
 - generic AI-managed platform operation,
 - that every ConfigHub Variant is deployable,
-- server-side governance until ConfigHub route enforcement is merged,
+- non-bypassable ConfigHub core write-path enforcement for mutation gates,
 - `cub plugin install confighub/cub-gen` until a plugin-compatible release
   artifact has been cut.
 
@@ -125,12 +143,13 @@ make ci-connected
 
 These are outside a cub-gen-only release:
 
-- ConfigHub server-side route enforcement: [#283](https://github.com/confighub/cub-gen/issues/283)
 - ConfigHub proof UI: [#209](https://github.com/confighub/cub-gen/issues/209),
   [#210](https://github.com/confighub/cub-gen/issues/210),
   [#211](https://github.com/confighub/cub-gen/issues/211),
   [#212](https://github.com/confighub/cub-gen/issues/212),
   [#213](https://github.com/confighub/cub-gen/issues/213)
+- Non-bypassable ConfigHub core write-path hardening for direct UI/API
+  mutation bypass, if Initiative/apply gates are not enough for a customer.
 
 ## Remaining cub-gen Release Polish
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -120,7 +120,7 @@ Once those are clear, then expand into the broader module and lifecycle surface.
 | `../helm-paas/demo-governed-change.sh` | [`helm-paas`](../helm-paas/) | App-team ALLOW path vs platform-contract BLOCK path with the real PR ownership gate |
 | `../helm-paas/demo-layered-trace.sh` | [`helm-paas`](../helm-paas/) | Cluster labels -> ApplicationSet selector -> values overlay proof plus blocked customer security weakening |
 | `start-app-first.sh` | [`springboot-paas`](../springboot-paas/) + [`live-reconcile`](../live-reconcile/) follow-on | Opinionated app-first starter path |
-| `../springboot-paas/demo-governed-routes.sh` | [`springboot-paas`](../springboot-paas/) | App-owned field ALLOW versus platform-owned field BLOCKED with `springboot validate-mutation` |
+| `../springboot-paas/demo-governed-routes.sh` | [`springboot-paas`](../springboot-paas/) | App-owned ALLOW, source-change ESCALATE, and platform-owned BLOCK with `gate mutation` |
 | `../springboot-paas/demo-embedded-config-mutation.sh` | [`springboot-paas`](../springboot-paas/) | Direct embedded `application.yaml` mutation in the ConfigHub payload plus blocked datasource proof |
 | `start-score-first.sh` | [`scoredev-paas`](../scoredev-paas/) | Opinionated Score-first starter path with local governance and standalone runtime proof |
 | `../scoredev-paas/demo-governed-workload.sh` | [`scoredev-paas`](../scoredev-paas/) | App-owned image change ALLOW versus unapproved resource type ESCALATE with `score validate-workload` |

--- a/examples/demo/run-connected-smoke.sh
+++ b/examples/demo/run-connected-smoke.sh
@@ -30,12 +30,30 @@ run_example() {
   ./cub-gen attest --in "$example_out/bundle.json" --verifier "$VERIFIER" > "$example_out/attestation.json"
   ./cub-gen verify-attestation --json --in "$example_out/attestation.json" --bundle "$example_out/bundle.json" > "$example_out/attestation-verify.json"
 
+  if [ "$example" = "springboot-paas" ]; then
+    ./cub-gen gate mutation \
+      --routes ./examples/springboot-paas/operational/field-routes.yaml \
+      --json \
+      --space "$SPACE" \
+      --component inventory-api \
+      --variant inventory-api-prod \
+      --target prod \
+      --change-id "$(jq -r '.change_id // ""' "$example_out/bundle.json")" \
+      --at 2026-05-02T12:00:00Z \
+      feature.inventory.reservationMode > "$example_out/mutation-gate.json"
+  else
+    printf '{}\n' > "$example_out/mutation-gate.json"
+  fi
+
   jq -n \
     --arg example "$example" \
     --arg space "$SPACE" \
     --arg generator_profile "$(jq -r '.summary.generator_profiles[0] // ""' "$example_out/bundle.json")" \
     --arg change_id "$(jq -r '.change_id // ""' "$example_out/bundle.json")" \
     --arg bundle_digest "$(jq -r '.bundle_digest // ""' "$example_out/bundle.json")" \
+    --arg gate_route_kind "$(jq -r '.route.kind // ""' "$example_out/mutation-gate.json")" \
+    --arg gate_decision_state "$(jq -r '.decision.state // ""' "$example_out/mutation-gate.json")" \
+    --arg gate_decision_digest "$(jq -r '.decision_digest // ""' "$example_out/mutation-gate.json")" \
     --argjson dry_inputs "$(jq '.summary.dry_inputs // 0' "$example_out/bundle.json")" \
     --argjson wet_targets "$(jq '.summary.wet_manifest_targets // 0' "$example_out/bundle.json")" \
     --argjson verify_valid "$(jq '.valid // false' "$example_out/verify.json")" \
@@ -47,6 +65,9 @@ run_example() {
       generator_profile: $generator_profile,
       change_id: $change_id,
       bundle_digest: $bundle_digest,
+      gate_route_kind: $gate_route_kind,
+      gate_decision_state: $gate_decision_state,
+      gate_decision_digest: $gate_decision_digest,
       dry_inputs: $dry_inputs,
       wet_targets: $wet_targets,
       verify_valid: $verify_valid,
@@ -55,6 +76,9 @@ run_example() {
     }' > "$example_out/summary.json"
 
   jq -e '.change_id != "" and .verify_valid == true and .attestation_valid == true and .linked_bundle_check == true' "$example_out/summary.json" >/dev/null
+  if [ "$example" = "springboot-paas" ]; then
+    jq -e '.gate_route_kind == "apply-here" and .gate_decision_state == "ALLOW" and (.gate_decision_digest | startswith("sha256:"))' "$example_out/summary.json" >/dev/null
+  fi
 }
 
 echo "[connected-smoke] preflight (requires ConfigHub auth login or CONFIGHUB_* env)"

--- a/examples/demo/v0.4-quickstart.sh
+++ b/examples/demo/v0.4-quickstart.sh
@@ -58,15 +58,27 @@ jq -r '
 echo
 echo "[v0.4] 3. Change route proof"
 ALLOW="$OUT_DIR/spring-allow.json"
+LIFT="$OUT_DIR/spring-lift.json"
 BLOCK="$OUT_DIR/spring-block.json"
-./cub-gen springboot validate-mutation \
+./cub-gen gate mutation \
   --routes ./examples/springboot-paas/operational/field-routes.yaml \
-  --json feature.inventory.reservationMode >"$ALLOW"
+  --json \
+  --at 2026-05-02T12:00:00Z \
+  feature.inventory.reservationMode >"$ALLOW"
+
+./cub-gen gate mutation \
+  --routes ./examples/springboot-paas/operational/field-routes.yaml \
+  --json \
+  --at 2026-05-02T12:00:00Z \
+  spring.cache.type >"$LIFT"
 
 set +e
-./cub-gen springboot validate-mutation \
+./cub-gen gate mutation \
   --routes ./examples/springboot-paas/operational/field-routes.yaml \
-  --json spring.datasource.url >"$BLOCK" 2>"$OUT_DIR/spring-block.err"
+  --json \
+  --enforce \
+  --at 2026-05-02T12:00:00Z \
+  spring.datasource.url >"$BLOCK" 2>"$OUT_DIR/spring-block.err"
 block_status=$?
 set -e
 
@@ -75,13 +87,17 @@ if [[ "$block_status" -eq 0 ]]; then
   exit 1
 fi
 
-jq -e '.allowed == true and .action == "mutable-in-ch"' "$ALLOW" >/dev/null
-jq -e '.allowed == false and .action == "generator-owned"' "$BLOCK" >/dev/null
+jq -e '.route.kind == "apply-here" and .decision.state == "ALLOW" and (.proof_events | length) == 1' "$ALLOW" >/dev/null
+jq -e '.route.kind == "lift-upstream" and .decision.state == "ESCALATE" and (.proof_events | length) == 1' "$LIFT" >/dev/null
+jq -e '.route.kind == "block/escalate" and .decision.state == "BLOCK" and (.proof_events | length) == 1' "$BLOCK" >/dev/null
 jq -r '
-  "Apply here: " + .field_path + " action=" + .action + " owner=" + .owner + " reason=" + .reason
+  "Apply here: " + .mutation.rendered_field + " route=" + .route.kind + " decision=" + .decision.state + " owner=" + .proof.owner
 ' "$ALLOW"
 jq -r '
-  "Block/escalate: " + .field_path + " action=" + .action + " owner=" + .owner + " reason=" + .reason
+  "Lift upstream: " + .mutation.rendered_field + " route=" + .route.kind + " decision=" + .decision.state + " next=" + .next_actions[0].kind
+' "$LIFT"
+jq -r '
+  "Block/escalate: " + .mutation.rendered_field + " route=" + .route.kind + " decision=" + .decision.state + " owner=" + .proof.owner
 ' "$BLOCK"
 
 echo

--- a/examples/springboot-paas/AI_START_HERE.md
+++ b/examples/springboot-paas/AI_START_HERE.md
@@ -6,7 +6,7 @@ Use this example when the question is not just "what rendered this field?" but
 ## What this proves
 
 - Spring config provenance and ownership from `application*.yaml` plus platform policy
-- a local `ALLOW` path and a local `BLOCKED` path for mutation routing
+- local `ALLOW`, `ESCALATE`, and `BLOCK` paths for mutation routing
 - direct embedded ConfigHub payload mutation for an app-owned field
 - a deeper connected ConfigHub walkthrough
 - a real standalone live-cluster app proof
@@ -78,7 +78,7 @@ Success looks like:
 ## What to verify after each major step
 
 - Repo-only preview: the explain output and import JSON agree on the source/config boundary.
-- Local route proof: `feature.inventory.reservationMode` is allowed and `spring.datasource.url` is blocked; artifacts land under `.tmp/springboot-governed-routes/...`.
+- Local route proof: `feature.inventory.reservationMode` is `apply-here/ALLOW`, `spring.cache.type` is `lift-upstream/ESCALATE`, and `spring.datasource.url` is `block/escalate/BLOCK`; artifacts land under `.tmp/springboot-governed-routes/...`.
 - Local apply-here proof: the reservation mode changes in the embedded payload and the datasource mutation is rejected; artifacts land under `.tmp/springboot-embedded-config/...`.
 - Connected smoke: ConfigHub auth/context is valid and the smoke summaries include a non-empty `change_id`.
 - Deep connected walkthrough: a terminal connected decision state is returned for the same `change_id`.
@@ -93,7 +93,7 @@ Success looks like:
 ## Trust order when outputs disagree
 
 1. Trust the generator explain/import output for ownership and field routing.
-2. Trust `springboot validate-mutation` and embedded-config mutation results for local route enforcement.
+2. Trust `gate mutation` and embedded-config mutation results for local route enforcement.
 3. Trust the connected backend decision output for connected decision state.
 4. Trust live HTTP and kubectl checks for runtime truth.
 

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -23,12 +23,13 @@ The app is `inventory-api`, a Spring Boot 3.3.2 service (Java 21) deployed acros
 | Source-side provenance and ownership | Real | `./examples/springboot-paas/demo-local.sh` |
 | Deep connected bridge path | Real | `./examples/springboot-paas/demo-connected.sh` |
 | Standalone live-cluster app proof | Real | `./bin/create-cluster && ./bin/build-image && ./bin/install-worker && ./verify-e2e.sh` |
-| Governed route proof (`ALLOW` + `BLOCKED`) | Real but client-side | `./examples/springboot-paas/demo-governed-routes.sh` |
+| Governed route proof (`ALLOW` / `ESCALATE` / `BLOCK`) | Real local mutation gate | `./examples/springboot-paas/demo-governed-routes.sh` |
 | Direct embedded ConfigHub payload mutation | Real but client-side | `./examples/springboot-paas/demo-embedded-config-mutation.sh` |
 
 The strongest caveat is enforcement depth, not demo truth. The ownership
-boundary is real and documented, but server-side rejection in ConfigHub is not
-implemented yet.
+boundary is real and documented. ConfigHub can show this decision through
+Initiatives/apply gates; non-bypassable core write-path rejection is later
+hardening if needed.
 
 ## AI-first bundle
 
@@ -222,19 +223,21 @@ This is the **block/escalate** path. The field `spring.datasource.*` is platform
 ./block-escalate.sh --render-attempt  # the dry-run: what would happen
 ```
 
-### Enforcement via validate-mutation
+### Enforcement via mutation apply gate
 
-Use `cub-gen springboot validate-mutation` to enforce field routes directly, or
-run the example-owned wrapper first:
+Use `cub-gen gate mutation` to evaluate the same route model that ConfigHub can
+show on an Initiative/apply gate: route, decision, owner, next action, and
+proof event. Run the example-owned wrapper first:
 
 ```bash
 ./examples/springboot-paas/demo-governed-routes.sh
 ```
 
-That wrapper proves both sides of the route boundary:
+That wrapper proves all three main route outcomes:
 
-- `feature.inventory.reservationMode` returns `ALLOWED`
-- `spring.datasource.url` returns `BLOCKED`
+- `feature.inventory.reservationMode` returns `route.kind=apply-here` and `decision.state=ALLOW`
+- `spring.cache.type` returns `route.kind=lift-upstream` and `decision.state=ESCALATE`
+- `spring.datasource.url` returns `route.kind=block/escalate` and `decision.state=BLOCK`
 
 For the stronger direct payload path, use:
 
@@ -254,17 +257,29 @@ If you want the raw commands underneath it:
 
 ```bash
 # Allowed: app-owned field
-cub-gen springboot validate-mutation --routes ./operational/field-routes.yaml \
+cub-gen gate mutation --routes ./operational/field-routes.yaml --json \
   feature.inventory.reservationMode
-# ALLOWED (exit 0)
+# route.kind=apply-here, decision.state=ALLOW
 
 # Blocked: platform-owned field
-cub-gen springboot validate-mutation --routes ./operational/field-routes.yaml \
+cub-gen gate mutation --routes ./operational/field-routes.yaml --json --enforce \
   spring.datasource.url
-# BLOCKED (exit 1)
+# route.kind=block/escalate, decision.state=BLOCK, exit non-zero with --enforce
+
+# Source change required
+cub-gen gate mutation --routes ./operational/field-routes.yaml --json \
+  spring.cache.type
+# route.kind=lift-upstream, decision.state=ESCALATE
 ```
 
-This command reads `field-routes.yaml` and rejects mutations to fields with `defaultAction: generator-owned` (platform-owned) or `defaultAction: lift-upstream` (requires source change).
+This command reads `field-routes.yaml` and rejects or escalates mutations to
+fields with `defaultAction: generator-owned` (platform-owned) or
+`defaultAction: lift-upstream` (requires source change). The JSON carries
+`decision_digest` and `proof_events[]`, so it can be logged with:
+
+```bash
+cub-gen proof events --in mutation-gate-decision.json --ndjson
+```
 
 Direct embedded payload edits use the companion command:
 
@@ -279,18 +294,21 @@ cub-gen springboot set-embedded-config \
 It edits `ConfigMap.data["application.yaml"]` in-place, after validating the
 field route when `--routes` is provided.
 
-**What is now enforced:**
+**What is now enforced locally:**
 - Field routes are read from `operational/field-routes.yaml`
-- Mutations to `spring.datasource.*` and `securityContext.*` are blocked (exit 1)
-- Mutations to `spring.cache.*` are blocked (lift-upstream: requires source change)
-- Mutations to `feature.{app}.*` are allowed (exit 0)
+- Mutations to `spring.datasource.*` and `securityContext.*` return `BLOCK`
+- Mutations to `spring.cache.*` return `ESCALATE` with `lift-upstream`
+- Mutations to `feature.{app}.*` return `ALLOW`
+- The decision is digest-backed and carries a loggable proof event
 
 **What is NOT yet enforced:**
-- Server-side rejection in ConfigHub (this is client-side validation)
-- Automatic rejection during `cub unit apply`
-- Worker-side enforcement at deploy time
+- Non-bypassable ConfigHub core write-path rejection
+- Automatic source PR creation for `lift-upstream`
+- Worker-side deploy-time enforcement
 
-This is a client-side gate. Integrate it into CI/CD to enforce the boundary before mutations reach ConfigHub.
+For v0.4, this is the cub-gen side of the mutation apply gate. In ConfigHub, an
+Initiative/MR can show the same route/decision/proof object and use an apply
+gate to stop governed flows before apply.
 
 ## Normalize preview
 

--- a/examples/springboot-paas/contracts.md
+++ b/examples/springboot-paas/contracts.md
@@ -53,14 +53,17 @@ mutates:
 expects:
   stdout_contains:
     - "[spring-routes] success"
-    - "ALLOWED"
-    - "BLOCKED"
+    - "allowed field"
+    - "lift-upstream field"
+    - "blocked field"
   files_exist:
-    - ".tmp/springboot-governed-routes/<run>/allow.txt"
-    - ".tmp/springboot-governed-routes/<run>/block.txt"
+    - ".tmp/springboot-governed-routes/<run>/allow.json"
+    - ".tmp/springboot-governed-routes/<run>/lift.json"
+    - ".tmp/springboot-governed-routes/<run>/block.json"
 inspect_with:
-  - cat .tmp/springboot-governed-routes/<run>/allow.txt
-  - cat .tmp/springboot-governed-routes/<run>/block.txt
+  - jq '{route: .route.kind, decision: .decision.state}' .tmp/springboot-governed-routes/<run>/allow.json
+  - jq '{route: .route.kind, decision: .decision.state}' .tmp/springboot-governed-routes/<run>/lift.json
+  - jq '{route: .route.kind, decision: .decision.state}' .tmp/springboot-governed-routes/<run>/block.json
 ```
 
 ## Local embedded payload proof

--- a/examples/springboot-paas/demo-governed-routes.sh
+++ b/examples/springboot-paas/demo-governed-routes.sh
@@ -9,7 +9,13 @@ RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
 OUT_DIR="$OUT_ROOT/$RUN_ID"
 ROUTES="${ROUTES:-./examples/springboot-paas/operational/field-routes.yaml}"
 ALLOW_FIELD="${ALLOW_FIELD:-feature.inventory.reservationMode}"
+LIFT_FIELD="${LIFT_FIELD:-spring.cache.type}"
 BLOCK_FIELD="${BLOCK_FIELD:-spring.datasource.url}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required for spring route proof" >&2
+  exit 1
+fi
 
 mkdir -p "$OUT_DIR"
 
@@ -18,28 +24,38 @@ if [ "${SKIP_BUILD:-0}" != "1" ]; then
   go build -o ./cub-gen ./cmd/cub-gen
 fi
 
-echo "[spring-routes] proof 1/2: app-owned field stays mutable"
-./cub-gen springboot validate-mutation --routes "$ROUTES" "$ALLOW_FIELD" \
-  | tee "$OUT_DIR/allow.txt"
+echo "[spring-routes] proof 1/3: app-owned field stays mutable"
+./cub-gen gate mutation --routes "$ROUTES" --json "$ALLOW_FIELD" \
+  | tee "$OUT_DIR/allow.json"
 
-echo "[spring-routes] proof 2/2: platform-owned field is blocked"
+jq -e '.route.kind == "apply-here" and .decision.state == "ALLOW"' "$OUT_DIR/allow.json" >/dev/null
+
+echo "[spring-routes] proof 2/3: source change is lifted upstream"
+./cub-gen gate mutation --routes "$ROUTES" --json "$LIFT_FIELD" \
+  | tee "$OUT_DIR/lift.json"
+
+jq -e '.route.kind == "lift-upstream" and .decision.state == "ESCALATE"' "$OUT_DIR/lift.json" >/dev/null
+
+echo "[spring-routes] proof 3/3: platform-owned field is blocked"
 set +e
-./cub-gen springboot validate-mutation --routes "$ROUTES" "$BLOCK_FIELD" \
-  >"$OUT_DIR/block.txt" 2>&1
+./cub-gen gate mutation --routes "$ROUTES" --json --enforce "$BLOCK_FIELD" \
+  >"$OUT_DIR/block.json" 2>"$OUT_DIR/block.err"
 block_exit="$?"
 set -e
 
-if [ "$block_exit" -ne 1 ]; then
+if [ "$block_exit" -eq 0 ]; then
   echo "error: expected blocked mutation exit code 1 for $BLOCK_FIELD, got $block_exit" >&2
   exit 1
 fi
 
-cat "$OUT_DIR/block.txt"
+jq -e '.route.kind == "block/escalate" and .decision.state == "BLOCK"' "$OUT_DIR/block.json" >/dev/null
+cat "$OUT_DIR/block.json"
 
 cat <<EOF
 
 [spring-routes] success
   allowed field: $ALLOW_FIELD
+  lift-upstream field: $LIFT_FIELD
   blocked field: $BLOCK_FIELD
   artifacts: $OUT_DIR
 EOF

--- a/internal/contracts/schemas/proof-event.v1.schema.json
+++ b/internal/contracts/schemas/proof-event.v1.schema.json
@@ -58,7 +58,8 @@
       "enum": [
         "change_bundle",
         "attestation",
-        "governed_decision"
+        "governed_decision",
+        "mutation_apply_gate"
       ]
     },
     "artifact_digest": {

--- a/internal/mutationgate/gate.go
+++ b/internal/mutationgate/gate.go
@@ -1,0 +1,693 @@
+package mutationgate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-gen/internal/model"
+	"github.com/confighub/cub-gen/internal/proof"
+	"github.com/confighub/cub-gen/internal/publish"
+	"github.com/confighub/cub-gen/internal/springboot"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	SchemaVersion = "cub.confighub.io/mutation-apply-gate-decision/v1"
+
+	RouteApplyHere     = "apply-here"
+	RouteOverlay       = "overlay"
+	RouteLiftUpstream  = "lift-upstream"
+	RouteBlockEscalate = "block/escalate"
+	RouteReview        = "review-required"
+
+	DecisionAllow    = "ALLOW"
+	DecisionEscalate = "ESCALATE"
+	DecisionBlock    = "BLOCK"
+)
+
+type Subject struct {
+	Space        string `json:"space,omitempty"`
+	Component    string `json:"component,omitempty"`
+	Variant      string `json:"variant,omitempty"`
+	Target       string `json:"target,omitempty"`
+	ResourceType string `json:"resource_type,omitempty"`
+	ResourceName string `json:"resource_name,omitempty"`
+}
+
+type Mutation struct {
+	Origin         string `json:"origin,omitempty"`
+	RenderedField  string `json:"rendered_field"`
+	AttemptedLayer string `json:"attempted_layer"`
+	NewValue       string `json:"new_value,omitempty"`
+}
+
+type Rule struct {
+	ResourceType string  `json:"resource_type,omitempty" yaml:"resource_type,omitempty"`
+	ResourceName string  `json:"resource_name,omitempty" yaml:"resource_name,omitempty"`
+	Path         string  `json:"path,omitempty" yaml:"path,omitempty"`
+	WetPath      string  `json:"wet_path,omitempty" yaml:"wet_path,omitempty"`
+	Route        string  `json:"route" yaml:"route"`
+	Owner        string  `json:"owner,omitempty" yaml:"owner,omitempty"`
+	SourcePath   string  `json:"source_path,omitempty" yaml:"source_path,omitempty"`
+	SourceField  string  `json:"source_field,omitempty" yaml:"source_field,omitempty"`
+	Generator    string  `json:"generator,omitempty" yaml:"generator,omitempty"`
+	ProposalHint string  `json:"proposal_hint,omitempty" yaml:"proposal_hint,omitempty"`
+	Confidence   float64 `json:"confidence,omitempty" yaml:"confidence,omitempty"`
+}
+
+type Policy struct {
+	SchemaVersion string `json:"schema_version" yaml:"schema_version"`
+	Routes        []Rule `json:"routes" yaml:"routes"`
+}
+
+type ProofSummary struct {
+	Source        string  `json:"source"`
+	Generator     string  `json:"generator,omitempty"`
+	SourceField   string  `json:"source_field,omitempty"`
+	SourceFile    string  `json:"source_file,omitempty"`
+	Owner         string  `json:"owner,omitempty"`
+	Confidence    float64 `json:"confidence,omitempty"`
+	MatchedRule   string  `json:"matched_rule,omitempty"`
+	OriginalRoute string  `json:"original_route,omitempty"`
+}
+
+type RouteDecision struct {
+	Kind                   string `json:"kind"`
+	DirectRenderedMutation string `json:"direct_rendered_mutation"`
+	Reason                 string `json:"reason"`
+}
+
+type GateDecision struct {
+	State  string `json:"state"`
+	Reason string `json:"reason"`
+}
+
+type NextAction struct {
+	Kind        string   `json:"kind"`
+	Description string   `json:"description"`
+	Owner       string   `json:"owner,omitempty"`
+	Repo        string   `json:"repo,omitempty"`
+	Files       []string `json:"files,omitempty"`
+}
+
+type Link struct {
+	Mode        string `json:"mode,omitempty"`
+	ConfigHubMR string `json:"confighub_mr,omitempty"`
+	GitHubPR    string `json:"github_pr,omitempty"`
+}
+
+type Gate struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type Decision struct {
+	SchemaVersion  string        `json:"schema_version"`
+	Kind           string        `json:"kind"`
+	ChangeID       string        `json:"change_id,omitempty"`
+	TraceID        string        `json:"trace_id"`
+	DecisionDigest string        `json:"decision_digest,omitempty"`
+	Gate           Gate          `json:"gate"`
+	Subject        Subject       `json:"subject"`
+	Mutation       Mutation      `json:"mutation"`
+	Proof          ProofSummary  `json:"proof"`
+	Route          RouteDecision `json:"route"`
+	Decision       GateDecision  `json:"decision"`
+	NextActions    []NextAction  `json:"next_actions,omitempty"`
+	Link           *Link         `json:"link,omitempty"`
+	ProofEvents    []proof.Event `json:"proof_events"`
+}
+
+type Request struct {
+	ChangeID     string
+	TraceID      string
+	Subject      Subject
+	Mutation     Mutation
+	Link         *Link
+	GitHubPRRepo string
+	SourceFiles  []string
+	EvaluatedAt  time.Time
+	PolicySource string
+}
+
+func PolicyFromSpringRoutes(routes springboot.FieldRoutes, sourcePath string) Policy {
+	out := Policy{SchemaVersion: "cub.confighub.io/generator-route-policy/v1"}
+	for _, route := range routes.Routes {
+		if strings.TrimSpace(route.Match) == "" {
+			continue
+		}
+		out.Routes = append(out.Routes, Rule{
+			Path:         strings.TrimSpace(route.Match),
+			WetPath:      strings.TrimSpace(route.Match),
+			Route:        routeForSpringAction(route.DefaultAction),
+			Owner:        strings.TrimSpace(route.Owner),
+			SourcePath:   strings.TrimSpace(sourcePath),
+			SourceField:  strings.TrimSpace(route.Match),
+			Generator:    "springboot",
+			ProposalHint: strings.TrimSpace(route.Reason),
+			Confidence:   0.94,
+		})
+	}
+	sortRules(out.Routes)
+	return out
+}
+
+func PolicyFromBundle(bundle publish.ChangeBundle) (Policy, error) {
+	if err := publish.VerifyBundle(bundle); err != nil {
+		return Policy{}, err
+	}
+	out := Policy{SchemaVersion: "cub.confighub.io/generator-route-policy/v1"}
+	for _, prov := range bundle.Provenance {
+		origins := originsByWetPath(prov.FieldOriginMap)
+		for _, pointer := range prov.InverseEditPointers {
+			wetPath := strings.TrimSpace(pointer.WetPath)
+			if wetPath == "" {
+				continue
+			}
+			origin := origins[wetPath]
+			out.Routes = append(out.Routes, Rule{
+				WetPath:      wetPath,
+				Path:         wetPath,
+				Route:        normalizeRoute(pointer.Route),
+				Owner:        strings.TrimSpace(pointer.Owner),
+				SourcePath:   strings.TrimSpace(origin.SourcePath),
+				SourceField:  firstNonEmpty(pointer.DryPath, origin.DryPath),
+				Generator:    firstNonEmpty(prov.GeneratorProfile, prov.GeneratorName, prov.GeneratorID),
+				ProposalHint: strings.TrimSpace(pointer.EditHint),
+				Confidence:   pointer.Confidence,
+			})
+		}
+	}
+	sortRules(out.Routes)
+	return out, nil
+}
+
+func Evaluate(policy Policy, req Request) (Decision, error) {
+	mutation := req.Mutation
+	mutation.RenderedField = strings.TrimSpace(mutation.RenderedField)
+	if mutation.RenderedField == "" {
+		return Decision{}, fmt.Errorf("rendered_field is required")
+	}
+	if strings.TrimSpace(mutation.AttemptedLayer) == "" {
+		mutation.AttemptedLayer = "rendered-config"
+	}
+	at := req.EvaluatedAt
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	traceID := strings.TrimSpace(req.TraceID)
+	if traceID == "" {
+		traceID = proof.TraceID(req.ChangeID, req.Subject.Space, req.Subject.Target, "", mutation.RenderedField)
+	}
+
+	rule, ok := selectRule(policy.Routes, req.Subject, mutation.RenderedField)
+	if !ok {
+		rule = Rule{
+			Route:        RouteReview,
+			ProposalHint: "missing or ambiguous route metadata; review before apply",
+		}
+	}
+	routeKind := normalizeRoute(rule.Route)
+	if routeKind == "" {
+		routeKind = RouteReview
+	}
+
+	decisionState, direct, reason := routeDecision(routeKind, rule)
+	actions := nextActions(routeKind, rule, req)
+	decisionReason := gateReason(routeKind, decisionState, rule)
+
+	out := Decision{
+		SchemaVersion: SchemaVersion,
+		Kind:          "MutationApplyGateDecision",
+		ChangeID:      strings.TrimSpace(req.ChangeID),
+		TraceID:       traceID,
+		Gate: Gate{
+			Name:    "generator-route",
+			Version: "v1",
+		},
+		Subject:  req.Subject,
+		Mutation: mutation,
+		Proof: ProofSummary{
+			Source:        firstNonEmpty(req.PolicySource, "generator-route-policy"),
+			Generator:     rule.Generator,
+			SourceField:   rule.SourceField,
+			SourceFile:    rule.SourcePath,
+			Owner:         rule.Owner,
+			Confidence:    rule.Confidence,
+			MatchedRule:   firstNonEmpty(rule.WetPath, rule.Path),
+			OriginalRoute: strings.TrimSpace(rule.Route),
+		},
+		Route: RouteDecision{
+			Kind:                   routeKind,
+			DirectRenderedMutation: direct,
+			Reason:                 reason,
+		},
+		Decision: GateDecision{
+			State:  decisionState,
+			Reason: decisionReason,
+		},
+		NextActions: actions,
+		Link:        normalizedLink(req.Link),
+	}
+	out.ProofEvents = []proof.Event{proof.NewEvent(proof.Input{
+		EventType:     proof.EventTypeMutationGateEvaluated,
+		EventTime:     at,
+		Source:        "cub-gen",
+		TraceID:       out.TraceID,
+		ChangeID:      out.ChangeID,
+		Space:         out.Subject.Space,
+		TargetSlug:    out.Subject.Target,
+		ArtifactKind:  proof.ArtifactKindMutationGate,
+		SummaryCounts: map[string]int{"mutation_apply_gate_decisions": 1},
+		GeneratorProfiles: uniqueStrings([]string{
+			out.Proof.Generator,
+		}),
+		RouteKind:      out.Route.Kind,
+		Owner:          out.Proof.Owner,
+		DecisionState:  out.Decision.State,
+		DecisionReason: out.Decision.Reason,
+	})}
+	out.DecisionDigest = DecisionDigest(out)
+	out.ProofEvents = proof.SetArtifactDigest(out.ProofEvents, proof.ArtifactKindMutationGate, out.DecisionDigest)
+	return out, nil
+}
+
+func ValidateDecisionRecord(decision Decision) error {
+	if decision.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("unsupported schema_version %q", decision.SchemaVersion)
+	}
+	if decision.Kind != "MutationApplyGateDecision" {
+		return fmt.Errorf("unsupported kind %q", decision.Kind)
+	}
+	if strings.TrimSpace(decision.TraceID) == "" {
+		return fmt.Errorf("missing trace_id")
+	}
+	if strings.TrimSpace(decision.Mutation.RenderedField) == "" {
+		return fmt.Errorf("missing mutation.rendered_field")
+	}
+	if strings.TrimSpace(decision.Route.Kind) == "" {
+		return fmt.Errorf("missing route.kind")
+	}
+	if strings.TrimSpace(decision.Decision.State) == "" {
+		return fmt.Errorf("missing decision.state")
+	}
+	expectedDigest := DecisionDigest(decision)
+	if strings.TrimSpace(decision.DecisionDigest) != expectedDigest {
+		return fmt.Errorf("decision_digest mismatch: expected %s, got %s", expectedDigest, decision.DecisionDigest)
+	}
+	eventTime := ""
+	for _, event := range decision.ProofEvents {
+		if event.EventType == proof.EventTypeMutationGateEvaluated {
+			eventTime = event.EventTime
+			break
+		}
+	}
+	if err := proof.ValidateArtifactEvents(decision.ProofEvents, proof.Expected{
+		EventType:      proof.EventTypeMutationGateEvaluated,
+		EventTime:      eventTime,
+		Source:         "cub-gen",
+		TraceID:        decision.TraceID,
+		ChangeID:       decision.ChangeID,
+		Space:          decision.Subject.Space,
+		TargetSlug:     decision.Subject.Target,
+		ArtifactKind:   proof.ArtifactKindMutationGate,
+		ArtifactDigest: decision.DecisionDigest,
+	}); err != nil {
+		return err
+	}
+	for i, event := range decision.ProofEvents {
+		if event.EventType != proof.EventTypeMutationGateEvaluated {
+			continue
+		}
+		if event.RouteKind != decision.Route.Kind {
+			return fmt.Errorf("proof_events[%d]: route_kind mismatch: expected %q, got %q", i, decision.Route.Kind, event.RouteKind)
+		}
+		if event.DecisionState != decision.Decision.State {
+			return fmt.Errorf("proof_events[%d]: decision_state mismatch: expected %q, got %q", i, decision.Decision.State, event.DecisionState)
+		}
+	}
+	return nil
+}
+
+func DecisionDigest(decision Decision) string {
+	normalized := decision
+	normalized.DecisionDigest = ""
+	normalized.ProofEvents = proof.BlankArtifactDigests(normalized.ProofEvents)
+	b, err := json.Marshal(normalized)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func LoadPolicyFile(path string) (Policy, string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Policy{}, "", fmt.Errorf("read policy: %w", err)
+	}
+	policy, err := parsePolicy(raw)
+	if err != nil {
+		return Policy{}, "", err
+	}
+	return policy, path, nil
+}
+
+func LoadSpringRoutesFile(path string) (Policy, string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Policy{}, "", fmt.Errorf("read field routes: %w", err)
+	}
+	var routes springboot.FieldRoutes
+	if err := yaml.Unmarshal(raw, &routes); err != nil {
+		return Policy{}, "", fmt.Errorf("parse field routes: %w", err)
+	}
+	return PolicyFromSpringRoutes(routes, path), path, nil
+}
+
+func LoadBundleFile(path string) (Policy, string, string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Policy{}, "", "", fmt.Errorf("read bundle: %w", err)
+	}
+	var bundle publish.ChangeBundle
+	if err := json.Unmarshal(raw, &bundle); err != nil {
+		return Policy{}, "", "", fmt.Errorf("parse bundle: %w", err)
+	}
+	policy, err := PolicyFromBundle(bundle)
+	if err != nil {
+		return Policy{}, "", "", err
+	}
+	return policy, path, bundle.ChangeID, nil
+}
+
+func parsePolicy(raw []byte) (Policy, error) {
+	var policy Policy
+	if err := json.Unmarshal(raw, &policy); err == nil && len(policy.Routes) > 0 {
+		return normalizePolicy(policy), nil
+	}
+	var proposal struct {
+		Policy Policy `json:"policy" yaml:"policy"`
+	}
+	if err := json.Unmarshal(raw, &proposal); err == nil && len(proposal.Policy.Routes) > 0 {
+		return normalizePolicy(proposal.Policy), nil
+	}
+	var unit struct {
+		Metadata struct {
+			Annotations map[string]string `json:"annotations" yaml:"annotations"`
+		} `json:"metadata" yaml:"metadata"`
+	}
+	if err := yaml.Unmarshal(raw, &unit); err == nil && len(unit.Metadata.Annotations) > 0 {
+		if value := strings.TrimSpace(unit.Metadata.Annotations["confighub.io/generator-route-policy"]); value != "" {
+			var embedded Policy
+			if err := json.Unmarshal([]byte(value), &embedded); err != nil {
+				return Policy{}, fmt.Errorf("parse generator-route-policy annotation: %w", err)
+			}
+			return normalizePolicy(embedded), nil
+		}
+	}
+	if err := yaml.Unmarshal(raw, &policy); err == nil && len(policy.Routes) > 0 {
+		return normalizePolicy(policy), nil
+	}
+	if err := yaml.Unmarshal(raw, &proposal); err == nil && len(proposal.Policy.Routes) > 0 {
+		return normalizePolicy(proposal.Policy), nil
+	}
+	return Policy{}, fmt.Errorf("policy must be generator-route-policy/v1, annotation proposal, or Unit annotations")
+}
+
+func normalizePolicy(policy Policy) Policy {
+	if policy.SchemaVersion == "" {
+		policy.SchemaVersion = "cub.confighub.io/generator-route-policy/v1"
+	}
+	for i := range policy.Routes {
+		policy.Routes[i].Route = normalizeRoute(policy.Routes[i].Route)
+	}
+	sortRules(policy.Routes)
+	return policy
+}
+
+func routeForSpringAction(action springboot.RouteAction) string {
+	switch action {
+	case springboot.ActionMutableInCH:
+		return RouteApplyHere
+	case springboot.ActionLiftUpstream:
+		return RouteLiftUpstream
+	case springboot.ActionGeneratorOwned:
+		return RouteBlockEscalate
+	default:
+		return RouteReview
+	}
+}
+
+func normalizeRoute(route string) string {
+	switch strings.ToLower(strings.TrimSpace(route)) {
+	case "", "unknown", "explain", "review", "review-required":
+		return RouteReview
+	case "mutable-in-ch", "mutable", "apply", "apply-here":
+		return RouteApplyHere
+	case "overlay", "temporary-overlay":
+		return RouteOverlay
+	case "lift", "lift-upstream":
+		return RouteLiftUpstream
+	case "generator-owned", "platform-owned", "block", "blocked", "block-escalate", "block/escalate":
+		return RouteBlockEscalate
+	default:
+		return RouteReview
+	}
+}
+
+func routeDecision(routeKind string, rule Rule) (state, direct, reason string) {
+	switch routeKind {
+	case RouteApplyHere:
+		return DecisionAllow, "allowed", firstNonEmpty(rule.ProposalHint, "route metadata says this field may be changed here")
+	case RouteOverlay:
+		return DecisionEscalate, "blocked", firstNonEmpty(rule.ProposalHint, "overlay changes need owner review before apply")
+	case RouteLiftUpstream:
+		return DecisionEscalate, "blocked", firstNonEmpty(rule.ProposalHint, "change belongs upstream in source config or code")
+	case RouteBlockEscalate:
+		return DecisionBlock, "blocked", firstNonEmpty(rule.ProposalHint, "field crosses a generator/platform ownership boundary")
+	default:
+		return DecisionEscalate, "review-required", firstNonEmpty(rule.ProposalHint, "missing route proof; review before apply")
+	}
+}
+
+func gateReason(routeKind, state string, rule Rule) string {
+	owner := strings.TrimSpace(rule.Owner)
+	if owner == "" {
+		owner = "the owning team"
+	}
+	switch routeKind {
+	case RouteApplyHere:
+		return "route apply-here allows this mutation here with recorded proof"
+	case RouteOverlay:
+		return "route overlay requires " + owner + " review before this exception is applied"
+	case RouteLiftUpstream:
+		return "route lift-upstream blocks direct rendered mutation and asks for a source change"
+	case RouteBlockEscalate:
+		if state == DecisionBlock {
+			return "route block/escalate blocks direct mutation and requires " + owner
+		}
+	}
+	return "route review-required needs owner review because route proof is missing or ambiguous"
+}
+
+func nextActions(routeKind string, rule Rule, req Request) []NextAction {
+	owner := strings.TrimSpace(rule.Owner)
+	switch routeKind {
+	case RouteApplyHere:
+		return []NextAction{{
+			Kind:        "apply-config-mutation",
+			Description: "apply this mutation through the ConfigHub Initiative/apply-gate flow",
+			Owner:       owner,
+		}}
+	case RouteOverlay:
+		return []NextAction{{
+			Kind:        "review-overlay",
+			Description: "record this as a deployment-specific overlay with owner review and expiry policy",
+			Owner:       owner,
+		}}
+	case RouteLiftUpstream:
+		files := uniqueStrings(append(req.SourceFiles, rule.SourcePath))
+		return []NextAction{{
+			Kind:        "create-or-link-github-pr",
+			Description: firstNonEmpty(rule.ProposalHint, "create or link a source PR before accepting this as a durable change"),
+			Owner:       owner,
+			Repo:        strings.TrimSpace(req.GitHubPRRepo),
+			Files:       files,
+		}}
+	case RouteBlockEscalate:
+		return []NextAction{{
+			Kind:        "request-owner-review",
+			Description: firstNonEmpty(rule.ProposalHint, "request owner review or reject the direct mutation"),
+			Owner:       owner,
+		}}
+	default:
+		return []NextAction{{
+			Kind:        "import-or-enrich-provenance",
+			Description: "import/enrich Generator proof before allowing this mutation",
+			Owner:       owner,
+		}}
+	}
+}
+
+func selectRule(rules []Rule, subject Subject, field string) (Rule, bool) {
+	type candidate struct {
+		rule  Rule
+		score int
+	}
+	candidates := []candidate{}
+	for _, rule := range rules {
+		score, ok := matchRule(rule, subject, field)
+		if ok {
+			candidates = append(candidates, candidate{rule: rule, score: score})
+		}
+	}
+	if len(candidates) == 0 {
+		return Rule{}, false
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		return firstNonEmpty(candidates[i].rule.WetPath, candidates[i].rule.Path) < firstNonEmpty(candidates[j].rule.WetPath, candidates[j].rule.Path)
+	})
+	return candidates[0].rule, true
+}
+
+func matchRule(rule Rule, subject Subject, field string) (int, bool) {
+	score := 0
+	if !matchOptional(rule.ResourceType, subject.ResourceType) || !matchOptional(rule.ResourceName, subject.ResourceName) {
+		return 0, false
+	}
+	if strings.TrimSpace(rule.ResourceType) != "" {
+		score += 5
+	}
+	if strings.TrimSpace(rule.ResourceName) != "" {
+		score += 5
+	}
+	for _, pattern := range []string{rule.WetPath, rule.Path, rule.SourceField} {
+		if strings.TrimSpace(pattern) == "" {
+			continue
+		}
+		if matchFieldPattern(pattern, field) {
+			return score + specificity(pattern), true
+		}
+	}
+	return 0, false
+}
+
+func matchOptional(pattern, value string) bool {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return true
+	}
+	return strings.EqualFold(pattern, strings.TrimSpace(value)) || matchFieldPattern(pattern, value)
+}
+
+func matchFieldPattern(pattern, value string) bool {
+	pattern = strings.TrimSpace(pattern)
+	value = strings.TrimSpace(value)
+	if pattern == value {
+		return true
+	}
+	if ok, err := path.Match(pattern, value); err == nil && ok {
+		return true
+	}
+	if strings.Contains(value, ":") {
+		parts := strings.Split(value, ":")
+		if tail := parts[len(parts)-1]; tail != value && matchFieldPattern(pattern, tail) {
+			return true
+		}
+	}
+	re := regexp.QuoteMeta(pattern)
+	re = strings.ReplaceAll(re, `\*`, ".*")
+	re = "^" + re + "$"
+	ok, err := regexp.MatchString(re, value)
+	return err == nil && ok
+}
+
+func specificity(pattern string) int {
+	return len(strings.ReplaceAll(pattern, "*", ""))
+}
+
+func sortRules(rules []Rule) {
+	sort.Slice(rules, func(i, j int) bool {
+		if rules[i].Route != rules[j].Route {
+			return rules[i].Route < rules[j].Route
+		}
+		if rules[i].Owner != rules[j].Owner {
+			return rules[i].Owner < rules[j].Owner
+		}
+		if rules[i].ResourceType != rules[j].ResourceType {
+			return rules[i].ResourceType < rules[j].ResourceType
+		}
+		if rules[i].ResourceName != rules[j].ResourceName {
+			return rules[i].ResourceName < rules[j].ResourceName
+		}
+		return firstNonEmpty(rules[i].WetPath, rules[i].Path) < firstNonEmpty(rules[j].WetPath, rules[j].Path)
+	})
+}
+
+func originsByWetPath(origins []model.FieldOrigin) map[string]model.FieldOrigin {
+	out := map[string]model.FieldOrigin{}
+	for _, origin := range origins {
+		if strings.TrimSpace(origin.WetPath) != "" {
+			out[origin.WetPath] = origin
+		}
+	}
+	return out
+}
+
+func normalizedLink(link *Link) *Link {
+	if link == nil {
+		return nil
+	}
+	out := *link
+	if strings.TrimSpace(out.Mode) == "" && (strings.TrimSpace(out.ConfigHubMR) != "" || strings.TrimSpace(out.GitHubPR) != "") {
+		out.Mode = "paired"
+	}
+	if strings.TrimSpace(out.Mode) == "" {
+		return nil
+	}
+	return &out
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func StableChangeID(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
+	return "chg_" + hex.EncodeToString(sum[:])[:16]
+}

--- a/internal/mutationgate/gate_test.go
+++ b/internal/mutationgate/gate_test.go
@@ -1,0 +1,136 @@
+package mutationgate
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	gitopsflow "github.com/confighub/cub-gen/internal/gitops"
+	"github.com/confighub/cub-gen/internal/publish"
+)
+
+func TestEvaluateSpringRoutes(t *testing.T) {
+	policy, source, err := LoadSpringRoutesFile(filepath.Join("..", "..", "examples", "springboot-paas", "operational", "field-routes.yaml"))
+	if err != nil {
+		t.Fatalf("load spring routes: %v", err)
+	}
+
+	allow, err := Evaluate(policy, Request{
+		ChangeID:     "chg_spring",
+		PolicySource: source,
+		Mutation: Mutation{
+			RenderedField: "feature.inventory.reservationMode",
+		},
+		EvaluatedAt: time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("evaluate allow: %v", err)
+	}
+	if allow.Route.Kind != RouteApplyHere || allow.Decision.State != DecisionAllow {
+		t.Fatalf("expected apply-here/ALLOW, got route=%s state=%s", allow.Route.Kind, allow.Decision.State)
+	}
+	if len(allow.ProofEvents) != 1 || allow.ProofEvents[0].RouteKind != RouteApplyHere || allow.ProofEvents[0].DecisionState != DecisionAllow {
+		t.Fatalf("unexpected proof events: %+v", allow.ProofEvents)
+	}
+	if err := ValidateDecisionRecord(allow); err != nil {
+		t.Fatalf("allow decision should be valid proof: %v", err)
+	}
+
+	lift, err := Evaluate(policy, Request{
+		ChangeID:     "chg_spring",
+		PolicySource: source,
+		Mutation: Mutation{
+			RenderedField: "spring.cache.type",
+		},
+		GitHubPRRepo: "github.com/example/inventory-api",
+		EvaluatedAt:  time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("evaluate lift-upstream: %v", err)
+	}
+	if lift.Route.Kind != RouteLiftUpstream || lift.Decision.State != DecisionEscalate {
+		t.Fatalf("expected lift-upstream/ESCALATE, got route=%s state=%s", lift.Route.Kind, lift.Decision.State)
+	}
+	if len(lift.NextActions) != 1 || lift.NextActions[0].Kind != "create-or-link-github-pr" {
+		t.Fatalf("unexpected lift-upstream next actions: %+v", lift.NextActions)
+	}
+	if err := ValidateDecisionRecord(lift); err != nil {
+		t.Fatalf("lift decision should be valid proof: %v", err)
+	}
+
+	block, err := Evaluate(policy, Request{
+		ChangeID:     "chg_spring",
+		PolicySource: source,
+		Mutation: Mutation{
+			RenderedField: "spring.datasource.url",
+		},
+		EvaluatedAt: time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("evaluate block: %v", err)
+	}
+	if block.Route.Kind != RouteBlockEscalate || block.Decision.State != DecisionBlock {
+		t.Fatalf("expected block/escalate/BLOCK, got route=%s state=%s", block.Route.Kind, block.Decision.State)
+	}
+	if err := ValidateDecisionRecord(block); err != nil {
+		t.Fatalf("block decision should be valid proof: %v", err)
+	}
+}
+
+func TestEvaluateMissingRouteRequiresReview(t *testing.T) {
+	decision, err := Evaluate(Policy{
+		SchemaVersion: "cub.confighub.io/generator-route-policy/v1",
+		Routes: []Rule{{
+			WetPath: "Deployment/spec/replicas",
+			Route:   RouteApplyHere,
+			Owner:   "app-team",
+		}},
+	}, Request{
+		ChangeID: "chg_missing",
+		Mutation: Mutation{
+			RenderedField: "Deployment/spec/template/spec/securityContext/runAsUser",
+		},
+		EvaluatedAt: time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("evaluate missing route: %v", err)
+	}
+	if decision.Route.Kind != RouteReview || decision.Decision.State != DecisionEscalate {
+		t.Fatalf("expected review-required/ESCALATE, got route=%s state=%s", decision.Route.Kind, decision.Decision.State)
+	}
+}
+
+func TestPolicyFromBundleOpenChoreoRoute(t *testing.T) {
+	imported, err := gitopsflow.Import(
+		filepath.Join("..", "..", "testdata", "openchoreo-hardgate"),
+		filepath.Join("..", "..", "testdata", "openchoreo-hardgate"),
+		"HEAD",
+		"platform",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("import openchoreo: %v", err)
+	}
+	bundle := publish.BuildBundleAt(imported, time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
+	policy, err := PolicyFromBundle(bundle)
+	if err != nil {
+		t.Fatalf("policy from bundle: %v", err)
+	}
+	decision, err := Evaluate(policy, Request{
+		ChangeID:     bundle.ChangeID,
+		PolicySource: "bundle.json",
+		Mutation: Mutation{
+			RenderedField: "Deployment/spec/template/spec/containers[name=main]/image",
+		},
+		EvaluatedAt: time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("evaluate openchoreo: %v", err)
+	}
+	if decision.Route.Kind != RouteLiftUpstream || decision.Decision.State != DecisionEscalate {
+		t.Fatalf("expected lift-upstream/ESCALATE, got route=%s state=%s", decision.Route.Kind, decision.Decision.State)
+	}
+	if decision.Proof.Generator != "openchoreo" || decision.Proof.SourceFile == "" {
+		t.Fatalf("unexpected proof: %+v", decision.Proof)
+	}
+}

--- a/internal/proof/event.go
+++ b/internal/proof/event.go
@@ -17,10 +17,12 @@ const (
 	EventTypeDecisionCreated       = "governed_decision.created"
 	EventTypeDecisionAttested      = "governed_decision.attested"
 	EventTypeDecisionApplied       = "governed_decision.applied"
+	EventTypeMutationGateEvaluated = "mutation_apply_gate.evaluated"
 
 	ArtifactKindChangeBundle = "change_bundle"
 	ArtifactKindAttestation  = "attestation"
 	ArtifactKindDecision     = "governed_decision"
+	ArtifactKindMutationGate = "mutation_apply_gate"
 
 	digestAlgorithm = "sha256"
 )

--- a/test/checks/check-connected-release-gate.sh
+++ b/test/checks/check-connected-release-gate.sh
@@ -49,6 +49,13 @@ forbid_make_dep "test-live-reconcile-argo"
 forbid_make_dep "check-story-evidence"
 forbid_make_dep "check-flow-evidence"
 
+if ! grep -q "gate mutation" examples/demo/run-connected-smoke.sh; then
+  fail "connected smoke must record one mutation apply gate decision"
+fi
+if ! grep -q "gate_decision_digest" examples/demo/run-connected-smoke.sh; then
+  fail "connected smoke summary must expose the mutation gate decision digest"
+fi
+
 assert_jq "$tmp_json" '.summary.generator_fixtures == 8' "expected eight first-class generator fixtures"
 assert_jq "$tmp_json" '.summary.connected_release_gated == 2' "expected exactly two flagship examples in the connected smoke lane"
 assert_jq "$tmp_json" '[.rows[] | select(.connected_release_gated)] | map(.example) | sort == ["helm-paas", "springboot-paas"]' "connected smoke lane should cover helm-paas and springboot-paas"


### PR DESCRIPTION
## Summary
- add `cub-gen gate mutation` to produce `MutationApplyGateDecision` route/gate decisions from route policy, Spring field routes, or published bundles
- add digest-backed mutation gate proof events and make `proof events` extract them for Pilot/validation/attestation logs
- update v0.4 quickstart, Spring route demo, connected smoke summary, docs, roadmap, and release notes to reflect the Initiative/apply-gate #283 design

Fixes #283

## Validation
- `go test ./...`
- `make ci`
- `./examples/demo/v0.4-quickstart.sh`
- `./examples/springboot-paas/demo-governed-routes.sh`
- `make plugin-smoke`
- `.tmp/mkdocs-venv/bin/mkdocs build --strict`
- `git diff --check`
