### PR TITLE
[codex] Add live Spring Initiative evidence demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-plugin plugin-smoke test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-v04-quickstart test-initiative-gui test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
+.PHONY: build build-plugin plugin-smoke test test-parity test-contracts test-bridge-symmetry test-examples test-change-api-http test-v04-quickstart test-initiative-gui test-initiative-live test-connected-smoke test-connected-entrypoints test-connected-lifecycles test-phase-3-stories test-phase-4-stories test-flow-a-git-pr-to-mr test-flow-b-mr-to-git-pr test-connected-governed-reconcile-helm test-live-reconcile-flux test-live-reconcile-argo lint-dual-mode check-story-status check-story-evidence check-flow-evidence check-ai-only-scope check-docs-entrypoints check-platform-teaching-pack check-example-truth-matrix check-connected-release-gate check-connected-ingest-preflight check-springboot-worker-ready-guard check-no-legacy-provider-terms check-connected-auth-contract check-registry-discoverability update-goldens sync-triple-styles ci ci-local ci-connected ci-connected-deep ci-connected-troubleshoot docs docs-serve
 
 PARITY_TEST_PATTERN := ^(TestGitOpsParity|TestPublishGolden|TestVerifyGolden|TestAttestGolden|TestVerifyAttestationGolden|TestTopLevelCommand|TestGeneratorsGolden)
 BRIDGE_SYMMETRY_PATTERN := ^(TestBridgeSymmetryMatrix|TestExamplesPathModeBridgeFlow)$
@@ -36,6 +36,9 @@ test-v04-quickstart:
 test-initiative-gui:
 	./examples/springboot-paas/demo-initiative-gui.sh
 	jq -e '.scenarios[1].next_actions[0].files == ["pom.xml", "src/main/resources/application.yaml"] and .scenarios[1].source_file == "src/main/resources/application.yaml" and .scenarios[0].decision == "ALLOW" and .scenarios[2].decision == "BLOCK"' .tmp/springboot-initiative-gui/initiative-card.json
+
+test-initiative-live:
+	./examples/springboot-paas/demo-initiative-live.sh
 
 test-connected-smoke:
 	SKIP_BUILD=1 ./examples/demo/run-connected-smoke.sh

--- a/examples/springboot-paas/AI_START_HERE.md
+++ b/examples/springboot-paas/AI_START_HERE.md
@@ -8,6 +8,8 @@ Use this example when the question is not just "what rendered this field?" but
 - Spring config provenance and ownership from `application*.yaml` plus platform policy
 - local `ALLOW`, `ESCALATE`, and `BLOCK` paths for mutation routing
 - direct embedded ConfigHub payload mutation for an app-owned field
+- live ConfigHub Initiative evidence using current Space, Unit, ChangeSet,
+  Filter, and View primitives
 - a deeper connected ConfigHub walkthrough
 - a real standalone live-cluster app proof
 
@@ -28,6 +30,7 @@ Use this example when the question is not just "what rendered this field?" but
 | `gitops import --json` | `application*.yaml`, `pom.xml`, `platform/`, `gitops/` | stdout JSON only | no |
 | `demo-governed-routes.sh` | field-routes contract | `.tmp/springboot-governed-routes/<run>/...` | no repo/backend/live mutation |
 | `demo-embedded-config-mutation.sh` | payload yaml + field routes | `.tmp/springboot-embedded-config/<run>/...` | scratch clone only |
+| `demo-initiative-live.sh` | repo + ConfigHub auth/context | `.tmp/springboot-initiative-live/<run>/...` | backend evidence only |
 | `run-connected-smoke.sh` | repo + ConfigHub auth/context | `.tmp/connected-smoke/<run>/...` | backend evidence only |
 | `demo-connected.sh` | repo + ConfigHub auth/context | temporary connected lifecycle artifacts unless `OUTPUT_DIR` is set | backend evidence only |
 | live-cluster proof | repo + cluster helpers | cluster objects, image build artifacts, worker install state | yes, live cluster |
@@ -70,9 +73,11 @@ Success looks like:
    `./examples/springboot-paas/demo-embedded-config-mutation.sh`
 5. Connected environment check:
    `cub auth login && ./examples/demo/run-connected-smoke.sh`
-6. Deep connected walkthrough:
+6. Live Initiative evidence in ConfigHub:
+   `cub auth login && ./examples/springboot-paas/demo-initiative-live.sh`
+7. Deep connected walkthrough:
    `cub auth login && ./examples/springboot-paas/demo-connected.sh`
-7. Live-cluster proof:
+8. Live-cluster proof:
    `./bin/create-cluster && ./bin/build-image && ./bin/install-worker && ./verify-e2e.sh`
 
 ## What to verify after each major step
@@ -81,12 +86,15 @@ Success looks like:
 - Local route proof: `feature.inventory.reservationMode` is `apply-here/ALLOW`, `spring.cache.type` is `lift-upstream/ESCALATE`, and `spring.datasource.url` is `block/escalate/BLOCK`; artifacts land under `.tmp/springboot-governed-routes/...`.
 - Local apply-here proof: the reservation mode changes in the embedded payload and the datasource mutation is rejected; artifacts land under `.tmp/springboot-embedded-config/...`.
 - Connected smoke: ConfigHub auth/context is valid and the smoke summaries include a non-empty `change_id`.
+- Live Initiative evidence: a `springboot-initiative-live` space exists, the run summary reports at least five Units and three ChangeSets, and the Initiative View is labeled `initiative=true`.
 - Deep connected walkthrough: a terminal connected decision state is returned for the same `change_id`.
 - Live-cluster proof: `verify-e2e.sh` succeeds and `inventory-api` is reachable on the kind cluster.
 
 ## GUI checkpoints
 
 - ConfigHub GUI: inspect the change referenced by `change_id` after smoke or deep connected mode.
+- ConfigHub Initiative evidence: open the `springboot-initiative-live` space,
+  inspect the run-specific Initiative View, and open the compact card Unit.
 - Spring payload helpers: compare and refresh-preview outputs should show the app-owned override preserved.
 - Live runtime: inspect `inventory-api` health and cluster objects after `verify-e2e.sh`.
 
@@ -100,4 +108,6 @@ Success looks like:
 ## Cleanup
 
 - Remove local proof artifacts with `rm -rf .tmp/springboot-governed-routes .tmp/springboot-embedded-config .tmp/connected-smoke`
+- Delete live Initiative evidence with
+  `SPACE=springboot-initiative-live ./examples/springboot-paas/demo-initiative-live.sh --cleanup`
 - Tear down clusters and workers with the same helper scripts used for the live path

--- a/examples/springboot-paas/README.md
+++ b/examples/springboot-paas/README.md
@@ -25,6 +25,7 @@ The app is `inventory-api`, a Spring Boot 3.3.2 service (Java 21) deployed acros
 | Standalone live-cluster app proof | Real | `./bin/create-cluster && ./bin/build-image && ./bin/install-worker && ./verify-e2e.sh` |
 | Governed route proof (`ALLOW` / `ESCALATE` / `BLOCK`) | Real local mutation gate | `./examples/springboot-paas/demo-governed-routes.sh` |
 | Initiative GUI proof | Real local gate card for current ConfigHub Initiative UI | `./examples/springboot-paas/demo-initiative-gui.sh` |
+| Live ConfigHub Initiative evidence | Real backend objects in current ConfigHub UI | `./examples/springboot-paas/demo-initiative-live.sh` |
 | Direct embedded ConfigHub payload mutation | Real but client-side | `./examples/springboot-paas/demo-embedded-config-mutation.sh` |
 
 The strongest caveat is enforcement depth, not demo truth. The ownership
@@ -135,6 +136,10 @@ go build -o ./cub-gen ./cmd/cub-gen
 
 # ConfigHub Initiative GUI proof
 ./examples/springboot-paas/demo-initiative-gui.sh
+
+# Live ConfigHub Initiative evidence
+cub auth login
+./examples/springboot-paas/demo-initiative-live.sh
 
 # Direct embedded payload mutation proof
 ./examples/springboot-paas/demo-embedded-config-mutation.sh
@@ -319,6 +324,13 @@ For a concrete GUI card, run
 [`docs/initiative-gui.md`](./docs/initiative-gui.md). It shows the three review
 outcomes Brian and Jesper are likely to ask about: app-owned `ALLOW`,
 source-owned `ESCALATE`, and platform-owned `BLOCK`.
+
+To put the same evidence into a real ConfigHub account, run
+[`demo-initiative-live.sh`](./demo-initiative-live.sh). It creates a live Space,
+an Initiative-labeled View, a compact gate-card Unit, three decision Units, and
+three ChangeSets with route, owner, next action, and digest metadata. The
+current UI can show those objects today; first-class card rendering in the
+Initiative panel is the next ConfigHub UI/backend integration.
 
 ## Normalize preview
 

--- a/examples/springboot-paas/contracts.md
+++ b/examples/springboot-paas/contracts.md
@@ -133,6 +133,38 @@ inspect_with:
   - jq '{phase, change_id, decision_state, attestation_valid}' .tmp/springboot-connected/update/summary.json
 ```
 
+## Live ConfigHub Initiative evidence
+
+```yaml
+id: spring_initiative_live
+command: ./examples/springboot-paas/demo-initiative-live.sh
+mutates:
+  repo: false
+  backend: true
+  live: false
+expects:
+  files_exist:
+    - ".tmp/springboot-initiative-live/<run>/live-summary.json"
+  backend_objects:
+    - "Space springboot-initiative-live"
+    - "one Initiative-labeled View"
+    - "one rendered inventory-api Unit"
+    - "one compact gate-card Unit"
+    - "three mutation apply gate decision Units"
+    - "three ChangeSets"
+  decisions:
+    - "feature.inventory.reservationMode -> apply-here -> ALLOW"
+    - "spring.cache.type -> lift-upstream -> ESCALATE"
+    - "spring.datasource.url -> block/escalate -> BLOCK"
+inspect_with:
+  - jq '{space: .confighub.space, view: .confighub.initiative_view, card_unit: .confighub.card_unit, unit_hits: .run.unit_hits, changeset_hits: .run.changeset_hits}' .tmp/springboot-initiative-live/<run>/live-summary.json
+  - cub view get --space springboot-initiative-live -o json <initiative-view>
+  - cub unit get --space springboot-initiative-live -o json <card-unit>
+  - cub changeset get --space springboot-initiative-live -o json <redis-changeset>
+cleanup:
+  - SPACE=springboot-initiative-live ./examples/springboot-paas/demo-initiative-live.sh --cleanup
+```
+
 ## Live standalone app proof
 
 ```yaml

--- a/examples/springboot-paas/demo-initiative-live.sh
+++ b/examples/springboot-paas/demo-initiative-live.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/examples/demo/lib/connected-preflight.sh"
+
+CUB="${CUB:-cub}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+SPACE="${SPACE:-springboot-initiative-live}"
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/.tmp/springboot-initiative-live}"
+OUT_DIR="$OUT_ROOT/$RUN_ID"
+CARD_DIR="$OUT_DIR/card"
+EXAMPLE_LABEL="springboot-paas-initiative-live"
+INITIATIVE_LABEL="inventory-api-appconfig-gates"
+FILTER_SLUG="inventory-api-gate-units-${RUN_ID}"
+VIEW_SLUG="inventory-api-appconfig-gates-${RUN_ID}"
+CARD_UNIT="initiative-card-$(printf '%s' "$RUN_ID" | tr '[:upper:]' '[:lower:]')"
+RENDERED_UNIT="inventory-api-prod"
+
+usage() {
+  cat <<EOF
+Usage: ./examples/springboot-paas/demo-initiative-live.sh [--cleanup|--explain]
+
+Creates live ConfigHub evidence for the Spring cub-gen Initiative proof.
+
+Default space: ${SPACE}
+
+Environment overrides:
+  SPACE       ConfigHub space to create/use
+  RUN_ID      Suffix for run-specific live objects
+  OUT_ROOT    Local output root
+  CUB         cub binary
+
+The default run mutates ConfigHub by creating:
+  - one Space
+  - one rendered inventory-api Unit
+  - one compact Initiative card Unit
+  - three per-scenario decision Units
+  - three ChangeSets
+  - one Filter and one View labeled as an Initiative
+EOF
+}
+
+sanitize_slug() {
+  local input="$1"
+  input="$(printf '%s' "$input" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+  input="$(printf '%s' "$input" | sed -E 's/^-+//; s/-+$//; s/-+/-/g')"
+  printf '%s' "${input:0:63}"
+}
+
+write_configmap_unit() {
+  local name="$1"
+  local source="$2"
+  local dest="$3"
+
+  {
+    printf 'apiVersion: v1\n'
+    printf 'kind: ConfigMap\n'
+    printf 'metadata:\n'
+    printf '  name: %s\n' "$name"
+    printf '  namespace: apps\n'
+    printf '  labels:\n'
+    printf '    app.kubernetes.io/name: inventory-api\n'
+    printf '    cubgen.confighub.io/initiative: %s\n' "$INITIATIVE_LABEL"
+    printf 'data:\n'
+    printf '  gate.json: |-\n'
+    sed 's/^/    /' "$source"
+  } > "$dest"
+}
+
+case "${1:-}" in
+  --cleanup)
+    echo "[spring-initiative-live] deleting spaces with ExampleName=${EXAMPLE_LABEL}"
+    "$CUB" space delete --where "Labels.ExampleName = '${EXAMPLE_LABEL}'" --recursive
+    exit 0
+    ;;
+  --explain)
+    usage
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+require_connected_preflight
+require_cmd go
+
+mkdir -p "$OUT_DIR"
+
+echo "[spring-initiative-live] connected context"
+print_connected_context
+echo "[spring-initiative-live] output: $OUT_DIR"
+
+echo "[spring-initiative-live] generate local gate cards"
+OUT_DIR="$CARD_DIR" ./examples/springboot-paas/demo-initiative-gui.sh \
+  | tee "$OUT_DIR/local-card.stdout"
+
+echo "[spring-initiative-live] create or reuse ConfigHub space: $SPACE"
+"$CUB" space create "$SPACE" \
+  --allow-exists \
+  -o json \
+  --label "ExampleName=${EXAMPLE_LABEL}" \
+  --label "Component=inventory-api" \
+  --label "Purpose=mutation-apply-gate-live-proof" \
+  --annotation "Description=Live cub-gen Spring Initiative proof" \
+  > "$OUT_DIR/space.json"
+
+echo "[spring-initiative-live] publish rendered inventory-api Unit"
+"$CUB" unit create \
+  --space "$SPACE" \
+  --allow-exists \
+  -o json \
+  -t "Kubernetes/YAML" \
+  --label "ExampleName=${EXAMPLE_LABEL}" \
+  --label "CubGenInitiative=${INITIATIVE_LABEL}" \
+  --label "RunID=${RUN_ID}" \
+  --label "Component=inventory-api" \
+  --label "Variant=inventory-api-prod" \
+  --label "Target=prod-us" \
+  --label "UnitRole=rendered-config" \
+  --annotation "cubgen-note=Rendered Kubernetes config reviewed by the live Initiative proof" \
+  "$RENDERED_UNIT" \
+  ./examples/springboot-paas/confighub/inventory-api-prod.yaml \
+  > "$OUT_DIR/unit-rendered.json"
+
+"$CUB" unit update \
+  --space "$SPACE" \
+  --patch \
+  -o json \
+  --label "ExampleName=${EXAMPLE_LABEL}" \
+  --label "CubGenInitiative=${INITIATIVE_LABEL}" \
+  --label "RunID=${RUN_ID}" \
+  --label "Component=inventory-api" \
+  --label "Variant=inventory-api-prod" \
+  --label "Target=prod-us" \
+  --label "UnitRole=rendered-config" \
+  --annotation "cubgen-note=Rendered Kubernetes config reviewed by the live Initiative proof" \
+  "$RENDERED_UNIT" \
+  > "$OUT_DIR/unit-rendered-patch.json"
+
+echo "[spring-initiative-live] create run ChangeSets and decision Units"
+declare -a scenario_specs=(
+  "allow-feature-flag|01-allow-reservation-mode.json|allow-feature-flag"
+  "escalate-redis-cache|02-escalate-redis-cache.json|redis-cache"
+  "block-datasource|03-block-datasource.json|datasource-override"
+)
+
+for spec in "${scenario_specs[@]}"; do
+  IFS="|" read -r scenario_id decision_file suffix <<< "$spec"
+  decision_path="$CARD_DIR/$decision_file"
+  decision_state="$(jq -r '.decision.state' "$decision_path")"
+  route_kind="$(jq -r '.route.kind' "$decision_path")"
+  route_label="$(sanitize_slug "$route_kind")"
+  owner="$(jq -r '.proof.owner' "$decision_path")"
+  field="$(jq -r '.mutation.rendered_field' "$decision_path")"
+  field_label="$(sanitize_slug "$field")"
+  source_file="$(jq -r '.proof.source_file' "$decision_path")"
+  digest="$(jq -r '.decision_digest' "$decision_path")"
+  change_id="$(jq -r '.change_id' "$decision_path")"
+  next_action_kind="$(jq -r '.next_actions[0].kind // "none"' "$decision_path")"
+  proposal_files="$(jq -r '.next_actions[0].files // [] | join(";")' "$decision_path")"
+  changeset_slug="$(sanitize_slug "initiative-${suffix}-${RUN_ID}")"
+  decision_unit="$(sanitize_slug "decision-${suffix}-${RUN_ID}")"
+  decision_unit_file="$OUT_DIR/${decision_unit}.yaml"
+
+  write_configmap_unit "$decision_unit" "$decision_path" "$decision_unit_file"
+
+  "$CUB" changeset create \
+    --space "$SPACE" \
+    --allow-exists \
+    -o json \
+    "$changeset_slug" \
+    --description "${decision_state}: ${field} via ${route_kind} (${change_id})" \
+    --label "ExampleName=${EXAMPLE_LABEL}" \
+    --label "cubgen_initiative=${INITIATIVE_LABEL}" \
+    --label "run_id=${RUN_ID}" \
+    --label "scenario=${scenario_id}" \
+    --label "decision=${decision_state}" \
+    --label "route=${route_label}" \
+    --label "field=${field_label}" \
+    --annotation "cubgen-change-id=${change_id}" \
+    --annotation "cubgen-field=${field}" \
+    --annotation "cubgen-route=${route_kind}" \
+    --annotation "cubgen-decision=${decision_state}" \
+    --annotation "cubgen-owner=${owner}" \
+    --annotation "cubgen-source-file=${source_file}" \
+    --annotation "cubgen-next-action=${next_action_kind}" \
+    --annotation "cubgen-proposal-files=${proposal_files}" \
+    --annotation "cubgen-decision-digest=${digest}" \
+    --annotation "cubgen-decision-unit=${decision_unit}" \
+    > "$OUT_DIR/changeset-${scenario_id}.json"
+
+  "$CUB" unit create \
+    --space "$SPACE" \
+    --allow-exists \
+    -o json \
+    -t "Kubernetes/YAML" \
+    --changeset "$changeset_slug" \
+    --change-desc "Record cub-gen mutation apply gate decision for ${field}" \
+    --label "ExampleName=${EXAMPLE_LABEL}" \
+    --label "CubGenInitiative=${INITIATIVE_LABEL}" \
+    --label "RunID=${RUN_ID}" \
+    --label "Component=inventory-api" \
+    --label "Variant=inventory-api-prod" \
+    --label "Target=prod-us" \
+    --label "UnitRole=mutation-apply-gate-decision" \
+    --label "Scenario=${scenario_id}" \
+    --label "Decision=${decision_state}" \
+    --label "Route=${route_label}" \
+    --annotation "cubgen-change-id=${change_id}" \
+    --annotation "cubgen-field=${field}" \
+    --annotation "cubgen-source-file=${source_file}" \
+    --annotation "cubgen-decision-digest=${digest}" \
+    "$decision_unit" \
+    "$decision_unit_file" \
+    > "$OUT_DIR/unit-${scenario_id}.json"
+done
+
+echo "[spring-initiative-live] publish compact Initiative card Unit"
+card_unit_file="$OUT_DIR/${CARD_UNIT}.yaml"
+write_configmap_unit "$(sanitize_slug "$CARD_UNIT")" "$CARD_DIR/initiative-card.json" "$card_unit_file"
+
+"$CUB" unit create \
+  --space "$SPACE" \
+  --allow-exists \
+  -o json \
+  -t "Kubernetes/YAML" \
+  --label "ExampleName=${EXAMPLE_LABEL}" \
+  --label "CubGenInitiative=${INITIATIVE_LABEL}" \
+  --label "RunID=${RUN_ID}" \
+  --label "Component=inventory-api" \
+  --label "Variant=inventory-api-prod" \
+  --label "Target=prod-us" \
+  --label "UnitRole=initiative-card" \
+  --annotation "cubgen-note=Compact card for the current ConfigHub Initiative UI proof" \
+  "$CARD_UNIT" \
+  "$card_unit_file" \
+  > "$OUT_DIR/unit-card.json"
+
+echo "[spring-initiative-live] create Initiative filter and view"
+"$CUB" filter create \
+  --space "$SPACE" \
+  --allow-exists \
+  -o json \
+  "$FILTER_SLUG" \
+  Unit \
+  --where-field "Labels.CubGenInitiative = '${INITIATIVE_LABEL}' AND Labels.RunID = '${RUN_ID}'" \
+  --label "ExampleName=${EXAMPLE_LABEL}" \
+  --label "cubgen_initiative=${INITIATIVE_LABEL}" \
+  --label "run_id=${RUN_ID}" \
+  > "$OUT_DIR/filter.json"
+
+check_summary="$(jq -r '
+  {
+    allow: ([.scenarios[] | select(.decision == "ALLOW")] | length),
+    escalate: ([.scenarios[] | select(.decision == "ESCALATE")] | length),
+    block: ([.scenarios[] | select(.decision == "BLOCK")] | length),
+    total: (.scenarios | length)
+  } | "allow:\(.allow);escalate:\(.escalate);block:\(.block);total:\(.total)"
+' "$CARD_DIR/initiative-card.json")"
+
+"$CUB" view create \
+  --space "$SPACE" \
+  --allow-exists \
+  -o json \
+  "$VIEW_SLUG" \
+  "$FILTER_SLUG" \
+  --column Unit.Slug \
+  --column Labels.UnitRole \
+  --column Labels.Decision \
+  --column Labels.Route \
+  --column Labels.Scenario \
+  --label "initiative=true" \
+  --label "initiative-priority=HIGH" \
+  --label "initiative-status=in_progress" \
+  --label "ExampleName=${EXAMPLE_LABEL}" \
+  --label "cubgen_initiative=${INITIATIVE_LABEL}" \
+  --label "run_id=${RUN_ID}" \
+  --annotation "initiative-description=Review cub-gen mutation apply gates for inventory-api prod AppConfig edits" \
+  --annotation "initiative-deadline=2026-05-31" \
+  --annotation "initiative-check-summary=${check_summary}" \
+  --annotation "cubgen-card-unit=${CARD_UNIT}" \
+  --annotation "cubgen-rendered-unit=${RENDERED_UNIT}" \
+  --annotation "cubgen-doc=examples/springboot-paas/docs/initiative-gui.md" \
+  > "$OUT_DIR/view.json"
+
+echo "[spring-initiative-live] verify live queries"
+"$CUB" unit list \
+  --space "$SPACE" \
+  -o json \
+  --where "Labels.CubGenInitiative = '${INITIATIVE_LABEL}' AND Labels.RunID = '${RUN_ID}'" \
+  > "$OUT_DIR/unit-query.json"
+
+"$CUB" changeset list \
+  --space "$SPACE" \
+  -o json \
+  --where "Labels.cubgen_initiative = '${INITIATIVE_LABEL}' AND Labels.run_id = '${RUN_ID}'" \
+  > "$OUT_DIR/changeset-query.json"
+
+unit_hits="$(jq 'length' "$OUT_DIR/unit-query.json")"
+changeset_hits="$(jq 'length' "$OUT_DIR/changeset-query.json")"
+if [ "$unit_hits" -lt 5 ] || [ "$changeset_hits" -lt 3 ]; then
+  echo "error: live query proof incomplete (unit_hits=$unit_hits changeset_hits=$changeset_hits)" >&2
+  exit 1
+fi
+
+jq -n \
+  --arg schema_version "cub.confighub.io/springboot-initiative-live/v1" \
+  --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg base_url "$CONFIGHUB_BASE_URL" \
+  --arg space "$SPACE" \
+  --arg run_id "$RUN_ID" \
+  --arg initiative "$INITIATIVE_LABEL" \
+  --arg view "$VIEW_SLUG" \
+  --arg filter "$FILTER_SLUG" \
+  --arg card_unit "$CARD_UNIT" \
+  --arg rendered_unit "$RENDERED_UNIT" \
+  --arg local_card "$CARD_DIR/initiative-card.json" \
+  --arg unit_query "$OUT_DIR/unit-query.json" \
+  --arg changeset_query "$OUT_DIR/changeset-query.json" \
+  --argjson unit_hits "$unit_hits" \
+  --argjson changeset_hits "$changeset_hits" \
+  --slurpfile card "$CARD_DIR/initiative-card.json" \
+  '{
+    schema_version: $schema_version,
+    generated_at: $generated_at,
+    confighub: {
+      base_url: $base_url,
+      space: $space,
+      initiative_view: $view,
+      filter: $filter,
+      card_unit: $card_unit,
+      rendered_unit: $rendered_unit
+    },
+    run: {
+      run_id: $run_id,
+      initiative: $initiative,
+      local_card: $local_card,
+      unit_query: $unit_query,
+      changeset_query: $changeset_query,
+      unit_hits: $unit_hits,
+      changeset_hits: $changeset_hits
+    },
+    decisions: $card[0].scenarios,
+    current_ui_path: [
+      "Open ConfigHub",
+      ("Open space " + $space),
+      ("Open Views/Initiatives and select " + $view),
+      ("Open unit " + $card_unit + " for the compact gate card"),
+      "Open the three ChangeSets for route, owner, next action, and digest metadata"
+    ],
+    note: "This is live ConfigHub evidence using current Space, Unit, ChangeSet, Filter, and View primitives. First-class native card rendering is the next ConfigHub UI/backend integration."
+  }' > "$OUT_DIR/live-summary.json"
+
+REDIS_CHANGESET_SLUG="$(sanitize_slug "initiative-redis-cache-${RUN_ID}")"
+
+cat <<EOF
+
+Live ConfigHub Initiative evidence is ready.
+
+Space:          $SPACE
+Initiative view:$VIEW_SLUG
+Card unit:      $CARD_UNIT
+Run ID:         $RUN_ID
+Summary:        $OUT_DIR/live-summary.json
+
+Inspect with:
+  cub view get --space $SPACE -o json $VIEW_SLUG
+  cub unit get --space $SPACE -o json $CARD_UNIT
+  cub changeset list --space $SPACE -o json --where "Labels.cubgen_initiative = '$INITIATIVE_LABEL' AND Labels.run_id = '$RUN_ID'"
+  cub changeset get --space $SPACE -o json $REDIS_CHANGESET_SLUG
+
+Open in the current UI:
+  cub space get --web $SPACE
+  cub unit get --space $SPACE --web $CARD_UNIT
+  Then open Views/Initiatives in the $SPACE space and select $VIEW_SLUG.
+
+Cleanup:
+  SPACE=$SPACE ./examples/springboot-paas/demo-initiative-live.sh --cleanup
+EOF

--- a/examples/springboot-paas/docs/initiative-gui.md
+++ b/examples/springboot-paas/docs/initiative-gui.md
@@ -47,6 +47,8 @@ The Initiative should show five panels:
 
 ## Run It
 
+Local card only:
+
 ```bash
 ./examples/springboot-paas/demo-initiative-gui.sh
 ```
@@ -59,6 +61,37 @@ The script writes:
 | `.tmp/springboot-initiative-gui/02-escalate-redis-cache.json` | Redis cache request, `ESCALATE` and create/link PR |
 | `.tmp/springboot-initiative-gui/03-block-datasource.json` | Platform-owned datasource edit, `BLOCK` |
 | `.tmp/springboot-initiative-gui/initiative-card.json` | Compact GUI card for all three cases |
+
+Live ConfigHub evidence:
+
+```bash
+cub auth login
+./examples/springboot-paas/demo-initiative-live.sh
+```
+
+That script writes a local summary and creates live ConfigHub objects:
+
+| Object | Meaning |
+|---|---|
+| Space `springboot-initiative-live` | Isolated demo surface for this proof |
+| Rendered Unit `inventory-api-prod` | The Kubernetes config being reviewed |
+| Unit `initiative-card-<run>` | ConfigMap containing the compact gate card JSON |
+| Three decision Units | One `MutationApplyGateDecision` ConfigMap per route outcome |
+| Three ChangeSets | Review objects with decision, route, owner, next action, and digest metadata |
+| View `inventory-api-appconfig-gates-<run>` | Current UI Initiative surface, labeled `initiative=true` |
+
+Inspect the latest run with the commands printed by the script:
+
+```bash
+cub view get --space springboot-initiative-live -o json <initiative-view>
+cub unit get --space springboot-initiative-live -o json <card-unit>
+cub changeset get --space springboot-initiative-live -o json <redis-changeset>
+```
+
+In the current ConfigHub UI, open the `springboot-initiative-live` space, then
+open the run-specific View/Initiative and the compact card Unit. This is real
+backend evidence, not a screenshot mock. First-class rendering of the five
+panels above is still a ConfigHub UI/backend integration step.
 
 ## What The User Sees
 
@@ -101,8 +134,10 @@ cub unit get --space inventory-api-prod inventory-api \
   -o jq='.Unit.ApplyGates'
 ```
 
-The exact Trigger/Function wiring belongs to ConfigHub. The cub-gen contract is
-the stable decision object and proof event that the Initiative displays.
+The live script uses current ConfigHub primitives today: Space, Unit, ChangeSet,
+Filter, and View. The exact Trigger/Function/ApplyGate wiring belongs to the
+native ConfigHub integration. The cub-gen contract is the stable decision object
+and proof event that the Initiative displays.
 
 ## Do Not Claim
 

--- a/examples/springboot-paas/verify.sh
+++ b/examples/springboot-paas/verify.sh
@@ -32,6 +32,7 @@ required_files=(
   "$ROOT_DIR/block-escalate.sh"
   "$ROOT_DIR/block-escalate-verify.sh"
   "$ROOT_DIR/demo-initiative-gui.sh"
+  "$ROOT_DIR/demo-initiative-live.sh"
   "$ROOT_DIR/docs/initiative-gui.md"
   "$ROOT_DIR/lift-upstream.sh"
   "$ROOT_DIR/lift-upstream-verify.sh"


### PR DESCRIPTION
## Summary
- add `examples/springboot-paas/demo-initiative-live.sh`, a connected script that creates live ConfigHub evidence for the Spring mutation apply gate story
- publish a live Space, rendered Unit, compact gate-card Unit, three decision Units, three ChangeSets, and an Initiative-labeled View
- document the local card proof versus the live current-UI path in the Spring README, AI guide, contracts, and Initiative GUI doc

## Live proof
Clean run created real ConfigHub objects in `springboot-initiative-live`:

- View: `inventory-api-appconfig-gates-20260503T140736Z`
- Card unit: `initiative-card-20260503t140736z`
- Summary: `.tmp/springboot-initiative-live/20260503T140736Z/live-summary.json`
- Space URL: https://hub.confighub.com/spaces/70c2bde7-3557-4dd5-8c36-bd991fc99c20
- Card unit URL: https://hub.confighub.com/units/70c2bde7-3557-4dd5-8c36-bd991fc99c20/d91cccfc-8133-4447-8ab8-1a9e9350180c

The live run verifies five Units and three ChangeSets, with these decisions:

- `feature.inventory.reservationMode` -> `apply-here` -> `ALLOW`
- `spring.cache.type` -> `lift-upstream` -> `ESCALATE`
- `spring.datasource.url` -> `block/escalate` -> `BLOCK`

## Validation
- `bash -n examples/springboot-paas/demo-initiative-live.sh`
- `./examples/springboot-paas/demo-initiative-live.sh` against live ConfigHub
- live queries for View, Units, ChangeSets, and Redis ChangeSet annotations
- `./examples/springboot-paas/verify.sh`
- `make test-initiative-gui`
- `go test ./cmd/cub-gen -run '^(TestTopLevelCommand|TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1`
- `go test ./...`
- `make ci`
- `/tmp/cub-gen-docs-venv/bin/mkdocs build --strict`

## Boundary
This lands the current ConfigHub UI path: live Space/Unit/ChangeSet/View evidence. First-class native Initiative card rendering still belongs in ConfigHub UI/backend work.
