### PR TITLE
Add public OpenChoreo and Kubara examples

### DIFF
--- a/docs/testing/example-truth-matrix.json
+++ b/docs/testing/example-truth-matrix.json
@@ -169,6 +169,24 @@
       "tracking_issues": []
     },
     {
+      "example": "kubara",
+      "generator_fixture": false,
+      "source_chain_verified": false,
+      "connected_mode_present": true,
+      "connected_release_gated": false,
+      "real_live_proof": "none",
+      "ai_first_surface": "none",
+      "proof_commands": [
+        "./examples/kubara/demo-connected.sh"
+      ],
+      "proof_refs": {
+        "connected_mode": [
+          "./examples/kubara/demo-connected.sh"
+        ]
+      },
+      "tracking_issues": []
+    },
+    {
       "example": "live-reconcile",
       "generator_fixture": false,
       "source_chain_verified": false,
@@ -196,6 +214,29 @@
       "notes": [
         "Runtime harness for WET-\u003eLIVE proof; source-side generator proof lives in paired examples."
       ]
+    },
+    {
+      "example": "openchoreo",
+      "generator_fixture": true,
+      "generator_kind": "openchoreo",
+      "source_chain_verified": true,
+      "connected_mode_present": true,
+      "connected_release_gated": false,
+      "real_live_proof": "none",
+      "ai_first_surface": "none",
+      "proof_commands": [
+        "./examples/openchoreo/demo-connected.sh",
+        "go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v"
+      ],
+      "proof_refs": {
+        "source_chain": [
+          "go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v"
+        ],
+        "connected_mode": [
+          "./examples/openchoreo/demo-connected.sh"
+        ]
+      },
+      "tracking_issues": []
     },
     {
       "example": "ops-workflow",
@@ -362,19 +403,19 @@
     }
   ],
   "summary": {
-    "featured_examples": 12,
-    "generator_fixtures": 8,
-    "source_chain_verified": 8,
-    "connected_mode_present": 12,
+    "featured_examples": 14,
+    "generator_fixtures": 9,
+    "source_chain_verified": 9,
+    "connected_mode_present": 14,
     "connected_release_gated": 2,
     "real_live_proof": {
-      "none": 8,
+      "none": 10,
       "paired-harness": 1,
       "standalone": 3
     },
     "ai_first_surface": {
       "explicit": 7,
-      "none": 3,
+      "none": 5,
       "partial": 2
     }
   }

--- a/docs/testing/example-truth-matrix.md
+++ b/docs/testing/example-truth-matrix.md
@@ -4,13 +4,13 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 
 ## Summary
 
-- Featured examples: `12`
-- Generator fixtures: `8`
-- Source-chain verified: `8`
-- Connected mode present: `12`
+- Featured examples: `14`
+- Generator fixtures: `9`
+- Source-chain verified: `9`
+- Connected mode present: `14`
 - Connected smoke gated: `2`
-- Real live proof: `none=8`, `paired-harness=1`, `standalone=3`
-- AI-first surface: `none=3`, `partial=2`, `explicit=7`
+- Real live proof: `none=10`, `paired-harness=1`, `standalone=3`
+- AI-first surface: `none=5`, `partial=2`, `explicit=7`
 
 ## Matrix
 
@@ -22,7 +22,9 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 | `confighub-actions` | no | no | yes | no | `none` | `partial` |  |
 | `helm-paas` | yes | yes | yes | yes | `paired-harness` | `explicit` | [#238](https://github.com/confighub/cub-gen/issues/238), [#239](https://github.com/confighub/cub-gen/issues/239), [#240](https://github.com/confighub/cub-gen/issues/240), [#241](https://github.com/confighub/cub-gen/issues/241), [#242](https://github.com/confighub/cub-gen/issues/242) |
 | `just-apps-no-platform-config` | yes | yes | yes | no | `none` | `none` |  |
+| `kubara` | no | no | yes | no | `none` | `none` |  |
 | `live-reconcile` | no | no | yes | no | `standalone` | `none` |  |
+| `openchoreo` | yes | yes | yes | no | `none` | `none` |  |
 | `ops-workflow` | yes | yes | yes | no | `none` | `partial` |  |
 | `scoredev-paas` | yes | yes | yes | no | `standalone` | `explicit` |  |
 | `springboot-paas` | yes | yes | yes | yes | `standalone` | `explicit` |  |
@@ -80,6 +82,14 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Real live: --
 - AI-first: --
 
+### `kubara`
+
+- Source chain: --
+- Connected mode: `./examples/kubara/demo-connected.sh`
+- Connected smoke lane: --
+- Real live: --
+- AI-first: --
+
 ### `live-reconcile`
 
 - Source chain: --
@@ -88,6 +98,14 @@ Generated from repo structure, source-side tests, the connected smoke lane, and 
 - Real live: `./examples/demo/e2e-live-reconcile-flux.sh`, `./examples/demo/e2e-live-reconcile-argo.sh`, `./examples/demo/e2e-connected-governed-reconcile-helm.sh`
 - AI-first: --
 - Notes: Runtime harness for WET->LIVE proof; source-side generator proof lives in paired examples.
+
+### `openchoreo`
+
+- Source chain: `go test ./cmd/cub-gen -run '^(TestExamplesPathModeDiscoverAndImport|TestExamplesPathModeBridgeFlow)$' -count=1 -v`
+- Connected mode: `./examples/openchoreo/demo-connected.sh`
+- Connected smoke lane: --
+- Real live: --
+- AI-first: --
 
 ### `ops-workflow`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,8 @@ the stack you already run.
 | Helm plus Argo/Flux platform repos | [`helm-paas`](./helm-paas/) | `./examples/demo/start-platform-first.sh` | you can trace one rendered field back to chart or values ownership |
 | Spring Boot app repos | [`springboot-paas`](./springboot-paas/) | `./examples/demo/start-app-first.sh` | you can tell which config changes are app-owned, lift-upstream, or blocked |
 | Score.dev workloads | [`scoredev-paas`](./scoredev-paas/) | `./examples/demo/start-score-first.sh` | you can trace `score.yaml` intent to rendered runtime fields |
+| OpenChoreo-style platforms | [`openchoreo`](./openchoreo/) | `./examples/openchoreo/demo-local.sh` | you can trace Workload/ReleaseBinding/ComponentType/SecretReference to rendered resources |
+| Kubara-like app-config platforms | [`kubara`](./kubara/) | `./examples/kubara/demo-local.sh` | you can see app config, platform graph, and Base/Deployment Variant proof |
 | Real GitOps runtime proof | [`live-reconcile`](./live-reconcile/) | `RECONCILER=both ./examples/live-reconcile/demo-local.sh` | you see WET output survive Flux or Argo reconciliation on kind |
 
 If you are unsure, start with `helm-paas` for the platform view or
@@ -49,7 +51,8 @@ become full runnable adapters.
 
 | Pattern | Worked example | What it teaches | Product status |
 |---|---|---|---|
-| OpenChoreo-style component platform | [OpenChoreo as a Clean Generator](../docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md) | Workload + ReleaseBinding + SecretReference + ComponentType -> rendered release | fixture-backed hardgate; not full upstream conformance |
+| OpenChoreo-style component platform | [`openchoreo`](./openchoreo/) and [OpenChoreo as a Clean Generator](../docs/agentic-gitops/03-worked-examples/05-openchoreo-generator-worked-example.md) | Workload + ReleaseBinding + SecretReference + ComponentType -> rendered release | fixture-backed hardgate; not full upstream conformance |
+| Kubara-like app-config platform | [`kubara`](./kubara/) | app config + shared platform machinery + variants -> governed config data | pattern wrapper; not actual Kubara conformance |
 | Argo ApplicationSet | [Argo Generators](../docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md) | selectors, inventory, and templates generate child Applications | bounded support exists |
 | Argo app-of-apps | [Argo Generators](../docs/agentic-gitops/03-worked-examples/06-argo-generators-worked-example.md) | root app plus child app catalog behaves like a generator | fixture-backed initial adapter |
 | Multi-repo platform estate | [`platform-estate`](../testdata/platform-estate/) | read-only manifest import before rewrites or fanout | fixture-backed graph proof |
@@ -87,6 +90,9 @@ path for each flagship example.
 - [`springboot-paas`](./springboot-paas/) — Spring Boot app/team vs platform
   ownership
 - [`scoredev-paas`](./scoredev-paas/) — Score intent to rendered manifests
+- [`openchoreo`](./openchoreo/) — OpenChoreo-shaped Workload, bindings,
+  component type, secret reference, rendered release, and generated resources
+- [`kubara`](./kubara/) — Kubara-like app config manager/platform pattern
 - [`live-reconcile`](./live-reconcile/) — Flux and Argo runtime proof harness
 
 ### Workflow and automation

--- a/examples/kubara/README.md
+++ b/examples/kubara/README.md
@@ -1,0 +1,74 @@
+# Kubara-Like Platform Example
+
+This is the discoverable entrypoint for the Kubara-like platform pattern in the
+docs.
+
+It does not claim to be an actual Kubara product import. It shows the pattern:
+a platform or app-config manager reads source config, environment context, and
+shared machinery, then produces governed config data that ConfigHub can reason
+about.
+
+## What this proves today
+
+| Slice | Status | How to prove it now |
+|---|---|---|
+| App config without a Kubernetes platform | Real | `./examples/kubara/demo-local.sh` |
+| Multi-repo platform graph before rewrites | Real | `./examples/kubara/demo-local.sh` |
+| Base/Deployment Variant topology | Real | `./examples/kubara/demo-local.sh` |
+| Connected evidence smoke | Wrapper | `cub auth login && ./examples/kubara/demo-connected.sh` |
+| Actual Kubara repo import | Not claimed | use this as the pattern, not a conformance test |
+
+## If you already run a Kubara-like platform
+
+Start here if your platform is mostly an app config manager plus shared
+machinery:
+
+- app teams own provider/app config,
+- platform teams own shared defaults and policy,
+- environments or tenants provide deployment context,
+- the platform produces deployable or runtime config.
+
+The useful question is:
+
+```text
+If this deployed field is wrong, is the durable fix in app config, platform
+defaults, environment context, or a deployment-specific override?
+```
+
+## Why this maps cleanly to the cub-gen framework
+
+| Kubara-like concept | cub-gen concept | Why it matters |
+|---|---|---|
+| app-owned config file | Component source config | app teams keep editing familiar files |
+| shared machinery/defaults | Generator/platform contract | platform ownership stays explicit |
+| env/tenant context | Deployment Variant + Target | generated copies can be compared and governed |
+| rendered/runtime config | rendered config proof | every field can get owner and route evidence |
+
+## Local and Connected Entrypoints
+
+From the repo root:
+
+```bash
+go build -o ./cub-gen ./cmd/cub-gen
+
+./examples/kubara/demo-local.sh
+
+cub auth login
+./examples/kubara/demo-connected.sh
+```
+
+The connected wrapper validates authentication and runs the same deterministic
+proof locally. It does not deploy and does not rewrite actual Kubara repos.
+
+## Direct Commands
+
+```bash
+./cub-gen gitops import --space platform --json \
+  ./examples/just-apps-no-platform-config
+
+./cub-gen platform import --json \
+  ./testdata/platform-estate/platform.yaml
+
+./cub-gen platform import --json \
+  ./testdata/variant-topology/platform.yaml
+```

--- a/examples/kubara/demo-connected.sh
+++ b/examples/kubara/demo-connected.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/examples/demo/lib/connected-preflight.sh"
+
+require_connected_preflight
+
+echo "[kubara] connected context"
+print_connected_context
+echo "[kubara] running local deterministic proof; this wrapper does not deploy"
+
+./examples/kubara/demo-local.sh

--- a/examples/kubara/demo-local.sh
+++ b/examples/kubara/demo-local.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+go build -o ./cub-gen ./cmd/cub-gen
+
+OUT_DIR="$ROOT_DIR/.tmp/examples/kubara"
+mkdir -p "$OUT_DIR"
+
+./cub-gen gitops import --space platform --json ./examples/just-apps-no-platform-config \
+  > "$OUT_DIR/no-config-platform-import.json"
+
+./cub-gen platform import --json ./testdata/platform-estate/platform.yaml \
+  > "$OUT_DIR/platform-estate.json"
+
+./cub-gen platform import --json ./testdata/variant-topology/platform.yaml \
+  > "$OUT_DIR/variant-topology.json"
+
+jq '{
+  app_config_generator: .discovered[0].generator_profile,
+  first_origin: .provenance[0].field_origin_map[0]
+}' "$OUT_DIR/no-config-platform-import.json"
+
+jq '{
+  components: .summary.component_count,
+  variants: .summary.variant_count,
+  generators: .summary.generator_count,
+  diagnostics: .summary.diagnostic_count
+}' "$OUT_DIR/platform-estate.json"
+
+jq '{
+  base_variants: [.variants[] | select(.variant_kind == "base") | .id],
+  deployment_variants: [.variants[] | select(.variant_kind == "deployment") | .id]
+}' "$OUT_DIR/variant-topology.json"
+
+echo
+echo "Kubara-like platform proof written to: $OUT_DIR"

--- a/examples/openchoreo/README.md
+++ b/examples/openchoreo/README.md
@@ -1,0 +1,79 @@
+# OpenChoreo Example
+
+OpenChoreo is a good example of a platform that acts as a Generator: it reads
+component/workload config, environment bindings, platform contracts, and secret
+references, then returns deployable Kubernetes config.
+
+This example is the discoverable wrapper for the fixture-backed hardgate in
+[`testdata/openchoreo-hardgate`](../../testdata/openchoreo-hardgate/). It is
+intentionally honest: this proves the hard shape for OpenChoreo-style config,
+not full upstream OpenChoreo repo conformance.
+
+## What this proves today
+
+| Slice | Status | How to prove it now |
+|---|---|---|
+| OpenChoreo CRD-shaped detection | Real | `./examples/openchoreo/demo-local.sh` |
+| Workload to rendered-resource provenance | Real | `./examples/openchoreo/demo-local.sh` |
+| Generated-resource ownership and edit routing | Real | `./examples/openchoreo/demo-local.sh` |
+| Connected evidence smoke | Wrapper | `cub auth login && ./examples/openchoreo/demo-connected.sh` |
+| Full upstream OpenChoreo import | Not claimed | follow-on repo validation |
+
+## If you already run OpenChoreo
+
+Start here if you want to see whether cub-gen's Generator model matches the
+shape of OpenChoreo:
+
+- `Workload` is app-owned source config.
+- `ComponentType` is platform-owned contract config.
+- `ReleaseBinding` is environment-owned deployment context.
+- `SecretReference` is security-owned binding config.
+- `RenderedRelease` and generated Kubernetes resources are rendered config.
+
+The useful question is:
+
+```text
+If this generated Kubernetes field is wrong, should I edit the app workload,
+the environment binding, the platform component type, a secret reference, or
+the rendered object?
+```
+
+## Why this maps cleanly to the cub-gen framework
+
+| OpenChoreo concept | cub-gen concept | Why it matters |
+|---|---|---|
+| `Workload` | Component/app source config | app-owned fields can route back to app config |
+| `ReleaseBinding` | Deployment Variant context | environment-specific choices stay visible |
+| `ComponentType` | platform Generator contract | platform-owned structure is not silently editable by app teams |
+| `SecretReference` | Connection evidence | secret wiring has owner and route proof |
+| `RenderedRelease` | rendered config proof | generated Kubernetes resources can trace back to inputs |
+
+## Local and Connected Entrypoints
+
+From the repo root:
+
+```bash
+go build -o ./cub-gen ./cmd/cub-gen
+
+./examples/openchoreo/demo-local.sh
+
+cub auth login
+./examples/openchoreo/demo-connected.sh
+```
+
+The connected wrapper validates authentication and produces the same
+deterministic evidence locally. It does not deploy and does not rewrite
+OpenChoreo resources.
+
+## Direct Commands
+
+```bash
+./cub-gen gitops discover --space platform --adoption-report --json \
+  ./testdata/openchoreo-hardgate
+
+./cub-gen gitops import --space platform --json \
+  ./testdata/openchoreo-hardgate
+
+./cub-gen publish --space platform ./testdata/openchoreo-hardgate \
+  | ./cub-gen verify --in -
+```

--- a/examples/openchoreo/demo-connected.sh
+++ b/examples/openchoreo/demo-connected.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/examples/demo/lib/connected-preflight.sh"
+
+require_connected_preflight
+
+echo "[openchoreo] connected context"
+print_connected_context
+echo "[openchoreo] running local deterministic proof; this wrapper does not deploy"
+
+./examples/openchoreo/demo-local.sh

--- a/examples/openchoreo/demo-local.sh
+++ b/examples/openchoreo/demo-local.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+go build -o ./cub-gen ./cmd/cub-gen
+
+OUT_DIR="$ROOT_DIR/.tmp/examples/openchoreo"
+mkdir -p "$OUT_DIR"
+
+FIXTURE="./testdata/openchoreo-hardgate"
+
+./cub-gen gitops discover --space platform --adoption-report --json "$FIXTURE" \
+  > "$OUT_DIR/discover.json"
+
+./cub-gen gitops import --space platform --json "$FIXTURE" \
+  > "$OUT_DIR/import.json"
+
+./cub-gen publish --space platform "$FIXTURE" \
+  | ./cub-gen verify --in - \
+  > "$OUT_DIR/verify.txt"
+
+jq '{
+  generator: (.detections[0].profile // .resources[0].generator_profile),
+  adoption: .adoption_report.summary,
+  diagnostics: ([.adoption_report.diagnostics[]?.code, .diagnostics[]?.code] | unique)
+}' "$OUT_DIR/discover.json"
+
+echo
+echo "OpenChoreo example proof written to: $OUT_DIR"

--- a/internal/exampletruth/matrix.go
+++ b/internal/exampletruth/matrix.go
@@ -77,6 +77,7 @@ func Collect(root string) (Matrix, error) {
 	fixtures := map[string]FamilyFixture{}
 	for _, fixture := range BridgeSymmetryMatrix() {
 		fixtures[filepath.Base(fixture.RepoSuffix)] = fixture
+		fixtures[fixture.Name] = fixture
 	}
 
 	connectedSmokeExamples, err := parseExampleArray(filepath.Join(root, "examples", "demo", "run-connected-smoke.sh"))

--- a/internal/exampletruth/matrix_test.go
+++ b/internal/exampletruth/matrix_test.go
@@ -16,13 +16,13 @@ func TestCollect(t *testing.T) {
 	if matrix.SchemaVersion != schemaVersion {
 		t.Fatalf("unexpected schema version: %s", matrix.SchemaVersion)
 	}
-	if got, want := matrix.Summary.FeaturedExamples, 12; got != want {
+	if got, want := matrix.Summary.FeaturedExamples, 14; got != want {
 		t.Fatalf("featured examples = %d, want %d", got, want)
 	}
-	if got, want := matrix.Summary.GeneratorFixtures, 8; got != want {
+	if got, want := matrix.Summary.GeneratorFixtures, 9; got != want {
 		t.Fatalf("generator fixtures = %d, want %d", got, want)
 	}
-	if got, want := matrix.Summary.SourceChainVerified, 8; got != want {
+	if got, want := matrix.Summary.SourceChainVerified, 9; got != want {
 		t.Fatalf("source-chain verified = %d, want %d", got, want)
 	}
 	if got, want := matrix.Summary.ConnectedReleaseGated, 2; got != want {
@@ -72,5 +72,15 @@ func TestCollect(t *testing.T) {
 	ops := rows["ops-workflow"]
 	if ops.AIFirstSurface != AIFirstPartial {
 		t.Fatalf("ops-workflow ai_first_surface = %q, want %q", ops.AIFirstSurface, AIFirstPartial)
+	}
+
+	openChoreo := rows["openchoreo"]
+	if !openChoreo.SourceChainVerified || openChoreo.GeneratorKind != "openchoreo" {
+		t.Fatalf("openchoreo should be source-chain verified via the hardgate fixture: %+v", openChoreo)
+	}
+
+	kubara := rows["kubara"]
+	if kubara.GeneratorFixture {
+		t.Fatal("kubara is a pattern wrapper, not a private Kubara conformance fixture")
 	}
 }

--- a/test/checks/check-connected-release-gate.sh
+++ b/test/checks/check-connected-release-gate.sh
@@ -56,7 +56,7 @@ if ! grep -q "gate_decision_digest" examples/demo/run-connected-smoke.sh; then
   fail "connected smoke summary must expose the mutation gate decision digest"
 fi
 
-assert_jq "$tmp_json" '.summary.generator_fixtures == 8' "expected eight first-class generator fixtures"
+assert_jq "$tmp_json" '.summary.generator_fixtures == 9' "expected nine first-class generator fixtures"
 assert_jq "$tmp_json" '.summary.connected_release_gated == 2' "expected exactly two flagship examples in the connected smoke lane"
 assert_jq "$tmp_json" '[.rows[] | select(.connected_release_gated)] | map(.example) | sort == ["helm-paas", "springboot-paas"]' "connected smoke lane should cover helm-paas and springboot-paas"
 assert_jq "$tmp_json" '[.rows[] | select(.connected_release_gated and (.connected_mode_present | not))] | length == 0' "connected smoke examples must expose connected mode entrypoints"


### PR DESCRIPTION
## Summary
- add discoverable examples/openchoreo and examples/kubara entrypoints with local and connected wrapper scripts
- wire both examples into examples/README and the generated example truth matrix
- teach the truth matrix that the OpenChoreo public example maps to the existing hardgate fixture

## Validation
- ./examples/openchoreo/demo-local.sh
- ./examples/kubara/demo-local.sh
- make ci
- PYTHONPATH=/tmp/cub-gen-docs-site-packages python3 -m mkdocs build --strict