### PR TITLE
Add Initiative GUI proof example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-plugin plugin-smoke test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-v04-quickstart test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
+.PHONY: build build-plugin plugin-smoke test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-v04-quickstart test-initiative-gui test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -32,6 +32,10 @@ test-change-api-http:
 
 test-v04-quickstart:
 	./examples/demo/v0.4-quickstart.sh
+
+test-initiative-gui:
+	./examples/springboot-paas/demo-initiative-gui.sh
+	jq -e '.scenarios[1].next_actions[0].files == ["pom.xml", "src/main/resources/application.yaml"] and .scenarios[1].source_file == "src/main/resources/application.yaml" and .scenarios[0].decision == "ALLOW" and .scenarios[2].decision == "BLOCK"' .tmp/springboot-initiative-gui/initiative-card.json
 
 test-connected-smoke:
 	SKIP_BUILD=1 ./examples/demo/run-connected-smoke.sh
@@ -111,7 +115,7 @@ update-goldens:
 sync-triple-styles:
 	go run ./cmd/cub-gen-style-sync
 
-ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http test-v04-quickstart lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
+ci-local: build test test-contracts test-bridge-symmetry test-examples test-change-api-http test-v04-quickstart test-initiative-gui lint-dual-mode check-story-status check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 
 ci-connected: build test-connected-smoke check-ai-only-scope check-docs-entrypoints check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability
 

--- a/cmd/cub-gen/testdata/parity/gate-mutation-spring-lift.golden.json
+++ b/cmd/cub-gen/testdata/parity/gate-mutation-spring-lift.golden.json
@@ -4,7 +4,7 @@
     "reason": "route lift-upstream blocks direct rendered mutation and asks for a source change",
     "state": "ESCALATE"
   },
-  "decision_digest": "sha256:2e54749977f092a3fecffccf78adb8bc819a222d3bc52e5ab7225fcc4b217bdb",
+  "decision_digest": "sha256:fff6480de8f0d2022364e6e0941be758e42e3e8b6cf41c37b4deb2704a213433",
   "gate": {
     "name": "generator-route",
     "version": "v1"
@@ -19,7 +19,8 @@
     {
       "description": "Cache adoption changes the app contract and should update upstream app inputs.",
       "files": [
-        "../../examples/springboot-paas/operational/field-routes.yaml"
+        "pom.xml",
+        "src/main/resources/application.yaml"
       ],
       "kind": "create-or-link-github-pr",
       "owner": "app-team"
@@ -33,11 +34,11 @@
     "owner": "app-team",
     "source": "../../examples/springboot-paas/operational/field-routes.yaml",
     "source_field": "spring.cache.*",
-    "source_file": "../../examples/springboot-paas/operational/field-routes.yaml"
+    "source_file": "src/main/resources/application.yaml"
   },
   "proof_events": [
     {
-      "artifact_digest": "sha256:2e54749977f092a3fecffccf78adb8bc819a222d3bc52e5ab7225fcc4b217bdb",
+      "artifact_digest": "sha256:fff6480de8f0d2022364e6e0941be758e42e3e8b6cf41c37b4deb2704a213433",
       "artifact_kind": "mutation_apply_gate",
       "change_id": "chg_49442e92b2c2f14a",
       "decision_reason": "route lift-upstream blocks direct rendered mutation and asks for a source change",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -490,6 +490,11 @@ The output separates route from gate decision:
 | `decision_digest` | Stable digest for the gate decision artifact |
 | `proof_events[]` | Loggable proof record for Pilot, validation, and later attestation |
 
+For `lift-upstream`, route metadata should name the source files the user
+actually needs to change. In the Spring example, `spring.cache.type` points to
+`pom.xml` and `src/main/resources/application.yaml`, not the rendered ConfigMap
+or the route policy file.
+
 Examples:
 
 ```bash

--- a/docs/releases/v0.4-integration-beta.md
+++ b/docs/releases/v0.4-integration-beta.md
@@ -94,6 +94,9 @@ If this deployed field is wrong, where do I fix it?
    - The decision object separates `route.kind` from `decision.state`, carries
      next actions, optional PR/MR link intent, a stable `decision_digest`, and
      `proof_events[]`.
+   - `examples/springboot-paas/demo-initiative-gui.sh` emits compact
+     Initiative cards for the three GUI outcomes: app-owned `ALLOW`,
+     source-owned `ESCALATE`, and platform-owned `BLOCK`.
    - ConfigHub can show the same object on an Initiative/MR apply gate without
      requiring cub-gen to change ConfigHub core write paths.
 
@@ -105,6 +108,7 @@ Before cutting the release, run:
 make ci
 /tmp/cub-gen-docs-venv/bin/mkdocs build --strict
 ./examples/demo/v0.4-quickstart.sh
+./examples/springboot-paas/demo-initiative-gui.sh
 ./examples/helm-paas/demo-local.sh
 ./examples/scoredev-paas/demo-local.sh
 ./examples/springboot-paas/demo-local.sh

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -24,6 +24,7 @@ The app is `inventory-api`, a Spring Boot 3.3.2 service (Java 21) deployed acros
 | Deep connected bridge path | Real | `./examples/springboot-paas/demo-connected.sh` |
 | Standalone live-cluster app proof | Real | `./bin/create-cluster && ./bin/build-image && ./bin/install-worker && ./verify-e2e.sh` |
 | Governed route proof (`ALLOW` / `ESCALATE` / `BLOCK`) | Real local mutation gate | `./examples/springboot-paas/demo-governed-routes.sh` |
+| Initiative GUI proof | Real local gate card for current ConfigHub Initiative UI | `./examples/springboot-paas/demo-initiative-gui.sh` |
 | Direct embedded ConfigHub payload mutation | Real but client-side | `./examples/springboot-paas/demo-embedded-config-mutation.sh` |
 
 The strongest caveat is enforcement depth, not demo truth. The ownership
@@ -131,6 +132,9 @@ go build -o ./cub-gen ./cmd/cub-gen
 
 # Governed route proof
 ./examples/springboot-paas/demo-governed-routes.sh
+
+# ConfigHub Initiative GUI proof
+./examples/springboot-paas/demo-initiative-gui.sh
 
 # Direct embedded payload mutation proof
 ./examples/springboot-paas/demo-embedded-config-mutation.sh
@@ -309,6 +313,12 @@ field route when `--routes` is provided.
 For v0.4, this is the cub-gen side of the mutation apply gate. In ConfigHub, an
 Initiative/MR can show the same route/decision/proof object and use an apply
 gate to stop governed flows before apply.
+
+For a concrete GUI card, run
+[`demo-initiative-gui.sh`](./demo-initiative-gui.sh) and read
+[`docs/initiative-gui.md`](./docs/initiative-gui.md). It shows the three review
+outcomes Brian and Jesper are likely to ask about: app-owned `ALLOW`,
+source-owned `ESCALATE`, and platform-owned `BLOCK`.
 
 ## Normalize preview
 

--- a/examples/springboot-paas/demo-initiative-gui.sh
+++ b/examples/springboot-paas/demo-initiative-gui.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/.tmp/springboot-initiative-gui}"
+ROUTES="$ROOT_DIR/examples/springboot-paas/operational/field-routes.yaml"
+CUB_GEN="${CUB_GEN:-$ROOT_DIR/cub-gen}"
+AT="${AT:-2026-05-03T12:00:00Z}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 1
+fi
+
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  go build -o "$CUB_GEN" ./cmd/cub-gen
+elif [ ! -x "$CUB_GEN" ]; then
+  echo "error: $CUB_GEN is not executable and SKIP_BUILD=1" >&2
+  exit 1
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+common=(
+  gate mutation
+  --routes "$ROUTES"
+  --json
+  --pretty=false
+  --at "$AT"
+  --space inventory-api-prod
+  --component inventory-api
+  --variant inventory-api-prod
+  --target prod-us
+  --resource-type ConfigMap
+  --resource-name inventory-api-config
+  --origin confighub-initiative
+  --attempted-layer rendered-config
+)
+
+"$CUB_GEN" "${common[@]}" \
+  --change-id chg_inventory_reservation_mode \
+  --new-value optimistic \
+  feature.inventory.reservationMode \
+  >"$OUT_DIR/01-allow-reservation-mode.json"
+
+"$CUB_GEN" "${common[@]}" \
+  --change-id chg_inventory_redis_cache \
+  --new-value redis \
+  --github-pr-repo github.com/confighub/cub-gen \
+  spring.cache.type \
+  >"$OUT_DIR/02-escalate-redis-cache.json"
+
+"$CUB_GEN" "${common[@]}" \
+  --change-id chg_inventory_datasource_override \
+  --new-value jdbc:postgresql://shadow.platform.svc:5432/inventory \
+  spring.datasource.url \
+  >"$OUT_DIR/03-block-datasource.json"
+
+jq -s '
+  def scenario($id; $title; $question; $unit; $old; $new; $decision):
+    {
+      id: $id,
+      title: $title,
+      user_question: $question,
+      confighub_unit: $unit,
+      changed_field: $decision.mutation.rendered_field,
+      old_value: $old,
+      new_value: $new,
+      route: $decision.route.kind,
+      decision: $decision.decision.state,
+      owner: $decision.proof.owner,
+      generator: $decision.proof.generator,
+      source_file: $decision.proof.source_file,
+      source_field: $decision.proof.source_field,
+      gate: $decision.gate.name,
+      decision_digest: $decision.decision_digest,
+      next_actions: $decision.next_actions,
+      proof_event_count: ($decision.proof_events | length)
+    };
+
+  {
+    schema_version: "cub.confighub.io/initiative-gui-example/v1",
+    generated_at: "2026-05-03T12:00:00Z",
+    title: "ConfigHub Initiative: inventory-api prod AppConfig change",
+    component: "inventory-api",
+    variant: "inventory-api-prod",
+    target: "prod-us",
+    current_confighub_mapping: {
+      gui_object: "Initiative",
+      cli_backing: "ChangeSet + Unit revision + Function/Trigger result + ApplyGates",
+      note: "The current public cub CLI exposes ChangeSets and ApplyGates. This example produces the gate cards the GUI should show on an Initiative."
+    },
+    gui_panels: [
+      "changed AppConfig field",
+      "Generator proof",
+      "mutation apply gate",
+      "next action",
+      "proof events and digest"
+    ],
+    scenarios: [
+      scenario(
+        "allow-feature-flag";
+        "ALLOW: app-owned feature flag";
+        "Can I flip reservation mode in prod?";
+        "inventory-api-prod/inventory-api";
+        "normal";
+        "optimistic";
+        .[0]
+      ),
+      scenario(
+        "escalate-redis-cache";
+        "ESCALATE: source change required";
+        "Can I add Redis caching by editing rendered AppConfig?";
+        "inventory-api-prod/inventory-api";
+        "none";
+        "redis";
+        .[1]
+      ),
+      scenario(
+        "block-datasource";
+        "BLOCK: platform-owned connection";
+        "Can I point prod at a shadow datasource?";
+        "inventory-api-prod/inventory-api";
+        "managed connection";
+        "shadow database URL";
+        .[2]
+      )
+    ]
+  }
+' \
+  "$OUT_DIR/01-allow-reservation-mode.json" \
+  "$OUT_DIR/02-escalate-redis-cache.json" \
+  "$OUT_DIR/03-block-datasource.json" \
+  >"$OUT_DIR/initiative-card.json"
+
+jq -r '
+  "ConfigHub Initiative GUI example written to: " + input_filename,
+  "",
+  (.scenarios[] | "- " + .title + ": field=" + .changed_field + " route=" + .route + " decision=" + .decision + " owner=" + .owner)
+' "$OUT_DIR/initiative-card.json"

--- a/examples/springboot-paas/docs/initiative-gui.md
+++ b/examples/springboot-paas/docs/initiative-gui.md
@@ -1,0 +1,112 @@
+# ConfigHub Initiative GUI Example
+
+This is the Spring example to show in the ConfigHub UI.
+
+The screen is simple: a user proposes an AppConfig edit in an Initiative, and
+ConfigHub shows the cub-gen mutation apply gate beside the edited field.
+
+```text
+If this deployed field is wrong, where do I fix it?
+```
+
+## Current ConfigHub Mapping
+
+The current public `cub` CLI exposes ChangeSets, Unit revisions, Functions,
+Triggers, and Apply Gates. The GUI can present the review object as an
+Initiative, while the runnable CLI path uses those current primitives.
+
+| GUI term | Current CLI/API backing | What cub-gen adds |
+|---|---|---|
+| Initiative | ChangeSet plus proposed Unit revisions | Change ID, route decision, proof digest |
+| Edited AppConfig field | Unit data / mutation | Field origin and source file |
+| Apply gate | Trigger or validation result stored in `ApplyGates` | `MutationApplyGateDecision` |
+| Review result | approve/apply or revise | next action: apply here, lift upstream, or block |
+
+## One Screen
+
+```mermaid
+flowchart LR
+  U["User edits AppConfig<br/>in ConfigHub"] --> I["Initiative<br/>proposed Unit revision"]
+  I --> G["cub-gen gate mutation<br/>Generator proof"]
+  G --> D["Decision<br/>route + ALLOW/ESCALATE/BLOCK"]
+  D --> A["Apply gate"]
+  A -->|ALLOW| Apply["Apply Initiative"]
+  A -->|ESCALATE| PR["Create or link source PR"]
+  A -->|BLOCK| Stop["Reject or owner escalation"]
+```
+
+The Initiative should show five panels:
+
+| Panel | Content |
+|---|---|
+| Change | Unit, field path, old value, new value |
+| Generator proof | Component, Variant, Target, Generator, source file, source field |
+| Mutation apply gate | route, decision, owner, reason |
+| Next action | apply mutation, create/link PR, request owner review |
+| Audit | `change_id`, `decision_digest`, proof event count |
+
+## Run It
+
+```bash
+./examples/springboot-paas/demo-initiative-gui.sh
+```
+
+The script writes:
+
+| File | Meaning |
+|---|---|
+| `.tmp/springboot-initiative-gui/01-allow-reservation-mode.json` | App-owned feature flag, `ALLOW` |
+| `.tmp/springboot-initiative-gui/02-escalate-redis-cache.json` | Redis cache request, `ESCALATE` and create/link PR |
+| `.tmp/springboot-initiative-gui/03-block-datasource.json` | Platform-owned datasource edit, `BLOCK` |
+| `.tmp/springboot-initiative-gui/initiative-card.json` | Compact GUI card for all three cases |
+
+## What The User Sees
+
+| Proposed edit | Route | Decision | Why |
+|---|---|---|---|
+| `feature.inventory.reservationMode: optimistic` | `apply-here` | `ALLOW` | App-owned rollout tuning can be changed in ConfigHub. |
+| `spring.cache.type: redis` | `lift-upstream` | `ESCALATE` | Redis changes the app contract and needs `pom.xml` plus `application.yaml`. |
+| `spring.datasource.url: shadow database` | `block/escalate` | `BLOCK` | Datasource wiring is platform-owned connection policy. |
+
+For the Redis case, the generated next action names the source files:
+
+```text
+pom.xml
+src/main/resources/application.yaml
+```
+
+That is the important product point. The user should not be told to edit the
+rendered ConfigMap or the route policy file. They should see exactly where the
+durable source change belongs.
+
+## Current CLI Shape
+
+The GUI flow maps to current ConfigHub commands like this:
+
+```bash
+cub changeset create --space inventory-api-prod \
+  chg-inventory-redis-cache \
+  --description "Add Redis cache support to inventory-api"
+
+cub unit update --patch --space inventory-api-prod inventory-api \
+  --changeset chg-inventory-redis-cache \
+  --change-desc "Propose AppConfig change through Initiative"
+
+cub function vet --space inventory-api-prod \
+  --trigger generator-route \
+  --unit inventory-api \
+  --update-apply-gates
+
+cub unit get --space inventory-api-prod inventory-api \
+  -o jq='.Unit.ApplyGates'
+```
+
+The exact Trigger/Function wiring belongs to ConfigHub. The cub-gen contract is
+the stable decision object and proof event that the Initiative displays.
+
+## Do Not Claim
+
+- No `cub initiative` CLI is assumed here.
+- No automatic GitHub PR is created by this local example.
+- No non-bypassable core write-path enforcement is claimed.
+- The example does not deploy anything.

--- a/examples/springboot-paas/operational/field-routes.yaml
+++ b/examples/springboot-paas/operational/field-routes.yaml
@@ -3,15 +3,26 @@ routes:
     owner: app-team
     defaultAction: mutable-in-ch
     reason: Per-deployment rollout tuning is safe to keep in ConfigHub.
+    sourcePath: src/main/resources/application-prod.yaml
+    sourceField: feature.inventory.*
   - match: spring.cache.*
     owner: app-team
     defaultAction: lift-upstream
     reason: Cache adoption changes the app contract and should update upstream app inputs.
+    sourcePath: src/main/resources/application.yaml
+    sourceField: spring.cache.*
+    proposalFiles:
+      - pom.xml
+      - src/main/resources/application.yaml
   - match: spring.datasource.*
     owner: platform-engineering
     defaultAction: generator-owned
     reason: Datasource connectivity is part of the managed platform boundary.
+    sourcePath: platform/base/runtime-policy.yaml
+    sourceField: spring.datasource.*
   - match: securityContext.*
     owner: platform-engineering
     defaultAction: generator-owned
     reason: Runtime hardening must remain platform-controlled.
+    sourcePath: platform/base/runtime-policy.yaml
+    sourceField: securityContext.*

--- a/examples/springboot-paas/verify.sh
+++ b/examples/springboot-paas/verify.sh
@@ -31,6 +31,8 @@ required_files=(
   "$ROOT_DIR/changes/03-generator-owned.md"
   "$ROOT_DIR/block-escalate.sh"
   "$ROOT_DIR/block-escalate-verify.sh"
+  "$ROOT_DIR/demo-initiative-gui.sh"
+  "$ROOT_DIR/docs/initiative-gui.md"
   "$ROOT_DIR/lift-upstream.sh"
   "$ROOT_DIR/lift-upstream-verify.sh"
   "$ROOT_DIR/lift-upstream/redis-cache/upstream-app/pom.xml"

--- a/internal/appofapps/appofapps.go
+++ b/internal/appofapps/appofapps.go
@@ -176,11 +176,6 @@ func ParseApplicationFile(repo, path string) (Application, error) {
 	}, nil
 }
 
-func IsApplicationFile(repo, path string) bool {
-	_, err := ParseApplicationFile(repo, path)
-	return err == nil
-}
-
 func findRoot(repo, rootPath string) (Root, error) {
 	roots, err := FindRoots(repo)
 	if err != nil {

--- a/internal/exampletruth/matrix.go
+++ b/internal/exampletruth/matrix.go
@@ -250,29 +250,6 @@ func parseExampleArray(path string) (map[string]struct{}, error) {
 	return nil, fmt.Errorf("examples array not found in %s", path)
 }
 
-func makeTargetDependencies(path, target string) ([]string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("open makefile: %w", err)
-	}
-	defer file.Close()
-
-	prefix := target + ":"
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasPrefix(line, prefix) {
-			continue
-		}
-		fields := strings.Fields(strings.TrimSpace(strings.TrimPrefix(line, prefix)))
-		return fields, nil
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan makefile: %w", err)
-	}
-	return nil, fmt.Errorf("target not found in makefile: %s", target)
-}
-
 func parseReadmeSectionExamples(path, heading string, stopPrefixes ...string) (map[string]struct{}, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -374,19 +351,6 @@ func hasAIFirstBundle(root, slug string) bool {
 	return fileExists(filepath.Join(exampleDir, "AI_START_HERE.md")) &&
 		fileExists(filepath.Join(exampleDir, "prompts.md")) &&
 		fileExists(filepath.Join(exampleDir, "contracts.md"))
-}
-
-func hasAll(values []string, wanted ...string) bool {
-	set := map[string]struct{}{}
-	for _, value := range values {
-		set[value] = struct{}{}
-	}
-	for _, value := range wanted {
-		if _, ok := set[value]; !ok {
-			return false
-		}
-	}
-	return true
 }
 
 func uniqueStrings(values []string) []string {

--- a/internal/mutationgate/gate.go
+++ b/internal/mutationgate/gate.go
@@ -50,17 +50,18 @@ type Mutation struct {
 }
 
 type Rule struct {
-	ResourceType string  `json:"resource_type,omitempty" yaml:"resource_type,omitempty"`
-	ResourceName string  `json:"resource_name,omitempty" yaml:"resource_name,omitempty"`
-	Path         string  `json:"path,omitempty" yaml:"path,omitempty"`
-	WetPath      string  `json:"wet_path,omitempty" yaml:"wet_path,omitempty"`
-	Route        string  `json:"route" yaml:"route"`
-	Owner        string  `json:"owner,omitempty" yaml:"owner,omitempty"`
-	SourcePath   string  `json:"source_path,omitempty" yaml:"source_path,omitempty"`
-	SourceField  string  `json:"source_field,omitempty" yaml:"source_field,omitempty"`
-	Generator    string  `json:"generator,omitempty" yaml:"generator,omitempty"`
-	ProposalHint string  `json:"proposal_hint,omitempty" yaml:"proposal_hint,omitempty"`
-	Confidence   float64 `json:"confidence,omitempty" yaml:"confidence,omitempty"`
+	ResourceType  string   `json:"resource_type,omitempty" yaml:"resource_type,omitempty"`
+	ResourceName  string   `json:"resource_name,omitempty" yaml:"resource_name,omitempty"`
+	Path          string   `json:"path,omitempty" yaml:"path,omitempty"`
+	WetPath       string   `json:"wet_path,omitempty" yaml:"wet_path,omitempty"`
+	Route         string   `json:"route" yaml:"route"`
+	Owner         string   `json:"owner,omitempty" yaml:"owner,omitempty"`
+	SourcePath    string   `json:"source_path,omitempty" yaml:"source_path,omitempty"`
+	SourceField   string   `json:"source_field,omitempty" yaml:"source_field,omitempty"`
+	Generator     string   `json:"generator,omitempty" yaml:"generator,omitempty"`
+	ProposalHint  string   `json:"proposal_hint,omitempty" yaml:"proposal_hint,omitempty"`
+	ProposalFiles []string `json:"proposal_files,omitempty" yaml:"proposal_files,omitempty"`
+	Confidence    float64  `json:"confidence,omitempty" yaml:"confidence,omitempty"`
 }
 
 type Policy struct {
@@ -145,15 +146,16 @@ func PolicyFromSpringRoutes(routes springboot.FieldRoutes, sourcePath string) Po
 			continue
 		}
 		out.Routes = append(out.Routes, Rule{
-			Path:         strings.TrimSpace(route.Match),
-			WetPath:      strings.TrimSpace(route.Match),
-			Route:        routeForSpringAction(route.DefaultAction),
-			Owner:        strings.TrimSpace(route.Owner),
-			SourcePath:   strings.TrimSpace(sourcePath),
-			SourceField:  strings.TrimSpace(route.Match),
-			Generator:    "springboot",
-			ProposalHint: strings.TrimSpace(route.Reason),
-			Confidence:   0.94,
+			Path:          strings.TrimSpace(route.Match),
+			WetPath:       strings.TrimSpace(route.Match),
+			Route:         routeForSpringAction(route.DefaultAction),
+			Owner:         strings.TrimSpace(route.Owner),
+			SourcePath:    firstNonEmpty(route.SourcePath, sourcePath),
+			SourceField:   firstNonEmpty(route.SourceField, route.Match),
+			Generator:     "springboot",
+			ProposalHint:  strings.TrimSpace(route.Reason),
+			ProposalFiles: uniqueStrings(route.ProposalFiles),
+			Confidence:    0.94,
 		})
 	}
 	sortRules(out.Routes)
@@ -515,7 +517,10 @@ func nextActions(routeKind string, rule Rule, req Request) []NextAction {
 			Owner:       owner,
 		}}
 	case RouteLiftUpstream:
-		files := uniqueStrings(append(req.SourceFiles, rule.SourcePath))
+		files := uniqueStrings(append(append([]string{}, req.SourceFiles...), rule.ProposalFiles...))
+		if len(files) == 0 && strings.TrimSpace(rule.SourcePath) != "" {
+			files = []string{strings.TrimSpace(rule.SourcePath)}
+		}
 		return []NextAction{{
 			Kind:        "create-or-link-github-pr",
 			Description: firstNonEmpty(rule.ProposalHint, "create or link a source PR before accepting this as a durable change"),

--- a/internal/mutationgate/gate_test.go
+++ b/internal/mutationgate/gate_test.go
@@ -54,6 +54,9 @@ func TestEvaluateSpringRoutes(t *testing.T) {
 	if len(lift.NextActions) != 1 || lift.NextActions[0].Kind != "create-or-link-github-pr" {
 		t.Fatalf("unexpected lift-upstream next actions: %+v", lift.NextActions)
 	}
+	if !sameStrings(lift.NextActions[0].Files, []string{"pom.xml", "src/main/resources/application.yaml"}) {
+		t.Fatalf("lift-upstream should point at source proposal files, got %+v", lift.NextActions[0].Files)
+	}
 	if err := ValidateDecisionRecord(lift); err != nil {
 		t.Fatalf("lift decision should be valid proof: %v", err)
 	}
@@ -98,6 +101,18 @@ func TestEvaluateMissingRouteRequiresReview(t *testing.T) {
 	if decision.Route.Kind != RouteReview || decision.Decision.State != DecisionEscalate {
 		t.Fatalf("expected review-required/ESCALATE, got route=%s state=%s", decision.Route.Kind, decision.Decision.State)
 	}
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestPolicyFromBundleOpenChoreoRoute(t *testing.T) {

--- a/internal/platform/graph.go
+++ b/internal/platform/graph.go
@@ -637,11 +637,6 @@ func targetOwnerRank(role string) int {
 	}
 }
 
-func inferVariantKind(explicitKind, target string) string {
-	kind, _ := resolveVariantKind(explicitKind, target)
-	return kind
-}
-
 func resolveVariantKind(explicitKind, target string) (string, bool) {
 	clean := normalizeToken(explicitKind, "")
 	hasTarget := strings.TrimSpace(target) != ""

--- a/internal/springboot/init.go
+++ b/internal/springboot/init.go
@@ -222,25 +222,36 @@ routes:
     owner: app-team
     defaultAction: mutable-in-ch
     reason: Per-deployment feature tuning is safe to keep in ConfigHub.
+    sourcePath: src/main/resources/application-prod.yaml
+    sourceField: feature.%s.*
 
   # App-owned cache config: requires source change
   - match: spring.cache.*
     owner: app-team
     defaultAction: lift-upstream
     reason: Cache adoption changes the app contract and should update upstream app inputs.
+    sourcePath: src/main/resources/application.yaml
+    sourceField: spring.cache.*
+    proposalFiles:
+      - pom.xml
+      - src/main/resources/application.yaml
 
   # Platform-owned datasource: blocked from app changes
   - match: spring.datasource.*
     owner: platform-engineering
     defaultAction: generator-owned
     reason: Datasource connectivity is part of the managed platform boundary.
+    sourcePath: platform/base/runtime-policy.yaml
+    sourceField: spring.datasource.*
 
   # Platform-owned security: blocked from app changes
   - match: securityContext.*
     owner: platform-engineering
     defaultAction: generator-owned
     reason: Runtime hardening must remain platform-controlled.
-`, appName, appPrefix)
+    sourcePath: platform/base/runtime-policy.yaml
+    sourceField: securityContext.*
+`, appName, appPrefix, appPrefix)
 }
 
 func confighubUnitContent(appName, env, namespace string) string {

--- a/internal/springboot/init_test.go
+++ b/internal/springboot/init_test.go
@@ -1,0 +1,56 @@
+package springboot
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestFieldRoutesContentIncludesSourceProposalFiles(t *testing.T) {
+	content := fieldRoutesContent("inventory-api")
+	if strings.Contains(content, "\t") {
+		t.Fatalf("generated field-routes.yaml must not contain tab indentation:\n%s", content)
+	}
+
+	var routes FieldRoutes
+	if err := yaml.Unmarshal([]byte(content), &routes); err != nil {
+		t.Fatalf("generated field routes should parse as YAML: %v\n%s", err, content)
+	}
+
+	cache := findFieldRoute(t, routes, "spring.cache.*")
+	if cache.SourcePath != "src/main/resources/application.yaml" {
+		t.Fatalf("cache sourcePath = %q", cache.SourcePath)
+	}
+	if !sameStringSlice(cache.ProposalFiles, []string{"pom.xml", "src/main/resources/application.yaml"}) {
+		t.Fatalf("cache proposalFiles = %+v", cache.ProposalFiles)
+	}
+
+	feature := findFieldRoute(t, routes, "feature.inventoryapi.*")
+	if feature.SourceField != "feature.inventoryapi.*" {
+		t.Fatalf("feature sourceField = %q", feature.SourceField)
+	}
+}
+
+func findFieldRoute(t *testing.T, routes FieldRoutes, match string) FieldRoute {
+	t.Helper()
+	for _, route := range routes.Routes {
+		if route.Match == match {
+			return route
+		}
+	}
+	t.Fatalf("missing generated route %q in %+v", match, routes.Routes)
+	return FieldRoute{}
+}
+
+func sameStringSlice(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/springboot/routes.go
+++ b/internal/springboot/routes.go
@@ -1,7 +1,6 @@
 package springboot
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -26,6 +25,9 @@ type FieldRoute struct {
 	Owner         string      `yaml:"owner"`
 	DefaultAction RouteAction `yaml:"defaultAction"`
 	Reason        string      `yaml:"reason"`
+	SourcePath    string      `yaml:"sourcePath"`
+	SourceField   string      `yaml:"sourceField"`
+	ProposalFiles []string    `yaml:"proposalFiles"`
 }
 
 // FieldRoutes is the root structure of field-routes.yaml.
@@ -108,45 +110,4 @@ func matchRoute(pattern, fieldPath string) bool {
 		return false
 	}
 	return matched
-}
-
-// EnforceMutation validates a mutation and returns an error if blocked.
-// This is the enforcement entry point.
-func EnforceMutation(opts ValidateMutationOptions) error {
-	result, err := ValidateMutation(opts)
-	if err != nil {
-		return err
-	}
-
-	if !result.Allowed {
-		return &MutationBlockedError{
-			FieldPath: result.FieldPath,
-			Owner:     result.Owner,
-			Action:    result.Action,
-			Reason:    result.Reason,
-			Rule:      result.MatchedRule,
-		}
-	}
-
-	return nil
-}
-
-// MutationBlockedError indicates a mutation was blocked by field routes.
-type MutationBlockedError struct {
-	FieldPath string
-	Owner     string
-	Action    RouteAction
-	Reason    string
-	Rule      string
-}
-
-func (e *MutationBlockedError) Error() string {
-	return fmt.Sprintf("mutation blocked: field %q is %s-owned (action=%s, rule=%s): %s",
-		e.FieldPath, e.Owner, e.Action, e.Rule, e.Reason)
-}
-
-// IsMutationBlocked returns true if the error is a MutationBlockedError.
-func IsMutationBlocked(err error) bool {
-	var blocked *MutationBlockedError
-	return errors.As(err, &blocked)
 }

--- a/internal/springboot/routes_test.go
+++ b/internal/springboot/routes_test.go
@@ -1,7 +1,6 @@
 package springboot
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -41,20 +40,5 @@ func TestMatchRoute(t *testing.T) {
 				t.Fatalf("matchRoute(%q, %q) = %v, want %v", tt.pattern, tt.field, got, tt.expected)
 			}
 		})
-	}
-}
-
-func TestIsMutationBlockedMatchesWrappedError(t *testing.T) {
-	t.Parallel()
-
-	err := fmt.Errorf("wrapped: %w", &MutationBlockedError{
-		FieldPath: "spring.datasource.url",
-		Owner:     "platform-team",
-		Action:    ActionLiftUpstream,
-		Reason:    "managed by platform",
-		Rule:      "spring.datasource.*",
-	})
-	if !IsMutationBlocked(err) {
-		t.Fatal("expected wrapped MutationBlockedError to be detected")
 	}
 }


### PR DESCRIPTION
## Summary

- add a Spring Boot ConfigHub Initiative GUI example that emits ALLOW / ESCALATE / BLOCK gate cards from real `gate mutation` output
- make Spring route metadata carry real source/proposal files so lift-upstream points at `pom.xml` and `src/main/resources/application.yaml`, not the route policy file
- remove unreachable internal helpers found by a Brian-style dead-code pass
- wire the Initiative GUI proof into `make ci` and release/docs references

## Validation

- `go test ./...`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@latest -test ./...`
- `make test-initiative-gui`
- `make ci`
- `/tmp/cub-gen-docs-venv/bin/mkdocs build --strict`
- `git diff --check`

## Notes

The current public `cub` CLI does not expose a `cub initiative` command in this environment. The example is therefore grounded in the current ChangeSet + Unit revision + Function/Trigger result + ApplyGates model, while presenting the review object as a ConfigHub Initiative for the GUI.
