### PR TITLE
Clarify v0.4 release boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ A **mutation apply gate** is the decision point for that route. It records the
 field, owner, route, decision, next action, and proof so ConfigHub can show why
 a change may apply here, must move upstream, or should be blocked.
 
+Today `cub-gen` can publish that evidence into ConfigHub using current objects:
+Space, Unit, ChangeSet, Filter, and View. The first-class ConfigHub
+Function/Trigger/ApplyGate wiring and native Initiative card are the next
+integration step; `cub-gen` owns the deterministic decision and proof payload.
+
 Short version: `cub-gen` turns the app/platform repos people already have into
 explicit, governed functions on config data. It does this without pretending
 Kubernetes stopped being Kubernetes.

--- a/docs/plans/2026-04-30-platform-generator-product-worklist.md
+++ b/docs/plans/2026-04-30-platform-generator-product-worklist.md
@@ -13,12 +13,14 @@ and GitHub release tracker [#302](https://github.com/confighub/cub-gen/issues/30
 
 ## Current Roadmap Touchpoints
 
-Open and recently completed issues checked on 2026-05-02:
+Open and recently completed issues checked on 2026-05-03:
 
 | Issue | Title | Why it matters for the manifesto |
 |---|---|---|
-| [#287](https://github.com/confighub/cub-gen/issues/287) | make cub-gen role and value obvious | parent roadmap issue keeping the product story coherent |
+| [#302](https://github.com/confighub/cub-gen/issues/302) | v0.4 integration beta tracker | active release tracker for the Component -> Variant -> Proof release |
+| [#287](https://github.com/confighub/cub-gen/issues/287) | make cub-gen role and value obvious | historical parent roadmap issue keeping the product story coherent |
 | [#283](https://github.com/confighub/cub-gen/issues/283) | mutation apply gates for generator routes | route ownership now has a cub-gen decision object with next actions, digest, and proof events for ConfigHub Initiative/apply-gate display |
+| [#320](https://github.com/confighub/cub-gen/issues/320) | connect mutation apply gates to ConfigHub Function/Trigger/ApplyGate flow | post-v0.4 native ConfigHub integration; cub-gen already supplies the stable payload and live current-object evidence |
 | [#236](https://github.com/confighub/cub-gen/issues/236) | ship cub-gen as `cub gen` plugin | product workflow should feel like one platform; plugin proof now works, next release artifact remains |
 | [#213](https://github.com/confighub/cub-gen/issues/213) | GUI provenance trace | click-field-to-source is the core teaching moment |
 | [#212](https://github.com/confighub/cub-gen/issues/212) | GUI regeneration/refresh preview | users need to see generated impact before merge/apply |

--- a/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
+++ b/docs/plans/2026-04-30-v0.4-obvious-value-roadmap.md
@@ -1,10 +1,10 @@
 # v0.4 Working Roadmap: Component -> Variant -> Proof
 
-Status: post-PR #297 roadmap; connected trust, PR/MR linkage, teaching QA, OpenChoreo, app-of-apps, platform graph, fanout, and enrichment slices landed on main
+Status: v0.4 release-candidate roadmap; cub-gen-side Component/Variant proof, plugin surface, proof events, mutation apply gates, and live current-ConfigHub Initiative evidence are landed on main
 Date: 2026-05-02
 GitHub milestone: [v0.4: Component -> Variant -> Proof](https://github.com/confighub/cub-gen/milestone/4)
 GitHub release tracker: [#302](https://github.com/confighub/cub-gen/issues/302)
-ConfigHub topology alignment gate: [#304](https://github.com/confighub/cub-gen/issues/304)
+ConfigHub topology alignment gate: [#304](https://github.com/confighub/cub-gen/issues/304), closed
 
 This is a working title, not golden ConfigHub product language. The goal is
 simpler than the title: make `cub-gen`'s role and value obvious.
@@ -98,7 +98,7 @@ Subtasks:
 - [x] [#285](https://github.com/confighub/cub-gen/issues/285) Align spring-platform teaching docs with springboot-paas product path
 - [x] [#288](https://github.com/confighub/cub-gen/issues/288) Make README OpenChoreo claims honest and explicit
 - [x] [#289](https://github.com/confighub/cub-gen/issues/289) Add an OpenChoreo-shaped field trace example
-- [ ] [#304](https://github.com/confighub/cub-gen/issues/304) Align cub-gen wording with ConfigHub Base/Deployment Variant topology
+- [x] [#304](https://github.com/confighub/cub-gen/issues/304) Align cub-gen wording with ConfigHub Base/Deployment Variant topology
 
 Done means a new reader can explain `cub-gen` in one minute without starting
 from "generator contracts", and an OpenChoreo reader can tell whether support is
@@ -225,6 +225,12 @@ intent, `decision_digest`, and `proof_events[]`. This is designed to be shown
 by ConfigHub Initiatives/apply gates without requiring cub-gen to edit
 ConfigHub core write paths. Non-bypassable direct UI/API write-path hardening
 is a later ConfigHub decision if Initiative/apply gates are not enough.
+`examples/springboot-paas/demo-initiative-live.sh` now publishes the same
+evidence into real ConfigHub objects using the current public surface: Space,
+Unit, ChangeSet, Filter, and View. First-class ConfigHub
+Function/Trigger/ApplyGate wiring and native Initiative card rendering are
+tracked as external post-v0.4 integration in
+[#320](https://github.com/confighub/cub-gen/issues/320).
 
 Done means changes can be routed as apply-here, lift-upstream, or block/escalate
 without asking users to reason through implementation layers.
@@ -235,7 +241,9 @@ canonical local evidence, and can POST the link to ConfigHub with a deterministi
 idempotency key. `cub-gen normalize preview` now produces review-only sidecar
 patch sets for route policy annotations, lift-upstream source routing,
 Deployment Variants, owner annotations, and explicit secret references.
-Mutation apply gates remain the core open governance work.
+Mutation apply gates now have a cub-gen-side decision/proof payload and live
+current-ConfigHub evidence. Native ConfigHub apply-gate execution remains
+outside the v0.4 cub-gen release.
 
 ### Phase 6: Product Integration
 

--- a/docs/releases/v0.4-integration-beta.md
+++ b/docs/releases/v0.4-integration-beta.md
@@ -97,8 +97,13 @@ If this deployed field is wrong, where do I fix it?
    - `examples/springboot-paas/demo-initiative-gui.sh` emits compact
      Initiative cards for the three GUI outcomes: app-owned `ALLOW`,
      source-owned `ESCALATE`, and platform-owned `BLOCK`.
-   - ConfigHub can show the same object on an Initiative/MR apply gate without
-     requiring cub-gen to change ConfigHub core write paths.
+   - `examples/springboot-paas/demo-initiative-live.sh` publishes the same
+     evidence into real ConfigHub objects using the current public surface:
+     Space, Unit, ChangeSet, Filter, and View.
+   - First-class ConfigHub Function/Trigger/ApplyGate wiring and native
+     Initiative card rendering are post-v0.4 integration work. The v0.4
+     cub-gen claim is the stable decision/proof payload plus live current-object
+     evidence, not a ConfigHub core write-path change.
 
 ## Validation Bar
 
@@ -131,6 +136,12 @@ For connected release confidence, also run:
 make ci-connected
 ```
 
+For authenticated live Initiative evidence, run:
+
+```bash
+make test-initiative-live
+```
+
 ## Do Not Claim Yet
 
 - full upstream OpenChoreo estate support,
@@ -140,6 +151,8 @@ make ci-connected
 - generic AI-managed platform operation,
 - that every ConfigHub Variant is deployable,
 - non-bypassable ConfigHub core write-path enforcement for mutation gates,
+- first-class ConfigHub Function/Trigger/ApplyGate wiring or native Initiative
+  card rendering for mutation gates,
 - `cub plugin install confighub/cub-gen` until a plugin-compatible release
   artifact has been cut.
 
@@ -152,6 +165,8 @@ These are outside a cub-gen-only release:
   [#211](https://github.com/confighub/cub-gen/issues/211),
   [#212](https://github.com/confighub/cub-gen/issues/212),
   [#213](https://github.com/confighub/cub-gen/issues/213)
+- Native ConfigHub Function/Trigger/ApplyGate wiring for mutation apply gates:
+  [#320](https://github.com/confighub/cub-gen/issues/320)
 - Non-bypassable ConfigHub core write-path hardening for direct UI/API
   mutation bypass, if Initiative/apply gates are not enough for a customer.
 

--- a/examples/springboot-paas/docs/initiative-gui.md
+++ b/examples/springboot-paas/docs/initiative-gui.md
@@ -91,7 +91,9 @@ cub changeset get --space springboot-initiative-live -o json <redis-changeset>
 In the current ConfigHub UI, open the `springboot-initiative-live` space, then
 open the run-specific View/Initiative and the compact card Unit. This is real
 backend evidence, not a screenshot mock. First-class rendering of the five
-panels above is still a ConfigHub UI/backend integration step.
+panels above is still a post-v0.4 ConfigHub integration step. The cub-gen part
+is finished when the decision object, proof events, ChangeSets, and compact card
+Unit are present and traceable in ConfigHub.
 
 ## What The User Sees
 
@@ -136,8 +138,8 @@ cub unit get --space inventory-api-prod inventory-api \
 
 The live script uses current ConfigHub primitives today: Space, Unit, ChangeSet,
 Filter, and View. The exact Trigger/Function/ApplyGate wiring belongs to the
-native ConfigHub integration. The cub-gen contract is the stable decision object
-and proof event that the Initiative displays.
+native ConfigHub integration. The cub-gen contract is the stable decision
+object, next action, digest, and proof event that the Initiative displays.
 
 ## Do Not Claim
 


### PR DESCRIPTION
## Summary

- clarify the README and release notes: cub-gen ships the mutation gate decision/proof payload plus live current-ConfigHub evidence
- mark native ConfigHub Function/Trigger/ApplyGate wiring and Initiative card rendering as post-v0.4/external (#320)
- update the roadmap/worklist so #283 is no longer shown as the remaining v0.4 gate

## Validation

- git diff --check
- make ci
- mkdocs build --strict

## Tracker updates

- Updated #302 body to make final docs/validation the remaining v0.4 gate
- Moved #320 to the post-v0.4 ConfigHub proof UI milestone
- Updated v0.4 and post-v0.4 milestone descriptions
