### PR TITLE
Track ConfigHub merge-base dependency

### DIFF
--- a/docs/releases/v0.4-integration-beta.md
+++ b/docs/releases/v0.4-integration-beta.md
@@ -151,6 +151,19 @@ These are outside a cub-gen-only release:
 - Non-bypassable ConfigHub core write-path hardening for direct UI/API
   mutation bypass, if Initiative/apply gates are not enough for a customer.
 
+## ConfigHub Dependencies To Watch
+
+- ConfigHub now supports an explicit `--merge-base` override with
+  `--merge-external-source` in
+  [confighubai/confighub#4325](https://github.com/confighubai/confighub/pull/4325),
+  documented by
+  [confighubai/docs#101](https://github.com/confighubai/docs/pull/101). This
+  looks useful for repeated Generator refresh flows because ConfigHub can
+  preserve local data changes while resetting or rebasing the external merge
+  cursor. It is not a v0.4 cub-gen blocker, and public demos should not depend
+  on it until the next ConfigHub release includes the server change. Follow-up:
+  [#317](https://github.com/confighub/cub-gen/issues/317).
+
 ## Remaining cub-gen Release Polish
 
 The first flagship quickstart is now present. Before release, rerun it from a


### PR DESCRIPTION
## Summary

- add a v0.4 release-note dependency to watch for ConfigHub `--merge-external-source --merge-base`
- mark it as useful for later Generator refresh flows, but not a v0.4 cub-gen blocker
- link the post-v0.4 follow-up issue #317

## Validation

- `git diff --check`
- `/tmp/cub-gen-docs-venv/bin/mkdocs build --strict`
